### PR TITLE
Fix empty chat prompts and enhance message retrieval logic

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -54,7 +54,7 @@ class LLMMessageResponseActivity extends KanvasActivity
             integrationOperation: function ($message, $app, $integrationCompany, $additionalParams) use ($params) {
                 $prompt = $message->message['prompt'] ?? null;
                 // use trim to avoid prompts with only spaces
-                if (empty(trim($prompt))) { 
+                if (empty(trim($prompt))) {
                     return [
                         'error' => 'Prompt is empty',
                     ];

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -53,7 +53,6 @@ class LLMMessageResponseActivity extends KanvasActivity
             integration: IntegrationsEnum::PROMPT_MINE,
             integrationOperation: function ($message, $app, $integrationCompany, $additionalParams) use ($params) {
                 $prompt = $message->message['prompt'] ?? null;
-
                 // use trim to avoid prompts with only spaces
                 if (empty(trim($prompt))) { 
                     return [
@@ -447,8 +446,8 @@ class LLMMessageResponseActivity extends KanvasActivity
 
             //We need to make sure previous response is not nsfw or error in image creation(for some reason nsfw flag also works for other errors)
             while (
-                $previousChatResponse !== null 
-                && (isset($previousChatResponse->message['nsfw_flag']) && $previousChatResponse->message['nsfw_flag']) 
+                $previousChatResponse !== null
+                && (isset($previousChatResponse->message['nsfw_flag']) && $previousChatResponse->message['nsfw_flag'])
                 && $messagesSkipped < 3
             ) {
                 $previousChatResponse = $channel->getPreviousMessage($previousChatResponse);

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -27,6 +27,7 @@ use Kanvas\Social\Messages\DataTransferObject\MessageInput;
 use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Social\MessagesTypes\Actions\CreateMessageTypeAction;
 use Kanvas\Social\MessagesTypes\DataTransferObject\MessageTypeInput;
+use Kanvas\Social\MessagesTypes\Repositories\MessagesTypesRepository;
 use Kanvas\Users\Events\UpdateUserProfileEvent;
 use Kanvas\Users\Models\Users;
 use Kanvas\Workflow\Enums\IntegrationsEnum;
@@ -53,7 +54,8 @@ class LLMMessageResponseActivity extends KanvasActivity
             integrationOperation: function ($message, $app, $integrationCompany, $additionalParams) use ($params) {
                 $prompt = $message->message['prompt'] ?? null;
 
-                if (empty($prompt)) {
+                // use trim to avoid prompts with only spaces
+                if (empty(trim($prompt))) { 
                     return [
                         'error' => 'Prompt is empty',
                     ];
@@ -319,7 +321,7 @@ class LLMMessageResponseActivity extends KanvasActivity
                 title: 'Image Processing Error',
                 via: $endViaList,
                 templates: [
-                    'email_template' => 'email-new-message-nugget',
+                    'email_template' => 'a-message-nugget',
                     'push_template' => 'push-new-message-nugget',
                 ],
             );
@@ -422,6 +424,7 @@ class LLMMessageResponseActivity extends KanvasActivity
 
     private function generateImageResponse(Message $message): array
     {
+        $messagesSkipped = 0; // To track how many messages we've skipped due to NSFW or errors in image creation for previous responses search.
         new MessageOrderFulfillmentAction($message)->execute('image');
 
         $promptClient = new PromptClient($message->app);
@@ -438,8 +441,19 @@ class LLMMessageResponseActivity extends KanvasActivity
                 $params['enable_safety_checker'] = true;
             }
 
+            $chatResponseMessageType = MessagesTypesRepository::getByVerb('chat-response', $message->app);
             $channel = $message->channels?->first();
             $previousChatResponse = $channel !== null ? $channel->getPreviousMessage($message) : null;
+
+            //We need to make sure previous response is not nsfw or error in image creation(for some reason nsfw flag also works for other errors)
+            while (
+                $previousChatResponse !== null 
+                && (isset($previousChatResponse->message['nsfw_flag']) && $previousChatResponse->message['nsfw_flag']) 
+                && $messagesSkipped < 3
+            ) {
+                $previousChatResponse = $channel->getPreviousMessage($previousChatResponse);
+                $messagesSkipped++;
+            }
 
             //remix have a diff flow because its parent is not the main source
             if ($previousChatResponse instanceof Message && ($previousChatResponse->isRoot() || isset($previousChatResponse->message['remix_parent_id']))) {

--- a/src/Domains/Social/Channels/Models/Channel.php
+++ b/src/Domains/Social/Channels/Models/Channel.php
@@ -136,7 +136,7 @@ class Channel extends BaseModel
         // Find the previous message in this channel
         return $this->messages()
             ->wherePivot('channel_id', $this->id)
-            ->where(function ($query) use ($currentMessageTimestamp, $currentMessage) {
+            ->where(function ($query) use ($currentMessageTimestamp, $currentMessage, $messageTypeId) {
                 // Either find messages created before the current one
                 $query->where('messages.created_at', '<', $currentMessageTimestamp)
                     // Or if they have the same timestamp, find ones with a lower ID
@@ -144,6 +144,7 @@ class Channel extends BaseModel
                         $q->where('messages.created_at', '=', $currentMessageTimestamp)
                           ->where('messages.id', '<', $currentMessage->id);
                     });
+                $query->where('messages.message_types_id', $currentMessage->message_types_id);
             })
             ->orderBy('messages.created_at', 'desc')
             ->orderBy('messages.id', 'desc')

--- a/src/Domains/Social/Channels/Models/Channel.php
+++ b/src/Domains/Social/Channels/Models/Channel.php
@@ -136,7 +136,7 @@ class Channel extends BaseModel
         // Find the previous message in this channel
         return $this->messages()
             ->wherePivot('channel_id', $this->id)
-            ->where(function ($query) use ($currentMessageTimestamp, $currentMessage, $messageTypeId) {
+            ->where(function ($query) use ($currentMessageTimestamp, $currentMessage) {
                 // Either find messages created before the current one
                 $query->where('messages.created_at', '<', $currentMessageTimestamp)
                     // Or if they have the same timestamp, find ones with a lower ID


### PR DESCRIPTION
## General Description

Improve handling of empty chat prompts by trimming whitespace and ensuring that error messages are returned appropriately. Enhance message retrieval logic to skip previous messages that are marked as NSFW or have errors in image creation, ensuring a better user experience.

## Related Issue

N/A

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

N/A

