### PR TITLE
use 1.x.Dockerfile instead of development's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ service-account.json
 /tools/*
 /tools/php-cs-fixer/*
 /tools/php-cs-fixer/vendor/*
+
+/caddy
+frankenphp
+frankenphp-worker.php

--- a/Caddyfile
+++ b/Caddyfile
@@ -12,6 +12,19 @@ http://localhost {
 	# Enable compression (optional)
 	encode zstd br gzip
 
+	@options_method {
+        method OPTIONS
+    }
+
+    handle @options_method {
+        header Access-Control-Allow-Origin "*"
+        header Access-Control-Allow-Methods "GET, POST, OPTIONS, PUT, DELETE"
+        header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Public-Key,Authorization,X-Kanvas-App,X-Kanvas-Key,X-Kanvas-Location"
+        header Access-Control-Max-Age "1728000"
+        header Content-Type "text/plain charset=UTF-8"
+        respond "" 204
+    }
+
 	php_fastcgi /php-fpm
 	# Execute PHP files from the public/ directory and serve assets
 	php_server

--- a/docker-compose.1.x.yml
+++ b/docker-compose.1.x.yml
@@ -4,7 +4,7 @@ x-common-queue-settings: &common-queue-settings
   restart: always
   build:
     context: .
-    dockerfile: development.Dockerfile
+    dockerfile: 1.x.Dockerfile
   extra_hosts:
     - "host.docker.internal:host-gateway"
   command: 
@@ -28,7 +28,7 @@ services:
     container_name: php${APP_CONTAINER_NAME}
     build:
       context: .
-      dockerfile: development.Dockerfile
+      dockerfile: 1.x.Dockerfile
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -88,7 +88,7 @@ services:
     restart: always
     build:
       context: .
-      dockerfile: development.Dockerfile
+      dockerfile: 1.x.Dockerfile
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -4,7 +4,7 @@ x-common-queue-settings: &common-queue-settings
   restart: always
   build:
     context: .
-    dockerfile: development.Dockerfile
+    dockerfile: franken.Dockerfile
   extra_hosts:
     - "host.docker.internal:host-gateway"
   command: 
@@ -28,7 +28,7 @@ services:
     container_name: php${APP_CONTAINER_NAME}
     build:
       context: .
-      dockerfile: development.Dockerfile
+      dockerfile: franken.Dockerfile
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
@@ -88,7 +88,7 @@ services:
     restart: always
     build:
       context: .
-      dockerfile: development.Dockerfile
+      dockerfile: franken.Dockerfile
     extra_hosts:
       - "host.docker.internal:host-gateway"
     command:

--- a/franken.Dockerfile
+++ b/franken.Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp as base
+FROM dunglas/frankenphp
 
 ENV SERVER_NAME="http://"
 


### PR DESCRIPTION
Features and Changes:


- Use 1.x.Dockerfile instead of development.Dockerfile for 1.x docker compose file