### PR TITLE
Update thumbnail frame seconds for video processing consistency

### DIFF
--- a/src/Domains/Connectors/PromptMine/Services/VideoProcessingService.php
+++ b/src/Domains/Connectors/PromptMine/Services/VideoProcessingService.php
@@ -30,7 +30,7 @@ use Throwable;
 
 class VideoProcessingService
 {
-    private const THUMBNAIL_FRAME_SECONDS = 4;
+    private const THUMBNAIL_FRAME_SECONDS = 5;
 
     public function __construct(
         protected Message $entity,


### PR DESCRIPTION
## General Description  
This update changes the thumbnail frame seconds from 4 to 5 to ensure consistency in video processing. This adjustment aims to improve the overall quality and synchronization of video thumbnails.  

## Related Issue  
N/A  

## Checklist  
- [ ] I have performed a self-review of my code.  
- [ ] I have added tests to cover my changes.  
- [ ] I have updated the documentation (if needed).  
- [ ] My changes generate no new warnings.  
- [ ] My changes do not break any existing tests.  

## Screenshots (if applicable)  
N/A

