### PR TITLE
Update notification and user schemas to use slug and add unread notifications count

### DIFF
--- a/graphql/schemas/Ecosystem/notification.graphql
+++ b/graphql/schemas/Ecosystem/notification.graphql
@@ -67,7 +67,7 @@ input NotificationTypeFilterInput {
 }
 
 input SystemModuleFilterInput {
-    name: String
+    slug: String
     message_type_verb: String
 }
 

--- a/graphql/schemas/Ecosystem/user.graphql
+++ b/graphql/schemas/Ecosystem/user.graphql
@@ -34,6 +34,10 @@ type User {
     apps: [App!]! @HasManyThrough
     photo: Filesystem @method(name: "getPhoto")
     social: UserSocialInfo @method(name: "getSocialInfo")
+    notification_unread_count: Int
+        @field(
+            resolver: "Kanvas\\Notifications\\Models\\Notifications@getUnreadNotificationsCount"
+        )
     files: [Filesystem!]!
         @paginate(
             defaultCount: 25

--- a/graphql/schemas/Ecosystem/user.graphql
+++ b/graphql/schemas/Ecosystem/user.graphql
@@ -34,10 +34,7 @@ type User {
     apps: [App!]! @HasManyThrough
     photo: Filesystem @method(name: "getPhoto")
     social: UserSocialInfo @method(name: "getSocialInfo")
-    notification_unread_count: Int
-        @field(
-            resolver: "Kanvas\\Notifications\\Models\\Notifications@getUnreadNotificationsCount"
-        )
+    total_unread_notifications: Int! @method(name: "getUnreadNotificationsCount")
     files: [Filesystem!]!
         @paginate(
             defaultCount: 25

--- a/src/Kanvas/Notifications/Models/Notifications.php
+++ b/src/Kanvas/Notifications/Models/Notifications.php
@@ -169,14 +169,4 @@ class Notifications extends BaseModel
             $this->forceFill(['read' => 1])->save();
         }
     }
-
-    public function getUnreadNotificationsCount(): int
-    {
-        return (int) self::query()
-            ->where('users_id', auth()->user()->id)
-            ->where('is_deleted', StateEnums::NO->getValue())
-            ->where('read', StateEnums::NO->getValue())
-            ->where('apps_id', app(Apps::class)->id)
-            ->count();
-    }
 }

--- a/src/Kanvas/Notifications/Models/Notifications.php
+++ b/src/Kanvas/Notifications/Models/Notifications.php
@@ -111,8 +111,8 @@ class Notifications extends BaseModel
         if (isset($args['whereSystemModule'])) {
             $systemModuleFilter = $args['whereSystemModule'];
             $query->whereHas('systemModule', function ($query) use ($systemModuleFilter, $app) {
-                if ($systemModuleFilter['name']) {
-                    $notificationSystemModule = SystemModulesRepository::getByName($systemModuleFilter['name'], $app);
+                if ($systemModuleFilter['slug']) {
+                    $notificationSystemModule = SystemModulesRepository::getBySlug($systemModuleFilter['slug'], $app);
                     $query->where('system_modules_id', $notificationSystemModule->getId());
 
                     if ($notificationSystemModule::class == Message::class && isset($systemModuleFilter['message_type_verb'])) {
@@ -168,5 +168,15 @@ class Notifications extends BaseModel
         if (! $this->read) {
             $this->forceFill(['read' => 1])->save();
         }
+    }
+
+    public function getUnreadNotificationsCount(): int
+    {
+        return (int) self::query()
+            ->where('users_id', auth()->user()->id)
+            ->where('is_deleted', StateEnums::NO->getValue())
+            ->where('read', StateEnums::NO->getValue())
+            ->where('apps_id', app(Apps::class)->id)
+            ->count();
     }
 }

--- a/src/Kanvas/SystemModules/Repositories/SystemModulesRepository.php
+++ b/src/Kanvas/SystemModules/Repositories/SystemModulesRepository.php
@@ -67,6 +67,17 @@ class SystemModulesRepository
     }
 
     /**
+     * Get by slug
+     */
+    public static function getBySlug(string $slug, ?AppInterface $app = null): SystemModules
+    {
+        $app = $app === null ? app(Apps::class) : $app;
+        return SystemModules::where('slug', $slug)
+                                    ->where('apps_id', $app->getKey())
+                                    ->firstOrFail();
+    }
+
+    /**
      * Get the entity from the input
      */
     public static function getEntityFromInput(SystemModuleInputInterface $entityInput, Users $user, bool $useCompanyReference = true): Model

--- a/src/Kanvas/Users/Models/Users.php
+++ b/src/Kanvas/Users/Models/Users.php
@@ -1043,4 +1043,14 @@ class Users extends Authenticatable implements UserInterface, ContractsAuthentic
     {
         return $this->getRoles()->toArray();
     }
+
+    public function getUnreadNotificationsCount(): int
+    {
+        return (int) Notifications::query()
+            ->where('users_id', $this->id)
+            ->where('is_deleted', StateEnums::NO->getValue())
+            ->where('read', StateEnums::NO->getValue())
+            ->where('apps_id', app(Apps::class)->id)
+            ->count();
+    }
 }


### PR DESCRIPTION
Refactor the notification and user schemas to utilize a slug for system modules instead of a name. Introduce a new field to track the count of unread notifications for users.