### PR TITLE
Variant channel updates

### DIFF
--- a/app/GraphQL/Inventory/Mutations/Variants/Variants.php
+++ b/app/GraphQL/Inventory/Mutations/Variants/Variants.php
@@ -207,8 +207,8 @@ class Variants
     public function updateVariantInChannel(mixed $root, array $req)
     {
         $variant = VariantsRepository::getById((int) $req['variants_id'], auth()->user()->getCurrentCompany());
-        $warehouse = WarehouseRepository::getById((int) $req['warehouses_id']);
-        $channel = ChannelRepository::getById((int) $req['channels_id']);
+        $warehouse = WarehouseRepository::getById((int) $req['warehouses_id'], auth()->user()->getCurrentCompany());
+        $channel = ChannelRepository::getById((int) $req['channels_id'], auth()->user()->getCurrentCompany());
 
         $variantChannel = VariantsChannels::where('products_variants_id', $variant->getId())
             ->where('warehouses_id', $warehouse->getId())

--- a/app/GraphQL/Inventory/Mutations/Variants/Variants.php
+++ b/app/GraphQL/Inventory/Mutations/Variants/Variants.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\GraphQL\Inventory\Mutations\Variants;
 
 use Kanvas\Inventory\Attributes\Repositories\AttributesRepository;
+use Kanvas\Inventory\Channels\Models\Channels;
 use Kanvas\Inventory\Channels\Repositories\ChannelRepository;
 use Kanvas\Inventory\Status\Models\Status;
 use Kanvas\Inventory\Status\Repositories\StatusRepository;
@@ -16,6 +17,7 @@ use Kanvas\Inventory\Variants\DataTransferObject\VariantChannel;
 use Kanvas\Inventory\Variants\DataTransferObject\Variants as VariantDto;
 use Kanvas\Inventory\Variants\DataTransferObject\VariantsWarehouses;
 use Kanvas\Inventory\Variants\Models\Variants as VariantModel;
+use Kanvas\Inventory\Variants\Models\VariantsChannels;
 use Kanvas\Inventory\Variants\Models\VariantsWarehouses as ModelsVariantsWarehouses;
 use Kanvas\Inventory\Variants\Repositories\VariantsRepository;
 use Kanvas\Inventory\Variants\Services\VariantService;
@@ -195,6 +197,28 @@ class Variants
         $channel = ChannelRepository::getById((int) $req['channels_id']);
         $variantChannel = VariantChannel::from($req['input']);
         (new AddVariantToChannelAction($variantWarehouses, $channel, $variantChannel))->execute();
+
+        return $variant;
+    }
+
+    /**
+     * update variant In channels.
+     */
+    public function updateVariantInChannel(mixed $root, array $req)
+    {
+        $variant = VariantsRepository::getById((int) $req['variants_id'], auth()->user()->getCurrentCompany());
+        $warehouse = WarehouseRepository::getById((int) $req['warehouses_id']);
+        $channel = ChannelRepository::getById((int) $req['channels_id']);
+
+        $variantChannel = VariantsChannels::where('products_variants_id', $variant->getId())
+            ->where('warehouses_id', $warehouse->getId())
+            ->where('channels_id', $channel->getId())
+            ->firstOrFail();
+
+        VariantService::updateVariantChannel(
+            $variantChannel,
+            $req['input']
+        );
 
         return $variant;
     }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -13,8 +13,10 @@ use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Observers\LeadObserver;
 use Kanvas\Inventory\Channels\Models\Channels;
 use Kanvas\Inventory\Channels\Observers\ChannelObserver;
+use Kanvas\Inventory\Channels\Observers\VariantsChannelObserver;
 use Kanvas\Inventory\Status\Models\Status;
 use Kanvas\Inventory\Status\Observers\StatusObserver;
+use Kanvas\Inventory\Variants\Models\VariantsChannels;
 use Kanvas\Inventory\Variants\Models\VariantsWarehouses;
 use Kanvas\Inventory\Warehouses\Models\Warehouses;
 use Kanvas\Inventory\Warehouses\Observers\VariantsWarehouseObserver;
