### PR TITLE
[Fix] Observers default delete

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -14,6 +14,8 @@ use Kanvas\Guild\Leads\Observers\LeadObserver;
 use Kanvas\Inventory\Channels\Models\Channels;
 use Kanvas\Inventory\Channels\Observers\ChannelObserver;
 use Kanvas\Inventory\Channels\Observers\VariantsChannelObserver;
+use Kanvas\Inventory\Regions\Models\Regions;
+use Kanvas\Inventory\Regions\Observers\RegionObserver;
 use Kanvas\Inventory\Status\Models\Status;
 use Kanvas\Inventory\Status\Observers\StatusObserver;
 use Kanvas\Inventory\Variants\Models\VariantsChannels;
@@ -64,6 +66,7 @@ class EventServiceProvider extends ServiceProvider
         Lead::observe(LeadObserver::class);
         UserMessage::observe(UserMessageObserver::class);
         Warehouses::observe(WarehouseObserver::class);
+        Regions::observe(RegionObserver::class);
         Status::observe(StatusObserver::class);
         VariantsWarehouses::observe(VariantsWarehouseObserver::class);
         Channels::observe(ChannelObserver::class);

--- a/src/Domains/Inventory/Channels/Observers/ChannelObserver.php
+++ b/src/Domains/Inventory/Channels/Observers/ChannelObserver.php
@@ -42,4 +42,13 @@ class ChannelObserver
             throw new ValidationException('Can\'t Save, you have to have at least one default Channel');
         }
     }
+
+    public function deleting(Channels $channel): void
+    {
+        $defaultChannel = $channel::getDefault($channel->company);
+
+        if ($defaultChannel->getId() == $channel->getId()) {
+            throw new ValidationException('Can\'t delete, you have to have at least one default Channel');
+        }
+    }
 }

--- a/src/Domains/Inventory/Regions/Observers/RegionObserver.php
+++ b/src/Domains/Inventory/Regions/Observers/RegionObserver.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Inventory\Regions\Observers;
+
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Inventory\Regions\Models\Regions;
+
+class RegionObserver
+{
+    public function creating(Regions $region): void
+    {
+        $defaultRegion = $region::getDefault($region->company);
+
+        // if default already exist remove its default
+        if ($region->is_default && $defaultRegion) {
+            $defaultRegion->is_default = false;
+            $defaultRegion->saveQuietly();
+        }
+
+        if (! $region->is_default && ! $defaultRegion) {
+            throw new ValidationException('Can\'t Save, you have to have at least one default Region');
+        }
+    }
+
+    public function updating(Regions $region): void
+    {
+        $defaultRegion = Regions::getDefault($region->company);
+
+        // if default already exist remove its default
+        if ($defaultRegion &&
+            $region->is_default &&
+            $region->getId() != $defaultRegion->getId()
+        ) {
+            $defaultRegion->is_default = false;
+            $defaultRegion->saveQuietly();
+        } elseif ($defaultRegion &&
+            ! $region->is_default &&
+            $region->getId() == $defaultRegion->getId()
+        ) {
+            throw new ValidationException('Can\'t Save, you have to have at least one default Region');
+        }
+    }
+
+    public function deleting(Regions $region): void
+    {
+        $defaultRegion = $region::getDefault($region->company);
+
+        if ($defaultRegion->getId() == $region->getId()) {
+            throw new ValidationException('Can\'t delete, you have to have at least one default Region');
+        }
+    }
+}

--- a/src/Domains/Inventory/Status/Observers/StatusObserver.php
+++ b/src/Domains/Inventory/Status/Observers/StatusObserver.php
@@ -42,4 +42,13 @@ class StatusObserver
             throw new ValidationException('Can\'t Save, you have to have at least one default Status');
         }
     }
+
+    public function deleting(Status $status): void
+    {
+        $defaultStatus = $status::getDefault($status->company);
+
+        if ($defaultStatus->getId() == $status->getId()) {
+            throw new ValidationException('Can\'t delete, you have to have at least one default Status');
+        }
+    }
 }

--- a/src/Domains/Inventory/Warehouses/Observers/WarehouseObserver.php
+++ b/src/Domains/Inventory/Warehouses/Observers/WarehouseObserver.php
@@ -46,4 +46,13 @@ class WarehouseObserver
             throw new ValidationException('Can\'t Save, you have to have at least one default Warehouse');
         }
     }
+
+    public function deleting(Warehouses $warehouse): void
+    {
+        $defaultWarehouse = $warehouse::getDefault($warehouse->company);
+
+        if ($defaultWarehouse->getId() == $warehouse->getId()) {
+            throw new ValidationException('Can\'t delete, you have to have at least one default Warehouse');
+        }
+    }
 }

--- a/tests/GraphQL/Inventory/ChannelTest.php
+++ b/tests/GraphQL/Inventory/ChannelTest.php
@@ -113,7 +113,7 @@ class ChannelTest extends TestCase
     {
         $data = [
             'name' => fake()->name,
-            'is_default' => true,
+            'is_default' => false,
         ];
         $newChannel = $this->graphQL('
             mutation($data: CreateChannelInput!) {

--- a/tests/GraphQL/Inventory/WarehouseTest.php
+++ b/tests/GraphQL/Inventory/WarehouseTest.php
@@ -260,7 +260,7 @@ class WarehouseTest extends TestCase
             'regions_id' => $response['data']['createRegion']['id'],
             'name' => 'Test Warehouse',
             'location' => 'Test Location',
-            'is_default' => true,
+            'is_default' => false,
             'is_published' => true,
         ];
         $response = $this->graphQL('


### PR DESCRIPTION
### Overview
The user shouldnt be able to delete the default entity.
The user shouldnt be able to create multiples defaults regions.

### Resolve
Add observer for region entity.
Add deleting event to observers to disable the default entity deletion.