### PR TITLE
fix: use OS Login user with sudo to add key to ubuntu's authorized_keys

### DIFF
--- a/.github/workflows/ansible-gcp-deploy.yml
+++ b/.github/workflows/ansible-gcp-deploy.yml
@@ -141,11 +141,11 @@ jobs:
 
             echo "Adding SSH key to instance: $INSTANCE_NAME (zone: $ZONE, IP: $EXTERNAL_IP)"
 
-            # Use gcloud compute ssh to add the key directly to authorized_keys
-            gcloud compute ssh ubuntu@"$INSTANCE_NAME" \
+            # Use gcloud compute ssh (OS Login) then sudo to ubuntu user to add the key
+            gcloud compute ssh "$INSTANCE_NAME" \
               --project="${{ secrets.GCP_PROJECT_ID }}" \
               --zone="$ZONE" \
-              --command="mkdir -p ~/.ssh && echo '$SSH_PUBLIC_KEY' >> ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys" \
+              --command="sudo -u ubuntu bash -c 'mkdir -p ~/.ssh && echo \"$SSH_PUBLIC_KEY\" >> ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys'" \
               --quiet
           done
 

--- a/.github/workflows/ansible-gcp-deploy.yml
+++ b/.github/workflows/ansible-gcp-deploy.yml
@@ -155,6 +155,8 @@ jobs:
         run: |
           ansible-playbook ansible/playbooks/${{ github.ref_name }}-deploy.yaml \
             -i ansible/inventory.gcp.yaml \
+            -u ubuntu \
+            --private-key /home/runner/.ssh/id_rsa \
             -e '{
               "app_dir": "${{ secrets.GCP_INSTANCE_APP_DIR }}",
               "repo_url": "git@github.com:${{ github.repository }}.git",


### PR DESCRIPTION
## Summary
- Use `gcloud compute ssh` with OS Login (service account user)
- Use `sudo -u ubuntu` to add the SSH key to the correct user's authorized_keys
- Explicitly set `-u ubuntu` and `--private-key` in ansible-playbook command

## Test plan
- [ ] Trigger the Ansible GCP deploy workflow manually
- [ ] Verify SSH key is added to ubuntu's authorized_keys
- [ ] Confirm Ansible playbook connects as ubuntu and runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)