### PR TITLE
Refactor Tag type to enhance pagination parameters

### DIFF
--- a/graphql/schemas/Social/tags.graphql
+++ b/graphql/schemas/Social/tags.graphql
@@ -24,7 +24,10 @@ type Tag {
             defaultCount: 25
             builder: "App\\GraphQL\\Ecosystem\\Queries\\Filesystem\\FilesystemQuery@getFileByGraphType"
         )
-    children: [Tag!] @hasMany(relation: "children", type: PAGINATOR)
+    children(
+        first: Int
+        orderBy: _ @orderBy(columns: ["weight", "name", "created_at"])
+    ): [Tag!] @hasMany(relation: "children", type: PAGINATOR)
 }
 
 type TagEntity {


### PR DESCRIPTION
## General Description

Update the `children` field in the `Tag` type to include parameters for pagination, allowing for more flexible querying. This change enhances the GraphQL API by enabling clients to specify pagination options and ordering for child tags.


