### PR TITLE
Set message visibility to private and add random order option for retrieval

### DIFF
--- a/app/GraphQL/Social/Builders/Messages/MessageBuilder.php
+++ b/app/GraphQL/Social/Builders/Messages/MessageBuilder.php
@@ -67,6 +67,10 @@ class MessageBuilder
                 $query->cacheFor($messageCacheTime);
             }
         }
+        
+        if (isset($args['random']) && $args['random'] === true) {
+            $query->inRandomOrder();
+        }
 
         //Check in this condition if the message is an item and if then check if it has been bought by the current user via status=completed on Order
         if (! $user->isAppOwner()) {

--- a/app/GraphQL/Social/Builders/Messages/MessageBuilder.php
+++ b/app/GraphQL/Social/Builders/Messages/MessageBuilder.php
@@ -67,7 +67,6 @@ class MessageBuilder
                 $query->cacheFor($messageCacheTime);
             }
         }
-        
         if (isset($args['random']) && $args['random'] === true) {
             $query->inRandomOrder();
         }

--- a/graphql/schemas/Social/message.graphql
+++ b/graphql/schemas/Social/message.graphql
@@ -231,6 +231,7 @@ extend type Query @guard {
                 ]
             )
         search: String @search
+        random: Boolean = false
     ): [Message!]!
         @paginate(
             defaultCount: 25

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -270,6 +270,28 @@ class LLMMessageResponseActivity extends KanvasActivity
             $errorBody = $e->getResponse()->getBody()->getContents();
             $isNotSafeForWork = Str::contains($errorBody, ['NSFW', 'blocked']);
 
+            $endViaList = array_map(
+                [NotificationChannelEnum::class, 'getNotificationChannelBySlug'],
+                ['push']
+            );
+            $errorProcessingImageNotification = new ImageProcessingPushNotification(
+                user: $message->user,
+                entity: $message,
+                message: 'Your image prompt was flagged as not safe for work and could not be processed.',
+                title: 'Image Processing Error',
+                via: $endViaList,
+                templates: [
+                    'email_template' => 'email-new-message-nugget',
+                    'push_template' => 'push-new-message-nugget',
+                ],
+            );
+
+            $errorProcessingImageNotification->setData([
+                    'destination_id' => $message->getId(),
+                    'destination_type' => 'USER',
+                    'destination_event' => 'FOLLOWING',
+                ]);
+            $message->user->notify($errorProcessingImageNotification);
             return $isNotSafeForWork ? $message->app->get('NSFW_IMAGE_URL') : '';
         }
 
@@ -324,11 +346,11 @@ class LLMMessageResponseActivity extends KanvasActivity
 
             return $useOnlyImageResponse ? $message->app->get('LIMIT_IMAGE_URL') :
                 (string) json_encode([
-                'error' => 'You have reached your daily image generation limit.',
-                'image_url' => $message->app->get('LIMIT_IMAGE_URL') ?? '',
-                'limit' => $message->app->get('message-post-limit') ?? 0,
-                'flag' => true,
-            ]);
+                    'error' => 'You have reached your daily image generation limit.',
+                    'image_url' => $message->app->get('LIMIT_IMAGE_URL') ?? '',
+                    'limit' => $message->app->get('message-post-limit') ?? 0,
+                    'flag' => true,
+                ]);
         }
 
         return null;

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -95,6 +95,7 @@ class LLMMessageResponseActivity extends KanvasActivity
                     'total_shared' => 0,
                     'ip_address' => '127.0.0.1',
                     'parent_id' => $message->id,
+                    'is_public' => 0
                 ];
 
                 $messageTypeDto = MessageTypeInput::from([
@@ -120,6 +121,9 @@ class LLMMessageResponseActivity extends KanvasActivity
                     $promptChannel->title = $channelName;
                     $promptChannel->update();
                 }
+
+                $message->is_public = 0;
+                $message->save();
 
                 return [
                     'result' => true,


### PR DESCRIPTION
Update the message retrieval process to include an option for random ordering and ensure messages are set to private when executed.