### PR TITLE
Fix parent message handling in finalizeProcessing method

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -355,7 +355,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
         // Create a new nugget message with the processed image
         $cdnImageUrl = $entity->app->get('cloud-cdn') . '/' . $fileSystemRecord->path;
         $createNuggetMessage = (new CreateNuggetMessageAction(
-            parentMessage: $entity,
+            parentMessage: $entity->parent_id ? $entity->parent :$entity,
             messageData: [
                 'title' => $title,
                 'type' => 'image-format',

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -355,7 +355,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
         // Create a new nugget message with the processed image
         $cdnImageUrl = $entity->app->get('cloud-cdn') . '/' . $fileSystemRecord->path;
         $createNuggetMessage = (new CreateNuggetMessageAction(
-            parentMessage: $entity->parent_id ? $entity->parent :$entity,
+            parentMessage: $entity->parent_id ? $entity->parent : $entity,
             messageData: [
                 'title' => $title,
                 'type' => 'image-format',


### PR DESCRIPTION
Update the handling of the parent message to ensure the correct message is used when creating a new nugget message.