### PR TITLE
Fix: Improve prompt formatting for Gemini tagging

### DIFF
--- a/src/Domains/Connectors/Google/Actions/GenerateMessageTagAction.php
+++ b/src/Domains/Connectors/Google/Actions/GenerateMessageTagAction.php
@@ -44,7 +44,7 @@ class GenerateMessageTagAction
         $additionalInstructions = "If you detect/encounter any of this keys on the message please add the specific tag for it: 
                 - 'image' or the key 'type' with a value 'image-format': image
                 - 'video' or the key 'type' with a value 'video-format': video
-                - 'nugget' or the key 'type' with a value 'text-format': text
+                - 'nugget' or the key 'type' with a value 'text-format': text \n
                 You should only assign one tag per type, if you detect more than one just assign the most relevant one.";
 
         $geminiTagService = new GeminiTagService();

--- a/src/Domains/Connectors/Google/Services/GeminiTagService.php
+++ b/src/Domains/Connectors/Google/Services/GeminiTagService.php
@@ -15,7 +15,7 @@ class GeminiTagService
      */
     public function generateTags(string $message, array $availableTags, int $limit = 3, string $additionalInstructions = ''): array
     {
-        $prompt = "Given the following message:\n\n\"$message\"\n\nSelect the **{$limit} most relevant** tags from this list: " . implode(', ', $availableTags) . $additionalInstructions;
+        $prompt = "Given the following message:\n\n\"$message\"\n\nSelect the **{$limit} most relevant** tags from this list: " . implode(', ', $availableTags) . PHP_EOL . $additionalInstructions;
         $response = Prism::text()
             ->using(Provider::Gemini, 'gemini-2.0-flash')
             ->withPrompt($prompt)


### PR DESCRIPTION
Add a newline character to the prompt sent to the Gemini service for tag generation.

This change separates the list of available tags from the additional instructions, creating a clearer and more structured prompt. Improving the prompt's readability helps the AI model better interpret the instructions, leading to more accurate and consistent results.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
