### PR TITLE
Fix image URL assignment for proper array values

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -636,7 +636,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
     {
         if (isset($params['additional_images']) && ! empty($params['additional_images'])) {
             $params['additional_images'][] = $imageUrl;
-            $imageUrl = $params['additional_images'];
+            $imageUrl = array_values($params['additional_images']);
         }
         $response = Http::withHeaders([
             'Content-Type' => 'application/json',


### PR DESCRIPTION
Correct the assignment of image URLs to ensure that only the proper array values are used when submitting images.