### PR TITLE
Add user search GraphQL query

### DIFF
--- a/app/GraphQL/Ecosystem/Queries/Users/UsersBuilder.php
+++ b/app/GraphQL/Ecosystem/Queries/Users/UsersBuilder.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Ecosystem\Queries\Users;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Users\Models\Users;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Database\Eloquent\Builder;
+
+class UsersBuilder
+{
+    public function getAll(
+        mixed $root,
+        array $args,
+        GraphQLContext $context,
+        ResolveInfo $resolveInfo
+    ): Builder {
+        return Users::query();
+    }
+    
+}

--- a/app/GraphQL/Ecosystem/Queries/Users/UsersBuilder.php
+++ b/app/GraphQL/Ecosystem/Queries/Users/UsersBuilder.php
@@ -21,5 +21,4 @@ class UsersBuilder
     ): Builder {
         return Users::query();
     }
-    
 }

--- a/graphql/schemas/Ecosystem/user.graphql
+++ b/graphql/schemas/Ecosystem/user.graphql
@@ -305,3 +305,45 @@ type Query @guard {
             resolver: "App\\GraphQL\\Ecosystem\\Queries\\Users\\UsersListQuery@getByDisplayNameFromApp"
         )
 }
+
+extend type Query @guard {
+    users(
+        search: String @search
+        where: _
+            @whereConditions(
+                columns: [
+                    "id"
+                    "uuid"
+                    "firstname"
+                    "lastname"
+                    "displayname"
+                    "description"
+                    "dob"
+                    "email"
+                    "is_active"
+                    "verify_two_factor"
+                    "sex"
+                    "user_active"
+                    "timezone"
+                    "mainRole"
+                    "welcome"
+                    "created_at"
+                    "updated_at"
+                ]
+            )
+        orderBy: _
+            @orderBy(
+                columns: [
+                    "created_at"
+                    "updated_at"
+                    "id"
+                ]
+            )
+        search: String @search
+    ): [User!]!
+        @paginate(
+            defaultCount: 25
+            builder: "App\\GraphQL\\Ecosystem\\Queries\\Users\\UsersBuilder@getAll"
+            scopes: ["fromApp", "notDeleted"]
+        )
+}


### PR DESCRIPTION
Introduce a new GraphQL query for searching users, along with a corresponding query builder to handle the request.