### PR TITLE
Refactor nugget data handling based on message type

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -211,17 +211,23 @@ class FixPromptDataCommand extends Command
             $messageData['type'] = $parentMessageData['type'];
 
             $this->info('Added message type to message data: ' . $messageData['type']);
-        }
 
-        if (! isset($messageData['nugget'])) {
-            $response = Prism::text()
-                ->using(Provider::Gemini, 'gemini-2.0-flash')
-                ->withPrompt($parentMessageData['prompt'])
-                ->generate();
+            if (! isset($messageData['nugget']) && $messageData['type'] === 'text-format') {
+                $this->info('Generating nugget for message ID: ' . $message->getId());
+                $response = Prism::text()
+                    ->using(Provider::Gemini, 'gemini-2.0-flash')
+                    ->withPrompt($parentMessageData['prompt'])
+                    ->generate();
+    
+                $responseText = str_replace(['```', 'json'], '', $response->text);
+                $messageData['nugget'] = $responseText;
+                $this->info('Added message nugget to message data');
+            }
 
-            $responseText = str_replace(['```', 'json'], '', $response->text);
-            $messageData['nugget'] = $responseText;
-            $this->info('Added message nugget to message data');
+            if (isset($messageData['nugget']) && $messageData['type'] === 'image-format') {
+                unset($messageData['nugget']);
+                $this->info('Removed nugget from message data on image format');
+            }
         }
 
         if (isset($messageData['display_type'])) {

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -211,14 +211,12 @@ class FixPromptDataCommand extends Command
             $messageData['type'] = $parentMessageData['type'];
 
             $this->info('Added message type to message data: ' . $messageData['type']);
-
             if (! isset($messageData['nugget']) && $messageData['type'] === 'text-format') {
                 $this->info('Generating nugget for message ID: ' . $message->getId());
                 $response = Prism::text()
                     ->using(Provider::Gemini, 'gemini-2.0-flash')
                     ->withPrompt($parentMessageData['prompt'])
                     ->generate();
-    
                 $responseText = str_replace(['```', 'json'], '', $response->text);
                 $messageData['nugget'] = $responseText;
                 $this->info('Added message nugget to message data');


### PR DESCRIPTION
Improve data handling by conditionally generating and removing nuggets based on the message type. This change ensures that nuggets are only created for text-format messages and removed for image-format messages.