### PR TITLE
Remove unnecessary image key check for child messages

### DIFF
--- a/src/Domains/Social/Messages/Workflows/Activities/OptimizeImageFromMessageActivity.php
+++ b/src/Domains/Social/Messages/Workflows/Activities/OptimizeImageFromMessageActivity.php
@@ -66,9 +66,6 @@ class OptimizeImageFromMessageActivity extends KanvasActivity
             // Update child messages too
 
             foreach ($message->children as $childMessage) {
-                if (! array_key_exists('image', $childMessage->message)) {
-                    continue;
-                }
                 $tempChildMessageArray = $childMessage->message;
                 $tempChildMessageArray['image'] = $fileSystemRecord->url;
                 $childMessage->message = $tempChildMessageArray;


### PR DESCRIPTION
Eliminate the redundant check for the 'image' key in child messages, simplifying the code execution.