### PR TITLE
Enhance message type handling in post limit checks

### DIFF
--- a/src/Domains/Social/Messages/Actions/CheckMessagePostLimitAction.php
+++ b/src/Domains/Social/Messages/Actions/CheckMessagePostLimitAction.php
@@ -30,7 +30,7 @@ class CheckMessagePostLimitAction
      */
     public function execute()
     {
-        Log::info("Checking...");
+        Log::info("Checking with message type $this->messageTypeId");
         $messageCount = Message::getUserMessageCountInTimeFrame(
             $this->message->user->getId(),
             $this->message->app,
@@ -38,6 +38,9 @@ class CheckMessagePostLimitAction
             $this->messageTypeId,
             $this->getChildrenCount
         );
+
+        $messageLimit = $this->message->app->get('message-post-limit');
+        Log:info("Message Count for today: $messageCount of $messageLimit");
 
         if ($messageCount >= $this->message->app->get('message-post-limit')) {
             throw new Exception('Your daily limit has been reached.');

--- a/src/Domains/Social/Messages/Observers/MessageObserver.php
+++ b/src/Domains/Social/Messages/Observers/MessageObserver.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Log;
 use Kanvas\Social\Messages\Actions\CheckMessagePostLimitAction;
 use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Social\Messages\Validations\MessageSchemaValidator;
+use Kanvas\Social\MessagesTypes\Repositories\MessagesTypesRepository;
 use Kanvas\Workflow\Enums\WorkflowEnum;
 
 class MessageObserver
@@ -15,11 +16,15 @@ class MessageObserver
     public function creating(Message $message): void
     {
         //$messageData = is_array($message->message) ? $message->message : json_decode($message->message, true);
-        if ($message->app->get('message-image-type') && is_array($message->message) && isset($message->message['type']) && $message->message['type'] === 'image-format') {
+        if ($message->app->get('message-image-type') 
+                && is_array($message->message) 
+                && isset($message->message['type']) 
+                && $message->message['type'] === 'image-format'
+                && MessagesTypesRepository::getById($message->message_types_id, $message->app)->verb == $message->app->get('image-generation-limit-message-type-verb') 
+                ) {
             Log::info('Checking Message Post Limit');
             (new CheckMessagePostLimitAction(
                 message: $message,
-                getChildrenCount: true,
                 messageTypeId: $message->message_types_id
             ))->execute();
         }

--- a/src/Domains/Social/Messages/Observers/MessageObserver.php
+++ b/src/Domains/Social/Messages/Observers/MessageObserver.php
@@ -16,11 +16,13 @@ class MessageObserver
     public function creating(Message $message): void
     {
         //$messageData = is_array($message->message) ? $message->message : json_decode($message->message, true);
-        if ($message->app->get('message-image-type') 
-                && is_array($message->message) 
-                && isset($message->message['type']) 
-                && $message->message['type'] === 'image-format'
-                && MessagesTypesRepository::getById($message->message_types_id, $message->app)->verb == $message->app->get('image-generation-limit-message-type-verb') ) {
+        if (
+            $message->app->get('message-image-type')
+            && is_array($message->message)
+            && isset($message->message['type'])
+            && $message->message['type'] === 'image-format'
+            && MessagesTypesRepository::getById($message->message_types_id, $message->app)->verb == $message->app->get('image-generation-limit-message-type-verb')
+        ) {
             Log::info('Checking Message Post Limit');
             (new CheckMessagePostLimitAction(
                 message: $message,

--- a/src/Domains/Social/Messages/Observers/MessageObserver.php
+++ b/src/Domains/Social/Messages/Observers/MessageObserver.php
@@ -20,8 +20,7 @@ class MessageObserver
                 && is_array($message->message) 
                 && isset($message->message['type']) 
                 && $message->message['type'] === 'image-format'
-                && MessagesTypesRepository::getById($message->message_types_id, $message->app)->verb == $message->app->get('image-generation-limit-message-type-verb') 
-                ) {
+                && MessagesTypesRepository::getById($message->message_types_id, $message->app)->verb == $message->app->get('image-generation-limit-message-type-verb') ) {
             Log::info('Checking Message Post Limit');
             (new CheckMessagePostLimitAction(
                 message: $message,


### PR DESCRIPTION
Improve handling of message types in the `CheckMessagePostLimitAction` and `MessageObserver` to ensure accurate logging and limit checks based on message type.