### PR TITLE
Feat/update order

### DIFF
--- a/app/Console/Commands/Workflows/CreateEntityWorkflowCommand.php
+++ b/app/Console/Commands/Workflows/CreateEntityWorkflowCommand.php
@@ -18,7 +18,6 @@ use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\multiselect;
-
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\table;
 use function Laravel\Prompts\text;

--- a/app/GraphQL/Directives/GuardByAppKeyDirective.php
+++ b/app/GraphQL/Directives/GuardByAppKeyDirective.php
@@ -10,7 +10,6 @@ use Nuwave\Lighthouse\Auth\AuthServiceProvider;
 use Nuwave\Lighthouse\Auth\GuardDirective;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
-
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 

--- a/app/GraphQL/Directives/GuardByCompanyDirective.php
+++ b/app/GraphQL/Directives/GuardByCompanyDirective.php
@@ -7,7 +7,6 @@ namespace App\GraphQL\Directives;
 use Kanvas\Companies\Models\CompaniesBranches;
 use Nuwave\Lighthouse\Auth\GuardDirective;
 use Nuwave\Lighthouse\Execution\ResolveInfo;
-
 use Nuwave\Lighthouse\Schema\Values\FieldValue;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 

--- a/app/GraphQL/Directives/WhereJsonNestedKeyDirective.php
+++ b/app/GraphQL/Directives/WhereJsonNestedKeyDirective.php
@@ -6,7 +6,6 @@ namespace App\GraphQL\Directives;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\Relation;
-
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use Nuwave\Lighthouse\Schema\Directives\BaseDirective;
 use Nuwave\Lighthouse\Support\Contracts\ArgBuilderDirective;

--- a/app/GraphQL/Souk/Mutations/Orders/OrderManagementMutation.php
+++ b/app/GraphQL/Souk/Mutations/Orders/OrderManagementMutation.php
@@ -50,6 +50,8 @@ class OrderManagementMutation
         return $this->handlePaymentResponse($response, $isSubscription);
     }
 
+ 
+
     public function createFromCart(mixed $root, array $request): array
     {
         $user = auth()->user();
@@ -96,6 +98,38 @@ class OrderManagementMutation
         return [
             'order' => $createOrder->execute(),
             'message' => 'Order created successfully',
+        ];
+    }
+
+    public function update(mixed $root, array $request): array
+    {
+        $user = auth()->user();
+        $app = app(Apps::class);
+
+        $orderId = $request['id'];
+        $orderData = $request['input'];
+
+        
+        if (empty($request['input']['items'])) {
+            return [
+                'order' => null,
+                'message' => [
+                    'error_code' => 'Cart is empty',
+                    'error_message' => 'Cart is empty',
+                ],
+            ];
+        }
+
+        $updateOrder = new UpdateOrderAction(
+            $orderId,
+            $orderData,
+            $user,
+            $app
+        );
+
+        return [
+            'order' => $updateOrder->execute(),
+            'message' => 'Order updated successfully',
         ];
     }
 

--- a/app/GraphQL/Souk/Mutations/Orders/OrderManagementMutation.php
+++ b/app/GraphQL/Souk/Mutations/Orders/OrderManagementMutation.php
@@ -110,16 +110,6 @@ class OrderManagementMutation
         $orderId = (int) $request['id'];
         $orderData = $request['input'];
 
