### PR TITLE
Add FixPromptDataCommand for message synchronization and nugget creation

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Connectors\PromptMine;
+
+use Baka\Traits\KanvasJobsTrait;
+use Illuminate\Console\Command;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\PromptMine\Services\RecombeeIndexService;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Social\MessagesTypes\Models\MessageType;
+use Throwable;
+
+class FixPromptDataCommand extends Command
+{
+    use KanvasJobsTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'kanvas:promptmine-fix-prompt-data {app_id} {companies_id} {message_type_id}';
+
+    /**
+     * The console command description.
+     *
+     * @var string|null
+     */
+    protected $description = 'Fix promptmine prompt data';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $app = Apps::getById((int) $this->argument('app_id'));
+        $this->overwriteAppService($app);
+        $messageTypeId = (int) $this->argument('message_type_id');
+        $messageType = MessageType::find($messageTypeId);
+        $companiesId = (int) $this->argument('companies_id');
+
+        //Get all messages for the given message type and app
+        $this->SyncPromptData($app, $messageType, $companiesId);
+    }
+
+    private function SyncPromptData($app, $messageType, $companiesId): void
+    {
+        Message::fromApp($app)
+            ->where('message_types_id', $messageType->getId())
+            ->where('companies_id', $companiesId)
+            ->orderBy('id', 'asc')
+            ->chunk(100, function ($messages) {
+                foreach ($messages as $message) {
+                    try {
+                        $this->fixPromptData($message);
+                        $this->info('Message ID: ' . $message->getId() . ' updated');
+                        die();
+                    } catch (Throwable $e) {
+                        $this->error('Error updating message ID: ' . $message->getId() . ' - ' . $e->getMessage());
+                    }
+                }
+            });
+    }
+
+    private function SyncNuggetData(Apps $app, MessageType $messageType, int $companiesId, int $parentId): void
+    {
+        Message::fromApp($app)
+            ->where('message_types_id', $messageType->getId())
+            ->where('companies_id', $companiesId)
+            ->orderBy('id', 'asc')
+            ->chunk(100, function ($messages) {
+                foreach ($messages as $message) {
+                    try {
+                        $this->info('Message ID: ' . $message->getId() . ' updated');
+                    } catch (Throwable $e) {
+                        $this->error('Error updating message ID: ' . $message->getId() . ' - ' . $e->getMessage());
+                    }
+                }
+            });
+    }
+
+    private function fixPromptData(Message $message): void
+    {
+        $messageData = is_array($message->message) ? $message->message : json_decode($message->message, true);
+
+
+        if (! isset($messageData['ai_model'])) {
+            $messageData['ai_model'] = [
+                'name'=> 'gpt-3.5-turbo',
+                'value'=> 'gpt-3.5-turbo',
+                'icon'=> 'https://cdn.openai.com/papers/gpt-3.5-turbo.png',
+                'payment' => [
+                    'price' => 0,
+                    'is_locked' => false,
+                    'free_regeneration' => false
+                ]
+            ];
+        }
+
+        if (! isset($messageData['type'])) {
+            $messageData['type'] = 'text-format';
+        }
+
+        if (isset($messageData['preview'])) {
+            unset($messageData['preview']);
+        }
+
+        if ($message->is_premium && ! isset($messageData['payment'])) {
+            $messageData['payment'] = [
+                'price' => 0,
+                'is_locked' => false,
+                'free_regeneration' => false
+            ];
+        }
+
+        $message->message = $messageData;
+        $message->save();
+    }
+}

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -154,10 +154,10 @@ class FixPromptDataCommand extends Command
             $this->info('Added payment to message data');
         }
 
-        if (isset($messageData['ai_nugged'])) {
-            unset($messageData['ai_nugged']);
-            $this->info('Removed ai_nugged from message data');
-        }
+        // if (isset($messageData['ai_nugged'])) {
+        //     unset($messageData['ai_nugged']);
+        //     $this->info('Removed ai_nugged from message data');
+        // }
 
         $message->message = $messageData;
         $message->save();
@@ -205,10 +205,10 @@ class FixPromptDataCommand extends Command
             $this->info('Added message nugget to message data');
         }
 
