### PR TITLE
Add filters for public and non-deleted messages in search suggestions

### DIFF
--- a/app/GraphQL/Social/Builders/Messages/MessageBuilder.php
+++ b/app/GraphQL/Social/Builders/Messages/MessageBuilder.php
@@ -264,6 +264,7 @@ class MessageBuilder
         $results = $index->search($args['search'], [
             'hitsPerPage' => 15,
             'attributesToRetrieve' => ['name', 'description'],
+            'filters' => 'is_public = 1 AND is_deleted = 0',
         ]);
 
         return $results['hits'];

--- a/src/Domains/Social/Messages/Models/Message.php
+++ b/src/Domains/Social/Messages/Models/Message.php
@@ -404,6 +404,8 @@ class Message extends BaseModel
                 'name' => $this->messageType->name,
                 'verb' => $this->messageType->verb,
             ] : null,
+            'is_public' => $this->is_public,
+            'is_deleted' => $this->is_deleted,
         ];
 
         // Add parent reference for child messages


### PR DESCRIPTION
Implement filters in search suggestions to only include public and non-deleted messages, enhancing the relevance of search results.