### PR TITLE
refactor: Refine Google AI tag generation

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/GoogleGenerateTagsForAllMessageCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/GoogleGenerateTagsForAllMessageCommand.php
@@ -51,7 +51,7 @@ class GoogleGenerateTagsForAllMessageCommand extends Command
 
         $this->output->progressStart($totalMessages);
         $featureTags = Tag::fromApp($app)->where('is_feature', 1)->get()->pluck('name')->toArray();
-        $tagsToIgnore = ['openai', 'gemini', 'claude', 'xai', 'groq', 'flux', 'dalle3', 'deepseekai', 'trending'];
+        $tagsToIgnore = ['openai', 'gemini', 'claude', 'xai', 'groq', 'flux', 'dalle3', 'deepseekai', 'trending', 'Trending'];
         $allTags = Tag::fromApp($app)->notDeleted()->whereNotIn('slug', $tagsToIgnore)->get()->pluck('name')->toArray();
 
         foreach ($cursor as $message) {

--- a/src/Domains/Connectors/Google/Actions/GenerateMessageTagAction.php
+++ b/src/Domains/Connectors/Google/Actions/GenerateMessageTagAction.php
@@ -41,12 +41,11 @@ class GenerateMessageTagAction
             return $this->message;
         }
 
-        $additionalInstructions = "If you detect/encounter any of this please use the specific tag for it: 
-                - 'text-to-image': image
-                - 'text-to-video': video
-                - 'text-to-text': text
-                Take into account that it's possible that the message contains multiple topics, so choose the most relevant tags.
-                Also, not always the type of format(image, video, text) is evident, so use your best judgement.";
+        $additionalInstructions = "If you detect/encounter any of this keys on the message please add theses specific tag for it: 
+                - 'image': image
+                - 'video': video
+                - 'nugget': text
+                Take into account that it's possible that the message contains multiple topics, so choose the most relevant tags.";
 
         $geminiTagService = new GeminiTagService();
         $tags = $geminiTagService->generateTags($messageText, $tags, $totalTags, $additionalInstructions);


### PR DESCRIPTION
This commit improves the automatic tag generation process by updating the instructions provided to the Google Gemini model and refining the tag ignore list.

- The AI instructions are simplified to use more direct keywords ('image', 'video') and a new keyword ('nugget') to trigger the 'text' tag, aiming for more accurate results.
- The capitalized 'Trending' tag is added to the ignore list to handle case-sensitivity issues in the generation command.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
