### PR TITLE
fix: send all errors at once

### DIFF
--- a/tests/GraphQL/Souk/ImportOrderItemsCsvTest.php
+++ b/tests/GraphQL/Souk/ImportOrderItemsCsvTest.php
@@ -240,7 +240,7 @@ class ImportOrderItemsCsvTest extends TestCase
         $response->assertJson([
             "data" => [
                 "importOrderCsv" => [
-                    "message" => "Not enough stock for product {$variantResponse['name']}",
+                    "message" => "Not enough stock for product {$variantResponse['name']}, Not enough stock for product {$variantResponse2['name']}",
                     "status" => "error"
                 ]
             ]


### PR DESCRIPTION
## General Description

Send all validation errors at once instead of one by one when processing order items to import to the cart

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [x] I have performed a self-review of my code.
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings.
- [x] My changes do not break any existing tests.
