### PR TITLE
Add message type parameter to trending feed command

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/PopulateTrendingFeedCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/PopulateTrendingFeedCommand.php
@@ -22,7 +22,7 @@ class PopulateTrendingFeedCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'kanvas:prompt-generate-trending-feed {app_id} {company_id}';
+    protected $signature = 'kanvas:prompt-generate-trending-feed {app_id} {company_id} {message_type_id}';
 
     /**
      * The console command description.
@@ -41,11 +41,11 @@ class PopulateTrendingFeedCommand extends Command
         $this->overwriteAppService($app);
 
         $company = Companies::getById((int) $this->argument('company_id'));
-        //$messageType = (int) $this->argument('message_type_id');
+        $messageType = (int) $this->argument('message_type_id');
 
-        //$messageType = MessageType::getById($messageType, $app);
+        $messageType = MessageType::getById($messageType, $app);
 
-        $populateTrendingFeedAction = new PopulateTrendingFeedAction($app, $company, true);
+        $populateTrendingFeedAction = new PopulateTrendingFeedAction($app, $company, $messageType, true);
         $populateTrendingFeedAction->execute();
 
         /*  $tag = (new CreateTagAction(

--- a/src/Domains/Connectors/Recombee/Actions/PopulateTrendingFeedAction.php
+++ b/src/Domains/Connectors/Recombee/Actions/PopulateTrendingFeedAction.php
@@ -9,6 +9,7 @@ use Baka\Contracts\CompanyInterface;
 use Baka\Users\Contracts\UserInterface;
 use Exception;
 use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Social\MessagesTypes\Models\MessageType;
 use Kanvas\Workflow\Enums\WorkflowEnum;
 
 class PopulateTrendingFeedAction
@@ -18,6 +19,7 @@ class PopulateTrendingFeedAction
     public function __construct(
         protected AppInterface $app,
         protected CompanyInterface $company,
+        protected MessageType $messageType,
         protected bool $cleanUserFeed = false
     ) {
         $this->user = $this->company->user;
@@ -47,6 +49,7 @@ class PopulateTrendingFeedAction
                     ->where('is_public', 1)
                     ->where('is_deleted', 0)
                     ->where('created_at', '>=', now()->subDays($timePeriod))
+                    ->where('message_types_id', $this->messageType->getId())
                     ->selectRaw('messages.*, 
                         (total_liked * ' . $likesWeight . ') + (total_shared * ' . $sharedWeight . ') + ((total_children - 1) * ' . $remixWeight . ') as trending_score')
                     ->orderBy('trending_score', 'desc')


### PR DESCRIPTION
## General Description

Introduce a new message type parameter to the trending feed command, allowing for more specific queries related to message types. This change enhances the functionality of the command by enabling it to filter messages based on their type.

## Related Issue

N/A

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

N/A

