### PR TITLE
[1.x] Create default variant

### DIFF
--- a/graphql/schemas/Inventory/product.graphql
+++ b/graphql/schemas/Inventory/product.graphql
@@ -23,7 +23,7 @@ type Product {
     attributes: [ProductAttribute!]! @BelongsToMany
     variants: [Variant!]! @HasMany
     productsTypes: ProductType @belongsTo
-    companies: Company! @belongsTo
+    companies: Company! @belongsTo(relation: "company")
     custom_fields: [CustomField!]!
         @paginate(
             defaultCount: 25

--- a/src/Domains/Inventory/Products/Actions/CreateProductAction.php
+++ b/src/Domains/Inventory/Products/Actions/CreateProductAction.php
@@ -95,6 +95,8 @@ class CreateProductAction
 
             if ($this->productDto->variants) {
                 VariantService::createVariantsFromArray($products, $this->productDto->variants, $this->user);
+            } else {
+                VariantService::createDefaultVariant($products, $this->user);
             }
 
             DB::connection('inventory')->commit();


### PR DESCRIPTION
### Overview
When an user create a product, the sistem must be able to create a default variant if a variant is not sent.

### Resolve
Add method to service to verify variant and create a default one