### PR TITLE
Refactor filesystem entity queries to use query builder and disable caching

### DIFF
--- a/src/Kanvas/Filesystem/Repositories/FilesystemEntitiesRepository.php
+++ b/src/Kanvas/Filesystem/Repositories/FilesystemEntitiesRepository.php
@@ -30,12 +30,12 @@ class FilesystemEntitiesRepository
         // }
 
         return FilesystemEntities::where('id', $id)
-                                ->where('system_modules_id', $systemModule->getKey())
-                                ->where('is_deleted', StateEnums::NO->getValue())
-                                ->whereRaw(
-                                    "filesystem_id in (SELECT s.id from filesystem s WHERE s.apps_id = {$app->getKey()})"
-                                )
-                                ->firstOrFail();
+            ->where('system_modules_id', $systemModule->getKey())
+            ->where('is_deleted', StateEnums::NO->getValue())
+            ->whereRaw(
+                "filesystem_id in (SELECT s.id from filesystem s WHERE s.apps_id = {$app->getKey()})"
+            )
+            ->firstOrFail();
     }
 
     /**
@@ -49,22 +49,24 @@ class FilesystemEntitiesRepository
         $app = $entity->app ?? app(Apps::class);
         $systemModule = SystemModulesRepository::getByModelName($entity::class, $app);
 
-        return FilesystemEntities::join('filesystem', 'filesystem.id', '=', 'filesystem_entities.filesystem_id')
-                    ->where('filesystem_entities.entity_id', '=', $entity->getKey())
-                    ->where('filesystem_entities.system_modules_id', '=', $systemModule->getKey())
-                    ->where('filesystem_entities.is_deleted', '=', StateEnums::NO->getValue())
-                    ->where('filesystem.is_deleted', '=', StateEnums::NO->getValue())
-                    ->select(
-                        'filesystem_entities.*',
-                        'filesystem.url',
-                        'filesystem.path',
-                        'filesystem.name',
-                        'filesystem.apps_id',
-                        'filesystem.users_id',
-                        'filesystem.size',
-                        'filesystem.file_type'
-                    )
-                    ->get();
+        return FilesystemEntities::query()
+            ->disableCache()
+            ->join('filesystem', 'filesystem.id', '=', 'filesystem_entities.filesystem_id')
+            ->where('filesystem_entities.entity_id', '=', $entity->getKey())
+            ->where('filesystem_entities.system_modules_id', '=', $systemModule->getKey())
+            ->where('filesystem_entities.is_deleted', '=', StateEnums::NO->getValue())
+            ->where('filesystem.is_deleted', '=', StateEnums::NO->getValue())
+            ->select(
+                'filesystem_entities.*',
+                'filesystem.url',
+                'filesystem.path',
+                'filesystem.name',
+                'filesystem.apps_id',
+                'filesystem.users_id',
+                'filesystem.size',
+                'filesystem.file_type'
+            )
+            ->get();
     }
 
     /**
@@ -75,42 +77,46 @@ class FilesystemEntitiesRepository
         $app = $entity->app ?? app(Apps::class);
         $systemModule = SystemModulesRepository::getByModelName($entity::class, $app);
 
-        return FilesystemEntities::join('filesystem', 'filesystem.id', '=', 'filesystem_entities.filesystem_id')
-                    ->where('filesystem_entities.entity_id', '=', $entity->getKey())
-                    ->where('filesystem_entities.system_modules_id', '=', $systemModule->getKey())
-                    ->where('filesystem_entities.is_deleted', '=', StateEnums::NO->getValue())
-                    ->where('filesystem_entities.field_name', '=', $name)
-                    ->where('filesystem.is_deleted', '=', StateEnums::NO->getValue())
-                    ->select(
-                        'filesystem_entities.*',
-                        'filesystem.url',
-                        'filesystem.path',
-                        'filesystem.name',
-                        'filesystem.apps_id',
-                        'filesystem.users_id',
-                        'filesystem.size',
-                        'filesystem.file_type'
-                    )
-                    ->first();
+        return FilesystemEntities::query()
+            ->disableCache()
+            ->join('filesystem', 'filesystem.id', '=', 'filesystem_entities.filesystem_id')
+            ->where('filesystem_entities.entity_id', '=', $entity->getKey())
+            ->where('filesystem_entities.system_modules_id', '=', $systemModule->getKey())
+            ->where('filesystem_entities.is_deleted', '=', StateEnums::NO->getValue())
+            ->where('filesystem_entities.field_name', '=', $name)
+            ->where('filesystem.is_deleted', '=', StateEnums::NO->getValue())
+            ->select(
+                'filesystem_entities.*',
+                'filesystem.url',
+                'filesystem.path',
+                'filesystem.name',
+                'filesystem.apps_id',
+                'filesystem.users_id',
+                'filesystem.size',
+                'filesystem.file_type'
+            )
+            ->first();
     }
 
     public static function getFileFromEntityById(int $id): ?FilesystemEntities
     {
-        return FilesystemEntities::join('filesystem', 'filesystem.id', '=', 'filesystem_entities.filesystem_id')
-                    ->where('filesystem_entities.id', '=', $id)
-                    ->where('filesystem_entities.is_deleted', '=', StateEnums::NO->getValue())
-                    ->where('filesystem.is_deleted', '=', StateEnums::NO->getValue())
-                    ->select(
-                        'filesystem_entities.*',
-                        'filesystem.url',
-                        'filesystem.path',
-                        'filesystem.name',
-                        'filesystem.apps_id',
-                        'filesystem.users_id',
-                        'filesystem.size',
-                        'filesystem.file_type'
-                    )
-                    ->first();
+        return FilesystemEntities::query()
+            ->disableCache()
+            ->join('filesystem', 'filesystem.id', '=', 'filesystem_entities.filesystem_id')
+            ->where('filesystem_entities.id', '=', $id)
+            ->where('filesystem_entities.is_deleted', '=', StateEnums::NO->getValue())
+            ->where('filesystem.is_deleted', '=', StateEnums::NO->getValue())
+            ->select(
+                'filesystem_entities.*',
+                'filesystem.url',
+                'filesystem.path',
+                'filesystem.name',
+                'filesystem.apps_id',
+                'filesystem.users_id',
+                'filesystem.size',
+                'filesystem.file_type'
+            )
+            ->first();
     }
 
     /**


### PR DESCRIPTION
Refactor filesystem entity queries to improve readability and performance by utilizing a query builder and disabling caching for specific queries.