### PR TITLE
Add booster handling in user feed recommendations

### DIFF
--- a/src/Domains/Connectors/PromptMine/Services/RecombeeIndexService.php
+++ b/src/Domains/Connectors/PromptMine/Services/RecombeeIndexService.php
@@ -58,7 +58,6 @@ class RecombeeIndexService
             'updated_at' => 'timestamp',
             'is_premium' => 'boolean',
             'ai_model' => 'string',
-            'type' => 'string',
             'image' => 'string',
             'categories' => 'set',
             'type' => 'string',

--- a/src/Domains/Connectors/PromptMine/Services/RecombeeIndexService.php
+++ b/src/Domains/Connectors/PromptMine/Services/RecombeeIndexService.php
@@ -58,8 +58,10 @@ class RecombeeIndexService
             'updated_at' => 'timestamp',
             'is_premium' => 'boolean',
             'ai_model' => 'string',
+            'type' => 'string',
             'image' => 'string',
             'categories' => 'set',
+            'type' => 'string',
         ];
         $existingProperties = $this->client->send(new ListItemProperties());
         $existingPropertyNames = array_column($existingProperties, 'name');
@@ -137,6 +139,7 @@ class RecombeeIndexService
                 'ai_model' => $messageData['ai_model']['name'] ?? null,
                 'image' => $messageData['ai_image']['image'] ?? null,
                 'categories' => $message->tags->pluck('name')->toArray(),
+                'type' => $messageData['type'] ?? null,
             ],
             ['cascadeCreate' => true]
         );

--- a/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
+++ b/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
@@ -42,6 +42,7 @@ class RecombeeUserRecommendationService
     ): array {
         $recommendationOptions = [
             'rotationRate' => $this->app->get(ConfigurationEnum::RECOMBEE_ROTATION_RATE->value ?? '0.2'),
+            'booster' => $this->getBoosters($user),
             // Uncomment when ready to use configuration
             // 'rotationTime' => $this->config->get(ConfigurationEnum::RECOMBEE_ROTATION_TIME->value, 7200.0),
         ];
@@ -109,5 +110,26 @@ class RecombeeUserRecommendationService
         );
 
         return $recommendation;
+    }
+
+    public function getBoosters(UserInterface $user): string
+    {
+        $booster = '';
+        // Get the booster queries from the app settings
+        // The format should be: ['preference' => 'booster']
+        // booster being the booster rule on recombee, no need to set it here.
+        // 1.0 is the default value for the booster, so we need to replace it with the booster rule
+        $recombeeUserContentPreferences = $this->app->get('recombee-user-content-preferences-boosters');
+        foreach ($$recombeeUserContentPreferences as $preference => $boosterRule) {
+            if ($user->get($preference)) {
+                if (str_contains($booster, '1.0')) {
+                    $booster = str_replace('1.0', "(" . addslashes($boosterRule) . ")", $booster);
+                    continue;
+                }
+                $booster .= addslashes($boosterRule);
+            }
+        }
+
+        return $booster;
     }
 }

--- a/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
+++ b/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
@@ -120,10 +120,10 @@ class RecombeeUserRecommendationService
         // booster being the booster rule on recombee, no need to set it here.
         // 1.0 is the default value for the booster, so we need to replace it with the booster rule
         $recombeeUserContentPreferences = $this->app->get('recombee-user-content-preferences-boosters');
