### PR TITLE
Replace html_entity_decode with direct string in notification message

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -578,14 +578,14 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
             $params['via'] ?? ['database']
         );
 
-        $title = trim($title);
+        $title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
 
         try {
             // Send notification to the user
             $newMessageNotification = new ImageProcessingPushNotification(
                 user: $entity->user,
                 entity: $entity,
-                message: html_entity_decode("Your image for {$title} has been processed", ENT_QUOTES, 'UTF-8'),
+                message: "Your image for {$title} has been processed",
                 title: 'Image Processed',
                 via: $endViaList,
                 templates: [


### PR DESCRIPTION
Simplify the notification message by removing unnecessary HTML entity decoding, improving performance and readability.