### PR TITLE
Stop Redis container in queues EC2 deployment workflow

### DIFF
--- a/.github/workflows/queues-ec2-deploy.yaml
+++ b/.github/workflows/queues-ec2-deploy.yaml
@@ -45,6 +45,7 @@ jobs:
             
             docker stop phpkanvas-ecosystem
             docker stop nginxkanvas-ecosystem
+            docker stop rediskanvas-ecosystem
             docker restart queue-scrapper
             docker restart queue-scrapper-worker-1
             docker restart queue-scrapper-worker-2


### PR DESCRIPTION
Ensure the Redis container stops during the queues EC2 deployment process to maintain proper resource management.