### PR TITLE
Add method to retrieve children of Message entities

### DIFF
--- a/graphql/schemas/Ecosystem/notification.graphql
+++ b/graphql/schemas/Ecosystem/notification.graphql
@@ -9,6 +9,7 @@ type Notification {
     types(filter: NotificationTypeFilterInput): NotificationType!
     entity_id: String!
     entity(fields: JSON): Mixed @method(name: "getEntityData")
+    entity_children(fields: JSON): Mixed @method(name: "getEntityChildrenData")
     content: String
     read: Int!
     content_group: String

--- a/src/Kanvas/Notifications/Models/Notifications.php
+++ b/src/Kanvas/Notifications/Models/Notifications.php
@@ -173,7 +173,6 @@ class Notifications extends BaseModel
             $systemModule = $this->systemModule()->firstOrFail();
             $modelName = $systemModule->model_name;
             $entity = $modelName::getById($this->entity_id);
-            
             if ($entity instanceof Message && is_null($entity->parent_id)) {
                 return $entity->children;
             }

--- a/src/Kanvas/Notifications/Models/Notifications.php
+++ b/src/Kanvas/Notifications/Models/Notifications.php
@@ -165,6 +165,25 @@ class Notifications extends BaseModel
     }
 
     /**
+     * Get entity children if it is a instance of Messages and has parent_id NULL
+     */
+    public function getEntityChildrenData(): mixed
+    {
+        try {
+            $systemModule = $this->systemModule()->firstOrFail();
+            $modelName = $systemModule->model_name;
+            $entity = $modelName::getById($this->entity_id);
+            
+            if ($entity instanceof Message && is_null($entity->parent_id)) {
+                return $entity->children;
+            }
+        } catch (Throwable $e) {
+        }
+
+        return null;
+    }
+
+    /**
      * Mark the notification as read.
      */
     public function markAsRead(): void


### PR DESCRIPTION
Introduce a new method to fetch children of Message entities when the parent_id is null. This enhances the functionality related to entity data retrieval.