### PR TITLE
Warehouse info product creation

### DIFF
--- a/src/Inventory/Variants/DataTransferObject/VariantsWarehouses.php
+++ b/src/Inventory/Variants/DataTransferObject/VariantsWarehouses.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Kanvas\Inventory\Variants\DataTransferObject;
 
-use Kanvas\Inventory\Status\Repositories\StatusRepository;
 use Spatie\LaravelData\Data;
 
 class VariantsWarehouses extends Data

--- a/src/Inventory/Variants/Services/VariantService.php
+++ b/src/Inventory/Variants/Services/VariantService.php
@@ -43,7 +43,7 @@ class VariantService
             $warehouse = WarehouseRepository::getById($variantDto->warehouse_id, $variantDto->product->company()->get()->first());
 
             if (isset($variant['warehouse']['status'])) {
-                $variant['warehouse']['status_id'] = StatusRepository::getById((int) $variant['warehouse']['status']['id'], auth()->user()->getCurrentCompany())->getId();
+                $variant['warehouse']['status_id'] = StatusRepository::getById((int) $variant['warehouse']['status']['id'], $variantDto->product->company()->get()->first())->getId();
             }
 
             $variantWarehouses = VariantsWarehouses::from($variant['warehouse']);


### PR DESCRIPTION
### Overview
The must should be able to create the extra info on the warehouse variant on the product creation flow. (EX. prices, status, quantity, etc).

### Resolve
Remove the relationship creation and use the addToWarehouse action to map and add manually.