### PR TITLE
Fix method name typo and add cache disable option for file retrieval

### DIFF
--- a/src/Kanvas/Filesystem/Repositories/FilesystemEntitiesRepository.php
+++ b/src/Kanvas/Filesystem/Repositories/FilesystemEntitiesRepository.php
@@ -75,7 +75,7 @@ class FilesystemEntitiesRepository
      *
      * @psalm-suppress MixedReturnStatement
      */
-    public static function getFileFromEntityByNamBuilder(Model $entity, string $name): Builder
+    public static function getFileFromEntityByNameBuilder(Model $entity, string $name): Builder
     {
         $app = $entity->app ?? app(Apps::class);
         $systemModule = SystemModulesRepository::getByModelName($entity::class, $app);
@@ -100,7 +100,7 @@ class FilesystemEntitiesRepository
 
     public static function getFileFromEntityByName(Model $entity, string $name): ?FilesystemEntities
     {
-        return self::getFileFromEntityByNamBuilder($entity, $name)->orderBy('filesystem_entities.id', 'DESC')->first();
+        return self::getFileFromEntityByNameBuilder($entity, $name)->orderBy('filesystem_entities.id', 'DESC')->first();
     }
 
     /**
@@ -128,9 +128,10 @@ class FilesystemEntitiesRepository
     /**
      * Get file from entity by ID.
      */
-    public static function getFileFromEntityById(int $id): ?FilesystemEntities
+    public static function getFileFromEntityById(int $id, bool $disableCache = false): ?FilesystemEntities
     {
-        return FilesystemEntities::join('filesystem', 'filesystem.id', '=', 'filesystem_entities.filesystem_id')
+        $query = FilesystemEntities::query()
+            ->join('filesystem', 'filesystem.id', '=', 'filesystem_entities.filesystem_id')
             ->where('filesystem_entities.id', '=', $id)
             ->where('filesystem_entities.is_deleted', '=', StateEnums::NO->getValue())
             ->where('filesystem.is_deleted', '=', StateEnums::NO->getValue())
@@ -143,8 +144,8 @@ class FilesystemEntitiesRepository
                 'filesystem.users_id',
                 'filesystem.size',
                 'filesystem.file_type'
-            )
-            ->first();
+            );
+        return $disableCache ? $query->disableCache()->first() : $query->first();
     }
 
     /**

--- a/src/Kanvas/Users/Models/Users.php
+++ b/src/Kanvas/Users/Models/Users.php
@@ -792,7 +792,7 @@ class Users extends Authenticatable implements UserInterface, ContractsAuthentic
         $app = app(Apps::class);
         $defaultAvatarId = $app->get(AppSettingsEnums::DEFAULT_USER_AVATAR->getValue());
 
-        return $this->getFileByName('photo') ?: ($defaultAvatarId ? FilesystemEntitiesRepository::getFileFromEntityById($defaultAvatarId) : null);
+        return $this->getFileByName('photo') ?: ($defaultAvatarId ? FilesystemEntitiesRepository::getFileFromEntityById($defaultAvatarId, true) : null);
     }
 
     public function getSocialInfo(): array


### PR DESCRIPTION
Correct a method name typo and introduce an option to disable caching when retrieving files by ID. This enhances flexibility in file retrieval operations.