### PR TITLE
Update delete method for hard delete and unsearchable operation

### DIFF
--- a/app/GraphQL/Social/Mutations/Messages/MessageManagementMutation.php
+++ b/app/GraphQL/Social/Mutations/Messages/MessageManagementMutation.php
@@ -166,7 +166,13 @@ class MessageManagementMutation
             throw new AuthenticationException('You are not allowed to delete this message');
         }
 
-        return $message->softDelete();
+        $deleteStatus = $message->delete();
+
+        if ($deleteStatus && $message->searchable()) {
+            $message->unsearchable();
+        }
+
+        return $deleteStatus;
     }
 
     public function deleteMultiple(mixed $root, array $request): bool


### PR DESCRIPTION
The delete method now performs a hard delete and marks the message as unsearchable if it was previously searchable. This change enhances message management by ensuring proper deletion and searchability status.