### PR TITLE
Remove cacheRedis directive from Tag type files

### DIFF
--- a/graphql/schemas/Social/tags.graphql
+++ b/graphql/schemas/Social/tags.graphql
@@ -20,7 +20,6 @@ type Tag {
     updated_at: String
     taggables: [TagEntity!]! @hasMany(method: "taggables")
     files: [Filesystem!]!
-        @cacheRedis
         @paginate(
             defaultCount: 25
             builder: "App\\GraphQL\\Ecosystem\\Queries\\Filesystem\\FilesystemQuery@getFileByGraphType"


### PR DESCRIPTION
## General Description

Remove the `@cacheRedis` directive from the `files` field in the `Tag` type to improve caching behavior and ensure consistency in data retrieval.

## Related Issue

N/A

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

N/A

