### PR TITLE
[1.x] Create default channel

### DIFF
--- a/app/Console/Commands/KanvasInventoryDefaultUpdate.php
+++ b/app/Console/Commands/KanvasInventoryDefaultUpdate.php
@@ -9,6 +9,7 @@ use Illuminate\Console\Command;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Currencies\Models\Currencies;
+use Kanvas\Inventory\Channels\Models\Channels;
 use Kanvas\Inventory\Regions\Models\Regions;
 use Kanvas\Inventory\Status\Models\Status;
 use Kanvas\Inventory\Warehouses\Models\Warehouses;
@@ -51,6 +52,7 @@ class KanvasInventoryDefaultUpdate extends Command
             $defaultWarehouses = Warehouses::getDefault($companyData);
             $defaultStatus = Status::getDefault($companyData);
             $defaultRegion = Regions::getDefault($companyData);
+            $defaultChannel = Channels::getDefault($companyData);
 
             $this->info("Checking company {$companyData->getId()} \n");
             $this->info("Checking company {$companyData->getId()} default status \n");
@@ -88,7 +90,6 @@ class KanvasInventoryDefaultUpdate extends Command
                         'is_published' => true
                     ]);
                 } catch (Throwable $e) {
-                    dd($e);
                     $this->error('Error creating default warehouse for : ' . $companyData->getId() . ' ' . $e->getMessage());
                 }
             }
@@ -106,6 +107,24 @@ class KanvasInventoryDefaultUpdate extends Command
                     ]);
                 } catch (Throwable $e) {
                     $this->error('Error creating default status for : ' . $companyData->getId() . ' ' . $e->getMessage());
+                }
+            }
+
+            if (! $defaultChannel) {
+                $this->info("Working company {$companyData->getId()} default channel \n");
+                try {
+                    $defaultChannel = Channels::firstOrCreate([
+                        'apps_id' => $app->getId(),
+                        'companies_id' => $companyData->getId(),
+                        'apps_id' => $app->getId(),
+                        'slug' => Str::slug("Default"),
+                    ], [
+                        'name' => "Default",
+                        'users_id' => $companyData->users_id,
+                        'is_default' => true,
+                    ]);
+                } catch (Throwable $e) {
+                    $this->error('Error creating default channel for : ' . $companyData->getId() . ' ' . $e->getMessage());
                 }
             }
         }

