### PR TITLE
Increase max body size and request body buffer size in unit.json

### DIFF
--- a/docker/unit.json
+++ b/docker/unit.json
@@ -1,4 +1,9 @@
 {
+    "settings": {
+        "http": {
+            "max_body_size": 100000000
+        }
+    },
     "listeners": {
         "*:8000": {
             "pass": "routes"
@@ -25,6 +30,7 @@
             "options": {
                 "file": "/usr/local/etc/php/conf.d/zx-app-config.ini"
             },
+            "request_body_buffer_size": 100000000,
             "processes": {}
         }
     }


### PR DESCRIPTION
Adjust the configuration to allow larger request bodies by increasing the maximum body size and request body buffer size.