### PR TITLE
Add TagsObserver and enable cacheRedis for Tag files

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -45,6 +45,7 @@ use Kanvas\Social\Messages\Models\UserMessageActivity;
 use Kanvas\Social\Messages\Observers\UserMessageActivityObserver;
 use Kanvas\Social\Messages\Observers\UserMessageObserver;
 use Kanvas\Social\Tags\Models\Tag;
+use Kanvas\Social\Tags\Observers\TagsObserver;
 use Kanvas\Social\UsersLists\Models\UserList;
 use Kanvas\Social\UsersLists\Observers\UsersListsObserver;
 use Kanvas\Users\Models\UserCompanyApps;
@@ -53,7 +54,6 @@ use Kanvas\Users\Models\UsersAssociatedApps;
 use Kanvas\Users\Observers\UsersAssociatedAppsObserver;
 use Kanvas\Users\Observers\UsersAssociatedCompaniesObserver;
 use Kanvas\Users\Observers\UsersObserver;
-use Kanvas\Social\Tags\Observers\TagsObserver;
 use Override;
 
 class EventServiceProvider extends ServiceProvider

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -44,6 +44,7 @@ use Kanvas\Social\Messages\Models\UserMessage;
 use Kanvas\Social\Messages\Models\UserMessageActivity;
 use Kanvas\Social\Messages\Observers\UserMessageActivityObserver;
 use Kanvas\Social\Messages\Observers\UserMessageObserver;
+use Kanvas\Social\Tags\Models\Tag;
 use Kanvas\Social\UsersLists\Models\UserList;
 use Kanvas\Social\UsersLists\Observers\UsersListsObserver;
 use Kanvas\Users\Models\UserCompanyApps;
@@ -52,6 +53,7 @@ use Kanvas\Users\Models\UsersAssociatedApps;
 use Kanvas\Users\Observers\UsersAssociatedAppsObserver;
 use Kanvas\Users\Observers\UsersAssociatedCompaniesObserver;
 use Kanvas\Users\Observers\UsersObserver;
+use Kanvas\Social\Tags\Observers\TagsObserver;
 use Override;
 
 class EventServiceProvider extends ServiceProvider
@@ -106,6 +108,7 @@ class EventServiceProvider extends ServiceProvider
         ProductsCategories::observe(ProductsCategoriesObserver::class);
         PeopleEmploymentHistory::observe(PeopleEmploymentHistoryObserver::class);
         People::observe(PeopleObserver::class);
+        Tag::observe(TagsObserver::class);
     }
 
     /**

--- a/graphql/schemas/Social/tags.graphql
+++ b/graphql/schemas/Social/tags.graphql
@@ -20,7 +20,7 @@ type Tag {
     updated_at: String
     taggables: [TagEntity!]! @hasMany(method: "taggables")
     files: [Filesystem!]!
-        # @cacheRedis
+        @cacheRedis
         @paginate(
             defaultCount: 25
             builder: "App\\GraphQL\\Ecosystem\\Queries\\Filesystem\\FilesystemQuery@getFileByGraphType"

--- a/src/Domains/Social/Tags/Observers/TagsObserver.php
+++ b/src/Domains/Social/Tags/Observers/TagsObserver.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Social\Tags\Observers;
+
+use Kanvas\Social\Tags\Models\Tag;
+
+class TagsObserver
+{
+    public function updated(Tag $tag): void
+    {
+        $tag->clearLightHouseCacheJob();
+    }
+}


### PR DESCRIPTION
## General Description

Introduce the `TagsObserver` to handle cache clearing for updated tags. Additionally, enable Redis caching for files associated with the Tag type to improve performance.

