### PR TITLE
Create warehouse observer

### DIFF
--- a/app/GraphQL/Inventory/Mutations/Warehouses/Warehouse.php
+++ b/app/GraphQL/Inventory/Mutations/Warehouses/Warehouse.php
@@ -41,19 +41,15 @@ class Warehouse
      */
     public function update(mixed $root, array $request): Warehouses
     {
-        try {
-            $warehouse = WarehouseRepository::getById($request['id'], auth()->user()->getCurrentCompany());
-            $request = $request['input'];
-            if (key_exists('regions_id', $request)) {
-                $request['regions_id'] = RegionRepository::getById(
-                    $request['regions_id'],
-                    auth()->user()->getCurrentCompany()
-                )->getKey();
-            }
-            $warehouse->update($request);
-        } catch (ValidationException $e) {
-            throw new ValidationException($e->getMessage());
+        $warehouse = WarehouseRepository::getById($request['id'], auth()->user()->getCurrentCompany());
+        $request = $request['input'];
+        if (key_exists('regions_id', $request)) {
+            $request['regions_id'] = RegionRepository::getById(
+                $request['regions_id'],
+                auth()->user()->getCurrentCompany()
+            )->getKey();
         }
+        $warehouse->update($request);
 
         return $warehouse;
     }

--- a/app/GraphQL/Inventory/Mutations/Warehouses/Warehouse.php
+++ b/app/GraphQL/Inventory/Mutations/Warehouses/Warehouse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Inventory\Mutations\Warehouses;
 
+use Kanvas\Exceptions\ValidationException;
 use Kanvas\Inventory\Regions\Repositories\RegionRepository;
 use Kanvas\Inventory\Warehouses\Actions\CreateWarehouseAction;
 use Kanvas\Inventory\Warehouses\DataTransferObject\Warehouses as WarehousesDto;
@@ -40,15 +41,20 @@ class Warehouse
      */
     public function update(mixed $root, array $request): Warehouses
     {
-        $warehouse = WarehouseRepository::getById($request['id'], auth()->user()->getCurrentCompany());
-        $request = $request['input'];
-        if (key_exists('regions_id', $request)) {
-            $request['regions_id'] = RegionRepository::getById(
-                $request['regions_id'],
-                auth()->user()->getCurrentCompany()
-            )->getKey();
+        try {
+            $warehouse = WarehouseRepository::getById($request['id'], auth()->user()->getCurrentCompany());
+            $request = $request['input'];
+            if (key_exists('regions_id', $request)) {
+                $request['regions_id'] = RegionRepository::getById(
+                    $request['regions_id'],
+                    auth()->user()->getCurrentCompany()
+                )->getKey();
+            }
+            $warehouse->update($request);
+        } catch (ValidationException $e) {
+            throw new ValidationException($e->getMessage());
         }
-        $warehouse->update($request);
+
         return $warehouse;
     }
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -11,6 +11,8 @@ use Kanvas\Companies\Models\CompaniesGroups;
 use Kanvas\Companies\Observers\CompaniesObserver;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Observers\LeadObserver;
+use Kanvas\Inventory\Warehouses\Models\Warehouses;
+use Kanvas\Inventory\Warehouses\Observers\WarehouseObserver;
 use Kanvas\Social\Messages\Models\UserMessageActivity;
 use Kanvas\Social\Messages\Observers\UserMessageActivityObserver;
 use Kanvas\Social\UsersLists\Models\UserList;
@@ -41,6 +43,7 @@ class EventServiceProvider extends ServiceProvider
         UserMessageActivity::observe(UserMessageActivityObserver::class);
         UserList::observe(UsersListsObserver::class);
         Lead::observe(LeadObserver::class);
+        Warehouses::observe(WarehouseObserver::class);
     }
 
     /**

--- a/graphql/schemas/Inventory/warehouse.graphql
+++ b/graphql/schemas/Inventory/warehouse.graphql
@@ -10,7 +10,7 @@ type Warehouse {
     name: String!
     location: String
     is_default: Boolean!
-    is_published: Int!
+    is_published: Boolean!
 }
 
 input WarehouseInput {
@@ -18,7 +18,7 @@ input WarehouseInput {
     name: String!
     location: String
     is_default: Boolean!
-    is_published: Int!
+    is_published: Boolean!
     source_id: Mixed
 }
 

--- a/src/Inventory/Support/Setup.php
+++ b/src/Inventory/Support/Setup.php
@@ -115,7 +115,7 @@ class Setup
                 StateEnums::DEFAULT_NAME->getValue(),
                 StateEnums::DEFAULT_NAME->getValue(),
                 (bool) StateEnums::YES->getValue(),
-                StateEnums::YES->getValue(),
+                (bool) StateEnums::YES->getValue(),
             ),
             $this->user
         );

--- a/src/Inventory/Warehouses/Actions/CreateWarehouseAction.php
+++ b/src/Inventory/Warehouses/Actions/CreateWarehouseAction.php
@@ -37,21 +37,17 @@ class CreateWarehouseAction
             $this->user
         );
 
-        try {
-            $warehouse = Warehouses::firstOrCreate([
-                'name' => $this->data->name,
-                'companies_id' => $this->data->company->getId(),
-                'apps_id' => $this->data->app->getId(),
-                'regions_id' => $this->data->region->getId(),
-            ], [
-                'users_id' => $this->data->user->getId(),
-                'location' => $this->data->location,
-                'is_default' => $this->data->is_default,
-                'is_published' => $this->data->is_published,
-            ]);
-        } catch (ValidationException $e) {
-            throw new ValidationException($e->getMessage());
-        }
+        $warehouse = Warehouses::firstOrCreate([
+            'name' => $this->data->name,
+            'companies_id' => $this->data->company->getId(),
+            'apps_id' => $this->data->app->getId(),
+            'regions_id' => $this->data->region->getId(),
+        ], [
+            'users_id' => $this->data->user->getId(),
+            'location' => $this->data->location,
+            'is_default' => $this->data->is_default,
+            'is_published' => $this->data->is_published,
+        ]);
 
         return $warehouse;
     }

--- a/src/Inventory/Warehouses/Actions/CreateWarehouseAction.php
+++ b/src/Inventory/Warehouses/Actions/CreateWarehouseAction.php
@@ -6,6 +6,7 @@ namespace Kanvas\Inventory\Warehouses\Actions;
 
 use Baka\Users\Contracts\UserInterface;
 use Kanvas\Companies\Repositories\CompaniesRepository;
+use Kanvas\Exceptions\ValidationException;
 use Kanvas\Inventory\Warehouses\DataTransferObject\Warehouses as WarehousesDto;
 use Kanvas\Inventory\Warehouses\Models\Warehouses;
 
@@ -36,16 +37,22 @@ class CreateWarehouseAction
             $this->user
         );
 
-        return Warehouses::firstOrCreate([
-            'name' => $this->data->name,
-            'companies_id' => $this->data->company->getId(),
-            'apps_id' => $this->data->app->getId(),
-            'regions_id' => $this->data->region->getId(),
-        ], [
-            'users_id' => $this->data->user->getId(),
-            'location' => $this->data->location,
-            'is_default' => $this->data->is_default,
-            'is_published' => $this->data->is_published,
-        ]);
+        try {
+            $warehouse = Warehouses::firstOrCreate([
+                'name' => $this->data->name,
+                'companies_id' => $this->data->company->getId(),
+                'apps_id' => $this->data->app->getId(),
+                'regions_id' => $this->data->region->getId(),
+            ], [
+                'users_id' => $this->data->user->getId(),
+                'location' => $this->data->location,
+                'is_default' => $this->data->is_default,
+                'is_published' => $this->data->is_published,
+            ]);
+        } catch (ValidationException $e) {
+            throw new ValidationException($e->getMessage());
+        }
+
+        return $warehouse;
     }
 }

--- a/src/Inventory/Warehouses/DataTransferObject/Warehouses.php
+++ b/src/Inventory/Warehouses/DataTransferObject/Warehouses.php
@@ -30,7 +30,7 @@ class Warehouses extends Data
         public string $name,
         public ?string $location = null,
         public bool $is_default = false,
-        public int $is_published = 1,
+        public bool $is_published = true,
     ) {
     }
 
@@ -57,7 +57,7 @@ class Warehouses extends Data
             $request['name'],
             $request['location'] ?? null,
             $request['is_default'] ?? (bool) StateEnums::NO->getValue(),
-            $request['is_published'] ?? StateEnums::YES->getValue(),
+            $request['is_published'] ?? (bool) StateEnums::YES->getValue(),
         );
     }
 }

--- a/src/Inventory/Warehouses/Observers/WarehouseObserver.php
+++ b/src/Inventory/Warehouses/Observers/WarehouseObserver.php
@@ -46,5 +46,4 @@ class WarehouseObserver
             throw new ValidationException('Can\'t Save, you have to have at least one default Warehouse');
         }
     }
-
 }

--- a/src/Inventory/Warehouses/Observers/WarehouseObserver.php
+++ b/src/Inventory/Warehouses/Observers/WarehouseObserver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Inventory\Warehouses\Observers;
+
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Inventory\Warehouses\Models\Warehouses;
+use Throwable;
+
+class WarehouseObserver
+{
+    public function saving(Warehouses $warehouse): void
+    {
+        try {
+            $defaultWarehouse = Warehouses::where('companies_id', $warehouse->companies_id)
+            ->where('is_default', 1)
+            ->first();
+    
+            // if default already exist remove its default
+            if ($warehouse->is_default && $defaultWarehouse) {
+                $defaultWarehouse->is_default = false;
+                $defaultWarehouse->saveOrFail();
+            }
+    
+            if(!$warehouse->is_default && !$defaultWarehouse) {
+                throw new ValidationException('Can\'t Save, you have to have at least one default Warehouse');
+            }
+        } catch (Throwable $e) {
+            dd($e);
+            // throw new ValidationException('Can\'t Save, you have to have at least one default Warehouse');
+        }
+
+    }
+
+}

--- a/src/Inventory/Warehouses/Observers/WarehouseObserver.php
+++ b/src/Inventory/Warehouses/Observers/WarehouseObserver.php
@@ -21,7 +21,7 @@ class WarehouseObserver
             $defaultWarehouse->saveQuietly();
         }
 
-        if(!$warehouse->is_default && !$defaultWarehouse) {
+        if (!$warehouse->is_default && !$defaultWarehouse) {
             throw new ValidationException('Can\'t Save, you have to have at least one default Warehouse');
         }
     }
@@ -34,15 +34,15 @@ class WarehouseObserver
 
         // if default already exist remove its default
         if ($defaultWarehouse &&
-            $warehouse->is_default &&  
+            $warehouse->is_default &&
             $warehouse->getId() != $defaultWarehouse->getId()
         ) {
             $defaultWarehouse->is_default = false;
             $defaultWarehouse->saveQuietly();
-        }elseif ($defaultWarehouse &&
+        } elseif ($defaultWarehouse &&
             !$warehouse->is_default &&
             $warehouse->getId() == $defaultWarehouse->getId()
-            ) {
+        ) {
             throw new ValidationException('Can\'t Save, you have to have at least one default Warehouse');
         }
     }

--- a/tests/GraphQL/Inventory/ProductsTest.php
+++ b/tests/GraphQL/Inventory/ProductsTest.php
@@ -181,8 +181,8 @@ class ProductsTest extends TestCase
             'regions_id' => $regionResponse['data']['createRegion']['id'],
             'name' => fake()->name,
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
 
         $warehouseResponse = $this->graphQL('
@@ -289,8 +289,8 @@ class ProductsTest extends TestCase
             'regions_id' => $regionResponse['data']['createRegion']['id'],
             'name' => fake()->name,
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
 
         $warehouseResponse = $this->graphQL('

--- a/tests/GraphQL/Inventory/RemoveVariantsToWarehouseTest.php
+++ b/tests/GraphQL/Inventory/RemoveVariantsToWarehouseTest.php
@@ -42,8 +42,8 @@ class RemoveVariantsToWarehouseTest extends TestCase
             'regions_id' => $idRegion,
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
 
         $response = $this->graphQL('

--- a/tests/GraphQL/Inventory/VariantAttributeTest.php
+++ b/tests/GraphQL/Inventory/VariantAttributeTest.php
@@ -42,8 +42,8 @@ class VariantAttributeTest extends TestCase
             'regions_id' => $idRegion,
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
 
         $response = $this->graphQL('
@@ -167,8 +167,8 @@ class VariantAttributeTest extends TestCase
             'regions_id' => $idRegion,
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
 
         $response = $this->graphQL('

--- a/tests/GraphQL/Inventory/VariantTest.php
+++ b/tests/GraphQL/Inventory/VariantTest.php
@@ -45,8 +45,8 @@ class VariantTest extends TestCase
             'regions_id' => $regionResponse['data']['createRegion']['id'],
             'name' => fake()->name,
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
 
         $warehouseResponse = $this->graphQL('
@@ -172,8 +172,8 @@ class VariantTest extends TestCase
             'regions_id' => $idRegion,
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
 
         $response = $this->graphQL('
@@ -233,8 +233,8 @@ class VariantTest extends TestCase
             'regions_id' => $idRegion,
             'name' => fake()->name,
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
         $response = $this->graphQL('
         mutation($data: WarehouseInput!) {
@@ -319,8 +319,8 @@ class VariantTest extends TestCase
             'regions_id' => $idRegion,
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
 
         $response = $this->graphQL('

--- a/tests/GraphQL/Inventory/VariantsChannelsTest.php
+++ b/tests/GraphQL/Inventory/VariantsChannelsTest.php
@@ -42,8 +42,8 @@ class VariantsChannelsTest extends TestCase
             'regions_id' => $idRegion,
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
 
         $response = $this->graphQL('

--- a/tests/GraphQL/Inventory/WarehouseProductTest.php
+++ b/tests/GraphQL/Inventory/WarehouseProductTest.php
@@ -41,8 +41,8 @@ class WarehouseProductTest extends TestCase
             'regions_id' => $response['data']['createRegion']['id'],
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
 
         $response = $this->graphQL('

--- a/tests/GraphQL/Inventory/WarehouseTest.php
+++ b/tests/GraphQL/Inventory/WarehouseTest.php
@@ -46,8 +46,8 @@ class WarehouseTest extends TestCase
             'regions_id' => $response['data']['createRegion']['id'],
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
 
         $response = $this->graphQL('
@@ -102,8 +102,8 @@ class WarehouseTest extends TestCase
             'regions_id' => $response['data']['createRegion']['id'],
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
         $response = $this->graphQL('
             mutation($data: WarehouseInput!) {
@@ -177,8 +177,8 @@ class WarehouseTest extends TestCase
             'regions_id' => $response['data']['createRegion']['id'],
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
         $response = $this->graphQL('
             mutation($data: WarehouseInput!) {
@@ -259,8 +259,8 @@ class WarehouseTest extends TestCase
             'regions_id' => $response['data']['createRegion']['id'],
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => false,
-            'is_published' => 1,
+            'is_default' => true,
+            'is_published' => true,
         ];
         $response = $this->graphQL('
             mutation($data: WarehouseInput!) {

--- a/tests/Inventory/Integration/ImporterTest.php
+++ b/tests/Inventory/Integration/ImporterTest.php
@@ -45,7 +45,7 @@ final class ImporterTest extends TestCase
             'name' => fake()->word(),
             'regions_id' => $region->getId(),
             'is_default' => true,
-            'is_published' => 1,
+            'is_published' => true,
         ];
 
         $warehouseData = (new CreateWarehouseAction(


### PR DESCRIPTION
### Overview
As user we need a default warehouse always setup on the app.

### Resolve
- Update the warehouses creations and update, in order to always have a default warehouse, and dont allow the user to remove the default if isnt another one.
- Create an observer for the creation and update of the warehouses.
- Change the is_published data type from Int to boolean.