### PR TITLE
Fix image response condition to check for 'ai_image' key

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -68,7 +68,7 @@ class LLMMessageResponseActivity extends KanvasActivity
                     $response = $result['response'];
                     $chatHistory = $result['chat_history'];
                     $messageTypeKey = 'nugget';
-                } elseif ($isTypeImage && $message->getFiles()->count() > 0) {
+                } elseif ($isTypeImage && isset($message->message['ai_image']) && count($message->message['ai_image']) > 0) {
                     $result = $this->generateFilteredImageResponse($message);
                     $response = $result['response'];
                     $chatHistory = $result['chat_history'];


### PR DESCRIPTION
Update the image response logic to ensure it checks for the presence of the 'ai_image' key in the message before processing.