### PR TITLE
Use updateOrCreate for user messages

### DIFF
--- a/src/Domains/Social/Messages/Actions/CreateUserMessageAction.php
+++ b/src/Domains/Social/Messages/Actions/CreateUserMessageAction.php
@@ -34,11 +34,18 @@ class CreateUserMessageAction
             ])->lockForUpdate()->first();
 
             if (! $userMessage) {
-                $userMessage = UserMessage::create([
-                    'messages_id' => $this->message->getId(),
-                    'users_id' => $this->user->getId(),
-                    'apps_id' => $this->message->apps_id,
-                ]);
+                $userMessage = UserMessage::updateOrCreate(
+                    [
+                        'messages_id' => $this->message->getId(),
+                        'users_id' => $this->user->getId(),
+                        'apps_id' => $this->message->apps_id,
+                    ],
+                    [
+                        'messages_id' => $this->message->getId(),
+                        'users_id' => $this->user->getId(),
+                        'apps_id' => $this->message->apps_id,
+                    ]
+                );
             }
 
             if ($this->message->appModuleMessage && ! empty($this->activity)) {

--- a/src/Domains/Social/Messages/Actions/CreateUserMessageAction.php
+++ b/src/Domains/Social/Messages/Actions/CreateUserMessageAction.php
@@ -34,18 +34,11 @@ class CreateUserMessageAction
             ])->lockForUpdate()->first();
 
             if (! $userMessage) {
-                $userMessage = UserMessage::updateOrCreate(
-                    [
-                        'messages_id' => $this->message->getId(),
-                        'users_id' => $this->user->getId(),
-                        'apps_id' => $this->message->apps_id,
-                    ],
-                    [
-                        'messages_id' => $this->message->getId(),
-                        'users_id' => $this->user->getId(),
-                        'apps_id' => $this->message->apps_id,
-                    ]
-                );
+                $userMessage = UserMessage::updateOrCreate([
+                    'messages_id' => $this->message->getId(),
+                    'users_id' => $this->user->getId(),
+                    'apps_id' => $this->message->apps_id,
+                ]);
             }
 
             if ($this->message->appModuleMessage && ! empty($this->activity)) {


### PR DESCRIPTION
Replace the creation of user messages with the updateOrCreate method to streamline the process and ensure that existing records are updated instead of creating duplicates.