### PR TITLE
Add command to reindex social users records by app

### DIFF
--- a/app/Console/Commands/Search/Algolia/ReindexUsersRecordsCommand.php
+++ b/app/Console/Commands/Search/Algolia/ReindexUsersRecordsCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Social;
+
+use Baka\Traits\KanvasJobsTrait;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Social\Messages\Models\Message;
+
+class ReindexUsersRecordsCommand extends Command
+{
+    use KanvasJobsTrait;
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'kanvas-social:reindex-users-records {app_id}';
+
+    /**
+     * The console command description.
+     *
+     * @var string|null
+     */
+    protected $description = 'Reindex social users records by app';
+
+    /**
+     * Execute the console command.
+     *
+     */
+    public function handle()
+    {
+        $app = Apps::getById($this->argument('app_id'));
+        $this->overwriteAppService($app);
+
+        $this->reindex($app);
+
+        return;
+    }
+
+    public function reindex(Apps $app)
+    {
+        $this->info('Reindex scout index for user App ' . $app->name);
+        $users = DB::table('users')
+            ->join('users_associated_apps', 'users.id', '=', 'users_associated_apps.users_id')
+            ->where('users_associated_apps.apps_id', $app->getId())
+            ->where('users_associated_apps.user_active', 1)
+            ->where('companies_id', 0)
+            ->where('users.is_deleted', 0)
+            ->get();
+
+        $this->info('Total users to reindexed: ' . $users->count());
+        $users->searchable();
+    }
+}

--- a/app/Console/Commands/Search/Algolia/ReindexUsersRecordsCommand.php
+++ b/app/Console/Commands/Search/Algolia/ReindexUsersRecordsCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Console\Commands\Social;
+namespace App\Console\Commands\Search\Algolia;
 
 use Baka\Traits\KanvasJobsTrait;
 use Illuminate\Console\Command;

--- a/app/Console/Commands/Search/Algolia/ReindexUsersRecordsCommand.php
+++ b/app/Console/Commands/Search/Algolia/ReindexUsersRecordsCommand.php
@@ -6,9 +6,8 @@ namespace App\Console\Commands\Social;
 
 use Baka\Traits\KanvasJobsTrait;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
 use Kanvas\Apps\Models\Apps;
-use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Users\Models\Users;
 
 class ReindexUsersRecordsCommand extends Command
 {
@@ -44,12 +43,13 @@ class ReindexUsersRecordsCommand extends Command
     public function reindex(Apps $app)
     {
         $this->info('Reindex scout index for user App ' . $app->name);
-        $users = DB::table('users')
+        $users = Users::query()
             ->join('users_associated_apps', 'users.id', '=', 'users_associated_apps.users_id')
             ->where('users_associated_apps.apps_id', $app->getId())
             ->where('users_associated_apps.user_active', 1)
             ->where('companies_id', 0)
             ->where('users.is_deleted', 0)
+            ->select('users.*')
             ->get();
 
         $this->info('Total users to reindexed: ' . $users->count());


### PR DESCRIPTION
Introduce a console command to reindex social user records associated with a specific app, enhancing data management capabilities.