### PR TITLE
Fix searchable method in MessageObserver

### DIFF
--- a/src/Domains/Social/Messages/Observers/MessageObserver.php
+++ b/src/Domains/Social/Messages/Observers/MessageObserver.php
@@ -54,7 +54,7 @@ class MessageObserver
         $message->clearLightHouseCacheJob();
 
         if ($message->messageType->verb === $message->app->get('index_message_by_type')) {
-            $message->searchable();
+            $message->searchableSync();
         }
     }
 


### PR DESCRIPTION
## General Description

Replace the `searchable()` method with `searchableSync()` in the `updated` method of `MessageObserver` to ensure synchronous behavior when updating messages.

## Related Issue

N/A

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

N/A

