### PR TITLE
[1.x] Product category multi update

### DIFF
--- a/graphql/schemas/Inventory/product.graphql
+++ b/graphql/schemas/Inventory/product.graphql
@@ -72,6 +72,7 @@ input ProductInputUpdate {
     status: StatusReferenceInput
     attributes: [ProductAttributesInput!]
     files: [FilesystemInputUrl!]
+    categories: [ProductCategoriesReferenceInput!]
 }
 
 extend type Mutation @guard {

--- a/graphql/schemas/Inventory/variant.graphql
+++ b/graphql/schemas/Inventory/variant.graphql
@@ -89,7 +89,7 @@ input VariantsUpdateInput {
     attributes: [VariantsAttributesInput!]
     serial_number: String
     is_published: Boolean
-    warehouses: [VariantsWarehousesInput!]
+    warehouses: [WarehouseReferenceInput!]
 }
 
 extend type Mutation @guard {

--- a/src/Domains/Inventory/Categories/Observers/ProductsCategoriesObserver.php
+++ b/src/Domains/Inventory/Categories/Observers/ProductsCategoriesObserver.php
@@ -10,9 +10,9 @@ class ProductsCategoriesObserver
 {
     public function saved(ProductsCategories $productsCategories): void
     {
-        $productsCategories->set(
+        $productsCategories->category->set(
             'total_products',
-            $productsCategories->categories->getTotalProducts()
+            $productsCategories->category->getTotalProducts()
         );
     }
 }

--- a/src/Domains/Inventory/Products/Actions/AddCategoryAction.php
+++ b/src/Domains/Inventory/Products/Actions/AddCategoryAction.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Inventory\Products\Actions;
+
+use Kanvas\Inventory\Categories\Models\Categories;
+use Kanvas\Inventory\Products\Models\Products;
+use Kanvas\Inventory\Products\Models\ProductsCategories;
+
+class AddCategoryAction
+{
+    public function __construct(
+        protected Products $product,
+        protected Categories $category
+    ) {
+    }
+
+    public function execute(): void
+    {
+        ProductsCategories::firstOrCreate(
+            [
+                'categories_id' => $this->category->getId(),
+                'products_id' => $this->product->getId(),
+            ]
+        );
+    }
+}

--- a/src/Domains/Inventory/Products/Actions/CreateProductAction.php
+++ b/src/Domains/Inventory/Products/Actions/CreateProductAction.php
@@ -75,7 +75,10 @@ class CreateProductAction
             if ($this->productDto->categories) {
                 foreach ($this->productDto->categories as $category) {
                     $category = CategoriesRepository::getById((int) $category['id'], $this->productDto->company);
-                    $products->categories()->attach($category);
+                    (new AddCategoryAction(
+                        $products,
+                        $category
+                    ))->execute();
                 }
             }
 

--- a/src/Domains/Inventory/Products/Actions/UpdateProductAction.php
+++ b/src/Domains/Inventory/Products/Actions/UpdateProductAction.php
@@ -9,6 +9,7 @@ use Baka\Users\Contracts\UserInterface;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Kanvas\Companies\Repositories\CompaniesRepository;
+use Kanvas\Inventory\Categories\Repositories\CategoriesRepository;
 use Kanvas\Inventory\Products\DataTransferObject\Product as ProductDto;
 use Kanvas\Inventory\Products\Models\Products;
 use Throwable;
@@ -59,6 +60,17 @@ class UpdateProductAction
 
             if (! empty($this->productDto->files)) {
                 $this->product->addMultipleFilesFromUrl($this->productDto->files);
+            }
+
+            if (! empty($this->productDto->categories)) {
+                $this->product->productsCategories()->forceDelete();
+
+                foreach($this->productDto->categories as $category) {
+                    (new AddCategoryAction(
+                        $this->product,
+                        CategoriesRepository::getById((int) $category['id'],$this->product->company)
+                    ))->execute();
+                }
             }
 
             DB::connection('inventory')->commit();

--- a/src/Domains/Inventory/Products/Models/Products.php
+++ b/src/Domains/Inventory/Products/Models/Products.php
@@ -74,7 +74,7 @@ class Products extends BaseModel
     {
         return $this->belongsToMany(
             Categories::class,
-            'products_categories',
+            ProductsCategories::class,
             'products_id',
             'categories_id'
         );

--- a/src/Domains/Inventory/Products/Models/ProductsCategories.php
+++ b/src/Domains/Inventory/Products/Models/ProductsCategories.php
@@ -6,6 +6,8 @@ namespace Kanvas\Inventory\Products\Models;
 
 use Awobaz\Compoships\Compoships;
 use Baka\Traits\HasCompositePrimaryKeyTrait;
+use Baka\Traits\NoAppRelationshipTrait;
+use Baka\Traits\NoCompanyRelationshipTrait;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Kanvas\Inventory\Categories\Models\Categories;
 use Kanvas\Inventory\Models\BaseModel;
@@ -22,10 +24,12 @@ use Kanvas\Inventory\Models\BaseModel;
 class ProductsCategories extends BaseModel
 {
     use HasCompositePrimaryKeyTrait;
+    use NoAppRelationshipTrait;
+    use NoCompanyRelationshipTrait;
     use Compoships;
 
     protected $table = 'products_categories';
-    protected $guarded = [
+    protected $fillable = [
         'products_id',
         'categories_id'
     ];

--- a/tests/GraphQL/Inventory/ProductCategoryTest.php
+++ b/tests/GraphQL/Inventory/ProductCategoryTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\GraphQL\Inventory;
+
+use Tests\TestCase;
+
+class ProductCategoryTest extends TestCase
+{
+    public function testAddProductCategoryTest(): void
+    {
+        $dataRegion = [
+            'name' => 'Test Region',
+            'slug' => 'test-region',
+            'short_slug' => 'test-region',
+            'is_default' => 1,
+            'currency_id' => 1,
+        ];
+        $response = $this->graphQL('
+            mutation($data: RegionInput!) {
+                createRegion(input: $data)
+                {
+                    id
+                    name
+                    slug
+                    short_slug
+                    currency_id
+                    is_default
+                }
+            }', ['data' => $dataRegion])
+            ->assertJson([
+                'data' => ['createRegion' => $dataRegion]
+            ]);
+        $idRegion = $response->json()['data']['createRegion']['id'];
+        $data = [
+            'regions_id' => $idRegion,
+            'name' => 'Test Warehouse',
+            'location' => 'Test Location',
+            'is_default' => true,
+            'is_published' => true,
+        ];
+
+        $response = $this->graphQL('
+            mutation($data: WarehouseInput!) {
+                createWarehouse(input: $data)
+                {
+                    id
+                    regions_id
+                    name
+                    location
+                    is_default
+                    is_published
+                }
+            }', ['data' => $data])->assertJson([
+            'data' => ['createWarehouse' => $data]
+        ]);
+
+        $categoryData = [
+            'name' => fake()->name,
+            'code' => fake()->name,
+            'position' => 1,
+            'is_published' => true,
+            'weight' => 0
+        ];
+        $categoryResponse = $this->graphQL('
+            mutation($data: CategoryInput!) {
+                createCategory(input: $data)
+                {
+                    id
+                    name,
+                    code,
+                    position,
+                    is_published
+                    weight
+                }
+            }', ['data' => $categoryData])->assertJson([
+            'data' => ['createCategory' => $categoryData]
+        ]);
+        $idCategory = $categoryResponse->json()['data']['createCategory']['id'];
+
+        $data = [
+            'name' => fake()->name,
+            'sku' => fake()->time,
+            'description' => fake()->text,
+            'categories' => [
+                [
+                    'id' => $idCategory
+                ]
+            ]
+        ];
+
+        $response = $this->graphQL('
+            mutation($data: ProductInput!) {
+                createProduct(input: $data)
+                {
+                    id
+                    name
+                    description
+                    categories{
+                        id
+                    }
+                }
+            }', ['data' => $data]);
+
+        unset($data['sku']);
+        $response->assertJson([
+            'data' => ['createProduct' => $data],
+        ]);
+    }
+}


### PR DESCRIPTION
### Overview
The user must be able to update multiples products categories on the product update mutation.

### Resolve
Add array type for products categories.
Remove old categories before repopulate.
Create test for products categories.