### PR TITLE
Ensure users have at least one message before recommendations

### DIFF
--- a/src/Domains/Connectors/Recombee/Actions/GenerateWhoToFollowRecommendationsAction.php
+++ b/src/Domains/Connectors/Recombee/Actions/GenerateWhoToFollowRecommendationsAction.php
@@ -56,7 +56,8 @@ class GenerateWhoToFollowRecommendationsAction
                     ->whereNotNull('users_associated_apps.firstname')
                     ->where('users_associated_apps.firstname', '!=', '')
                     ->where('users_associated_apps.is_deleted', 0)
-                    ->where('users_associated_apps.status', 1);
+                    ->where('users_associated_apps.status', 1)
+                    ->where('users_associated_apps.total_messages_count', '>=', 1);
             })
             ->whereNotIn('users.id', $followedIds)
             ->whereIn('users.id', $entityIds)


### PR DESCRIPTION
## General Description

This update ensures that users must have at least one message before receiving recommendations. This change improves the relevance of recommendations by filtering out users without any messages.


