### PR TITLE
Update generateImageResponse method to return a string

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -120,11 +120,11 @@ class LLMMessageResponseActivity extends KanvasActivity
         return str_replace(['```', 'json'], '', $response->text);
     }
 
-    private function generateImageResponse(Message $message): array
+    private function generateImageResponse(Message $message): string
     {
         $promptClient = new PromptClient($message->app);
         $prompt = $message->message['prompt'] ?? null;
 
-        return $promptClient->generateImageWithIdeogram($prompt);
+        return $promptClient->extractImageUrl($promptClient->generateImageWithIdeogram($prompt));
     }
 }


### PR DESCRIPTION
Refactor the `generateImageResponse` method to return a string containing the image URL instead of an array. This change simplifies the response format.