### PR TITLE
add api rate limiter for graphql

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,7 @@ jobs:
       MEILISEARCH_HOST: http://localhost:7700
       MEILISEARCH_KEY: masterKey
       SCOUT_QUEUE: false
+      API_LIMIT_ATTEMPTS_PER_MINUTE: 200
       # APP_DEBUG: true
 
       #third party integration

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,9 @@ use Kanvas\Sessions\Models\Sessions;
 use Kanvas\Subscription\Subscriptions\Models\AppsStripeCustomer;
 use Laravel\Cashier\Cashier;
 use Laravel\Sanctum\Sanctum;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Http\Request;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -29,5 +32,10 @@ class AppServiceProvider extends ServiceProvider
     {
         Sanctum::usePersonalAccessTokenModel(Sessions::class);
         Cashier::useCustomerModel(AppsStripeCustomer::class);
+
+        RateLimiter::for('graphql', function (Request $request) {
+            return Limit::perMinute(getenv('API_LIMIT_ATTEMPTS_PER_MINUTE',60))->by($request->user()?->id ?: $request->ip());
+        });
+        
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,8 +34,7 @@ class AppServiceProvider extends ServiceProvider
         Cashier::useCustomerModel(AppsStripeCustomer::class);
 
         RateLimiter::for('graphql', function (Request $request) {
-            return Limit::perMinute(getenv('API_LIMIT_ATTEMPTS_PER_MINUTE',60))->by($request->user()?->id ?: $request->ip());
+            return Limit::perMinute(getenv('API_LIMIT_ATTEMPTS_PER_MINUTE', 60))->by($request->user()?->id ?: $request->ip());
         });
-        
     }
 }

--- a/config/lighthouse.php
+++ b/config/lighthouse.php
@@ -34,6 +34,7 @@ return [
             // \App\Http\Middleware\KanvasAppKey::class,
             //  \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
             \Nuwave\Lighthouse\Http\Middleware\AcceptJson::class,
+            'throttle:graphql'
 
             // Logs every incoming GraphQL query.
             // \Nuwave\Lighthouse\Support\Http\Middleware\LogGraphQLQueries::class,


### PR DESCRIPTION
## General Description

- Add basic api rate limiter for graphql

- Use env variable for setting the attempts per minute.

## Related Issue

https://ottoradio.atlassian.net/browse/MK-3253