@@ -61,6 +63,7 @@ class EventServiceProvider extends ServiceProvider
         Status::observe(StatusObserver::class);
         VariantsWarehouses::observe(VariantsWarehouseObserver::class);
         Channels::observe(ChannelObserver::class);
+        VariantsChannels::observe(VariantsChannelObserver::class);
     }
 
     /**

--- a/graphql/schemas/Inventory/variantChannel.graphql
+++ b/graphql/schemas/Inventory/variantChannel.graphql
@@ -57,6 +57,15 @@ extend type Mutation @guard {
         @field(
             resolver: "App\\GraphQL\\Inventory\\Mutations\\Variants\\Variants@addToChannel"
         )
+    updateVariantInChannel(
+        variants_id: ID!
+        channels_id: ID!
+        warehouses_id: ID!
+        input: VariantChannelInput!
+    ): Variant
+        @field(
+            resolver: "App\\GraphQL\\Inventory\\Mutations\\Variants\\Variants@updateVariantInChannel"
+        )
     removeVariantChannel(
         variants_id: ID!
         channels_id: ID!

--- a/src/Domains/Inventory/Channels/Observers/VariantsChannelObserver.php
+++ b/src/Domains/Inventory/Channels/Observers/VariantsChannelObserver.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Inventory\Channels\Observers;
+
+use Kanvas\Inventory\Channels\Actions\CreatePriceHistoryAction;
+use Kanvas\Inventory\Variants\Models\VariantsChannels;
+
+class VariantsChannelObserver
+{
+    public function saved(VariantsChannels $variantChannel): void
+    {
+        if ($variantChannel->wasChanged('price')) {
+            (new CreatePriceHistoryAction(
+                $variantChannel->productVariantWarehouse,
+                $variantChannel->channel,
+                $variantChannel->price
+            ))->execute();
+        }
+    }
+}

--- a/src/Domains/Inventory/Variants/Actions/UpdateToChannelAction.php
+++ b/src/Domains/Inventory/Variants/Actions/UpdateToChannelAction.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Inventory\Variants\Actions;
+
+use Kanvas\Inventory\Variants\DataTransferObject\VariantChannel as VariantChannelDto;
+use Kanvas\Inventory\Variants\Models\VariantsChannels;
+
+class UpdateToChannelAction
+{
+    /**
+     * __construct.
+     *
+     * @return void
+     */
+    public function __construct(
+        public VariantsChannels $variantsChannels,
+        public VariantChannelDto $variantsChannelsDto,
+    ) {
+        // Set default values in the DTO
+        $variantsChannelsDto->price = $variantsChannelsDto->price ?? $variantsChannels->price; // Set your default value
+        $variantsChannelsDto->discounted_price = $variantsChannelsDto->discounted_price ?? $variantsChannels->discounted_price;
+        $variantsChannelsDto->is_published = $variantsChannelsDto->is_published ?? $variantsChannels->is_published;
+        $this->variantsChannelsDto = $variantsChannelsDto;
+    }
+
+    /**
+     * execute.
+     * @psalm-suppress ArgumentTypeCoercion
+     */
+    public function execute(): VariantsChannels
+    {
+        $this->variantsChannels->update(
+            [
+                'price' => $this->variantsChannelsDto->price,
+                'discounted_price' => $this->variantsChannelsDto->discounted_price,
+                'is_published' => $this->variantsChannelsDto->is_published,
+            ]
+        );
+
+        return $this->variantsChannels;
+    }
+}

--- a/src/Domains/Inventory/Variants/Services/VariantService.php
+++ b/src/Domains/Inventory/Variants/Services/VariantService.php
@@ -10,10 +10,13 @@ use Kanvas\Inventory\Status\Models\Status;
 use Kanvas\Inventory\Status\Repositories\StatusRepository;
 use Kanvas\Inventory\Variants\Actions\AddToWarehouseAction as AddToWarehouse;
 use Kanvas\Inventory\Variants\Actions\CreateVariantsAction;
+use Kanvas\Inventory\Variants\Actions\UpdateToChannelAction;
 use Kanvas\Inventory\Variants\Actions\UpdateToWarehouseAction;
