### PR TITLE
Update AWS credentials audience in Docker Swarm deployment workflow

### DIFF
--- a/.github/workflows/docker-swarm-deploy copy.yaml
+++ b/.github/workflows/docker-swarm-deploy copy.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          audience: sts.amazonaws.com.cn
+          audience: sts.amazonaws.com
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ECR_ROLE_NAME }}
           aws-region: ${{ secrets.AWS_REGION }}
 


### PR DESCRIPTION
Change the AWS credentials audience from `sts.amazonaws.com.cn` to `sts.amazonaws.com` for improved compatibility.