### PR TITLE
Use metadata SSH keys for ubuntu user instead of OS Login

### DIFF
--- a/.github/workflows/ansible-gcp-deploy.yml
+++ b/.github/workflows/ansible-gcp-deploy.yml
@@ -52,7 +52,7 @@ jobs:
             - name
           compose:
             ansible_host: networkInterfaces[0].networkIP
-            ansible_user: sa_${{ secrets.GCP_SERVICE_ACCOUNT_UNIQUE_ID }}
+            ansible_user: ubuntu
           groups:
             ${{ github.ref_name }}: "'${{ secrets.INSTANCE_GROUP_NAME }}' in name"
           EOF
@@ -106,10 +106,23 @@ jobs:
           echo "Inventory hosts:"
           ansible-inventory -i ansible/inventory.gcp.yaml --graph
       
-      - name: Setup OS Login SSH
+      - name: Setup SSH key for ubuntu user
         run: |
-          gcloud compute os-login ssh-keys add --key-file=~/.ssh/id_rsa.pub 2>/dev/null || \
-          (ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa && gcloud compute os-login ssh-keys add --key-file=~/.ssh/id_rsa.pub)
+          # Generate SSH key
+          ssh-keygen -t rsa -b 3072 -N '' -f /home/runner/.ssh/id_rsa
+
+          # Get the instance name
+          INSTANCE_NAME=$(gcloud compute instances list \
+            --project="${{ secrets.GCP_PROJECT_ID }}" \
+            --filter="name~'${{ secrets.INSTANCE_GROUP_NAME }}' AND status=RUNNING" \
+            --format="value(name)" \
+            --limit=1)
+
+          # Add SSH key to instance metadata for ubuntu user
+          gcloud compute instances add-metadata "$INSTANCE_NAME" \
+            --project="${{ secrets.GCP_PROJECT_ID }}" \
+            --zone="${{ secrets.GCP_ZONE }}" \
+            --metadata "ssh-keys=ubuntu:$(cat /home/runner/.ssh/id_rsa.pub)"
 
       - name: Run Ansible playbook
         env:

--- a/.github/workflows/ansible-gcp-deploy.yml
+++ b/.github/workflows/ansible-gcp-deploy.yml
@@ -110,19 +110,20 @@ jobs:
         run: |
           # Generate SSH key
           ssh-keygen -t rsa -b 3072 -N '' -f /home/runner/.ssh/id_rsa
+          SSH_PUBLIC_KEY=$(cat /home/runner/.ssh/id_rsa.pub)
 
-          # Get the instance name
-          INSTANCE_NAME=$(gcloud compute instances list \
+          # Get all matching instances (name and zone)
+          gcloud compute instances list \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
             --filter="name~'${{ secrets.INSTANCE_GROUP_NAME }}' AND status=RUNNING" \
-            --format="value(name)" \
-            --limit=1)
+            --format="value(name,zone)" | while read -r INSTANCE_NAME ZONE; do
 
-          # Add SSH key to instance metadata for ubuntu user
-          gcloud compute instances add-metadata "$INSTANCE_NAME" \
-            --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --zone="${{ secrets.GCP_ZONE }}" \
-            --metadata "ssh-keys=ubuntu:$(cat /home/runner/.ssh/id_rsa.pub)"
+            echo "Adding SSH key to instance: $INSTANCE_NAME (zone: $ZONE)"
+            gcloud compute instances add-metadata "$INSTANCE_NAME" \
+              --project="${{ secrets.GCP_PROJECT_ID }}" \
+              --zone="$ZONE" \
+              --metadata "ssh-keys=ubuntu:$SSH_PUBLIC_KEY"
+          done
 
       - name: Run Ansible playbook
         env:


### PR DESCRIPTION
## Summary
- Switches from OS Login (service account user) to metadata-based SSH keys
- Allows direct SSH access as the `ubuntu` user via IAP tunnel
- Simplifies authentication by removing dependency on OS Login IAM roles

## Test plan
- [ ] Run the workflow manually via `workflow_dispatch`
- [ ] Verify SSH connection succeeds as `ubuntu` user
- [ ] Verify Ansible playbook runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)