### PR TITLE
Set a default total products for response

### DIFF
--- a/src/Domains/Inventory/Warehouses/Models/Warehouses.php
+++ b/src/Domains/Inventory/Warehouses/Models/Warehouses.php
@@ -174,12 +174,25 @@ class Warehouses extends BaseModel
     public function getTotalProducts(): int
     {
         if (! $totalProducts = $this->get('total_products')) {
-            $this->set(
-                'total_products',
-                $this->variantsWarehouses()->first()->getTotalProducts()
-            );
+            $this->setTotalProducts();
             return (int) $this->get('total_products');
         }
         return (int) $totalProducts;
+    }
+
+    /**
+     * Set the total amount of products of a warehouse.
+     *
+     * @return Int
+     */
+    public function setTotalProducts(): int
+    {
+        if ($this->variantsWarehouses()->exists()) {
+            return $this->set(
+                'total_products',
+                $this->variantsWarehouses()->first()->getTotalProducts()
+            );
+        }
+        return 0;
     }
 }

--- a/src/Domains/Inventory/Warehouses/Models/Warehouses.php
+++ b/src/Domains/Inventory/Warehouses/Models/Warehouses.php
@@ -174,8 +174,7 @@ class Warehouses extends BaseModel
     public function getTotalProducts(): int
     {
         if (! $totalProducts = $this->get('total_products')) {
-            $this->setTotalProducts();
-            return (int) $this->get('total_products');
+            return (int) $this->setTotalProducts();
         }
         return (int) $totalProducts;
     }


### PR DESCRIPTION
### Overview
When a warehouse do not have any products created, variant warehouses cant be used to get the total products.

### Resolve
Verify if the relation exist and if no, return a value of 0.