### PR TITLE
Refactor notification channel retrieval in push commands

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/SendPushMonthlyPromptCountCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/SendPushMonthlyPromptCountCommand.php
@@ -46,7 +46,7 @@ class SendPushMonthlyPromptCountCommand extends Command
         $messageType = MessageType::getById($messageTypeId);
         $config = [
             'via' => [
-                NotificationChannelEnum::PUSH->value,
+                NotificationChannelEnum::getNotificationChannelBySlug('push'),
             ],
         ];
         UsersAssociatedApps::fromApp($app)

--- a/app/Console/Commands/Connectors/PromptMine/SendPushPromptOfTheWeekCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/SendPushPromptOfTheWeekCommand.php
@@ -45,7 +45,7 @@ class SendPushPromptOfTheWeekCommand extends Command
         $messageType = MessageType::getById($messageTypeId);
         $config = [
             'via' => [
-                NotificationChannelEnum::PUSH->value,
+                NotificationChannelEnum::getNotificationChannelBySlug('push'),
             ],
         ];
         UsersAssociatedApps::fromApp($app)


### PR DESCRIPTION
Update the method for retrieving the notification channel in `SendPushMonthlyPromptCountCommand` and `SendPushPromptOfTheWeekCommand` to improve code clarity and maintainability.