### PR TITLE
feat: Refine Gemini instructions for message tagging

### DIFF
--- a/src/Domains/Connectors/Google/Actions/GenerateMessageTagAction.php
+++ b/src/Domains/Connectors/Google/Actions/GenerateMessageTagAction.php
@@ -42,9 +42,10 @@ class GenerateMessageTagAction
         }
 
         $additionalInstructions = "If you detect/encounter any of this keys on the message please add the specific tag for it: 
-                - 'image': image
-                - 'video': video
-                - 'nugget': text";
+                - 'image' or the key 'type' with a value 'image-format': image
+                - 'video' or the key 'type' with a value 'video-format': video
+                - 'nugget' or the key 'type' with a value 'text-format': text
+                You should only assign one tag per type, if you detect more than one just assign the most relevant one.";
 
         $geminiTagService = new GeminiTagService();
         $tags = $geminiTagService->generateTags($messageText, $tags, $totalTags, $additionalInstructions);


### PR DESCRIPTION
Update the additional instructions provided to the Gemini AI to improve the accuracy and flexibility of tag generation.

The new instructions allow the model to identify content types based on a 'type' key (e.g., 'type': 'image-format') in addition to the existing direct keys ('image', 'video', 'nugget').

A new rule is also introduced to ensure only the single most relevant tag is assigned per message, preventing ambiguity when multiple content types are detected.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
