### PR TITLE
fix: use JSON_VALID to prevent invalid JSON errors in duplicate metad…

### DIFF
--- a/app/GraphQL/Souk/Mutations/Orders/DraftOrderManagementMutation.php
+++ b/app/GraphQL/Souk/Mutations/Orders/DraftOrderManagementMutation.php
@@ -7,7 +7,7 @@ namespace App\GraphQL\Souk\Mutations\Orders;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\CompaniesBranches;
 use Kanvas\Exceptions\ValidationException;
-use Kanvas\Inventory\Regions\Models\Regions;
+use Kanvas\Regions\Models\Regions;
 use Kanvas\Souk\Orders\Actions\CreateDraftOrderAction;
 use Kanvas\Souk\Orders\DataTransferObject\DraftOrder;
 use Kanvas\Souk\Orders\Models\Order;
@@ -36,7 +36,7 @@ class DraftOrderManagementMutation
          ])
          ->log('User attempted to create order from draft');
 
-        $draftOrder = DraftOrder::viaRequest(
+        $draftOrder = DraftOrder::from(
             $app,
             $branch,
             $user,

--- a/graphql/schemas/Souk/order.graphql
+++ b/graphql/schemas/Souk/order.graphql
@@ -259,7 +259,7 @@ input DraftOrderInput {
     items: [OrderLineItemInput!]!
     note: String
     metadata: Mixed
-    channel_id: ID!
+    channel_id: ID
 }
 
 input OrderLineItemInput {

--- a/src/Domains/Souk/Orders/DataTransferObject/DraftOrder.php
+++ b/src/Domains/Souk/Orders/DataTransferObject/DraftOrder.php
@@ -17,7 +17,7 @@ use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
 use Kanvas\Guild\Customers\Models\Address as ModelsAddress;
 use Kanvas\Guild\Customers\Models\People as ModelsPeople;
 use Kanvas\Inventory\Channels\Models\Channels;
-use Kanvas\Inventory\Regions\Models\Regions;
+use Kanvas\Regions\Models\Regions;
 use Kanvas\Users\Models\Users;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Data;
@@ -50,8 +50,13 @@ class DraftOrder extends Data
     ) {
     }
 
-    public static function viaRequest(AppInterface $app, CompaniesBranches $branch, UserInterface $user, Regions $region, array $request): self
-    {
+    public static function fromMultiple(
+        AppInterface $app,
+        CompaniesBranches $branch,
+        UserInterface $user,
+        Regions $region,
+        array $request
+    ): self {
         $customer = $request['input']['customer'];
         $customer['contacts'] = [
             [
@@ -90,7 +95,9 @@ class DraftOrder extends Data
 
         $people = (new CreatePeopleAction($people))->execute();
 
-        $channel = Channels::getById($request['input']['channel_id'], $app);
+        $channel = isset($request['input']['channel_id'])
+            ? Channels::getByIdFromCompanyApp($request['input']['channel_id'], $branch->company, $app)
+            : Channels::getDefault($branch->company, $app);
 
         $shippingAddress = ! empty($request['input']['shipping_address']['address1']) ?
             $customer->addAddress(new Address(

--- a/src/Domains/Souk/Orders/Validations/DuplicatedMetadata.php
+++ b/src/Domains/Souk/Orders/Validations/DuplicatedMetadata.php
@@ -11,6 +11,7 @@ use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Kanvas\Souk\Orders\Models\Order;
+use Override;
 
 class DuplicatedMetadata implements ValidationRule
 {
@@ -20,10 +21,11 @@ class DuplicatedMetadata implements ValidationRule
     ) {
     }
 
+    #[Override]
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         // Check if validation is enabled for this app
-        $enabled = $this->app->get("validate_metadata_duplicated_enabled");
+        $enabled = $this->app->get('validate_metadata_duplicated_enabled');
         if (! $enabled || $enabled !== 1) {
             return;
         }
@@ -78,7 +80,9 @@ class DuplicatedMetadata implements ValidationRule
         $query = Order::fromApp($this->app)
             ->where('created_at', '>=', Carbon::now()->subHours($settings['cooldown_hours']))
             ->whereNotNull('metadata')
-            ->whereRaw("JSON_LENGTH(COALESCE(NULLIF(metadata, ''), '{}')) > 0")
+            ->where('metadata', '!=', '')
+            ->whereRaw("JSON_VALID(metadata)")
+            ->whereRaw("JSON_LENGTH(metadata) > 0")
             ->whereRaw("LOWER(JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.{$jsonPath}'))) = ?", [strtolower($value)]);
 
         // Exclude certain order statuses if configured


### PR DESCRIPTION
…ata check

The JSON_LENGTH function was failing when metadata contained invalid JSON. Added JSON_VALID check to ensure only valid JSON is processed.


