### PR TITLE
Remove branch restriction and update Docker build command

### DIFF
--- a/.github/workflows/docker-swarm-deploy copy.yaml
+++ b/.github/workflows/docker-swarm-deploy copy.yaml
@@ -2,9 +2,6 @@ name: Deploy to EC2 and Update Docker Swarm Service
 
 on:
   push:
-    branches:
-      - "development"
-
   workflow_dispatch:
 
 jobs:
@@ -33,7 +30,7 @@ jobs:
         run: |
           IMAGE_TAG=$(date +%s)
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
-          docker build -f ${{ github.ref_name }}.Dockerfile -t ${{ secrets.ECR_REPOSITORY_NAME }}:$IMAGE_TAG .
+          docker build -f ${{ github.ref_name }}.Dockerfile -t ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY_NAME }}:$IMAGE_TAG .
           docker tag ${{ secrets.ECR_REPOSITORY_NAME }}:$IMAGE_TAG ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY_NAME }}:$IMAGE_TAG
           docker push ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY_NAME }}:$IMAGE_TAG
 

--- a/.github/workflows/docker-swarm-deploy copy.yaml
+++ b/.github/workflows/docker-swarm-deploy copy.yaml
@@ -2,6 +2,9 @@ name: Deploy to EC2 and Update Docker Swarm Service
 
 on:
   push:
+    branches:
+      - "development"
+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Remove the branch restriction from the push event to allow deployments from any branch and update the Docker build command to utilize the ECR registry output for tagging and pushing images.