### PR TITLE
Simplify html_entity_decode usage in finalizeProcessing method

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -578,7 +578,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
             $params['via'] ?? ['database']
         );
 
-        $title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
+        $title = html_entity_decode($title, ENT_QUOTES);
 
         try {
             // Send notification to the user


### PR DESCRIPTION
Remove the unnecessary character set parameter from the html_entity_decode function in the finalizeProcessing method.