### PR TITLE
[1.x] Variant Warehouse update

### DIFF
--- a/app/GraphQL/Inventory/Mutations/Variants/Variants.php
+++ b/app/GraphQL/Inventory/Mutations/Variants/Variants.php
@@ -11,13 +11,13 @@ use Kanvas\Inventory\Variants\Actions\AddAttributeAction;
 use Kanvas\Inventory\Variants\Actions\AddToWarehouseAction as AddToWarehouse;
 use Kanvas\Inventory\Variants\Actions\AddVariantToChannelAction;
 use Kanvas\Inventory\Variants\Actions\CreateVariantsAction;
-use Kanvas\Inventory\Variants\Actions\UpdateToWarehouseAction;
 use Kanvas\Inventory\Variants\DataTransferObject\VariantChannel;
 use Kanvas\Inventory\Variants\DataTransferObject\Variants as VariantDto;
 use Kanvas\Inventory\Variants\DataTransferObject\VariantsWarehouses;
 use Kanvas\Inventory\Variants\Models\Variants as VariantModel;
 use Kanvas\Inventory\Variants\Models\VariantsWarehouses as ModelsVariantsWarehouses;
 use Kanvas\Inventory\Variants\Repositories\VariantsRepository;
+use Kanvas\Inventory\Variants\Services\VariantService;
 use Kanvas\Inventory\Warehouses\Models\Warehouses;
 use Kanvas\Inventory\Warehouses\Repositories\WarehouseRepository;
 
@@ -76,6 +76,11 @@ class Variants
             $variant->addAttributes(auth()->user(), $req['input']['attributes']);
         }
 
+        if (isset($req['input']['warehouse'])) {
+            $warehouse = WarehouseRepository::getById((int) $req['input']['warehouse']['warehouse_id'], auth()->user()->getCurrentCompany());
+            VariantService::updateWarehouseVariant($variant, $warehouse, $req['input']['warehouse']);
+        }
+
         return $variant;
     }
 
@@ -112,15 +117,8 @@ class Variants
     {
         $variant = VariantsRepository::getById((int) $req['id'], auth()->user()->getCurrentCompany());
         $warehouse = WarehouseRepository::getById((int) $req['input']['warehouse_id'], auth()->user()->getCurrentCompany());
-        if (isset($req['input']['status'])) {
-            $req['input']['status_id'] = StatusRepository::getById((int) $req['input']['status']['id'], auth()->user()->getCurrentCompany())->getId();
-        }
-        $variantWarehousesDto = VariantsWarehouses::viaRequest($req['input']);
-        $variantWarehouses = ModelsVariantsWarehouses::where('products_variants_id', $variant->getId())
-            ->where('warehouses_id', $warehouse->getId())
-            ->firstOrFail();
 
-        return (new UpdateToWarehouseAction($variantWarehouses, $variantWarehousesDto))->execute();
+        return VariantService::updateWarehouseVariant($variant, $warehouse, $req['input']);
     }
 
     /**

--- a/app/GraphQL/Inventory/Mutations/Warehouses/Warehouse.php
+++ b/app/GraphQL/Inventory/Mutations/Warehouses/Warehouse.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Inventory\Mutations\Warehouses;
 
-use Kanvas\Exceptions\ValidationException;
 use Kanvas\Inventory\Regions\Repositories\RegionRepository;
 use Kanvas\Inventory\Warehouses\Actions\CreateWarehouseAction;
 use Kanvas\Inventory\Warehouses\DataTransferObject\Warehouses as WarehousesDto;

--- a/graphql/schemas/Inventory/variant.graphql
+++ b/graphql/schemas/Inventory/variant.graphql
@@ -66,6 +66,7 @@ input VariantsUpdateInput {
     attributes: [VariantsAttributesInput]
     serial_number: String
     is_published: Boolean
+    warehouse: VariantsWarehousesInput
 }
 
 extend type Mutation @guard {

--- a/graphql/schemas/Inventory/variantWarehouse.graphql
+++ b/graphql/schemas/Inventory/variantWarehouse.graphql
@@ -1,5 +1,5 @@
 type WarehouseVariantRelationship {
-    id: ID!
+    warehouses_id: ID!
     warehouseinfo: Warehouse @belongsToMany(relation: "warehouse")
     channels: [VariantChannelRelationship]
     quantity: Float

--- a/src/Inventory/Variants/Services/VariantService.php
+++ b/src/Inventory/Variants/Services/VariantService.php
@@ -75,7 +75,7 @@ class VariantService
     public static function updateWarehouseVariant(Variants $variant, Warehouses $warehouse, array $data): Variants
     {
         if (isset($data['status'])) {
-            $data['status_id'] = StatusRepository::getById((int) $data['status']['id'], auth()->user()->getCurrentCompany())->getId();
+            $data['status_id'] = StatusRepository::getById((int) $data['status']['id'], $variant->product->company()->get()->first())->getId();
         }
 
         $variantWarehousesDto = VariantsWarehouses::viaRequest($data);


### PR DESCRIPTION
### Overview
The user must be able to update the variant data on warehouse on the same mutation of the variant update.

### Resolve
- Add variant warehouse reference input to variant update input.
- Move variant on warehouse update method to variant service.
- Remove variant warehouse pivot id.
