### PR TITLE
Update API URL for Gemini-Nano-Banana image processing

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -8,7 +8,6 @@ use Baka\Contracts\AppInterface;
 use Baka\Support\Str;
 use Exception;
 use finfo;
-use GuzzleHttp\Handler\Proxy;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -8,6 +8,7 @@ use Baka\Contracts\AppInterface;
 use Baka\Support\Str;
 use Exception;
 use finfo;
+use GuzzleHttp\Handler\Proxy;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
@@ -446,7 +447,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
     protected function processImageWithGeminiBanana(string $imageUrl, string $prompt, Model $entity, string $imageFilter, array $params): ?Filesystem
     {
         $apiUrl = str_replace('api/image/fal-ai/image-to-image', '', $this->apiUrl);
-        $apiUrl = rtrim($apiUrl, '/') . '/api/image/google/Gemini-Nano-Banana/i2i';
+        $apiUrl = rtrim($apiUrl, '/') . '/api/image/Gemini-Nano-Banana/i2i';
 
         $imageContent = Http::get($imageUrl)->body();
         if (empty($imageContent)) {


### PR DESCRIPTION
Change the API URL used for processing images with the Gemini-Nano-Banana service to ensure correct functionality.