### PR TITLE
Fix Docker push command syntax in deployment workflow

### DIFF
--- a/.github/workflows/docker-swarm-deploy copy.yaml
+++ b/.github/workflows/docker-swarm-deploy copy.yaml
@@ -36,8 +36,7 @@ jobs:
           IMAGE_TAG: ${{ github.sha }}
         run: |
           docker build -f ${{ github.ref_name }}.Dockerfile -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
-          docker tag $REPOSITORY:$IMAGE_TAG $REGISTRY/$REPOSITORY:$IMAGE_TAG
-          docker push $REGISTRY /$REPOSITORY:$IMAGE_TAG
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
 
   # update-docker-swarm-service:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
Correct the syntax for the Docker push command in the deployment workflow to ensure proper image pushing to the registry.