### PR TITLE
Allow custom index for searchable users based on app configuration

### DIFF
--- a/src/Kanvas/Users/Models/Users.php
+++ b/src/Kanvas/Users/Models/Users.php
@@ -920,7 +920,8 @@ class Users extends Authenticatable implements UserInterface, ContractsAuthentic
 
     public function searchableAs(): string
     {
-        return config('scout.prefix') . '_users';
+        $customIndex = $this->app ? $this->app->get('app_custom_users_index') : null;
+        return $customIndex ?: config('scout.prefix') . '_users';
     }
 
     public static function search($query = '', $callback = null)


### PR DESCRIPTION
Enable the use of a custom index for searchable users, allowing for greater flexibility based on application settings.