### PR TITLE
Refactor nugget generation count checks in MessageObserver

### DIFF
--- a/app/Console/Commands/Workflows/KanvasWorkflowSynActionCommand.php
+++ b/app/Console/Commands/Workflows/KanvasWorkflowSynActionCommand.php
@@ -41,6 +41,7 @@ use Kanvas\Connectors\OfferLogix\Workflow\SoftPullActivity;
 use Kanvas\Connectors\OfferLogix\Workflow\SoftPullFromLeadActivity;
 use Kanvas\Connectors\PasoRapido\Workflows\Activities\CreatePasoRapidoOrderActivity;
 use Kanvas\Connectors\PlateRecognizer\Workflows\ProcessVehicleImageActivity;
+use Kanvas\Connectors\PromptMine\Workflows\Activities\CheckNuggetGenerationCountActivity;
 use Kanvas\Connectors\PromptMine\Workflows\Activities\LLMMessageResponseActivity;
 use Kanvas\Connectors\PromptMine\Workflows\Activities\PremiumPromptFlagActivity;
 use Kanvas\Connectors\PromptMine\Workflows\Activities\PromptImageFilterActivity;
@@ -198,7 +199,8 @@ class KanvasWorkflowSynActionCommand extends Command
             AddFundsToWalletActivity::class,
             PushOrderToNetsuiteActivity::class,
             CheckMessageContentActivity::class,
-            B2BUpdateCompanyOrderActivity::class
+            B2BUpdateCompanyOrderActivity::class,
+            CheckNuggetGenerationCountActivity::class,
         ];
 
         $createdActions = [];

