### PR TITLE
Restore child message visibility when parent is not deleted

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -198,6 +198,12 @@ class FixPromptDataCommand extends Command
             $message->save();
             $this->info('Parent message is deleted, setting child message as deleted and not public');
             return;
+        } else {
+            $message->is_deleted = 0;
+            $message->is_public = 1;
+            $message->save();
+            $this->info('Parent message is not deleted, restoring child message as not deleted and public');
+            return;
         }
 
         if (! isset($messageData['id'])) {


### PR DESCRIPTION
Ensure child messages are restored to visible and public status when the parent message remains intact.