### PR TITLE
Fix message deletion logic based on parent message state

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -192,7 +192,7 @@ class FixPromptDataCommand extends Command
         $parentMessageData = is_array($parentMessage->message) ? $parentMessage->message : json_decode($parentMessage->message, true);
         $messageData = is_array($message->message) ? $message->message : json_decode($message->message, true);
 
-        if ($parentMessage->is_deleted && ! isset($messageData['prompt'])) {
+        if ($parentMessage->is_deleted && ! isset($parentMessageData['prompt'])) {
             $message->is_deleted = 1;
             $message->is_public = 0;
             $message->save();

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -192,7 +192,7 @@ class FixPromptDataCommand extends Command
         $parentMessageData = is_array($parentMessage->message) ? $parentMessage->message : json_decode($parentMessage->message, true);
         $messageData = is_array($message->message) ? $message->message : json_decode($message->message, true);
 
-        if ($parentMessage->is_deleted) {
+        if ($parentMessage->is_deleted && ! isset($messageData['prompt'])) {
             $message->is_deleted = 1;
             $message->is_public = 0;
             $message->save();


### PR DESCRIPTION
Ensure child messages are marked as deleted when the parent message is deleted and the prompt is absent. Correct the prompt check in the `fixNuggetData` method to utilize the parent message data accurately.