### PR TITLE
Add Redis caching to user and message queries

### DIFF
--- a/graphql/schemas/Ecosystem/user.graphql
+++ b/graphql/schemas/Ecosystem/user.graphql
@@ -295,7 +295,7 @@ extend type Mutation {
 }
 
 type Query @guard {
-    me: User! @cacheRedis @auth
+    me: User! @auth @cacheRedis
     user(id: ID! @eq): User
         @field(
             resolver: "App\\GraphQL\\Ecosystem\\Queries\\Users\\UsersListQuery@getFromCurrentCompany"

--- a/graphql/schemas/Ecosystem/user.graphql
+++ b/graphql/schemas/Ecosystem/user.graphql
@@ -295,7 +295,7 @@ extend type Mutation {
 }
 
 type Query @guard {
-    me: User! @auth
+    me: User! @auth @cacheRedis
     user(id: ID! @eq): User
         @field(
             resolver: "App\\GraphQL\\Ecosystem\\Queries\\Users\\UsersListQuery@getFromCurrentCompany"

--- a/graphql/schemas/Ecosystem/user.graphql
+++ b/graphql/schemas/Ecosystem/user.graphql
@@ -295,7 +295,7 @@ extend type Mutation {
 }
 
 type Query @guard {
-    me: User! @auth @cacheRedis
+    me: User! @cacheRedis @auth
     user(id: ID! @eq): User
         @field(
             resolver: "App\\GraphQL\\Ecosystem\\Queries\\Users\\UsersListQuery@getFromCurrentCompany"

--- a/graphql/schemas/Social/message.graphql
+++ b/graphql/schemas/Social/message.graphql
@@ -230,6 +230,7 @@ extend type Query @guard {
             )
         search: String @search
     ): [Message!]!
+        @cacheRedis
         @paginate(
             defaultCount: 25
             builder: "App\\GraphQL\\Social\\Builders\\Messages\\MessageBuilder@getAll"

--- a/tests/GraphQL/Ecosystem/Users/UserTest.php
+++ b/tests/GraphQL/Ecosystem/Users/UserTest.php
@@ -99,7 +99,7 @@ class UserTest extends TestCase
         $currentPassword = 'abcabc123456';
         $userData = $this->graphQL(/** @lang GraphQL */ '
             { 
-                me {
+                me @skipCache{
                     id,
                     uuid,
                     email
@@ -193,7 +193,7 @@ class UserTest extends TestCase
         $currentPassword = 'abc12345676';
         $userData = $this->graphQL(/** @lang GraphQL */ '
             { 
-                me {
+                me @skipCache {
                     id,
                     uuid,
                     email


### PR DESCRIPTION
Implement Redis caching for the `me` query and message queries to improve performance and reduce database load.