### PR TITLE
change port to 8000 on 1.x dockerfile and add octane command on container start

### DIFF
--- a/1.x.Dockerfile
+++ b/1.x.Dockerfile
@@ -52,4 +52,4 @@ RUN chmod -R 777 /var/www/html/storage/logs/
 
 RUN composer install --no-dev --optimize-autoloader
 
-EXPOSE 8080
+EXPOSE 8000

--- a/docker-compose.1.x.yml
+++ b/docker-compose.1.x.yml
@@ -31,6 +31,10 @@ services:
       dockerfile: 1.x.Dockerfile
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    command: 
+    - "sh"
+    - "-c"
+    - "php artisan octane:start --server=swoole"
     environment:
       WWWUSER: "${WWWUSER}"
       LARAVEL_SAIL: 1
@@ -82,6 +86,14 @@ services:
       - "sh"
       - "-c"
       - "php artisan config:cache && php artisan queue:work --queue notifications --tries=3 --timeout=3750"
+  
+  batch-logger-queue:
+    <<: *common-queue-settings
+    container_name: batch-logger-queue
+    command: 
+        - "sh"
+        - "-c"
+        - "php artisan config:cache && php artisan queue:work --queue=batch-logger --tries=3 --timeout=3750"
 
   laravel-scheduler:
     container_name: laravel-scheduler


### PR DESCRIPTION
Features and Changes:

- Change port on 1.x Docker to 8000 to support laravel octane.
- Add octane on container startup on 1.x docker compose.