### PR TITLE
Ensure setFromUser is called in NewFollowerNotification constructor

### DIFF
--- a/src/Domains/Social/Follows/Notifications/NewFollowerNotification.php
+++ b/src/Domains/Social/Follows/Notifications/NewFollowerNotification.php
@@ -19,6 +19,7 @@ class NewFollowerNotification extends Notification
         ?string $notificationTypeName = null
     ) {
         parent::__construct($user, $data);
+        $this->setFromUser($user);
         $this->setType($notificationTypeName ?? EmailTemplateEnum::BLANK->value);
         $this->setTemplateName(NotificationTemplateEnum::EMAIL_NEW_FOLLOWER->value);
         $this->setPushTemplateName(NotificationTemplateEnum::PUSH_NEW_FOLLOWER->value);


### PR DESCRIPTION
Call setFromUser in the constructor of NewFollowerNotification to ensure the user is properly set.