### PR TITLE
Add default reference to video and handle single file case

### DIFF
--- a/src/Domains/Connectors/PromptMine/Actions/ProcessVideoRequestAction.php
+++ b/src/Domains/Connectors/PromptMine/Actions/ProcessVideoRequestAction.php
@@ -352,20 +352,21 @@ class ProcessVideoRequestAction
         }
 
         switch ($this->entity->message['attachment_type']) {
-            case 'reference_to_video':
-                return array_merge($payload, [
-                    'referenceImageUrls' => $imageUrlsArray,
-                ]);
-                break;
             case 'start_end_frame':
                 return array_merge($payload, [
                     'image_url' => $imageUrlsArray[0],
                     'lastFrameUrl' => $imageUrlsArray[1],
                 ]);
                 break;
+            case 'reference_to_video':
             default:
+                if ($messageFiles->count() == 1) {
+                    return array_merge($payload, [
+                        'image_url' => $imageUrlsArray[0],
+                    ]);
+                }
                 return array_merge($payload, [
-                    'image_url' => $imageUrlsArray[0],
+                    'referenceImageUrls' => $imageUrlsArray,
                 ]);
                 break;
         }


### PR DESCRIPTION
Set the default behavior to include a reference to video and adjust the handling of image URLs when only one file is present.