### PR TITLE
Remove unnecessary AI model flags from message data

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -69,7 +69,6 @@ class FixPromptDataCommand extends Command
             ->chunk(100, function ($messages) use ($app, $childMessageType) {
                 foreach ($messages as $message) {
                     try {
-
                         $this->info('--Checking Parent Prompt Message Schema of ID: ' . $message->getId());
                         $this->fixPromptData($message);
                         // Need to check children manually

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -146,6 +146,16 @@ class FixPromptDataCommand extends Command
                 ]
             ];
             $this->info('Added AI model to message data');
+        } else {
+            if ($messageData['ai_model']['isDefault']) {
+                unset($messageData['ai_model']['isDefault']);
+                $this->info('Removed isDefault from message data');
+            }
+
+            if ($messageData['ai_model']['isNew']) {
+                unset($messageData['ai_model']['isNew']);
+                $this->info('Removed isNew from message data');
+            }
         }
 
         if (! isset($messageData['type'])) {


### PR DESCRIPTION
Eliminate the `isDefault` and `isNew` flags from the message data in the `fixPromptData` method to streamline the data structure.