### PR TITLE
Replace htmlspecialchars with html_entity_decode for message processing

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/PushFollowRecommendationNotificationCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/PushFollowRecommendationNotificationCommand.php
@@ -72,7 +72,7 @@ class PushFollowRecommendationNotificationCommand extends Command
                         $messageType->getId(),
                     );
                     $randomRecommendedUserTag =  $userMessagesCategories[array_rand($userMessagesCategories)];
-                    $dynamicMessage = htmlspecialchars($notificationMessages[array_rand($notificationMessages)], ENT_QUOTES, 'UTF-8');
+                    $dynamicMessage = html_entity_decode($notificationMessages[array_rand($notificationMessages)], ENT_QUOTES, 'UTF-8');
 
                     if (str_contains($dynamicMessage, '[category]')) {
                         $dynamicMessage = str_replace('[category]', $randomRecommendedUserTag, $dynamicMessage);

--- a/src/Domains/Connectors/PromptMine/Jobs/SendMessageOfTheWeekJob.php
+++ b/src/Domains/Connectors/PromptMine/Jobs/SendMessageOfTheWeekJob.php
@@ -49,7 +49,7 @@ class SendMessageOfTheWeekJob implements ShouldQueue
             [
                 'push_template' => NotificationTemplateEnum::PUSH_WEEKLY_FAVORITE_PROMPT->value,
                 'title' => 'Prompt of the Week',
-                'message' => htmlspecialchars("$messageOfTheWeek->message['title'] — Try it now and keep the momentum going.", ENT_QUOTES, 'UTF-8')
+                'message' => html_entity_decode("$messageOfTheWeek->message['title'] — Try it now and keep the momentum going.", ENT_QUOTES, 'UTF-8')
             ],
             $this->via
         );

--- a/src/Domains/Connectors/PromptMine/Services/VideoProcessingService.php
+++ b/src/Domains/Connectors/PromptMine/Services/VideoProcessingService.php
@@ -98,7 +98,7 @@ class VideoProcessingService
         $errorProcessingImageNotification = new ImageProcessingPushNotification(
             user: $this->entity->user,
             entity: $this->entity,
-            message: htmlspecialchars($result['error'] ?? 'Video processing failed', ENT_QUOTES, 'UTF-8'),
+            message: html_entity_decode($result['error'] ?? 'Video processing failed', ENT_QUOTES, 'UTF-8'),
             title: 'Video processing failed',
             via: $endViaList,
             templates: [
@@ -360,7 +360,7 @@ class VideoProcessingService
                 user: $this->entity->user,
                 entity: $this->entity,
                 message: 'Tap to view your AI-generated video on prompt mine.',
-                title: htmlspecialchars('Video is ready ' . $title, ENT_QUOTES, 'UTF-8'),
+                title: html_entity_decode('Video is ready ' . $title, ENT_QUOTES, 'UTF-8'),
                 via: $endViaList,
                 templates: [
                     'email_template' => $params['email_template'] ?? null,

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -585,7 +585,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
             $newMessageNotification = new ImageProcessingPushNotification(
                 user: $entity->user,
                 entity: $entity,
-                message: htmlspecialchars("Your image for {$title} has been processed", ENT_QUOTES, 'UTF-8'),
+                message: html_entity_decode("Your image for {$title} has been processed", ENT_QUOTES, 'UTF-8'),
                 title: 'Image Processed',
                 via: $endViaList,
                 templates: [


### PR DESCRIPTION
Update message processing to use `html_entity_decode` instead of `htmlspecialchars` for improved handling of HTML entities.