### PR TITLE
Fix response handling in GenerateWhoToFollowRecommendationsAction

### DIFF
--- a/src/Domains/Connectors/Recombee/Actions/GenerateWhoToFollowRecommendationsAction.php
+++ b/src/Domains/Connectors/Recombee/Actions/GenerateWhoToFollowRecommendationsAction.php
@@ -26,7 +26,7 @@ class GenerateWhoToFollowRecommendationsAction
 
         $response = $recommendationService->getUserToUserRecommendation($user, $pageSize, $scenario);
 
-        $entityIds = collect($response)
+        $entityIds = collect($response['recomms'])
             ->pluck('id')
             ->unique()
             ->filter()


### PR DESCRIPTION
Correct the response handling to properly access the 'recomms' key in the recommendation service response.