### PR TITLE
feat: add SSH key directly to authorized_keys via gcloud ssh

### DIFF
--- a/.github/workflows/ansible-gcp-deploy.yml
+++ b/.github/workflows/ansible-gcp-deploy.yml
@@ -133,17 +133,20 @@ jobs:
           EOF
           chmod 600 /home/runner/.ssh/config
 
-          # Get all matching instances (name and zone)
+          # Get all matching instances (name, zone, and external IP)
           gcloud compute instances list \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
             --filter="name~'${{ secrets.INSTANCE_GROUP_NAME }}' AND status=RUNNING" \
-            --format="value(name,zone)" | while read -r INSTANCE_NAME ZONE; do
+            --format="value(name,zone,networkInterfaces[0].accessConfigs[0].natIP)" | while read -r INSTANCE_NAME ZONE EXTERNAL_IP; do
 
-            echo "Adding SSH key to instance: $INSTANCE_NAME (zone: $ZONE)"
-            gcloud compute instances add-metadata "$INSTANCE_NAME" \
+            echo "Adding SSH key to instance: $INSTANCE_NAME (zone: $ZONE, IP: $EXTERNAL_IP)"
+
+            # Use gcloud compute ssh to add the key directly to authorized_keys
+            gcloud compute ssh ubuntu@"$INSTANCE_NAME" \
               --project="${{ secrets.GCP_PROJECT_ID }}" \
               --zone="$ZONE" \
-              --metadata "ssh-keys=ubuntu:$SSH_PUBLIC_KEY"
+              --command="mkdir -p ~/.ssh && echo '$SSH_PUBLIC_KEY' >> ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys" \
+              --quiet
           done
 
       - name: Run Ansible playbook


### PR DESCRIPTION
## Summary
- Use `gcloud compute ssh` with OS Login to add the runner's public key directly to `~/.ssh/authorized_keys`
- Replaces the metadata-based SSH key approach
- Requires OS Login to be enabled on the instances

## Test plan
- [ ] Trigger the Ansible GCP deploy workflow manually
- [ ] Verify SSH key is added to authorized_keys via gcloud ssh
- [ ] Confirm Ansible playbook runs successfully with direct SSH

🤖 Generated with [Claude Code](https://claude.com/claude-code)