### PR TITLE
Change message deletion to soft delete in MessageManagementMutation

### DIFF
--- a/app/GraphQL/Social/Mutations/Messages/MessageManagementMutation.php
+++ b/app/GraphQL/Social/Mutations/Messages/MessageManagementMutation.php
@@ -166,7 +166,7 @@ class MessageManagementMutation
             throw new AuthenticationException('You are not allowed to delete this message');
         }
 
-        return $message->delete();
+        return $message->softDelete();
     }
 
     public function deleteMultiple(mixed $root, array $request): bool


### PR DESCRIPTION
Update the message deletion method to perform a soft delete instead of a hard delete, preserving message data for potential recovery.