### PR TITLE
Error status format

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -3,6 +3,7 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\JsonResponse;
 use Sentry\Laravel\Integration;
 use Throwable;
 
@@ -38,5 +39,38 @@ class Handler extends ExceptionHandler
         $this->reportable(function (Throwable $e) {
             Integration::captureUnhandledException($e);
         });
+    }
+
+    /**
+     * Render an exception into an HTTP response.
+     *
+     * @param mixed $request
+     * @param Throwable $exception
+     * @return JsonResponse
+     */
+    public function render($request, Throwable $exception): JsonResponse
+    {
+        if(env('APP_ENV') == 'production') {
+            return response()->json([
+                'message' => "something went wrong",
+            ], 500);
+        }
+
+        return response()->json([
+            'type' => get_class($exception),
+            'message' => $exception->getMessage(),
+            'trace' => $exception->getTrace()
+        ], 500);
+    }
+
+    /**
+     * Send the exception to the error log.
+     *
+     * @param Throwable $exception
+     * @return void
+     */
+    public function report(Throwable $exception): void
+    {
+        parent::report($exception);
     }
 }

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -50,7 +50,7 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Throwable $exception): JsonResponse
     {
-        if(env('APP_ENV') == 'production') {
+        if (env('APP_ENV') == 'production') {
             return response()->json([
                 'message' => "something went wrong",
             ], 500);

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -50,9 +50,9 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Throwable $exception): JsonResponse
     {
-        if (env('APP_ENV') == 'production') {
+        if (env('APP_ENV') === 'production') {
             return response()->json([
-                'message' => "something went wrong",
+                'message' => "A server error has occurred. We are looking into it",
             ], 500);
         }
 


### PR DESCRIPTION
### Overview
When the server error happend on production env, the endpoint return a html page showing a 500 error. We need to return a json response.
When the server error happend we need to log that error, now with sentry installed and send it to a error log.

### Resolve
Add a Render and report function to send json response to the 500 error code (when production env is setted) and send the error to the log/sentry.