### PR TITLE
Set default lastname to empty string when not provided

### DIFF
--- a/src/Kanvas/Auth/Services/UserManagement.php
+++ b/src/Kanvas/Auth/Services/UserManagement.php
@@ -38,6 +38,10 @@ class UserManagement
 
             $userAppProfile = $this->user->getAppProfile($this->app);
 
+            if (! isset($data['lastname'])) {
+                $data['lastname'] = ''; //Save it empty to avoid having a fullName with unwanted lastnam
+            }
+
             //@todo when we update the login to use userAssociatedApps we need to remove this
             $this->user->update($data);
             $userAppProfile->update($data);


### PR DESCRIPTION
Ensure that the lastname field defaults to an empty string if not provided, preventing unwanted values in the fullName.