### PR TITLE
Comment out Redis settings regeneration in message post limit check

### DIFF
--- a/src/Domains/Social/Messages/Actions/CheckMessagePostLimitAction.php
+++ b/src/Domains/Social/Messages/Actions/CheckMessagePostLimitAction.php
@@ -39,7 +39,7 @@ class CheckMessagePostLimitAction
             $this->getChildrenCount
         );
 
-        $this->message->app->reGenerateRedisSettings();
+        // $this->message->app->reGenerateRedisSettings();
         //$messageLimit = $this->message->app->get('message-post-limit');
         //Log:info("Message Count for today: $messageCount of $messageLimit");
 


### PR DESCRIPTION
Disable the regeneration of Redis settings during the message post limit check to prevent unnecessary processing.