### PR TITLE
Add request timeout configuration to Octane

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -33,6 +33,7 @@ return [
             'task_worker_num' => 10,
             'enable_coroutine' => true,
             'max_request' => 1000,
+            'request_timeout' => 30,
         ],
     ],
 


### PR DESCRIPTION
Introduce a new configuration option for request timeout in the Octane settings, allowing for better control over request handling.