### PR TITLE
Remove unnecessary get() call in user recommendation query

### DIFF
--- a/src/Domains/Connectors/Recombee/Actions/GenerateWhoToFollowRecommendationsAction.php
+++ b/src/Domains/Connectors/Recombee/Actions/GenerateWhoToFollowRecommendationsAction.php
@@ -44,7 +44,6 @@ class GenerateWhoToFollowRecommendationsAction
                     ->where('users_follows.entity_namespace', Users::class)
                     ->whereRaw('users_follows.entity_id = users.id');
             })
-            ->select('users.*')
-            ->get();
+            ->select('users.*');
     }
 }


### PR DESCRIPTION
Eliminate an extraneous `get()` call in the user recommendation query to streamline the execution process.