-        if (isset($messageData['ai_nugged'])) {
-            unset($messageData['ai_nugged']);
-            $this->info('Removed ai_nugged from message data');
-        }
+        // if (isset($messageData['ai_nugged'])) {
+        //     unset($messageData['ai_nugged']);
+        //     $this->info('Removed ai_nugged from message data');
+        // }
 
         $message->message = $messageData;
         $message->save();

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -140,9 +140,9 @@ class FixPromptDataCommand extends Command
         if(! isset($messageData['type']) && isset($parentMessageData['type'])) {
             $messageData['type'] = $parentMessageData['type'];
             if ($parentMessageData['type'] == 'image-format') {
-                $messageData['image'] = '';
+                $messageData['image'] = ''; //Use nugget if not possible to generate image.
             } else {
-                $messageData['nugget'] = ""; // Check how we are going to generate the missing nugget from prompts?
+                $messageData['nugget'] = "";
             }
         }
 

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -233,6 +233,9 @@ class FixPromptDataCommand extends Command
             ->where('id', $nuggetId)
             ->update(['path' => $parentMessage->getId() . "." . $nuggetId]);
 
+        //Call fixNuggetData just in case something is missing
+        $this->fixNuggetData(Message::find($nuggetId));
+
         $this->info('Created nugget message with ID: ' . $nuggetId);
     }
 }

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -87,7 +87,6 @@ class FixPromptDataCommand extends Command
     {
         $messageData = is_array($message->message) ? $message->message : json_decode($message->message, true);
 
-
         if (! isset($messageData['ai_model'])) {
             $messageData['ai_model'] = [
                 'name'=> 'gpt-3.5-turbo',

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -62,7 +62,6 @@ class FixPromptDataCommand extends Command
             ->orderBy('id', 'asc')
             ->chunk(20, function ($messages) {
                 foreach ($messages as $message) {
-
                     try {
                         $this->fixPromptData($message);
 
@@ -74,9 +73,7 @@ class FixPromptDataCommand extends Command
                         }
 
                         foreach ($message->children as $childMessage) {
-
                             $validateMessageSchema = new MessageSchemaValidator($childMessage, MessageType::find(576), true);
-                            
                             $this->info('--Checking Child Nugget Message Schema of ID: ' . $childMessage->getId());
                             if ($validateMessageSchema->validate()) {
                                 $this->info('--Message Schema is OK');

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -154,6 +154,11 @@ class FixPromptDataCommand extends Command
             $this->info('Added payment to message data');
         }
 
+        if (isset($messageData['ai_nugged'])) {
+            unset($messageData['ai_nugged']);
+            $this->info('Removed ai_nugged from message data');
+        }
+
         $message->message = $messageData;
         $message->save();
         $this->info('-Prompt Message ID: ' . $message->getId() . ' updated');
@@ -193,16 +198,16 @@ class FixPromptDataCommand extends Command
                 ->generate();
 
                 $responseText = str_replace(['```', 'json'], '', $response->text);
-
-                if ($parentMessageData['type'] == 'image-format') {
-                    $messageData['image'] = ''; //Use nugget if not possible to generate image.
-                } else {
-                    $messageData['nugget'] = $responseText;
-                }
+                $messageData['nugget'] = $responseText;
             }
 
             $this->info('Added message type to message data' . $messageData['type']);
             $this->info('Added message nugget to message data');
+        }
+
+        if (isset($messageData['ai_nugged'])) {
+            unset($messageData['ai_nugged']);
+            $this->info('Removed ai_nugged from message data');
         }
 
         $message->message = $messageData;

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -60,7 +60,7 @@ class FixPromptDataCommand extends Command
             ->where('companies_id', $companiesId)
             ->where('is_deleted', 0)
             ->orderBy('id', 'asc')
-            ->chunk(20, function ($messages) {
+            ->chunk(100, function ($messages) {
                 foreach ($messages as $message) {
                     try {
                         $this->fixPromptData($message);
@@ -88,7 +88,6 @@ class FixPromptDataCommand extends Command
                         $this->error('Error updating message ID: ' . $message->getId() . ' - ' . $e->getMessage());
                     }
                 }
-                die();
             });
     }
 

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -102,7 +102,7 @@ class FixPromptDataCommand extends Command
 
         $this->info('--Checking Prompt Message Schema of ID: ' . $message->getId());
         if ($validateMessageSchema->validate()) {
-            $this->info('-- Prompt Message Schema is OK');
+            $this->info('-Prompt Message Schema is OK');
             return;
         }
         //Anything that is not a prompt, set as deleted
@@ -149,7 +149,7 @@ class FixPromptDataCommand extends Command
             $this->info('Removed preview from message data');
         }
 
-        if ($message->is_premium && ! isset($messageData['payment'])) {
+        if (! isset($messageData['payment'])) {
             $messageData['payment'] = [
                 'price' => 0,
                 'is_locked' => false,

--- a/src/Domains/Social/Messages/Models/Message.php
+++ b/src/Domains/Social/Messages/Models/Message.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Kanvas\Social\Messages\Models;
@@ -80,7 +81,6 @@ class Message extends BaseModel
     use AsTree;
     use CanUseWorkflow;
     use HasLightHouseCache;
-    //use Cachable;
     use HasFilesystemTrait;
     use QueryCacheable;
 
@@ -159,7 +159,6 @@ class Message extends BaseModel
             return json_decode($value, true);
         }
 
-        // If all attempts fail, return original value
         return is_array($value) ? $value : [];
     }
 

--- a/src/Domains/Social/Messages/Models/Message.php
+++ b/src/Domains/Social/Messages/Models/Message.php
@@ -98,6 +98,7 @@ class Message extends BaseModel
         'message' => Json::class,
         'message_types_id' => 'integer',
         'is_public' => 'integer',
+        'is_deleted' => 'integer',
     ];
 
     #[Override]

--- a/src/Domains/Social/Messages/Models/Message.php
+++ b/src/Domains/Social/Messages/Models/Message.php
@@ -1,3 +1,4 @@
+
 <?php
 
 declare(strict_types=1);
@@ -98,7 +99,7 @@ class Message extends BaseModel
         'message' => Json::class,
         'message_types_id' => 'integer',
         'is_public' => 'integer',
-        'is_deleted' => 'integer',
+        'is_deleted' => 'boolean',
     ];
 
     #[Override]

--- a/src/Domains/Social/Messages/Models/Message.php
+++ b/src/Domains/Social/Messages/Models/Message.php
@@ -1,6 +1,4 @@
-
 <?php
-
 declare(strict_types=1);
 
 namespace Kanvas\Social\Messages\Models;

--- a/src/Domains/Social/Messages/Validations/MessageSchemaValidator.php
+++ b/src/Domains/Social/Messages/Validations/MessageSchemaValidator.php
@@ -15,22 +15,29 @@ class MessageSchemaValidator
 
     public function __construct(
         private readonly Message $message,
-        private readonly MessageType $messageType
+        private readonly MessageType $messageType,
+        private bool $returnValidation = false
     ) {
     }
 
-    public function validate(): void
+    public function validate(): bool
     {
         $schema = json_decode($this->messageType->message_schema, true);
         $data = is_array($this->message->message) ? $this->message->message : json_decode($this->message->message, true);
-        $this->validateSchema($data, $schema);
+        return $this->validateSchema($data, $schema);
     }
 
-    private function validateSchema(array $data, array $schema): void
+    private function validateSchema(array $data, array $schema): bool
     {
         $validator = Validator::make($data, $schema);
         if ($validator->fails()) {
+
+            if ($this->returnValidation) {
+                return false;
+            }
             throw new MessageValidationException(implode(', ', $validator->errors()->all()));
         }
+
+        return true;
     }
 }

--- a/src/Domains/Social/Messages/Validations/MessageSchemaValidator.php
+++ b/src/Domains/Social/Messages/Validations/MessageSchemaValidator.php
@@ -31,7 +31,6 @@ class MessageSchemaValidator
     {
         $validator = Validator::make($data, $schema);
         if ($validator->fails()) {
-
             if ($this->returnValidation) {
                 return false;
             }


### PR DESCRIPTION
Introduce a new command to synchronize and update prompt data for messages, including enhancements for handling image-type messages and validating message schemas. Add an `is_deleted` field to the Message model to manage message visibility effectively. Improve logging and error handling throughout the process to ensure data integrity and clarity.