### PR TITLE
Ensure Redis settings are regenerated before checking message limits

### DIFF
--- a/src/Domains/Social/Messages/Actions/CheckMessagePostLimitAction.php
+++ b/src/Domains/Social/Messages/Actions/CheckMessagePostLimitAction.php
@@ -39,6 +39,7 @@ class CheckMessagePostLimitAction
             $this->getChildrenCount
         );
 
+        $this->message->app->reGenerateRedisSettings();
         $messageLimit = $this->message->app->get('message-post-limit');
         Log:info("Message Count for today: $messageCount of $messageLimit");
 


### PR DESCRIPTION
Regenerate Redis settings to ensure accurate message limit checks.