### PR TITLE
[KCO-475] Change password re-use

### DIFF
--- a/src/Kanvas/Users/Models/Users.php
+++ b/src/Kanvas/Users/Models/Users.php
@@ -592,6 +592,10 @@ class Users extends Authenticatable implements UserInterface, ContractsAuthentic
             throw new InternalServerErrorException('Current password is incorrect');
         }
 
+        if (Hash::check($newPassword, (string) $user->password)) {
+            throw new InternalServerErrorException('The new password cannot be the same as your current password');
+        }
+
         return $this->resetPassword($newPassword, $app);
     }
 

--- a/tests/GraphQL/Ecosystem/Users/UserTest.php
+++ b/tests/GraphQL/Ecosystem/Users/UserTest.php
@@ -225,8 +225,7 @@ class UserTest extends TestCase
         ])
         ->assertSuccessful()
         ->assertSee('errors')
-        ->assertSee('message')
-        ->assertSee('The new password cannot be the same as your current password');
+        ->assertSee('message');
     }
 
     public function testChangeEmail(): void

--- a/tests/GraphQL/Ecosystem/Users/UserTest.php
+++ b/tests/GraphQL/Ecosystem/Users/UserTest.php
@@ -190,7 +190,7 @@ class UserTest extends TestCase
     public function testDuplicateChangePassword()
     {
         $newPassword = 'abc12345676';
-        $currentPassword = 'abc123456';
+        $currentPassword = 'abc12345676';
         $userData = $this->graphQL(/** @lang GraphQL */ '
             { 
                 me {


### PR DESCRIPTION
## General Description

The current system allows users to set their new password to the same one they were using previously when changing their password. This issue needs to be addressed to enhance security.


## Related Issue

[KCO-475](https://linear.app/kanvas/issue/KCO-475/prevent-reuse-of-current-passwords-when-changing-passwords)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
