### PR TITLE
Add MCP service to Docker Compose with Nginx configuration

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -48,6 +48,15 @@ services:
         depends_on:
             - mysql
             - redis
+    mcp:
+        container_name: mcp${APP_CONTAINER_NAME}
+        image: "kanvas-mcp:dev"
+        ports:
+          - "8888:8888"
+        networks:
+            - sail
+        depends_on:
+            - php
     queue:
         <<: *common-queue-settings
         container_name: queue

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -24,6 +24,24 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location /mcp {
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE';
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range,Public-Key,Authorization,X-Kanvas-App,X-Kanvas-Key,X-Kanvas-Location';
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+
+        proxy_pass http://mcp:8888/mcp;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location ~ /\.ht {
         deny all;
     }


### PR DESCRIPTION
Introduce the MCP service in Docker Compose and configure Nginx to handle requests to the MCP endpoint, including CORS support.