-        if (empty($request['input']['items'])) {
-            return [
-                'order' => null,
-                'message' => [
-                    'error_code' => 'the items are empty',
-                    'error_message' => 'the items are empty',
-                ],
-            ];
-        }
-
         $order = Order::where([
             'apps_id' => $app->getId(),
             'id' => $orderId

--- a/graphql/schemas/Souk/order.graphql
+++ b/graphql/schemas/Souk/order.graphql
@@ -140,6 +140,11 @@ input OrderCartInput {
     metadata: Mixed
 }
 
+input UpdateOrderInput {
+    items: [OrderLineItemInput]
+    metadata: Mixed
+}
+
 input DraftOrderInput {
     email: String!
     phone: String
@@ -208,7 +213,7 @@ extend type Mutation @guard {
         @field(
             resolver: "App\\GraphQL\\Souk\\Mutations\\Orders\\DraftOrderManagementMutation@create"
         )
-    updateOrder(id: ID!, input: OrderCartInput!): OrderResult!
+    updateOrder(id: ID!, input: UpdateOrderInput!): OrderResult!
         @field(
             resolver: "App\\GraphQL\\Souk\\Mutations\\Orders\\OrderManagementMutation@update"
         )

--- a/graphql/schemas/Souk/order.graphql
+++ b/graphql/schemas/Souk/order.graphql
@@ -208,6 +208,10 @@ extend type Mutation @guard {
         @field(
             resolver: "App\\GraphQL\\Souk\\Mutations\\Orders\\DraftOrderManagementMutation@create"
         )
+    updateOrder(id: ID!, input: OrderCartInput!): OrderResult!
+        @field(
+            resolver: "App\\GraphQL\\Souk\\Mutations\\Orders\\OrderManagementMutation@update"
+        )
     createOrderFromAppleInAppPurchase(
         input: AppleInAppPurchaseReceipt!
     ): Order!

--- a/src/Domains/Guild/Support/CreateSystemModule.php
+++ b/src/Domains/Guild/Support/CreateSystemModule.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kanvas\Guild\Support;
 
 use Baka\Contracts\AppInterface;
-
 use Kanvas\Guild\Agents\Models\Agent;
 use Kanvas\Guild\Customers\Models\Contact;
 use Kanvas\Guild\Customers\Models\People;

--- a/src/Domains/Social/MessagesComments/DataTransferObject/MessageComment.php
+++ b/src/Domains/Social/MessagesComments/DataTransferObject/MessageComment.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kanvas\Social\MessagesComments\DataTransferObject;
 
 use Kanvas\Apps\Models\Apps;
-
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Users\Models\Users;

--- a/src/Domains/Souk/Orders/Actions/UpdateOrderAction.php
+++ b/src/Domains/Souk/Orders/Actions/UpdateOrderAction.php
@@ -6,6 +6,7 @@ namespace Kanvas\Souk\Orders\Actions;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException as EloquentModelNotFoundException;
 use Illuminate\Support\Facades\DB;
+use Kanvas\Exceptions\ModelNotFoundException;
 use Kanvas\Souk\Orders\DataTransferObject\OrderItem;
 use Kanvas\Souk\Orders\Models\Order as ModelsOrder;
 use Spatie\LaravelData\DataCollection;
@@ -40,8 +41,13 @@ class UpdateOrderAction
 
 
         return DB::connection('commerce')->transaction(function () use ($items) {
-            $this->order->metadata = $this->orderData['metadata'];
-
+            $this->order->metadata = [
+                ...($this->order->metadata ?? []),
+                'data' => [
+                    ...($this->order->metadata['data'] ?? []),
+                    ...($this->orderData['metadata']['data'] ?? []),
+                ],
+            ];
             $this->order->saveOrFail();
 
             $this->order->deleteItems();

--- a/src/Domains/Souk/Orders/Actions/UpdateOrderAction.php
+++ b/src/Domains/Souk/Orders/Actions/UpdateOrderAction.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Souk\Orders\Actions;
+
+use Baka\Users\Contracts\UserInterface;
+use Illuminate\Database\Eloquent\ModelNotFoundException as EloquentModelNotFoundException;
+use Illuminate\Support\Facades\DB;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Exceptions\ModelNotFoundException;
+use Kanvas\Inventory\Regions\Models\Regions;
+use Kanvas\Souk\Orders\DataTransferObject\OrderItem;
+use Kanvas\Souk\Orders\Models\Order as ModelsOrder;
+use Spatie\LaravelData\DataCollection;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Souk\Orders\Notifications\NewOrderNotification;
+use Kanvas\Workflow\Enums\WorkflowEnum;
+
+class UpdateOrderAction
+{
+    public bool $runWorkflow = true;
+
+    public function __construct(
+        protected int $orderId,
+        protected array $orderData,
+        protected Companies $company,
+        protected Regions $region,
+        protected UserInterface $user,
+        protected Apps $app,
+    ) {}
+
+    public function execute(): ModelsOrder
+    {
+
+        $total = 0;
+        $totalTax = 0;
+        $totalDiscount = 0;
+        $lineItems = [];
+
+        foreach ($this->orderData['items'] as $key => $lineItem) {
+            $lineItems[$key] = OrderItem::viaRequest($this->app, $this->company, $this->region, $lineItem);
+            $total += $lineItems[$key]->getTotal();
+            $totalTax += $lineItems[$key]->getTotalTax();
+            $totalDiscount = $lineItems[$key]->getTotalDiscount();
+        }
+
+        $items = OrderItem::collect($lineItems, DataCollection::class);
+
+
+        return DB::connection('commerce')->transaction(function () use ($items) {
+            // Lock the table for uniqueness check
+            $order = ModelsOrder::where([
+                'apps_id' => $this->app->getId(),
+                'id' => $this->orderId
+            ])->lockForUpdate()->first();
+
+            if ($order->fulfillment_status === 'fulfilled') {
+                throw new ValidationException('Order is already fulfilled');
+            }
+
+            $order->metadata = $this->orderData['metadata'];
+
+            $order->saveOrFail();
+
+            $order->deleteItems();
+            $order->addItems($items->toArray());
+
+            // Run after commit
+            DB::afterCommit(function () use ($order) {
+                if ($this->runWorkflow) {
+                    $order->fireWorkflow(
+                        WorkflowEnum::UPDATED->value,
+                        true,
+                        [
+                            'app' => $this->app,
+                        ]
+                    );
+                }
+
+                try {
+                    $order->user->notify(new NewOrderNotification($order, [
+                        'app' => $this->app,
+                        'company' => $this->company,
+                    ]));
+                } catch (ModelNotFoundException | EloquentModelNotFoundException $e) {
+                    // Handle notification failure
+                }
+
+                try {
+                    /**
+                     * @todo move to workflow
+                     */
+                    /*  UserRoleNotificationService::notify(
+                     RolesEnums::ADMIN->value,
+                     new NewOrderStoreOwnerNotification(
+                         $order,
+                         [
+                             'app' => $this->orderData->app,
+                             'company' => $this->orderData->company,
+                         ]
+                     ),
+                     $this->orderData->app
+                 ); */
+                } catch (EloquentModelNotFoundException $e) {
+                    // Handle admin notification failure
+                }
+            });
+
+            return $order;
+        });
+    }
+
+
+    public function disableWorkflow(): self
+    {
+        $this->runWorkflow = false;
+
+        return $this;
+    }
+}

--- a/src/Domains/Souk/Orders/Actions/UpdateOrderAction.php
+++ b/src/Domains/Souk/Orders/Actions/UpdateOrderAction.php
@@ -4,17 +4,11 @@ declare(strict_types=1);
 
 namespace Kanvas\Souk\Orders\Actions;
 
-use Baka\Users\Contracts\UserInterface;
 use Illuminate\Database\Eloquent\ModelNotFoundException as EloquentModelNotFoundException;
 use Illuminate\Support\Facades\DB;
-use Kanvas\Apps\Models\Apps;
-use Kanvas\Companies\Models\Companies;
-use Kanvas\Exceptions\ModelNotFoundException;
-use Kanvas\Inventory\Regions\Models\Regions;
 use Kanvas\Souk\Orders\DataTransferObject\OrderItem;
 use Kanvas\Souk\Orders\Models\Order as ModelsOrder;
 use Spatie\LaravelData\DataCollection;
-use Kanvas\Exceptions\ValidationException;
 use Kanvas\Souk\Orders\Notifications\NewOrderNotification;
 use Kanvas\Workflow\Enums\WorkflowEnum;
 
@@ -23,24 +17,20 @@ class UpdateOrderAction
     public bool $runWorkflow = true;
 
     public function __construct(
-        protected int $orderId,
+        protected ModelsOrder $order,
         protected array $orderData,
-        protected Companies $company,
-        protected Regions $region,
-        protected UserInterface $user,
-        protected Apps $app,
-    ) {}
+    ) {
+    }
 
     public function execute(): ModelsOrder
     {
-
         $total = 0;
         $totalTax = 0;
         $totalDiscount = 0;
         $lineItems = [];
 
         foreach ($this->orderData['items'] as $key => $lineItem) {
-            $lineItems[$key] = OrderItem::viaRequest($this->app, $this->company, $this->region, $lineItem);
+            $lineItems[$key] = OrderItem::viaRequest($this->order->app, $this->order->company, $this->order->region, $lineItem);
             $total += $lineItems[$key]->getTotal();
             $totalTax += $lineItems[$key]->getTotalTax();
             $totalDiscount = $lineItems[$key]->getTotalDiscount();
@@ -50,39 +40,29 @@ class UpdateOrderAction
 
 
         return DB::connection('commerce')->transaction(function () use ($items) {
-            // Lock the table for uniqueness check
-            $order = ModelsOrder::where([
-                'apps_id' => $this->app->getId(),
-                'id' => $this->orderId
-            ])->lockForUpdate()->first();
+            $this->order->metadata = $this->orderData['metadata'];
 
-            if ($order->fulfillment_status === 'fulfilled') {
-                throw new ValidationException('Order is already fulfilled');
-            }
+            $this->order->saveOrFail();
 
-            $order->metadata = $this->orderData['metadata'];
-
-            $order->saveOrFail();
-
-            $order->deleteItems();
-            $order->addItems($items->toArray());
+            $this->order->deleteItems();
+            $this->order->addItems($items);
 
             // Run after commit
-            DB::afterCommit(function () use ($order) {
+            DB::afterCommit(function () {
                 if ($this->runWorkflow) {
-                    $order->fireWorkflow(
+                    $this->order->fireWorkflow(
                         WorkflowEnum::UPDATED->value,
                         true,
                         [
-                            'app' => $this->app,
+                            'app' => $this->order->app,
                         ]
                     );
                 }
 
                 try {
-                    $order->user->notify(new NewOrderNotification($order, [
-                        'app' => $this->app,
-                        'company' => $this->company,
+                    $this->order->user->notify(new NewOrderNotification($this->order, [
+                        'app' => $this->order->app,
+                        'company' => $this->order->company,
                     ]));
                 } catch (ModelNotFoundException | EloquentModelNotFoundException $e) {
                     // Handle notification failure
@@ -108,7 +88,7 @@ class UpdateOrderAction
                 }
             });
 
-            return $order;
+            return $this->order;
         });
     }
 

--- a/src/Domains/Souk/Orders/Models/Order.php
+++ b/src/Domains/Souk/Orders/Models/Order.php
@@ -173,6 +173,11 @@ class Order extends BaseModel
         return $orderItem;
     }
 
+    public function deleteItems(): void
+    {
+        $this->items()->delete();
+    }
+
     public function fulfill(): void
     {
         $this->fulfillment_status = 'fulfilled';

--- a/src/Domains/Workflow/Models/Integrations.php
+++ b/src/Domains/Workflow/Models/Integrations.php
@@ -6,7 +6,6 @@ namespace Kanvas\Workflow\Models;
 
 use Baka\Casts\Json;
 use Baka\Traits\UuidTrait;
-
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Kanvas\Workflow\Enums\StatusEnum;

--- a/tests/GraphQL/Souk/OrderTest.php
+++ b/tests/GraphQL/Souk/OrderTest.php
@@ -239,6 +239,7 @@ class OrderTest extends TestCase
         $order = Order::find($orderData['id']);
 
         $this->assertEquals($extendedEndAt, $order->metadata['data']['end_at']);
+        $this->assertEquals($data['metadata']['data']['start_at'], $order->metadata['data']['start_at']);
         $this->assertCount(1, $order->items);
         $this->assertEquals(2, $order->items[0]->quantity);
     }

--- a/tests/GraphQL/Souk/OrderTest.php
+++ b/tests/GraphQL/Souk/OrderTest.php
@@ -243,4 +243,126 @@ class OrderTest extends TestCase
         $this->assertCount(1, $order->items);
         $this->assertEquals(2, $order->items[0]->quantity);
     }
+
+    public function testUpdateOrderWithoutItems()
+    {
+        $app = app(Apps::class);
+        $regionResponse = $this->createRegion()->json()['data']['createRegion'];
+        $warehouseResponse = $this->createWarehouses($regionResponse['id'])->json()['data']['createWarehouse'];
+        $productResponse = $this->createProduct()->json()['data']['createProduct'];
+        $region = Regions::find($regionResponse['id']);
+        $company = $region->company;
+
+        $warehouseData = [
+            'id' => $warehouseResponse['id'],
+        ];
+
+        $variantResponse = $this->createVariant(
+            productId: $productResponse['id'],
+            warehouseData: $warehouseData
+        )->json()['data']['createVariant'];
+
+
+        $channelResponse = $this->createChannel()->json()['data']['createChannel'];
+
+        $this->addVariantToChannel(
+            variantId: $variantResponse['id'],
+            channelId: $channelResponse['id'],
+            warehouseData: $warehouseData
+        );
+
+
+        $this->addVariantToWarehouse(
+            variantId: $variantResponse['id'],
+            warehouseId: $warehouseResponse['id'],
+            amount: 100
+        );
+
+        $variant = Variants::find($variantResponse['id']);
+        $channel = $variant->variantChannels()->where('channels_id', $channelResponse['id'])->first();
+        $variantWarehouse = $channel?->productVariantWarehouse()->first();
+        $endDate = now()->subDays(1);
+
+        $data = [
+            'email' => fake()->email(),
+            'region_id' => $region->getId(),
+            'metadata' => [
+                'data' => [
+                    'start_at' => now()->subDays(2)->toDateTimeString(),
+                    'end_at' => now()->subDays(1)->toDateTimeString(),
+                ],
+            ],
+            'customer' => [
+                'firstname' => fake()->firstName(),
+                'lastname' => fake()->lastName(),
+            ],
+            'shipping_address' => [
+                'address' => fake()->address(),
+                'address_2' => fake()->postcode(),
+                'city' => fake()->city(),
+                'state' => fake()->state(),
+            ],
+            'items' => [
+                [
+                    'variant_id' => $variantResponse['id'],
+                    'quantity' => 1,
+                ],
+            ],
+        ];
+
+        // Perform GraphQL mutation to create a draft order
+        $response = $this->graphQL('
+            mutation createDraftOrder($input: DraftOrderInput!) {
+                createDraftOrder(input: $input) {
+                    id
+                }
+            }
+        ', [
+            'input' => $data,
+        ], [], [
+            'X-Kanvas-Location' => $company->branch->uuid,
+        ]);
+
+
+
+        $createOrderResponse = $response->json()['data']['createDraftOrder'];
+
+        $extendedEndAt = $endDate->addMinutes(30)->toDateTimeString();
+
+        $response = $this->graphQL('
+            mutation updateOrder($id: ID!, $input: UpdateOrderInput!) {
+                updateOrder(id: $id, input: $input) {
+                    order { 
+                        id
+                        metadata
+                        items {
+                            id
+                            variant {
+                                id
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            "id" => $createOrderResponse['id'],
+            'input' => [
+                "metadata" => [
+                    "data" => [
+                        "end_at" => $extendedEndAt,
+                    ],
+                ],
+            ],
+        ], [], [
+            'X-Kanvas-Location' => $company->branch->uuid,
+        ]);
+
+        $orderData = $response->json()['data']['updateOrder']['order'];
+        $order = Order::find($orderData['id']);
+
+        $this->assertEquals($extendedEndAt, $order->metadata['data']['end_at']);
+        $this->assertEquals($data['metadata']['data']['start_at'], $order->metadata['data']['start_at']);
+        $this->assertCount(1, $order->items);
+        $this->assertEquals(1, $order->items[0]->quantity);
+    }
 }

--- a/tests/GraphQL/Souk/OrderTest.php
+++ b/tests/GraphQL/Souk/OrderTest.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\GraphQL\Souk;
 
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Inventory\Variants\Models\Variants;
 use Kanvas\Inventory\Variants\Models\VariantsWarehouses;
+use Kanvas\Regions\Models\Regions;
+use Kanvas\Souk\Orders\Models\Order;
+use Tests\GraphQL\Inventory\Traits\InventoryCases;
 use Tests\TestCase;
 
 class OrderTest extends TestCase
 {
+    use InventoryCases;
+
     public function testCreateDraftOrder()
     {
         $variantWarehouse = VariantsWarehouses::first();
@@ -107,5 +114,132 @@ class OrderTest extends TestCase
         ]);
 
         $response->assertSuccessful();
+    }
+
+    public function testUpdateOrder()
+    {
+        $app = app(Apps::class);
+        $regionResponse = $this->createRegion()->json()['data']['createRegion'];
+        $warehouseResponse = $this->createWarehouses($regionResponse['id'])->json()['data']['createWarehouse'];
+        $productResponse = $this->createProduct()->json()['data']['createProduct'];
+        $region = Regions::find($regionResponse['id']);
+        $company = $region->company;
+
+        $warehouseData = [
+            'id' => $warehouseResponse['id'],
+        ];
+
+        $variantResponse = $this->createVariant(
+            productId: $productResponse['id'],
+            warehouseData: $warehouseData
+        )->json()['data']['createVariant'];
+
+
+        $channelResponse = $this->createChannel()->json()['data']['createChannel'];
+
+        $this->addVariantToChannel(
+            variantId: $variantResponse['id'],
+            channelId: $channelResponse['id'],
+            warehouseData: $warehouseData
+        );
+
+
+        $this->addVariantToWarehouse(
+            variantId: $variantResponse['id'],
+            warehouseId: $warehouseResponse['id'],
+            amount: 100
+        );
+
+        $variant = Variants::find($variantResponse['id']);
+        $channel = $variant->variantChannels()->where('channels_id', $channelResponse['id'])->first();
+        $variantWarehouse = $channel?->productVariantWarehouse()->first();
+        $endDate = now()->subDays(1);
+
+        $data = [
+            'email' => fake()->email(),
+            'region_id' => $region->getId(),
+            'metadata' => [
+                'data' => [
+                    'start_at' => now()->subDays(2)->toDateTimeString(),
+                    'end_at' => now()->subDays(1)->toDateTimeString(),
+                ],
+            ],
+            'customer' => [
+                'firstname' => fake()->firstName(),
+                'lastname' => fake()->lastName(),
+            ],
+            'shipping_address' => [
+                'address' => fake()->address(),
+                'address_2' => fake()->postcode(),
+                'city' => fake()->city(),
+                'state' => fake()->state(),
+            ],
+            'items' => [
+                [
+                    'variant_id' => $variantResponse['id'],
+                    'quantity' => 1,
+                ],
+            ],
+        ];
+
+        // Perform GraphQL mutation to create a draft order
+        $response = $this->graphQL('
+            mutation createDraftOrder($input: DraftOrderInput!) {
+                createDraftOrder(input: $input) {
+                    id
+                }
+            }
+        ', [
+            'input' => $data,
+        ], [], [
+            'X-Kanvas-Location' => $company->branch->uuid,
+        ]);
+
+
+
+        $createOrderResponse = $response->json()['data']['createDraftOrder'];
+
+        $extendedEndAt = $endDate->addMinutes(30)->toDateTimeString();
+
+        $response = $this->graphQL('
+            mutation updateOrder($id: ID!, $input: UpdateOrderInput!) {
+                updateOrder(id: $id, input: $input) {
+                    order { 
+                        id
+                        metadata
+                        items {
+                            id
+                            variant {
+                                id
+                            }
+                        }
+                    }
+                }
+            }
+        ', [
+            "id" => $createOrderResponse['id'],
+            'input' => [
+                "items" => [
+                    [
+                        'variant_id' => $variantResponse['id'],
+                        'quantity' => 2,
+                    ],
+                ],
+                "metadata" => [
+                    "data" => [
+                        "end_at" => $extendedEndAt,
+                    ],
+                ],
+            ],
+        ], [], [
+            'X-Kanvas-Location' => $company->branch->uuid,
+        ]);
+
+        $orderData = $response->json()['data']['updateOrder']['order'];
+        $order = Order::find($orderData['id']);
+
+        $this->assertEquals($extendedEndAt, $order->metadata['data']['end_at']);
+        $this->assertCount(1, $order->items);
+        $this->assertEquals(2, $order->items[0]->quantity);
     }
 }


### PR DESCRIPTION
## General Description

GoParking needs to extend an order the way to extend should be update the quantity and the end_at date in metadata for their use case.

In this change I introduce a new graph `updateOrder` that allow them to do that.

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [x] I have performed a self-review of my code.
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings.
- [x] My changes do not break any existing tests.