--- a/src/Domains/Connectors/PromptMine/Actions/CheckNuggetGenerationCountAction.php
+++ b/src/Domains/Connectors/PromptMine/Actions/CheckNuggetGenerationCountAction.php
@@ -14,11 +14,12 @@ class CheckNuggetGenerationCountAction
 {
     public function __construct(
         private Message $message,
-    ) {}
+    ) {
+    }
 
     public function execute(): bool
     {
-        $loggedUsed = auth()->user();
+        //$loggedUsed = auth()->user();
         $messageType = MessageType::findOrFail($this->message->app->get('free-generation-check-message-type'));
         $messageOrder = AppModuleMessage::fromApp($this->message->app->getId())
             ->where('apps_id', $this->message->app->getId())
@@ -29,7 +30,8 @@ class CheckNuggetGenerationCountAction
             ->where('is_deleted', 0)
             ->first();
 
-        if (($this->message->parent->total_children > $this->message->app->get('nugget-free-generation-limit') && $loggedUsed->getId() == $this->message->user->getId()) || ($messageOrder && !$messageOrder->entity->isCompleted())) {
+        if (($this->message->parent->total_children > $this->message->app->get('nugget-free-generation-limit'))
+            || ($messageOrder && ! $messageOrder->entity->isCompleted())) {
             throw new Exception('You have reached the limit of nuggets you can generate for free');
         }
 

--- a/src/Domains/Connectors/PromptMine/Actions/CheckNuggetGenerationCountAction.php
+++ b/src/Domains/Connectors/PromptMine/Actions/CheckNuggetGenerationCountAction.php
@@ -7,34 +7,31 @@ namespace Kanvas\Connectors\PromptMine\Actions;
 use Exception;
 use Kanvas\Social\Messages\Models\AppModuleMessage;
 use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Social\MessagesTypes\Models\MessageType;
 use Kanvas\Souk\Orders\Models\Order;
 
 class CheckNuggetGenerationCountAction
 {
     public function __construct(
         private Message $message,
-    ) {
-    }
+    ) {}
 
     public function execute(): bool
     {
-        $freeGenerationCountCustomField = $this->message->user->getId() . '-nugget-free-generation-count';
+        $loggedUsed = auth()->user();
+        $messageType = MessageType::findOrFail($this->message->app->get('free-generation-check-message-type'));
         $messageOrder = AppModuleMessage::fromApp($this->message->app->getId())
             ->where('apps_id', $this->message->app->getId())
             ->where('companies_id', $this->message->company->getId())
+            ->where('message_types_id', $messageType->getId())
             ->where('system_modules', Order::class)
             ->where('entity_id', $this->message->getId())
             ->where('is_deleted', 0)
             ->first();
-        // $messageOrder = AppModuleMessage::find(121530);
 
-        if ($this->message->get($freeGenerationCountCustomField) > $this->message->app->get('nugget-free-generation-limit') && ! $messageOrder->entity->isCompleted()) {
+        if (($this->message->parent->total_children > $this->message->app->get('nugget-free-generation-limit') && $loggedUsed->getId() == $this->message->user->getId()) || ($messageOrder && !$messageOrder->entity->isCompleted())) {
             throw new Exception('You have reached the limit of nuggets you can generate for free');
         }
-
-        ! $this->message->get($freeGenerationCountCustomField) ?
-            $this->message->set($freeGenerationCountCustomField, 0) :
-            $this->message->increment($freeGenerationCountCustomField);
 
         return true;
     }

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/CheckNuggetGenerationCountActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/CheckNuggetGenerationCountActivity.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\PromptMine\Workflows\Activities;
+
+use Baka\Contracts\AppInterface;
+use Kanvas\Connectors\PromptMine\Actions\CheckNuggetGenerationCountAction;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\KanvasActivity;
+
+class CheckNuggetGenerationCountActivity extends KanvasActivity
+{
+    public $tries = 2;
+
+    public function execute(Message $message, AppInterface $app, array $params): array
+    {
+        $this->overwriteAppService($app);
+
+        if (! $app->get('check-free-generation-count') || ! $app->get('free-generation-check-message-type') || $message->parent_id === null) {
+            return [
+                'result' => true,
+                'message' => 'Free generation check is not enabled or message does not have a parent',
+            ];
+        }
+
+        return $this->executeIntegration(
+            entity: $message,
+            app: $app,
+            integration: IntegrationsEnum::PROMPT_MINE,
+            integrationOperation: function ($message, $app, $integrationCompany, $additionalParams) {
+                $checkNuggetGeneration = (new CheckNuggetGenerationCountAction($message))->execute();
+
+                return [
+                    'message' => 'Nugget generation count check completed successfully',
+                    'result' => $checkNuggetGeneration,
+                ];
+            },
+            company: $message->company,
+        );
+    }
+}

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PremiumPromptFlagActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PremiumPromptFlagActivity.php
@@ -49,7 +49,7 @@ class PremiumPromptFlagActivity extends KanvasActivity implements WorkflowActivi
             entity: $entity,
             app: $app,
             integration: IntegrationsEnum::PROMPT_MINE,
-            integrationOperation: function ($entity, $app) use ($messageData) {
+            integrationOperation: function ($entity, $app, $integrationCompany, $additionalParams) use ($messageData) {
                 $entity->setPremium();
 
                 $usersToNotify = UsersRepository::findUsersByArray($entity->app->get('owner_notification'), $app);

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/SaveLlmChoiceActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/SaveLlmChoiceActivity.php
@@ -39,7 +39,7 @@ class SaveLlmChoiceActivity extends KanvasActivity implements WorkflowActivityIn
             entity: $entity,
             app: $app,
             integration: IntegrationsEnum::PROMPT_MINE,
-            integrationOperation: function ($entity) use ($messageData) {
+            integrationOperation: function ($entity, $app, $integrationCompany, $additionalParams) use ($messageData) {
                 if (! isset($messageData['ai_model'])) {
                     return [
                         'result' => false,

--- a/src/Domains/Social/Messages/Observers/MessageObserver.php
+++ b/src/Domains/Social/Messages/Observers/MessageObserver.php
@@ -38,14 +38,9 @@ class MessageObserver
 
     public function created(Message $message): void
     {
-        /*         $message->fireWorkflow(WorkflowEnum::CREATED->value, true, [
-                    'app' => $message->app,
-                    'notification_name' => WorkflowEnum::CREATED->value . '-' . $message->messageType->name
-                ]); */
-
-        if ($message->app->get('check-free-generation-count') && $message->app->get('free-generation-check-message-type') && $message->parent_id) {
-            (new CheckNuggetGenerationCountAction($message))->execute();
-        }
+        /*         if ($message->app->get('check-free-generation-count') && $message->app->get('free-generation-check-message-type') && $message->parent_id) {
+                    (new CheckNuggetGenerationCountAction($message))->execute();
+                } */
 
         $message->clearLightHouseCacheJob();
     }

--- a/src/Domains/Social/Messages/Observers/MessageObserver.php
+++ b/src/Domains/Social/Messages/Observers/MessageObserver.php
@@ -26,10 +26,6 @@ class MessageObserver
             $checkJson = new MessageSchemaValidator($message, $message->messageType);
             $checkJson->validate();
         }
-
-        if ($message->app->get('check-free-generation-count')) {
-            //(new CheckNuggetGenerationCountAction($message))->execute();
-        }
     }
 
     public function saved(Message $message): void
@@ -46,6 +42,10 @@ class MessageObserver
                     'app' => $message->app,
                     'notification_name' => WorkflowEnum::CREATED->value . '-' . $message->messageType->name
                 ]); */
+
+        if ($message->app->get('check-free-generation-count') && $message->app->get('free-generation-check-message-type') && $message->parent_id) {
+            (new CheckNuggetGenerationCountAction($message))->execute();
+        }
 
         $message->clearLightHouseCacheJob();
     }


### PR DESCRIPTION
Streamline the checks for nugget generation limits by consolidating logic and ensuring the correct message type is used. This improves code clarity and efficiency in the `CheckNuggetGenerationCountAction`.