### PR TITLE
feat: finish expired orders and release occupied qty

### DIFF
--- a/app/Console/Commands/Souk/OrderFinishExpiredCommand.php
+++ b/app/Console/Commands/Souk/OrderFinishExpiredCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Souk;
+
+use Baka\Traits\KanvasJobsTrait;
+use Illuminate\Console\Command;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Souk\Orders\Models\Order;
+
+class OrderFinishExpiredCommand extends Command
+{
+    use KanvasJobsTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'kanvas-souk:order-finish-expired {app_id?}';
+
+    /**
+     * The console command description.
+     *
+     * @var string|null
+     */
+    protected $description = 'Finish expired orders';
+
+    public function handle(): void
+    {
+        $appsId = $this->argument('apps_id');
+        if (! $appsId) {
+            $this->info('No app id provided, skipping');
+            return;
+        }
+
+        $app = Apps::getById($appsId);
+        $this->overwriteAppService($app);
+
+        $ordersInProgress = Order::fromApp($app)->notDeleted()->whereNotFulfilled()->orderBy('id', 'desc')->get();
+
+        foreach ($ordersInProgress as $order) {
+            $endDate = $order->metadata['data']['end_date'] ?? null;
+            if ($endDate && $endDate < now()->toDateTimeString()) {
+                $this->finishOrdersExpiredOrder($order);
+            }
+        }
+    }
+
+    protected function finishOrdersExpiredOrder(Order $order): void
+    {
+        // get the variant
+        $variant = $order->items[0]->variant;
+        $channel = $variant->variantChannels()->first();
+        $variantWarehouse = $channel?->productVariantWarehouse()->first();
+        // Mark order as completed
+        $order->fulfill();
+        $variant->updateQuantityInWarehouse($variantWarehouse->warehouse, $variantWarehouse->quantity + 1);
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -30,7 +30,7 @@ class Kernel extends ConsoleKernel
         $schedule->command(ScheduleCheckHeartbeatCommand::class)->everyMinute();
         $schedule->command(DeleteUsersRequestedCommand::class)->dailyAt('00:00');
         $schedule->command(SocialUserCounterResetCommand::class, ['13'])->dailyAt('00:00');
-        $schedule->command(OrderFinishExpiredCommand::class)->everyMinute();
+        // $schedule->command(OrderFinishExpiredCommand::class)->everyMinute();
         #$schedule->command(ScoutMessageReindexCommand::class, [env('MESSAGE_REINDEX_SCOUT_APP_ID', '13'), env('MESSAGE_REINDEX_SCOUT_MESSAGE_TYPES_ID', '572')])->everyTenMinutes();
         #$schedule->command(MailunregisteredUsersCampaignCommand::class)->weeklyOn(2, '2:30'); //@todo move this to normal cron
         #$schedule->command(ImportPromptsFromDocsCommand::class)->weeklyOn(1, '00:00');

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -7,6 +7,7 @@ use App\Console\Commands\Ecosystem\Users\DeleteUsersRequestedCommand;
 use App\Console\Commands\ImportPromptsFromDocsCommand;
 use App\Console\Commands\Social\ScoutMessageReindexCommand;
 use App\Console\Commands\Social\SocialUserCounterResetCommand;
+use App\Console\Commands\Souk\OrderFinishExpiredCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use Override;
@@ -29,6 +30,7 @@ class Kernel extends ConsoleKernel
         $schedule->command(ScheduleCheckHeartbeatCommand::class)->everyMinute();
         $schedule->command(DeleteUsersRequestedCommand::class)->dailyAt('00:00');
         $schedule->command(SocialUserCounterResetCommand::class, ['13'])->dailyAt('00:00');
+        $schedule->command(OrderFinishExpiredCommand::class)->everyMinute();
         #$schedule->command(ScoutMessageReindexCommand::class, [env('MESSAGE_REINDEX_SCOUT_APP_ID', '13'), env('MESSAGE_REINDEX_SCOUT_MESSAGE_TYPES_ID', '572')])->everyTenMinutes();
         #$schedule->command(MailunregisteredUsersCampaignCommand::class)->weeklyOn(2, '2:30'); //@todo move this to normal cron
         #$schedule->command(ImportPromptsFromDocsCommand::class)->weeklyOn(1, '00:00');

--- a/tests/GraphQL/Souk/OrderExpirableTest.php
+++ b/tests/GraphQL/Souk/OrderExpirableTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\GraphQL\Souk;
+
+use Kanvas\Apps\Models\Apps;
+use Tests\GraphQL\Inventory\Traits\InventoryCases;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
+use Kanvas\Inventory\Variants\Models\Variants;
+use Kanvas\Regions\Models\Regions;
+use Kanvas\Souk\Orders\Models\Order;
+
+class OrderExpirableTest extends TestCase
+{
+    use InventoryCases;
+
+
+    public function testOrderExpirable(): void
+    {
+        $app = app(Apps::class);
+        $regionResponse = $this->createRegion()->json()['data']['createRegion'];
+        $warehouseResponse = $this->createWarehouses($regionResponse['id'])->json()['data']['createWarehouse'];
+        $productResponse = $this->createProduct()->json()['data']['createProduct'];
+        $region = Regions::find($regionResponse['id']);
+        $company = $region->company;
+
+        $warehouseData = [
+            'id' => $warehouseResponse['id'],
+        ];
+
+        $variantResponse = $this->createVariant(
+            productId: $productResponse['id'],
+            warehouseData: $warehouseData
+        )->json()['data']['createVariant'];
+
+
+        $channelResponse = $this->createChannel()->json()['data']['createChannel'];
+
+        $this->addVariantToChannel(
+            variantId: $variantResponse['id'],
+            channelId: $channelResponse['id'],
+            warehouseData: $warehouseData
+        );
+
+
+        $this->addVariantToWarehouse(
+            variantId: $variantResponse['id'],
+            warehouseId: $warehouseResponse['id'],
+            amount: 100
+        );
+
+        $variant = Variants::find($variantResponse['id']);
+        $channel = $variant->variantChannels()->where('channels_id', $channelResponse['id'])->first();
+        $variantWarehouse = $channel?->productVariantWarehouse()->first();
+
+        $data = [
+            'email' => fake()->email(),
+            'region_id' => $region->getId(),
+            'metadata' => [
+                'data' => [
+                    'start_date' => now()->subDays(2)->toDateTimeString(),
+                    'end_date' => now()->subDays(1)->toDateTimeString(),
+                ],
+            ],
+            'customer' => [
+                'firstname' => fake()->firstName(),
+                'lastname' => fake()->lastName(),
+            ],
+            'shipping_address' => [
+                'address' => fake()->address(),
+                'address_2' => fake()->postcode(),
+                'city' => fake()->city(),
+                'state' => fake()->state(),
+            ],
+            'items' => [
+                [
+                    'variant_id' => $variantResponse['id'],
+                    'quantity' => 1,
+                ],
+            ],
+        ];
+
+        // Perform GraphQL mutation to create a draft order
+        $response = $this->graphQL('
+            mutation createDraftOrder($input: DraftOrderInput!) {
+                createDraftOrder(input: $input) {
+                    id
+                }
+            }
+        ', [
+            'input' => $data,
+        ], [], [
+            'X-Kanvas-Location' => $company->branch->uuid,
+        ]);
+
+
+        $order = $response->json()['data']['createDraftOrder'];
+        $order = Order::fromApp($app)->find($order['id']);
+        // lets simulate the variant warehouse quantity decrease
+        $variantWarehouse->quantity = $variantWarehouse->quantity - 1;
+        $variantWarehouse->save();
+        // variant quantity should decrease
+        $this->assertEquals(99, $variantWarehouse->refresh()->quantity);
+
+        // finish expired order
+        Artisan::call('kanvas-souk:order-finish-expired', ['app_id' => $app->getId()]);
+        $this->assertEquals(100, $variantWarehouse->refresh()->quantity);
+    }
+}


### PR DESCRIPTION
## General Description

Add cron to look for expirable orders (orders with end_date in metadata). and check if the end_data has passed to release the quantity taken by the order.

The use case is scheduled products like Go Parking

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [x] I have performed a self-review of my code.
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings.
- [x] My changes do not break any existing tests.
