### PR TITLE
Refactor Ansible GCP deploy workflow and fix variable reference

### DIFF
--- a/.github/workflows/ansible-gcp-deploy.yml
+++ b/.github/workflows/ansible-gcp-deploy.yml
@@ -49,19 +49,13 @@ jobs:
             ${{ github.ref_name }} "'${{ secrets.INSTANCE_GROUP_NAME }}' in name"
           EOF
 
-      - name: Write SSH key
-        run: |
-          echo '${{ secrets.GCP_COMPUTE_SSH_PRIVATE_KEY }}' > ssh-key
-          chmod 600 ssh-key
-
       - name: Run Ansible playbook
         env:
           ANSIBLE_HOST_KEY_CHECKING: 'false'
         run: |
           ansible-playbook ansible/playbooks/${{ github.ref_name }}-deploy.yml \
             -i ansible/inventory.gcp.yml \
-            --private-key ssh-key \
-            -u ${{ vars.SSH_USER }}
+            --ssh-common-args="-o StrictHostKeyChecking=no" \
             -e '{
               "app_dir": "/var/www/html",
               "repo_url": "git@github.com:${{ github.repository }}.git",


### PR DESCRIPTION
## General Description

Refactor the Ansible GCP deploy workflow by removing SSH key handling and correcting the variable reference for the GitHub ref name. These changes streamline the deployment process and ensure proper variable usage.

## Related Issue

N/A

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

N/A

