### PR TITLE
Fix ansible playbook: remove invalid verbose params from command task

### DIFF
--- a/ansible/playbooks/development-deploy.yaml
+++ b/ansible/playbooks/development-deploy.yaml
@@ -27,8 +27,6 @@
 
     - name: Install dependencies
       command: composer install --optimize-autoloader
-      verbose: yes
-      verbosity: 2
       args:
         chdir: "{{ app_dir }}"
 


### PR DESCRIPTION
## Summary
- Removes `verbose` and `verbosity` options from the `command` task in the ansible playbook
- These options are only valid for the `synchronize` module, not `command`

## Test plan
- [ ] Run the workflow manually via `workflow_dispatch`
- [ ] Verify playbook executes without syntax errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)