### PR TITLE
Add title field to channels and update message title generation

### DIFF
--- a/database/migrations/Social/2025_05_28_121830_add_channel_title.php
+++ b/database/migrations/Social/2025_05_28_121830_add_channel_title.php
@@ -11,7 +11,7 @@ return new class () extends Migration {
     public function up(): void
     {
         Schema::table('channels', function (Blueprint $table) {
-            $table->string('title')->nullable()->after('users_id');
+            $table->string('title')->nullable()->after('name');
         });
     }
 

--- a/database/migrations/Social/2025_05_28_121830_add_channel_title.php
+++ b/database/migrations/Social/2025_05_28_121830_add_channel_title.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->string('title')->nullable()->after('users_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('channels', function (Blueprint $table) {
+            $table->dropColumn('title');
+        });
+    }
+};

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -7,7 +7,6 @@ namespace Kanvas\Connectors\PromptMine\Workflows\Activities;
 use Baka\Contracts\AppInterface;
 use Kanvas\Connectors\PromptMine\Client as PromptClient;
 use Kanvas\Connectors\PromptMine\Enums\MessageTypeEnum;
-use Kanvas\Social\Channels\Models\Channel;
 use Kanvas\Social\Messages\Actions\CreateMessageAction;
 use Kanvas\Social\Messages\DataTransferObject\MessageInput;
 use Kanvas\Social\Messages\Models\Message;
@@ -94,13 +93,9 @@ class LLMMessageResponseActivity extends KanvasActivity
                     ),
                 ))->execute();
 
-                $promptChannel = Channel::fromApp($app)
-                    ->where('entity_id', $message->getId())
-                    ->where('entity_namespace', $message::class)
-                    ->where('is_deleted', 0)
-                    ->first();
-                
-                if ($promptChannel) {
+                $promptChannel = $message->channels->first();
+
+                if ($promptChannel && empty($promptChannel->title)) {
                     $promptChannel->title = $message->message['title'] ?? $nuggetTitle;
                     $promptChannel->save();
                 }

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -99,7 +99,6 @@ class LLMMessageResponseActivity extends KanvasActivity
                     ->where('entity_namespace', $message::class)
                     ->where('is_deleted', 0)
                     ->first();
-                
                 $promptChannel->title = $nuggetTitle;
                 $promptChannel->save();
 

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -96,7 +96,8 @@ class LLMMessageResponseActivity extends KanvasActivity
                 $promptChannel = $message->channels->first();
 
                 if ($promptChannel && empty($promptChannel->title)) {
-                    $promptChannel->title = $message->message['title'] ?? $nuggetTitle;
+                    $promptChannel->name = $message->message['title'] ?? $nuggetTitle;
+                    $promptChannel->title = $promptChannel->name;
                     $promptChannel->save();
                 }
 

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -99,7 +99,7 @@ class LLMMessageResponseActivity extends KanvasActivity
                     ->where('entity_namespace', $message::class)
                     ->where('is_deleted', 0)
                     ->first();
-                $promptChannel->title = $nuggetTitle;
+                $promptChannel->title = $message->message['title'] ?? $nuggetTitle;
                 $promptChannel->save();
 
                 return [

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -7,6 +7,7 @@ namespace Kanvas\Connectors\PromptMine\Workflows\Activities;
 use Baka\Contracts\AppInterface;
 use Kanvas\Connectors\PromptMine\Client as PromptClient;
 use Kanvas\Connectors\PromptMine\Enums\MessageTypeEnum;
+use Kanvas\Social\Channels\Models\Channel;
 use Kanvas\Social\Messages\Actions\CreateMessageAction;
 use Kanvas\Social\Messages\DataTransferObject\MessageInput;
 use Kanvas\Social\Messages\Models\Message;
@@ -57,9 +58,12 @@ class LLMMessageResponseActivity extends KanvasActivity
                         'message_id' => $message->id,
                     ];
                 }
+
+                $nuggetTitle = $this->generateTitleByPrompt($prompt);
+
                 $messageInput = [
                     'message' => [
-                        'title' => 'Prompt Title',
+                        'title' => $nuggetTitle,
                         $messageTypeKey => $response,
                         'type' => $isTypeImage ? MessageTypeEnum::IMAGE_FORMAT->value : MessageTypeEnum::TEXT_FORMAT->value,
                     ],
@@ -90,6 +94,15 @@ class LLMMessageResponseActivity extends KanvasActivity
                     ),
                 ))->execute();
 
+                $promptChannel = Channel::fromApp($app)
+                    ->where('entity_id', $message->getId())
+                    ->where('entity_namespace', $message::class)
+                    ->where('is_deleted', 0)
+                    ->first();
+                
+                $promptChannel->title = $nuggetTitle;
+                $promptChannel->save();
+
                 return [
                     'result' => true,
                     'child_message' => $createMessage->toArray(),
@@ -113,9 +126,9 @@ class LLMMessageResponseActivity extends KanvasActivity
         }
 
         $response = Prism::text()
-           ->using(Provider::Gemini, 'gemini-2.0-flash')
-           ->withPrompt($prompt)
-           ->asText();
+            ->using(Provider::Gemini, 'gemini-2.0-flash')
+            ->withPrompt($prompt)
+            ->asText();
 
         return str_replace(['```', 'json'], '', $response->text);
     }
@@ -126,5 +139,15 @@ class LLMMessageResponseActivity extends KanvasActivity
         $prompt = $message->message['prompt'] ?? null;
 
         return $promptClient->extractImageUrl($promptClient->generateImageWithIdeogram($prompt));
+    }
+
+    private function generateTitleByPrompt(string $prompt): string
+    {
+        $response = Prism::text()
+            ->using(Provider::Gemini, 'gemini-2.0-flash')
+            ->withPrompt('Generate a short concise title from this prompt: ' . $prompt . '.Choose just one title, dont give me suggestions')
+            ->generate();
+
+        return str_replace(['```', 'json'], '', $response->text);
     }
 }

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -99,8 +99,11 @@ class LLMMessageResponseActivity extends KanvasActivity
                     ->where('entity_namespace', $message::class)
                     ->where('is_deleted', 0)
                     ->first();
-                $promptChannel->title = $message->message['title'] ?? $nuggetTitle;
-                $promptChannel->save();
+                
+                if ($promptChannel) {
+                    $promptChannel->title = $message->message['title'] ?? $nuggetTitle;
+                    $promptChannel->save();
+                }
 
                 return [
                     'result' => true,


### PR DESCRIPTION
Introduce a title field in the channels table and enhance message title generation by creating a concise title from prompts. This improves the organization and clarity of messages within channels.