### PR TITLE
feat: add concatenated support

### DIFF
--- a/src/Domains/Souk/Orders/Exports/OrderExportExcel.php
+++ b/src/Domains/Souk/Orders/Exports/OrderExportExcel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Souk\Orders\Exports;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
 use Kanvas\Souk\Orders\Models\Order;
 use Maatwebsite\Excel\Concerns\FromQuery;
 use Maatwebsite\Excel\Concerns\ShouldAutoSize;
@@ -85,8 +86,17 @@ class OrderExportExcel implements FromQuery, WithMapping, WithDrawings, WithColu
 
     private function getNestedValue($object, string $path)
     {
+        // Handle multiple paths for concatenation (e.g., "user.firstname user.lastname")
+        if (Str::contains($path, ' ')) {
+            return Str::of($path)
+                ->explode(' ')
+                ->map(fn ($singlePath) => $this->getNestedValue($object, $singlePath))
+                ->filter()
+                ->join(' ');
+        }
+
         // Handle array access like items[0].product_name
-        if (strpos($path, '[') !== false) {
+        if (Str::contains($path, '[')) {
             return $this->getArrayValue($object, $path);
         }
 


### PR DESCRIPTION
Add suport to concatenate fields in the field_mapper

## General Description

To export orders it has a field called field_mapper that maps a Header (any given name we want) to the value we want to render there (any field of the order is available). 

In this PR we are adding support to map multiple fields to a header example `Gruero: "user.firstname user.lastname"`

| Gruero  |
|_________|
| John Doe|


```
    field_mapper: {
      Numero_de_orden: "order_number"
      Placa: "metadata.data.vehiclePlate"
      Vehiculo: "metadata.data.vehicleBrand"
      Color: "metadata.data.vehicleColor"
      Gruero: "user.firstname user.lastname"
      Ubicacion: "items[0].product_name"
      Servicios: "items[1].product_name"
      Monto: "total_net_amount"
      Fecha: "updated_at"
      Estado: "orderStatus.name"
    }
```

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