-        foreach ($$recombeeUserContentPreferences as $preference => $boosterRule) {
+        foreach ($recombeeUserContentPreferences as $preference => $boosterRule) {
             if ($user->get($preference)) {
                 if (str_contains($booster, '1.0')) {
-                    $booster = str_replace('1.0', "(" . addslashes($boosterRule) . ")", $booster);
+                    $booster = str_replace('1.0', '('.addslashes($boosterRule).')', $booster);
                     continue;
                 }
                 $booster .= addslashes($boosterRule);

--- a/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
+++ b/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
@@ -42,7 +42,7 @@ class RecombeeUserRecommendationService
     ): array {
         $recommendationOptions = [
             'rotationRate' => $this->app->get(ConfigurationEnum::RECOMBEE_ROTATION_RATE->value ?? '0.2'),
-            'booster' => $this->getBoosters($user),
+            'booster' => $this->getUserSpecificBoosters($user),
             // Uncomment when ready to use configuration
             // 'rotationTime' => $this->config->get(ConfigurationEnum::RECOMBEE_ROTATION_TIME->value, 7200.0),
         ];
@@ -112,12 +112,12 @@ class RecombeeUserRecommendationService
         return $recommendation;
     }
 
-    public function getBoosters(UserInterface $user): string
+    public function getUserSpecificBoosters(UserInterface $user): string
     {
         $booster = '';
         // Get the booster queries from the app settings
         // The format should be: ['preference' => 'booster']
-        // booster being the booster rule on recombee, no need to set it here.
+        // booster being the booster rule
         // 1.0 is the default value for the booster, so we need to replace it with the booster rule
         $recombeeUserContentPreferences = $this->app->get('recombee-user-content-preferences-boosters');
         foreach ($recombeeUserContentPreferences as $preference => $boosterRule) {

--- a/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
+++ b/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
@@ -43,8 +43,7 @@ class RecombeeUserRecommendationService
         $recommendationOptions = [
             'rotationRate' => $this->app->get(ConfigurationEnum::RECOMBEE_ROTATION_RATE->value ?? '0.2'),
             'booster' => $this->getUserSpecificBoosters($user),
-            // Uncomment when ready to use configuration
-            // 'rotationTime' => $this->config->get(ConfigurationEnum::RECOMBEE_ROTATION_TIME->value, 7200.0),
+            'rotationTime' => $this->app->get(ConfigurationEnum::RECOMBEE_ROTATION_TIME->value, 7200.0),
         ];
 
         try {

--- a/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
+++ b/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
@@ -42,7 +42,7 @@ class RecombeeUserRecommendationService
     ): array {
         $recommendationOptions = [
             'rotationRate' => $this->app->get(ConfigurationEnum::RECOMBEE_ROTATION_RATE->value ?? '0.2'),
-            'booster' => $this->getUserSpecificBoosters($user),
+            'booster' => $this->app->get('recombee-user-content-preferences-boosters') ? $this->getUserSpecificBoosters($user) : '',
             'rotationTime' => $this->app->get(ConfigurationEnum::RECOMBEE_ROTATION_TIME->value, 7200.0),
         ];
 

--- a/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
+++ b/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
@@ -123,7 +123,7 @@ class RecombeeUserRecommendationService
         foreach ($recombeeUserContentPreferences as $preference => $boosterRule) {
             if ($user->get($preference)) {
                 if (str_contains($booster, '1.0')) {
-                    $booster = str_replace('1.0', '('.addslashes($boosterRule).')', $booster);
+                    $booster = str_replace('1.0', '(' . addslashes($boosterRule) . ')', $booster);
                     continue;
                 }
                 $booster .= addslashes($boosterRule);

--- a/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
+++ b/src/Domains/Connectors/Recombee/Services/RecombeeUserRecommendationService.php
@@ -42,9 +42,12 @@ class RecombeeUserRecommendationService
     ): array {
         $recommendationOptions = [
             'rotationRate' => $this->app->get(ConfigurationEnum::RECOMBEE_ROTATION_RATE->value ?? '0.2'),
-            'booster' => $this->app->get('recombee-user-content-preferences-boosters') ? $this->getUserSpecificBoosters($user) : '',
             'rotationTime' => $this->app->get(ConfigurationEnum::RECOMBEE_ROTATION_TIME->value, 7200.0),
         ];
+
+        if ($this->app->get('recombee-user-content-preferences-boosters')) {
+            $recommendationOptions['booster'] = $this->getUserSpecificBoosters($user);
+        }
 
         try {
             if ($recommId !== null) {


### PR DESCRIPTION
Implement booster handling in the `getUserForYouFeed` method and introduce a new `getBoosters` method to retrieve booster rules based on user preferences.