### PR TITLE
Add HTTP settings with max body size to unit configuration

### DIFF
--- a/docker/unit.json
+++ b/docker/unit.json
@@ -1,4 +1,9 @@
 {
+    "settings": {
+        "http": {
+            "max_body_size": 100000000
+        }
+    },
     "listeners": {
         "*:8000": {
             "pass": "routes"


### PR DESCRIPTION
Introduce a configuration for HTTP settings to specify a maximum body size limit.