### PR TITLE
Update recommendation options to prioritize diversity

### DIFF
--- a/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
+++ b/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
@@ -72,7 +72,6 @@ class RecombeeUserRecommendationService
         $options = array_merge([
             'scenario' => $scenario,
             'cascadeCreate' => true,
-            'diversity' => 0.3,
             //'filter' => "not ('itemId' in  user_interactions(context_user[\"userId\"], {\"detail_views\",\"ratings\"})) ",
         ], $additionalOptions);
 

--- a/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
+++ b/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
@@ -72,8 +72,7 @@ class RecombeeUserRecommendationService
         $options = array_merge([
             'scenario' => $scenario,
             'cascadeCreate' => true,
-            'rotationRate' => $this->app->get('for-you-feed-rotation-rate') ?? 0.1, // a float from 0 to 1
-            'rotationTime' => $this->app->get('for-you-feed-rotation-time-seconds') ?? 3600, // In seconds
+            'diversity' => 0.3,
             //'filter' => "not ('itemId' in  user_interactions(context_user[\"userId\"], {\"detail_views\",\"ratings\"})) ",
         ], $additionalOptions);
 


### PR DESCRIPTION
Change the default recommendation options to focus on diversity instead of rotation rate and time, and remove the default diversity option from the user recommendation retrieval.