### PR TITLE
Update .gitignore and refine GooglePlayInAppPurchaseReceipt input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ service-account.json
 frankenphp
 frankenphp-worker.php
 google_auth.json
+google-play-service-account.json
 typesense-data/

--- a/graphql/schemas/Souk/order.graphql
+++ b/graphql/schemas/Souk/order.graphql
@@ -193,8 +193,6 @@ input GooglePlayInAppPurchaseReceipt {
     product_id: ID!
     order_id: String!
     purchase_token: String!
-    purchase_time: Int!
-    purchase_state: Int!
     region_id: ID
     custom_fields: [CustomFieldEntityInput!]
 }

--- a/src/Domains/Connectors/InAppPurchase/Actions/CreateOrderFromGoogleReceiptAction.php
+++ b/src/Domains/Connectors/InAppPurchase/Actions/CreateOrderFromGoogleReceiptAction.php
@@ -51,11 +51,11 @@ class CreateOrderFromGoogleReceiptAction
             'productId' => $this->googlePlayInAppPurchase->product_id,
             'orderId' => $this->googlePlayInAppPurchase->order_id,
             'purchaseToken' => $this->googlePlayInAppPurchase->purchase_token,
-            'purchaseState' => $this->googlePlayInAppPurchase->purchase_state,
         ];
 
         $verifiedReceipt = $this->verifyReceipt($receipt);
 
+        // 0 = Purchased, 1 = Canceled, 2 = Pending
         if ($verifiedReceipt->getPurchaseState() == GooglePlayReceiptStatusEnum::CANCELED) {
             throw new ValidationException('Invalid Receipt');
         }

--- a/src/Domains/Connectors/InAppPurchase/DataTransferObject/GooglePlayInAppPurchaseReceipt.php
+++ b/src/Domains/Connectors/InAppPurchase/DataTransferObject/GooglePlayInAppPurchaseReceipt.php
@@ -20,7 +20,6 @@ class GooglePlayInAppPurchaseReceipt extends Data
         public readonly string $product_id,
         public readonly string $order_id,
         public readonly string $purchase_token,
-        public readonly int $purchase_state, // 0 = Purchased, 1 = Canceled, 2 = Pending
         public readonly array $custom_fields = []
     ) {
     }
@@ -40,7 +39,6 @@ class GooglePlayInAppPurchaseReceipt extends Data
             $data['product_id'],
             $data['order_id'],
             $data['purchase_token'],
-            (int) $data['purchase_state'],
             $data['custom_fields'] ?? []
         );
     }


### PR DESCRIPTION
Include `google-play-service-account.json` in `.gitignore` and remove unused fields from the `GooglePlayInAppPurchaseReceipt` input type.