### PR TITLE
[1.x] Get price history for variants

### DIFF
--- a/app/GraphQL/Inventory/Builders/Variants/VariantChannelBuilder.php
+++ b/app/GraphQL/Inventory/Builders/Variants/VariantChannelBuilder.php
@@ -74,4 +74,15 @@ class VariantChannelBuilder
             'is_published' => $root->is_published,
         ];
     }
+
+    /**
+     * Get channel prices history
+     */
+    public function getChannelHistory(mixed $root): array
+    {
+        return $root->pricesHistory(
+            'product_variants_warehouse_id', 
+            $root->pivot->product_variants_warehouse_id
+        )->get()->toArray();
+    }
 }

--- a/app/GraphQL/Inventory/Builders/Variants/VariantChannelBuilder.php
+++ b/app/GraphQL/Inventory/Builders/Variants/VariantChannelBuilder.php
@@ -81,7 +81,7 @@ class VariantChannelBuilder
     public function getChannelHistory(mixed $root): array
     {
         return $root->pricesHistory(
-            'product_variants_warehouse_id', 
+            'product_variants_warehouse_id',
             $root->pivot->product_variants_warehouse_id
         )->get()->toArray();
     }

--- a/graphql/schemas/Inventory/variantChannel.graphql
+++ b/graphql/schemas/Inventory/variantChannel.graphql
@@ -25,13 +25,20 @@ type VariantChannel {
         @hasMany(relation: "variantWarehouses")
     attributes: [VariantsAttributes!]!
 }
-
+type ChannelsPricesHistoryRelationship {
+    price: Float!
+    from_date: String!
+}
 type VariantChannelRelationship {
     name: String
     price: Float
     warehouses_id: Int
     discounted_price: Float
     is_published: Boolean
+    prices_history: [ChannelsPricesHistoryRelationship]
+        @field(
+            resolver: "App\\GraphQL\\Inventory\\Builders\\Variants\\VariantChannelBuilder@getChannelHistory"
+        )
 }
 
 input VariantChannelInput {

--- a/graphql/schemas/Inventory/variantChannel.graphql
+++ b/graphql/schemas/Inventory/variantChannel.graphql
@@ -35,7 +35,7 @@ type VariantChannelRelationship {
     warehouses_id: Int
     discounted_price: Float
     is_published: Boolean
-    prices_history: [ChannelsPricesHistoryRelationship]
+    prices_history: [ChannelsPricesHistoryRelationship!]!
         @field(
             resolver: "App\\GraphQL\\Inventory\\Builders\\Variants\\VariantChannelBuilder@getChannelHistory"
         )

--- a/graphql/schemas/Inventory/variantWarehouse.graphql
+++ b/graphql/schemas/Inventory/variantWarehouse.graphql
@@ -1,3 +1,7 @@
+type WarehousesPricesHistoryRelationship {
+    price: Float!
+    from_date: String!
+}
 type WarehouseVariantRelationship {
     warehouses_id: ID!
     warehouseinfo: Warehouse @belongsToMany(relation: "warehouse")
@@ -19,6 +23,8 @@ type WarehouseVariantRelationship {
     is_published: Boolean
     status_history: [StatusHistoryRelationship]
         @method(name: "getStatusHistory")
+    prices_history: [WarehousesPricesHistoryRelationship]
+        @hasMany(relation: "pricesHistory")
 }
 
 input VariantsWarehousesInput {

--- a/graphql/schemas/Inventory/variantWarehouse.graphql
+++ b/graphql/schemas/Inventory/variantWarehouse.graphql
@@ -21,9 +21,9 @@ type WarehouseVariantRelationship {
     is_coming_soon: Boolean
     is_new: Boolean
     is_published: Boolean
-    status_history: [StatusHistoryRelationship]
+    status_history: [StatusHistoryRelationship!]!
         @method(name: "getStatusHistory")
-    prices_history: [WarehousesPricesHistoryRelationship]
+    prices_history: [WarehousesPricesHistoryRelationship!]!
         @hasMany(relation: "pricesHistory")
 }
 

--- a/src/Domains/Inventory/Channels/Models/Channels.php
+++ b/src/Domains/Inventory/Channels/Models/Channels.php
@@ -139,4 +139,12 @@ class Channels extends BaseModel
     {
         return $this->availableProducts()->update(['is_published' => 0]) > 0;
     }
+
+    public function pricesHistory(): HasMany
+    {
+        return $this->hasMany(
+            VariantChannelPriceHistory::class,
+            'channels_id'
+        );
+    }
 }

--- a/src/Domains/Inventory/Variants/Models/VariantsChannels.php
+++ b/src/Domains/Inventory/Variants/Models/VariantsChannels.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Kanvas\Inventory\Variants\Models;
 
+use Awobaz\Compoships\Compoships;
 use Baka\Traits\HasCompositePrimaryKeyTrait;
 use Baka\Traits\NoAppRelationshipTrait;
 use Baka\Traits\NoCompanyRelationshipTrait;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Kanvas\Inventory\Channels\Models\Channels;
+use Kanvas\Inventory\Channels\Models\VariantChannelPriceHistory;
 use Kanvas\Inventory\Models\BaseModel;
 use Kanvas\Inventory\Warehouses\Models\Warehouses;
 
@@ -31,6 +34,7 @@ class VariantsChannels extends BaseModel
     use HasCompositePrimaryKeyTrait;
     use NoAppRelationshipTrait;
     use NoCompanyRelationshipTrait;
+    use Compoships;
 
     protected $table = 'products_variants_channels';
     protected $guarded = [];
@@ -55,5 +59,14 @@ class VariantsChannels extends BaseModel
     public function warehouse(): BelongsTo
     {
         return $this->belongsTo(Warehouses::class, 'warehouses_id');
+    }
+
+    public function pricesHistory(): HasMany
+    {
+        return $this->hasMany(
+            VariantChannelPriceHistory::class,
+            ['product_variants_warehouse_id','channels_id'],
+            ['product_variants_warehouse_id','channels_id']
+        );
     }
 }

--- a/src/Domains/Inventory/Variants/Models/VariantsWarehouses.php
+++ b/src/Domains/Inventory/Variants/Models/VariantsWarehouses.php
@@ -8,6 +8,7 @@ use Baka\Traits\NoAppRelationshipTrait;
 use Baka\Traits\NoCompanyRelationshipTrait;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Kanvas\Inventory\Channels\Models\Channels;
 use Kanvas\Inventory\Models\BaseModel;
@@ -89,6 +90,14 @@ class VariantsWarehouses extends BaseModel
             'status_id'
         )
             ->withPivot('from_date');
+    }
+
+    public function pricesHistory(): HasMany
+    {
+        return $this->hasMany(
+            VariantsWarehousesPriceHistory::class,
+            'product_variants_warehouse_id'
+        );
     }
 
     /**


### PR DESCRIPTION
### Overview
The user must be able to get the prices history for channels and warehouses.

### Resolve
- Add relation for channels to get history prices.
- Add field on the schemas for channels and warehouses to get prices history for variants.
