### PR TITLE
Add id-token permission to GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker-swarm-deploy copy.yaml
+++ b/.github/workflows/docker-swarm-deploy copy.yaml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Include the `id-token` permission in the GitHub Actions workflow to enhance authentication capabilities.