### PR TITLE
Enhance image format handling in fixNuggetData method

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -280,8 +280,18 @@ class FixPromptDataCommand extends Command
                 $messageData['nugget'] = $responseText;
                 $this->info('Added message nugget to message data');
             }
-        }
 
+            if ($messageData['type'] === 'image-format' && isset($messageData['image'])) {
+                if (! strpos($messageData['image'], "mc-canvas")) {
+                    $message->is_deleted = 1;
+                    $message->is_public = 0;
+                    $message->saveOrFail();
+                    $this->info('IMAGE DOES NOT HAVE A KANVAS URL, setting message as deleted and not public. Message ID: ' . $message->getId());
+                    return;
+                }
+            }
+        }
+        
         if (isset($messageData['nugget']) && $messageData['type'] === 'image-format') {
             unset($messageData['nugget']);
             $this->info('Removed nugget from message data on image format');

--- a/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/FixPromptDataCommand.php
@@ -291,7 +291,7 @@ class FixPromptDataCommand extends Command
                 }
             }
         }
-        
+
         if (isset($messageData['nugget']) && $messageData['type'] === 'image-format') {
             unset($messageData['nugget']);
             $this->info('Removed nugget from message data on image format');


### PR DESCRIPTION
Improve handling of image formats by ensuring messages without a valid Kanvas URL are marked as deleted and not public. This change enhances data integrity for image-type messages.