### PR TITLE
Add category_group_slug argument and update tag hierarchy

### DIFF
--- a/app/Console/Commands/Connectors/PromptMine/PopulateSubcategoriesFeedCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/PopulateSubcategoriesFeedCommand.php
@@ -99,10 +99,10 @@ class PopulateSubcategoriesFeedCommand extends Command
             )
         ))->execute();
 
-       if (! $subcategoryTag->parent_id) {
+        if (! $subcategoryTag->parent_id) {
             $subcategoryTag->parent_id = $categoryTag->id;
             $subcategoryTag->saveOrFail();
-       }
+        }
         //Lets tag all messages with the subcategory
         $messages = Message::fromApp($app)
             ->where('companies_id', $company->getId())
@@ -112,7 +112,7 @@ class PopulateSubcategoriesFeedCommand extends Command
 
         foreach ($messages as $message) {
             $message->addTag($subcategorySlug, $app, $company->user, $company);
-            echo("Tagged message ID {$message->id} with subcategory {$subcategorySlug} of category {$categorySlug}\n");
+            echo ("Tagged message ID {$message->id} with subcategory {$subcategorySlug} of category {$categorySlug}\n");
         }
     }
 }

--- a/app/Console/Commands/Connectors/PromptMine/PopulateSubcategoriesFeedCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/PopulateSubcategoriesFeedCommand.php
@@ -26,6 +26,7 @@ class PopulateSubcategoriesFeedCommand extends Command
         {app_id : The application ID}
         {company_id : The company ID}
         {message_type_id : The message type ID}
+        {category_group_slug : The category group slug}
         {category_slug : The category slug}
         {subcategory_slug : The subcategory slug}
         {message_id_list : Comma-separated message IDs}';
@@ -44,6 +45,7 @@ class PopulateSubcategoriesFeedCommand extends Command
     public function handle()
     {
         $messageType = (int) $this->argument('message_type_id');
+        $categoryGroupSlug = (string) $this->argument('category_group_slug');
         $categorySlug = (string) $this->argument('category_slug');
         $subcategorySlug = (string) $this->argument('subcategory_slug');
         $messageIdList = explode(',', (string) $this->argument('message_id_list'));
@@ -53,6 +55,20 @@ class PopulateSubcategoriesFeedCommand extends Command
         $company = Companies::getById((int) $this->argument('company_id'));
         $messageType = MessageType::getById($messageType, $app);
         $user = $company->user;
+
+        $categoryGroupTag = (new CreateTagAction(
+            new Tag(
+                $app,
+                $user,
+                $company,
+                $categoryGroupSlug
+            )
+        ))->execute();
+
+        if (! $categoryGroupTag->path) {
+            $categoryGroupTag->path = $categoryGroupTag->id;
+            $categoryGroupTag->saveOrFail();
+        }
 
         //Add the subcategory as a child of the category
         $categoryTag = (new CreateTagAction(
@@ -69,6 +85,11 @@ class PopulateSubcategoriesFeedCommand extends Command
             $categoryTag->saveOrFail();
         }
 
+        if (! $categoryTag->parent_id) {
+            $categoryTag->parent_id = $categoryGroupTag->id;
+            $categoryTag->saveOrFail();
+        }
+
         $subcategoryTag = (new CreateTagAction(
             new Tag(
                 $app,
@@ -78,9 +99,10 @@ class PopulateSubcategoriesFeedCommand extends Command
             )
         ))->execute();
 
-        $subcategoryTag->parent_id = $categoryTag->id;
-        $subcategoryTag->saveOrFail();
-
+       if (! $subcategoryTag->parent_id) {
+            $subcategoryTag->parent_id = $categoryTag->id;
+            $subcategoryTag->saveOrFail();
+       }
         //Lets tag all messages with the subcategory
         $messages = Message::fromApp($app)
             ->where('companies_id', $company->getId())

--- a/app/Console/Commands/Connectors/PromptMine/PopulateSubcategoriesFeedCommand.php
+++ b/app/Console/Commands/Connectors/PromptMine/PopulateSubcategoriesFeedCommand.php
@@ -112,7 +112,7 @@ class PopulateSubcategoriesFeedCommand extends Command
 
         foreach ($messages as $message) {
             $message->addTag($subcategorySlug, $app, $company->user, $company);
-            echo ("Tagged message ID {$message->id} with subcategory {$subcategorySlug} of category {$categorySlug}\n");
+            echo("Tagged message ID {$message->id} with subcategory {$subcategorySlug} of category {$categorySlug}\n");
         }
     }
 }

--- a/database/migrations/Social/2025_12_29_231853_add_description_tags.php
+++ b/database/migrations/Social/2025_12_29_231853_add_description_tags.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->string('description')->nullable()->after('slug')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->dropColumn('description');
+        });
+    }
+};


### PR DESCRIPTION
## General Description

Introduce a new `category_group_slug` argument to enhance the `PopulateSubcategoriesFeedCommand`. This change updates the tag hierarchy by ensuring that subcategories are correctly associated with their parent categories and groups. Additionally, a migration is included to add a `description` column to the `tags` table.

## Related Issue

N/A

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

N/A

