### PR TITLE
Include entity class and ID in response for non-public entities

### DIFF
--- a/src/Domains/Social/Follows/Workflows/SendPushNotificationActivity.php
+++ b/src/Domains/Social/Follows/Workflows/SendPushNotificationActivity.php
@@ -27,7 +27,7 @@ class SendPushNotificationActivity extends Activity implements WorkflowActivityI
     {
         $this->overwriteAppService($app);
 
-        if (!$entity->is_public) {
+        if (! $entity->is_public) {
             return [
                 'result' => false,
                 'message' => 'Entity is not public',

--- a/src/Domains/Social/Follows/Workflows/SendPushNotificationActivity.php
+++ b/src/Domains/Social/Follows/Workflows/SendPushNotificationActivity.php
@@ -27,6 +27,18 @@ class SendPushNotificationActivity extends Activity implements WorkflowActivityI
     {
         $this->overwriteAppService($app);
 
+        if (!$entity->is_public) {
+            return [
+                'result' => false,
+                'message' => 'Entity is not public',
+                'data' => $params,
+                'entity' => [
+                    get_class($entity),
+                    $entity->getId(),
+                ],
+            ];
+        }
+
         $user = Users::getById($entity->users_id);
         $notificationType = NotificationTypesRepository::getByName($params['notification_name'], $app);
         $toUsersArray = $params['toUsers'] ?? [];


### PR DESCRIPTION
Return the entity class and ID in the response when an entity is not public, enhancing the feedback provided to the user.