### PR TITLE
Ensure category tag has a path set and save if missing

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/PopulateSubcategoriesFeedCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/PopulateSubcategoriesFeedCommand.php
@@ -64,6 +64,11 @@ class PopulateSubcategoriesFeedCommand extends Command
             )
         ))->execute();
 
+        if (! $categoryTag->path) {
+            $categoryTag->path = $categoryTag->id;
+            $categoryTag->saveOrFail();
+        }
+
         $subcategoryTag = (new CreateTagAction(
             new Tag(
                 $app,


### PR DESCRIPTION
## General Description

This update ensures that a category tag has a path set. If the path is missing, it assigns the category tag's ID as the path and saves the changes. This enhancement improves data integrity for category tags.

## Related Issue

N/A

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

N/A

