### PR TITLE
[Fix] Shopify setup validation

### DIFF
--- a/app/GraphQL/Connector/Shopify/Mutations/ShopifyMutation.php
+++ b/app/GraphQL/Connector/Shopify/Mutations/ShopifyMutation.php
@@ -6,13 +6,14 @@ namespace App\GraphQL\Connector\Shopify\Mutations;
 
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Shopify\Client;
 use Kanvas\Connectors\Shopify\DataTransferObject\Shopify as ShopifyDto;
 use Kanvas\Connectors\Shopify\ShopifyService;
 use Kanvas\Users\Repositories\UsersRepository;
 
 class ShopifyMutation
 {
-    public function shopifySetup(mixed $root, array $request): bool
+    public function shopifySetup(mixed $root, array $request): String
     {
         $user = auth()->user();
         $company = isset($request['company_id']) ? Companies::getById($request['company_id']) : $user->getCurrentCompany();
@@ -22,6 +23,9 @@ class ShopifyMutation
 
         $shopifyDto = ShopifyDto::viaRequest($request['input'], $app, $company);
 
-        return ShopifyService::shopifySetup($shopifyDto);
+        Client::getInstance($app, $company, $shopifyDto->region)->Shop->get();
+        ShopifyService::shopifySetup($shopifyDto);
+
+        return "Shopify Integration Successfully";
     }
 }

--- a/app/GraphQL/Connector/Shopify/Mutations/ShopifyMutation.php
+++ b/app/GraphQL/Connector/Shopify/Mutations/ShopifyMutation.php
@@ -13,7 +13,7 @@ use Kanvas\Users\Repositories\UsersRepository;
 
 class ShopifyMutation
 {
-    public function shopifySetup(mixed $root, array $request): String
+    public function shopifySetup(mixed $root, array $request): bool
     {
         $user = auth()->user();
         $company = isset($request['company_id']) ? Companies::getById($request['company_id']) : $user->getCurrentCompany();
@@ -24,8 +24,7 @@ class ShopifyMutation
         $shopifyDto = ShopifyDto::viaRequest($request['input'], $app, $company);
 
         Client::getInstance($app, $company, $shopifyDto->region)->Shop->get();
-        ShopifyService::shopifySetup($shopifyDto);
 
-        return "Shopify Integration Successfully";
+        return ShopifyService::shopifySetup($shopifyDto);
     }
 }

--- a/graphql/schemas/Connector/shopify.graphql
+++ b/graphql/schemas/Connector/shopify.graphql
@@ -8,7 +8,7 @@ input ShopifySetupInput {
 }
 
 extend type Mutation @guard {
-    shopifySetup(input: ShopifySetupInput!): String
+    shopifySetup(input: ShopifySetupInput!): Boolean
         @field(
             resolver: "App\\GraphQL\\Connector\\Shopify\\Mutations\\ShopifyMutation@shopifySetup"
         )

--- a/graphql/schemas/Connector/shopify.graphql
+++ b/graphql/schemas/Connector/shopify.graphql
@@ -8,7 +8,7 @@ input ShopifySetupInput {
 }
 
 extend type Mutation @guard {
-    shopifySetup(input: ShopifySetupInput!): Boolean
+    shopifySetup(input: ShopifySetupInput!): String
         @field(
             resolver: "App\\GraphQL\\Connector\\Shopify\\Mutations\\ShopifyMutation@shopifySetup"
         )


### PR DESCRIPTION
### Overview
When a shopify integration its setup, the data must be a valid keys to make it successfull.

### Resolve
Create a request validation of the date before set it up.