### PR TITLE
Improve error message clarity in OptimizeImageFromMessageActivity

### DIFF
--- a/src/Domains/Connectors/PromptMine/Actions/CreateNuggetMessageAction.php
+++ b/src/Domains/Connectors/PromptMine/Actions/CreateNuggetMessageAction.php
@@ -29,7 +29,7 @@ class CreateNuggetMessageAction
                     'is_public' => 1,
                 ],
                 $this->parentMessage->user,
-                MessagesTypesRepository::getByVerb('memo', $this->parentMessage->app->getId()),
+                MessagesTypesRepository::getByVerb('memo', $this->parentMessage->app),
                 $this->parentMessage->company,
                 $this->parentMessage->app,
             )

--- a/src/Domains/Social/Messages/Workflows/Activities/OptimizeImageFromMessageActivity.php
+++ b/src/Domains/Social/Messages/Workflows/Activities/OptimizeImageFromMessageActivity.php
@@ -25,7 +25,7 @@ class OptimizeImageFromMessageActivity extends KanvasActivity
         if (! isset($messageContent['image']) && ! isset($messageContent['ai_image'])) {
             return [
                 'result' => false,
-                'message' => 'Message does not have an AI image url',
+                'message' => 'Message does not have an image url',
             ];
         }
 


### PR DESCRIPTION
Update the error message to provide clearer feedback when an image URL is missing. Adjust the method call to use the app instance directly for consistency.