### PR TITLE
Pass entity to ImageProcessingPushNotification for metadata accuracy

### DIFF
--- a/src/Domains/Connectors/PromptMine/Notifications/ImageProcessingPushNotification.php
+++ b/src/Domains/Connectors/PromptMine/Notifications/ImageProcessingPushNotification.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\PromptMine\Notifications;
 
-use Kanvas\Connectors\PromptMine\Enums\NotificationTemplateEnum;
 use Illuminate\Database\Eloquent\Model;
+use Kanvas\Connectors\PromptMine\Enums\NotificationTemplateEnum;
 use Kanvas\Social\Messages\Notifications\CustomMessageNotification;
 use Kanvas\Templates\Enums\EmailTemplateEnum;
 use Kanvas\Users\Models\Users;

--- a/src/Domains/Connectors/PromptMine/Notifications/ImageProcessingPushNotification.php
+++ b/src/Domains/Connectors/PromptMine/Notifications/ImageProcessingPushNotification.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Connectors\PromptMine\Notifications;
 
 use Kanvas\Connectors\PromptMine\Enums\NotificationTemplateEnum;
+use Illuminate\Database\Eloquent\Model;
 use Kanvas\Social\Messages\Notifications\CustomMessageNotification;
 use Kanvas\Templates\Enums\EmailTemplateEnum;
 use Kanvas\Users\Models\Users;
@@ -13,6 +14,7 @@ class ImageProcessingPushNotification extends CustomMessageNotification
 {
     public function __construct(
         Users $user,
+        Model $entity,
         string $message,
         string $title,
         array $via,
@@ -25,7 +27,7 @@ class ImageProcessingPushNotification extends CustomMessageNotification
             'company' => $user->company,
             'message' => $message,
             'title' => $title,
-            'metadata' => $user->getMessage(),
+            'metadata' => $entity->getMessage(),
             'via' => $via,
             'message_owner_id' => $user->user->getId(),
             'message_id' => $user->getId(),

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -270,6 +270,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
             );
             $errorProcessingImageNotification = new ImageProcessingPushNotification(
                 user: $entity->user,
+                entity: $entity,
                 message: 'Your image could not be processed because it violated our content policy. Please try again with a different image.',
                 title: 'Error processing image',
                 via: $endViaList,
@@ -352,6 +353,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
             // Send notification to the user
             $newMessageNotification = new ImageProcessingPushNotification(
                 user: $entity->user,
+                entity: $entity,
                 message: "Your image for {$title} has been processed",
                 title: 'Image Processed',
                 via: $endViaList,


### PR DESCRIPTION
Accurate metadata handling is achieved by passing the entity to the ImageProcessingPushNotification constructor. This change ensures that the correct message is retrieved from the entity instead of the user.