### PR TITLE
Improve clarity and engagement of remix notifications

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
@@ -73,9 +73,9 @@ class RemixCreationActivity extends KanvasActivity implements WorkflowActivityIn
                     $promptRemixTitle = $remixMessage->message['title'] ?? '';
                     $newMessageNotification = new MessageOwnerPushNotification(
                         user: $remixMessage->user,
-                        entity: $remixMessage,
-                        message: "Your AI creation {$promptRemixTitle} has been remixed!",
-                        title: 'AI creation remixed',
+                        entity: $entity,
+                        message: "Your prompt { $promptRemixTitle } was just remixed by another creator!",
+                        title: 'Your prompt has been remixed!',
                         via: $endViaList,
                         templates: [
                             'email_template' => $params['email_template'],


### PR DESCRIPTION
## General Description

Update the remix message notification to enhance clarity and user engagement. The message now specifies that the user's prompt has been remixed by another creator, making it more informative and engaging.

## Related Issue

N/A

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

N/A

