### PR TITLE
Mark message as unsearchable upon deletion if indexed type matches

### DIFF
--- a/src/Domains/Social/Messages/Observers/MessageObserver.php
+++ b/src/Domains/Social/Messages/Observers/MessageObserver.php
@@ -76,5 +76,8 @@ class MessageObserver
                 $channel->saveOrFail();
             }
         }
+        if ($message->messageType->verb === $message->app->get('index_message_by_type')) {
+            $message->unsearchable();
+        }
     }
 }


### PR DESCRIPTION
## General Description

This change ensures that a message is marked as unsearchable when it is deleted, provided it matches the indexed type. This enhancement improves the accuracy of search functionalities by preventing deleted messages from appearing in search results.

## Related Issue

N/A

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

N/A