+use Kanvas\Inventory\Variants\DataTransferObject\VariantChannel as VariantChannelDto;
 use Kanvas\Inventory\Variants\DataTransferObject\Variants as VariantsDto;
 use Kanvas\Inventory\Variants\DataTransferObject\VariantsWarehouses;
 use Kanvas\Inventory\Variants\Models\Variants;
+use Kanvas\Inventory\Variants\Models\VariantsChannels;
 use Kanvas\Inventory\Variants\Models\VariantsWarehouses as ModelsVariantsWarehouses;
 use Kanvas\Inventory\Warehouses\Models\Warehouses;
 use Kanvas\Inventory\Warehouses\Repositories\WarehouseRepository;
@@ -94,5 +97,15 @@ class VariantService
             ->firstOrFail();
 
         return (new UpdateToWarehouseAction($variantWarehouses, $variantWarehousesDto))->execute();
+    }
+
+    /**
+     * Update data of variant in a channel.
+     */
+    public static function updateVariantChannel(VariantsChannels $variantChannel, array $data): VariantsChannels
+    {
+        $variantChannelDto = VariantChannelDto::from($data);
+
+        return (new UpdateToChannelAction($variantChannel, $variantChannelDto))->execute();
     }
 }

--- a/src/Domains/Inventory/Warehouses/Observers/VariantsWarehouseObserver.php
+++ b/src/Domains/Inventory/Warehouses/Observers/VariantsWarehouseObserver.php
@@ -11,7 +11,7 @@ class VariantsWarehouseObserver
 {
     public function saved(VariantsWarehouses $variantWarehouse): void
     {
-        if ($variantWarehouse->price) {
+        if ($variantWarehouse->wasChanged('price')) {
             (new CreatePriceHistoryAction(
                 $variantWarehouse,
                 $variantWarehouse->price

--- a/tests/GraphQL/Inventory/VariantsChannelsTest.php
+++ b/tests/GraphQL/Inventory/VariantsChannelsTest.php
@@ -315,7 +315,6 @@ class VariantsChannelsTest extends TestCase
             'data' => ['updateVariantInChannel' => ['id' => $variantId]]
         ]);
 
-
         $response = $this->graphQL(
             'mutation ($variants_id: ID! $channels_id: ID! $warehouses_id: ID!) {
                 removeVariantChannel(variants_id: $variants_id channels_id: $channels_id warehouses_id: $warehouses_id)

--- a/tests/GraphQL/Inventory/VariantsChannelsTest.php
+++ b/tests/GraphQL/Inventory/VariantsChannelsTest.php
@@ -160,4 +160,178 @@ class VariantsChannelsTest extends TestCase
             'data' => ['removeVariantChannel' => ['id' => $variantId]]
         ]);
     }
+
+    public function testUpdateVariantToChannel(): void
+    {
+        $dataRegion = [
+            'name' => 'Test Region',
+            'slug' => 'test-region',
+            'short_slug' => 'test-region',
+            'is_default' => 1,
+            'currency_id' => 1,
+        ];
+        $response = $this->graphQL('
+            mutation($data: RegionInput!) {
+                createRegion(input: $data)
+                {
+                    id
+                    name
+                    slug
+                    short_slug
+                    currency_id
+                    is_default
+                }
+            }', ['data' => $dataRegion])
+            ->assertJson([
+                'data' => ['createRegion' => $dataRegion]
+            ]);
+        $idRegion = $response->json()['data']['createRegion']['id'];
+        $data = [
+            'regions_id' => $idRegion,
+            'name' => 'Test Warehouse',
+            'location' => 'Test Location',
+            'is_default' => true,
+            'is_published' => true,
+        ];
+
+        $response = $this->graphQL('
+            mutation($data: WarehouseInput!) {
+                createWarehouse(input: $data)
+                {
+                    id
+                    regions_id
+                    name
+                    location
+                    is_default
+                    is_published
+                }
+            }', ['data' => $data])->assertJson([
+            'data' => ['createWarehouse' => $data]
+        ]);
+        $warehouseData = [
+            'id' => $response->json()['data']['createWarehouse']['id'],
+        ];
+        $data = [
+            'name' => fake()->name,
+            'description' => fake()->text,
+        ];
+        $response = $this->graphQL('
+        mutation($data: ProductInput!) {
+            createProduct(input: $data)
+            {
+                id
+                name
+                description
+            }
+        }', ['data' => $data])->assertJson([
+            'data' => ['createProduct' => $data]
+        ]);
+        $productId = $response->json()['data']['createProduct']['id'];
+        $data = [
+            'name' => fake()->name,
+            'description' => fake()->text,
+            'products_id' => $productId,
+            'warehouse' => $warehouseData
+        ];
+        $response = $this->graphQL('
+        mutation($data: VariantsInput!) {
+            createVariant(input: $data)
+            { 
+                id
+                name
+                description
+                products_id
+            }
+        }', ['data' => $data]);
+        $variantId = $response->json()['data']['createVariant']['id'];
+
+        $dataChannel = [
+            'name' => fake()->name,
+            'description' => fake()->text,
+            'is_default' => true,
+        ];
+
+        $response = $this->graphQL('
+        mutation($data: CreateChannelInput!) {
+            createChannel(input: $data)
+            {
+                id
+                name
+                description,
+                is_default
+            }
+        }', ['data' => $dataChannel]);
+
+        $response->assertJson([
+            'data' => ['createChannel' => $dataChannel]
+        ]);
+
+        $channelId = $response->json()['data']['createChannel']['id'];
+        $response = $this->graphQL(
+            '
+        mutation addVariantToChannel($variants_id: ID! $channels_id: ID! $warehouses_id: ID! $input: VariantChannelInput!){
+            addVariantToChannel(variants_id: $variants_id channels_id:$channels_id warehouses_id:$warehouses_id input:$input){
+                id
+            } 
+        }
+        ',
+            [
+                'variants_id' => $variantId,
+                'channels_id' => $channelId,
+                'warehouses_id' => $warehouseData['id'],
+                'input' => [
+                    'price' => 100,
+                    'discounted_price' => 10,
+                    'is_published' => 1,
+                    'is_published' => false
+                ]
+            ]
+        );
+        $response->assertJson([
+            'data' => ['addVariantToChannel' => ['id' => $variantId]]
+        ]);
+
+        $response = $this->graphQL(
+            '
+        mutation addVariantToChannel($variants_id: ID! $channels_id: ID! $warehouses_id: ID! $input: VariantChannelInput!){
+            updateVariantInChannel(variants_id: $variants_id channels_id:$channels_id warehouses_id:$warehouses_id input:$input){
+                id
+            } 
+        }
+        ',
+            [
+                'variants_id' => $variantId,
+                'channels_id' => $channelId,
+                'warehouses_id' => $warehouseData['id'],
+                'input' => [
+                    'price' => 344,
+                    'discounted_price' => 120,
+                    'is_published' => 1,
+                    'is_published' => false
+                ]
+            ]
+        );
+        $response->assertJson([
+            'data' => ['updateVariantInChannel' => ['id' => $variantId]]
+        ]);
+
+
+        $response = $this->graphQL(
+            'mutation ($variants_id: ID! $channels_id: ID! $warehouses_id: ID!) {
+                removeVariantChannel(variants_id: $variants_id channels_id: $channels_id warehouses_id: $warehouses_id)
+                {
+                    id
+                }
+            }',
+            [
+                'variants_id' => $variantId,
+                'channels_id' => $channelId,
+                'warehouses_id' => $warehouseData['id'],
+            ]
+        );
+        $response->assertJson([
+            'data' => ['removeVariantChannel' => ['id' => $variantId]]
+        ]);
+    }
+
 }

--- a/tests/GraphQL/Inventory/VariantsChannelsTest.php
+++ b/tests/GraphQL/Inventory/VariantsChannelsTest.php
@@ -332,5 +332,4 @@ class VariantsChannelsTest extends TestCase
             'data' => ['removeVariantChannel' => ['id' => $variantId]]
         ]);
     }
-
 }


### PR DESCRIPTION
### Overview
Allow the user to update the information of a variante in a channel (EX. prices, discounts, etc). And be register in the channel prices hisotory if it was changed.


### Resolve
- Create mutation to update variant channel data.
- Create observer to update prices history for channel variant data.