### PR TITLE
[1.x] Variant Update Attributes

### DIFF
--- a/app/GraphQL/Inventory/Mutations/Variants/Variants.php
+++ b/app/GraphQL/Inventory/Mutations/Variants/Variants.php
@@ -50,8 +50,16 @@ class Variants
      */
     public function update(mixed $root, array $req): VariantModel
     {
+        if (isset($req['input']['status'])) {
+            $req['input']['status_id'] = StatusRepository::getById((int) $req['input']['status']['id'], auth()->user()->getCurrentCompany())->getId();
+        }  
+
         $variant = VariantsRepository::getById((int) $req['id'], auth()->user()->getCurrentCompany());
         $variant->update($req['input']);
+
+        if (isset($req['input']['attributes'])) {
+            $variant->addAttributes(auth()->user(), $req['input']['attributes']);
+        }
 
         return $variant;
     }

--- a/graphql/schemas/Inventory/variant.graphql
+++ b/graphql/schemas/Inventory/variant.graphql
@@ -142,6 +142,7 @@ input VariantsUpdateInput {
     sku: String
     ean: String
     barcode: String
+    attributes: [VariantsAttributesInput]
     serial_number: String
     is_published: Boolean
 }

--- a/src/Inventory/Variants/Models/Variants.php
+++ b/src/Inventory/Variants/Models/Variants.php
@@ -51,6 +51,8 @@ class Variants extends BaseModel
 
     protected $table = 'products_variants';
     protected $fillable = [
+        'users_id',
+        'products_id',
         'name',
         'uuid',
         'description',

--- a/src/Inventory/Variants/Models/Variants.php
+++ b/src/Inventory/Variants/Models/Variants.php
@@ -50,6 +50,19 @@ class Variants extends BaseModel
     use SocialInteractionsTrait;
 
     protected $table = 'products_variants';
+    protected $fillable = [
+        'name',
+        'uuid',
+        'description',
+        'short_description',
+        'status_id',
+        'barcode',
+        'serial_number',
+        'slug',
+        'html_description',
+        'sku',
+        'ean'
+    ];
     protected $guarded = [];
     protected static ?string $overWriteSearchIndex = null;
 


### PR DESCRIPTION
### Overview
The user must be able to update  the variant's attributes and status in the same call as the update of the base fields of the variant.

### Resolve
Add to the variant update mutation the assignment of the attributes and status fields so can be updated.
Add to the variant model a fillable properties so can only update the passed fields on mass assigments update methods.