### PR TITLE
Improve company retrieval logic in PremiumPromptFlagActivity

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PremiumPromptFlagActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PremiumPromptFlagActivity.php
@@ -6,8 +6,8 @@ namespace Kanvas\Connectors\PromptMine\Workflows\Activities;
 
 use Baka\Contracts\AppInterface;
 use Illuminate\Database\Eloquent\Model;
-use Kanvas\Companies\Models\CompaniesBranches;
 use Illuminate\Support\Facades\Notification;
+use Kanvas\Companies\Models\CompaniesBranches;
 use Kanvas\Enums\AppSettingsEnums;
 use Kanvas\Exceptions\ModelNotFoundException;
 use Kanvas\Notifications\Templates\Blank;

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PremiumPromptFlagActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PremiumPromptFlagActivity.php
@@ -6,7 +6,10 @@ namespace Kanvas\Connectors\PromptMine\Workflows\Activities;
 
 use Baka\Contracts\AppInterface;
 use Illuminate\Database\Eloquent\Model;
+use Kanvas\Companies\Models\CompaniesBranches;
 use Illuminate\Support\Facades\Notification;
+use Kanvas\Enums\AppSettingsEnums;
+use Kanvas\Exceptions\ModelNotFoundException;
 use Kanvas\Notifications\Templates\Blank;
 use Kanvas\Users\Repositories\UsersRepository;
 use Kanvas\Workflow\Contracts\WorkflowActivityInterface;
@@ -24,7 +27,14 @@ class PremiumPromptFlagActivity extends KanvasActivity implements WorkflowActivi
         $this->overwriteAppService($app);
 
         $messageData = $entity->message;
-        $company = $entity->company;
+        $defaultAppCompanyBranch = $app->get(AppSettingsEnums::GLOBAL_USER_REGISTRATION_ASSIGN_GLOBAL_COMPANY->getValue());
+
+        try {
+            $branch = CompaniesBranches::getById($defaultAppCompanyBranch);
+            $company = $branch->company;
+        } catch (ModelNotFoundException $e) {
+            $company = $entity->company;
+        }
 
         if (! isset($messageData['price']) || ! isset($messageData['price']['sku']) || ! isset($messageData['price']['price'])) {
             return [

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PremiumPromptFlagActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PremiumPromptFlagActivity.php
@@ -38,7 +38,10 @@ class PremiumPromptFlagActivity extends KanvasActivity implements WorkflowActivi
 
         if (! isset($messageData['price']) || ! isset($messageData['price']['sku']) || ! isset($messageData['price']['price'])) {
             return [
+                'result' => false,
+                'message_id' => $entity->getId(),
                 'message' => 'Not a premium prompt request',
+                'messageData' => $messageData,
             ];
         }
 
@@ -67,6 +70,9 @@ class PremiumPromptFlagActivity extends KanvasActivity implements WorkflowActivi
                 Notification::send($usersToNotify, $notification);
 
                 return [
+                    'result' => true,
+                    'message_id' => $entity->getId(),
+                    'messageData' => $messageData,
                     'message' => 'Premium prompt flagged - ' . $messageData['title'],
                 ];
             },


### PR DESCRIPTION
Enhance the logic for retrieving the company in the PremiumPromptFlagActivity by attempting to get the company from the default app's global user registration settings, falling back to the entity's company if not found.