### PR TITLE
Remove duplicate logic for handling empty lastname in user update

### DIFF
--- a/src/Kanvas/Auth/Services/UserManagement.php
+++ b/src/Kanvas/Auth/Services/UserManagement.php
@@ -44,6 +44,13 @@ class UserManagement
                       }
  */
             //@todo when we update the login to use userAssociatedApps we need to remove this
+
+
+            //Save it empty to avoid having a fullName with unwanted lastname, ex: "Max Max". We are having issues with some frontends sending only the firstname as a fullname.
+            if (! isset($data['lastname']) && $this->app->get('dont_force_lastname_default')) {
+                $data['lastname'] = '';
+            }
+            
             $this->user->update($data);
             $userAppProfile->update($data);
 
@@ -91,12 +98,6 @@ class UserManagement
 
             if ($files) {
                 $this->user->addMultipleFilesFromUrl($files);
-            }
-
-
-            //Save it empty to avoid having a fullName with unwanted lastname, ex: "Max Max". We are having issues with some frontends sending only the firstname as a fullname.
-            if (! isset($data['lastname']) && $this->app->get('dont_force_lastname_default')) {
-                $data['lastname'] = '';
             }
 
             //update roles if

--- a/src/Kanvas/Auth/Services/UserManagement.php
+++ b/src/Kanvas/Auth/Services/UserManagement.php
@@ -50,7 +50,6 @@ class UserManagement
             if (! isset($data['lastname']) && $this->app->get('dont_force_lastname_default')) {
                 $data['lastname'] = '';
             }
-            
             $this->user->update($data);
             $userAppProfile->update($data);
 


### PR DESCRIPTION
Consolidate the logic for setting the lastname to avoid duplication and ensure consistent handling of empty lastnames during user updates.