### PR TITLE
Populate subcategories feed command and update tags schema

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/PopulateSubcategoriesFeedCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/PopulateSubcategoriesFeedCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Connectors\PromptMine;
+
+use Baka\Traits\KanvasJobsTrait;
+use Illuminate\Console\Command;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Social\MessagesTypes\Models\MessageType;
+use Kanvas\Social\Tags\Actions\CreateTagAction;
+use Kanvas\Social\Tags\DataTransferObjects\Tag;
+
+class PopulateSubcategoriesFeedCommand extends Command
+{
+    use KanvasJobsTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'kanvas:prompt-populate-subcategories-feed 
+        {app_id : The application ID}
+        {company_id : The company ID}
+        {message_type_id : The message type ID}
+        {category_slug : The category slug}
+        {subcategory_slug : The subcategory slug}
+        {message_id_list : Comma-separated message IDs}';
+
+    /**
+     * The console command description.
+     *
+     * @var string|null
+     */
+    protected $description = 'Populate subcategories feed with a curated list of prompts';
+
+    /**
+     * Execute the console command.
+     *
+     */
+    public function handle()
+    {
+        $messageType = (int) $this->argument('message_type_id');
+        $categorySlug = (string) $this->argument('category_slug');
+        $subcategorySlug = (string) $this->argument('subcategory_slug');
+        $messageIdList = explode(',', (string) $this->argument('message_id_list'));
+
+        $app = Apps::getById((int) $this->argument('app_id'));
+        $this->overwriteAppService($app);
+        $company = Companies::getById((int) $this->argument('company_id'));
+        $messageType = MessageType::getById($messageType, $app);
+        $user = $company->user;
+
+        //Add the subcategory as a child of the category
+        $categoryTag = (new CreateTagAction(
+            new Tag(
+                $app,
+                $user,
+                $company,
+                $categorySlug
+            )
+        ))->execute();
+
+        $subcategoryTag = (new CreateTagAction(
+            new Tag(
+                $app,
+                $user,
+                $company,
+                $subcategorySlug
+            )
+        ))->execute();
+
+        $subcategoryTag->parent_id = $categoryTag->id;
+        $subcategoryTag->saveOrFail();
+
+        //Lets tag all messages with the subcategory
+        $messages = Message::fromApp($app)
+            ->where('companies_id', $company->getId())
+            ->where('message_types_id', $messageType->getId())
+            ->whereIn('id', $messageIdList)
+            ->get();
+
+        foreach ($messages as $message) {
+            $message->addTag($subcategorySlug, $app, $company->user, $company);
+            echo("Tagged message ID {$message->id} with subcategory {$subcategorySlug} of category {$categorySlug}\n");
+        }
+    }
+}

--- a/database/migrations/Social/2025_12_22_231852_add_parent_id_tags.php
+++ b/database/migrations/Social/2025_12_22_231852_add_parent_id_tags.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->bigInteger('parent_id')->nullable()->index('parent_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->dropColumn('parent_id');
+        });
+    }
+};

--- a/database/migrations/Social/2025_12_22_231852_add_parent_id_tags.php
+++ b/database/migrations/Social/2025_12_22_231852_add_parent_id_tags.php
@@ -11,7 +11,7 @@ return new class () extends Migration {
     public function up(): void
     {
         Schema::table('tags', function (Blueprint $table) {
-            $table->bigInteger('parent_id')->nullable()->index('parent_id');
+            $table->bigInteger('parent_id')->nullable()->index('parent_id')->after('companies_id');
             $table->string('path')->nullable()->after('parent_id')->index();
         });
     }

--- a/database/migrations/Social/2025_12_22_231852_add_parent_id_tags.php
+++ b/database/migrations/Social/2025_12_22_231852_add_parent_id_tags.php
@@ -12,6 +12,7 @@ return new class () extends Migration {
     {
         Schema::table('tags', function (Blueprint $table) {
             $table->bigInteger('parent_id')->nullable()->index('parent_id');
+            $table->string('path')->nullable()->after('parent_id')->index();
         });
     }
 
@@ -22,6 +23,7 @@ return new class () extends Migration {
     {
         Schema::table('tags', function (Blueprint $table) {
             $table->dropColumn('parent_id');
+            $table->dropColumn('path');
         });
     }
 };

--- a/graphql/schemas/Social/tags.graphql
+++ b/graphql/schemas/Social/tags.graphql
@@ -62,6 +62,7 @@ extend type Query @guard {
             @whereConditions(
                 columns: [
                     "id"
+                    "parent_id"
                     "name"
                     "slug"
                     "weight"

--- a/graphql/schemas/Social/tags.graphql
+++ b/graphql/schemas/Social/tags.graphql
@@ -6,7 +6,11 @@ input TagInput {
 
 type Tag {
     id: ID!
+    parent_id: ID
+    parent: Tag @belongsTo(method: "parent")
     user: User! @belongsTo(method: "user")
+    companies_id: ID!
+    apps_id: ID!
     name: String!
     slug: String
     weight: Int

--- a/graphql/schemas/Social/tags.graphql
+++ b/graphql/schemas/Social/tags.graphql
@@ -9,8 +9,6 @@ type Tag {
     parent_id: ID
     parent: Tag @belongsTo(method: "parent")
     user: User! @belongsTo(method: "user")
-    companies_id: ID!
-    apps_id: ID!
     name: String!
     slug: String
     weight: Int
@@ -18,6 +16,7 @@ type Tag {
     created_at: String
     updated_at: String
     taggables: [TagEntity!]! @hasMany(method: "taggables")
+    children: [Tag!] @hasMany(type: PAGINATOR)
 }
 
 type TagEntity {

--- a/src/Domains/Social/Tags/Models/Tag.php
+++ b/src/Domains/Social/Tags/Models/Tag.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\DB;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Social\Models\BaseModel;
 use Nevadskiy\Tree\AsTree;
+use Override;
 
 /**
  * @property int id

--- a/src/Domains/Social/Tags/Models/Tag.php
+++ b/src/Domains/Social/Tags/Models/Tag.php
@@ -12,16 +12,18 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Facades\DB;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Social\Models\BaseModel;
-use Override;
+use Nevadskiy\Tree\AsTree;
 
 /**
  * @property int id
  * @property int parent_id
+ * @property string path
  * @property int apps_id
  * @property int companies_id
  * @property int users_id
  * @property string name
  * @property string slug
+ * @property int weight
  * @property string color
  * @property int status
  * @property int is_feature
@@ -29,6 +31,7 @@ use Override;
 class Tag extends BaseModel
 {
     use SlugTrait;
+    use AsTree;
     use DynamicSearchableTrait {
         search as public traitSearch;
     }

--- a/src/Domains/Social/Tags/Models/Tag.php
+++ b/src/Domains/Social/Tags/Models/Tag.php
@@ -16,6 +16,7 @@ use Override;
 
 /**
  * @property int id
+ * @property int parent_id
  * @property int apps_id
  * @property int companies_id
  * @property int users_id


### PR DESCRIPTION
## General Description

Introduce the `PopulateSubcategoriesFeedCommand` to facilitate the population of a subcategories feed with a curated list of prompts. Update the tags schema to support parent-child relationships by adding a `parent_id` field. This change enhances the tagging system, allowing for better organization of categories and subcategories.