--- a/app/Console/Commands/KanvasInventoryDefaultUpdate.php
+++ b/app/Console/Commands/KanvasInventoryDefaultUpdate.php
@@ -114,7 +114,6 @@ class KanvasInventoryDefaultUpdate extends Command
                 $this->info("Working company {$companyData->getId()} default channel \n");
                 try {
                     $defaultChannel = Channels::firstOrCreate([
-                        'apps_id' => $app->getId(),
                         'companies_id' => $companyData->getId(),
                         'apps_id' => $app->getId(),
                         'slug' => Str::slug("Default"),

--- a/app/GraphQL/Inventory/Builders/Variants/VariantChannelBuilder.php
+++ b/app/GraphQL/Inventory/Builders/Variants/VariantChannelBuilder.php
@@ -69,7 +69,6 @@ class VariantChannelBuilder
         return [
             'name' => $root->channel_name,
             'price' => $root->price,
-            'warehouses_id' => 0, //remove -_-
             'discounted_price' => $root->discounted_price,
             'is_published' => $root->is_published,
         ];

--- a/app/GraphQL/Inventory/Mutations/Channels/ChannelMutation.php
+++ b/app/GraphQL/Inventory/Mutations/Channels/ChannelMutation.php
@@ -74,8 +74,6 @@ class ChannelMutation
         $id = $request['id'];
         $channel = ChannelRepository::getById($id, auth()->user()->getCurrentCompany());
 
-        //print_r($channel->availableProducts()->get()->toArray()); die();
-
         return $channel->unPublishAllVariants();
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -11,6 +11,8 @@ use Kanvas\Companies\Models\CompaniesGroups;
 use Kanvas\Companies\Observers\CompaniesObserver;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Observers\LeadObserver;
+use Kanvas\Inventory\Channels\Models\Channels;
+use Kanvas\Inventory\Channels\Observers\ChannelObserver;
 use Kanvas\Inventory\Status\Models\Status;
 use Kanvas\Inventory\Status\Observers\StatusObserver;
 use Kanvas\Inventory\Variants\Models\VariantsWarehouses;
@@ -58,6 +60,7 @@ class EventServiceProvider extends ServiceProvider
         Warehouses::observe(WarehouseObserver::class);
         Status::observe(StatusObserver::class);
         VariantsWarehouses::observe(VariantsWarehouseObserver::class);
+        Channels::observe(ChannelObserver::class);
     }
 
     /**

--- a/database/migrations/Inventory/2024_01_09_171343_create-default-channel.php
+++ b/database/migrations/Inventory/2024_01_09_171343_create-default-channel.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/Inventory/2024_01_09_171343_create-default-channel.php
+++ b/database/migrations/Inventory/2024_01_09_171343_create-default-channel.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->boolean('is_default')->default(false);
+            $table->index(['is_default', 'companies_id'], 'is_default_companies_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/migrations/Inventory/2024_01_09_171343_create-default-channel.php
+++ b/database/migrations/Inventory/2024_01_09_171343_create-default-channel.php
@@ -12,7 +12,7 @@ return new class () extends Migration {
     {
         Schema::table('channels', function (Blueprint $table) {
             $table->boolean('is_default')->default(false);
-            $table->index(['is_default', 'companies_id'], 'is_default_companies_id');
+            $table->index(['is_default', 'companies_id', 'apps_id'], 'is_default_companies_id_app');
         });
     }
 

--- a/graphql/schemas/Inventory/channel.graphql
+++ b/graphql/schemas/Inventory/channel.graphql
@@ -8,6 +8,7 @@ type Channel {
     uuid: String!
     description: String
     slug: String!
+    is_default: Boolean!
     is_published: Boolean!
 }
 
@@ -15,12 +16,16 @@ input CreateChannelInput {
     name: String!
     description: String
     slug: String
+    is_default: Boolean
+    is_published: Boolean
 }
 
 input UpdateChannelInput {
     name: String
     description: String
     slug: String
+    is_default: Boolean
+    is_published: Int
 }
 
 extend type Mutation @guard {

--- a/src/Domains/Inventory/Channels/Actions/CreateChannel.php
+++ b/src/Domains/Inventory/Channels/Actions/CreateChannel.php
@@ -42,6 +42,7 @@ class CreateChannel
         ], [
             'description' => $this->dto->description,
             'slug' => $this->dto->slug ?? Str::slug($this->dto->name),
+            'is_default' => $this->dto->is_default,
             'is_published' => $this->dto->is_published,
             'users_id' => $this->user->getId(),
         ]);

--- a/src/Domains/Inventory/Channels/DataTransferObject/Channels.php
+++ b/src/Domains/Inventory/Channels/DataTransferObject/Channels.php
@@ -25,7 +25,8 @@ class Channels extends Data
         public UserInterface $user,
         public string $name,
         public ?string $description = null,
-        public int $is_published = 1,
+        public bool $is_default = false,
+        public bool $is_published = true,
     ) {
     }
 
@@ -37,7 +38,8 @@ class Channels extends Data
             auth()->user(),
             $request['name'],
             $request['description'] ?? null,
-            $request['is_published'] ?? StateEnums::YES->getValue(),
+            $request['is_default'] ?? (bool) StateEnums::NO->getValue(),
+            $request['is_published'] ?? (bool) StateEnums::YES->getValue(),
         );
     }
 }

--- a/src/Domains/Inventory/Channels/Models/Channels.php
+++ b/src/Domains/Inventory/Channels/Models/Channels.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Inventory\Models\BaseModel;
+use Kanvas\Inventory\Traits\DefaultTrait;
 use Kanvas\Inventory\Variants\Models\VariantsChannels;
 use Kanvas\Users\Models\Users;
 
@@ -35,6 +36,7 @@ class Channels extends BaseModel
 {
     use UuidTrait;
     use SlugTrait;
+    use DefaultTrait;
 
     protected $table = 'channels';
     protected $guarded = [];

--- a/src/Domains/Inventory/Channels/Observers/ChannelObserver.php
+++ b/src/Domains/Inventory/Channels/Observers/ChannelObserver.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Inventory\Channels\Observers;
+
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Inventory\Channels\Models\Channels;
+
+class ChannelObserver
+{
+    public function creating(Channels $channel): void
+    {
+        $defaultChannel = $channel::getDefault($channel->company);
+
+        // if default already exist remove its default
+        if ($channel->is_default && $defaultChannel) {
+            $defaultChannel->is_default = false;
+            $defaultChannel->saveQuietly();
+        }
+
+        if (! $channel->is_default && ! $defaultChannel) {
+            throw new ValidationException('Can\'t Save, you have to have at least one default Channel');
+        }
+    }
+
+    public function updating(Channels $channel): void
+    {
+        $defaultChannel = Channels::getDefault($channel->company);
+
+        // if default already exist remove its default
+        if ($defaultChannel &&
+            $channel->is_default &&
+            $channel->getId() != $defaultChannel->getId()
+        ) {
+            $defaultChannel->is_default = false;
+            $defaultChannel->saveQuietly();
+        } elseif ($defaultChannel &&
+            ! $channel->is_default &&
+            $channel->getId() == $defaultChannel->getId()
+        ) {
+            throw new ValidationException('Can\'t Save, you have to have at least one default Channel');
+        }
+    }
+}

--- a/src/Domains/Inventory/Support/Setup.php
+++ b/src/Domains/Inventory/Support/Setup.php
@@ -86,8 +86,8 @@ class Setup
                 $this->user,
                 StateEnums::DEFAULT_NAME->getValue(),
                 StateEnums::DEFAULT_NAME->getValue(),
-                StateEnums::YES->getValue(),
-                StateEnums::YES->getValue()
+                (bool) StateEnums::YES->getValue(),
+                (bool) StateEnums::YES->getValue()
             ),
             $this->user
         );

--- a/src/Domains/Inventory/Support/Setup.php
+++ b/src/Domains/Inventory/Support/Setup.php
@@ -86,6 +86,7 @@ class Setup
                 $this->user,
                 StateEnums::DEFAULT_NAME->getValue(),
                 StateEnums::DEFAULT_NAME->getValue(),
+                StateEnums::YES->getValue(),
                 StateEnums::YES->getValue()
             ),
             $this->user

--- a/tests/GraphQL/Inventory/ChannelTest.php
+++ b/tests/GraphQL/Inventory/ChannelTest.php
@@ -24,7 +24,8 @@ class ChannelTest extends TestCase
                 createChannel(input: $data)
                 {
                     id
-                    name
+                    name,
+                    is_default
                 }
             }', ['data' => $data])->assertJson([
             'data' => ['createChannel' => $data]
@@ -57,7 +58,8 @@ class ChannelTest extends TestCase
                 channels {
                     data {
                         id,
-                        name
+                        name,
+                        is_default
                     }
                 }
             }')->assertJson([
@@ -91,7 +93,8 @@ class ChannelTest extends TestCase
             channels {
                 data {
                     id,
-                    name
+                    name,
+                    is_default
                 }
             }
         }')->assertJson([
@@ -138,7 +141,8 @@ class ChannelTest extends TestCase
             channels {
                 data {
                     id,
-                    name
+                    name,
+                    is_default
                 }
             }
         }')->assertJson([
@@ -179,7 +183,8 @@ class ChannelTest extends TestCase
             channels {
                 data {
                     id,
-                    name
+                    name,
+                    is_default
                 }
             }
         }')->assertJson([

--- a/tests/GraphQL/Inventory/ChannelTest.php
+++ b/tests/GraphQL/Inventory/ChannelTest.php
@@ -17,6 +17,7 @@ class ChannelTest extends TestCase
     {
         $data = [
             'name' => fake()->name,
+            'is_default' => 1,
         ];
         $this->graphQL('
             mutation($data: CreateChannelInput!) {
@@ -39,6 +40,7 @@ class ChannelTest extends TestCase
     {
         $data = [
             'name' => fake()->name,
+            'is_default' => 1,
         ];
         $this->graphQL('
             mutation($data: CreateChannelInput!) {
@@ -72,6 +74,7 @@ class ChannelTest extends TestCase
     {
         $data = [
             'name' => fake()->name,
+            'is_default' => 1,
         ];
         $this->graphQL('
             mutation($data: CreateChannelInput!) {
@@ -118,6 +121,7 @@ class ChannelTest extends TestCase
     {
         $data = [
             'name' => fake()->name,
+            'is_default' => 1,
         ];
         $this->graphQL('
             mutation($data: CreateChannelInput!) {
@@ -158,6 +162,7 @@ class ChannelTest extends TestCase
     {
         $data = [
             'name' => fake()->name,
+            'is_default' => 1,
         ];
         $this->graphQL('
             mutation($data: CreateChannelInput!) {

--- a/tests/GraphQL/Inventory/ChannelTest.php
+++ b/tests/GraphQL/Inventory/ChannelTest.php
@@ -48,7 +48,8 @@ class ChannelTest extends TestCase
                 createChannel(input: $data)
                 {
                     id
-                    name
+                    name,
+                    is_default
                 }
             }', ['data' => $data])->assertJson([
             'data' => ['createChannel' => $data]
@@ -83,7 +84,8 @@ class ChannelTest extends TestCase
                 createChannel(input: $data)
                 {
                     id
-                    name
+                    name,
+                    is_default
                 }
             }', ['data' => $data])->assertJson([
             'data' => ['createChannel' => $data]
@@ -131,7 +133,8 @@ class ChannelTest extends TestCase
                 createChannel(input: $data)
                 {
                     id
-                    name
+                    name,
+                    is_default
                 }
             }', ['data' => $data])->assertJson([
             'data' => ['createChannel' => $data]
@@ -173,7 +176,8 @@ class ChannelTest extends TestCase
                 createChannel(input: $data)
                 {
                     id
-                    name
+                    name,
+                    is_default
                 }
             }', ['data' => $data])->assertJson([
             'data' => ['createChannel' => $data]

--- a/tests/GraphQL/Inventory/ChannelTest.php
+++ b/tests/GraphQL/Inventory/ChannelTest.php
@@ -17,7 +17,7 @@ class ChannelTest extends TestCase
     {
         $data = [
             'name' => fake()->name,
-            'is_default' => 1,
+            'is_default' => true,
         ];
         $this->graphQL('
             mutation($data: CreateChannelInput!) {
@@ -40,7 +40,7 @@ class ChannelTest extends TestCase
     {
         $data = [
             'name' => fake()->name,
-            'is_default' => 1,
+            'is_default' => true,
         ];
         $this->graphQL('
             mutation($data: CreateChannelInput!) {
@@ -74,7 +74,7 @@ class ChannelTest extends TestCase
     {
         $data = [
             'name' => fake()->name,
-            'is_default' => 1,
+            'is_default' => true,
         ];
         $this->graphQL('
             mutation($data: CreateChannelInput!) {
@@ -121,7 +121,7 @@ class ChannelTest extends TestCase
     {
         $data = [
             'name' => fake()->name,
-            'is_default' => 1,
+            'is_default' => true,
         ];
         $this->graphQL('
             mutation($data: CreateChannelInput!) {
@@ -162,7 +162,7 @@ class ChannelTest extends TestCase
     {
         $data = [
             'name' => fake()->name,
-            'is_default' => 1,
+            'is_default' => true,
         ];
         $this->graphQL('
             mutation($data: CreateChannelInput!) {

--- a/tests/GraphQL/Inventory/VariantsChannelsTest.php
+++ b/tests/GraphQL/Inventory/VariantsChannelsTest.php
@@ -100,6 +100,7 @@ class VariantsChannelsTest extends TestCase
         $dataChannel = [
             'name' => fake()->name,
             'description' => fake()->text,
+            'is_default' => true,
         ];
 
         $response = $this->graphQL('

--- a/tests/GraphQL/Inventory/VariantsChannelsTest.php
+++ b/tests/GraphQL/Inventory/VariantsChannelsTest.php
@@ -109,7 +109,8 @@ class VariantsChannelsTest extends TestCase
             {
                 id
                 name
-                description
+                description,
+                is_default
             }
         }', ['data' => $dataChannel]);
 


### PR DESCRIPTION
### Overview
The user(s) companies need to have an already ready channel as default to use in the variants data manipulation.

### Resolve
- Create migration to add default on channels table.
- Create channels observer to ensure 1 default channel on channel data manipulation.
- Update channel creation flow to add default values to channels.
- Update the "default" command to update the current channels to assign a default channel if not exist.