### PR TITLE
Add messageTypeId parameter to CheckMessagePostLimitAction

### DIFF
--- a/src/Domains/Social/Messages/Observers/MessageObserver.php
+++ b/src/Domains/Social/Messages/Observers/MessageObserver.php
@@ -19,7 +19,8 @@ class MessageObserver
             Log::info('Checking Message Post Limit');
             (new CheckMessagePostLimitAction(
                 message: $message,
-                getChildrenCount: true
+                getChildrenCount: true,
+                messageTypeId: $message->message_types_id
             ))->execute();
         }
 


### PR DESCRIPTION
Include the messageTypeId parameter in the CheckMessagePostLimitAction to enhance message limit checks based on message type.