### PR TITLE
Change message cast from Json to array in Message model

### DIFF
--- a/src/Domains/Social/Messages/Models/Message.php
+++ b/src/Domains/Social/Messages/Models/Message.php
@@ -93,7 +93,7 @@ class Message extends BaseModel
     ];
 
     protected $casts = [
-        'message' => Json::class,
+        'message' => 'array',
         'message_types_id' => 'integer',
         'is_public' => 'integer',
         'is_deleted' => 'boolean',


### PR DESCRIPTION
Update the Message model to cast the 'message' attribute as an array instead of Json, improving data handling.