### PR TITLE
fix: Add status, plan_name, started_at, is_active fields to UserSubscription schema

### DIFF
--- a/app/GraphQL/Subscription/Types/SubscriptionType.php
+++ b/app/GraphQL/Subscription/Types/SubscriptionType.php
@@ -16,4 +16,24 @@ class SubscriptionType
 
         return $customer?->provider;
     }
+
+    public function status(Subscription $subscription): string
+    {
+        return $subscription->stripe_status;
+    }
+
+    public function planName(Subscription $subscription): string
+    {
+        return $subscription->type;
+    }
+
+    public function startedAt(Subscription $subscription): string
+    {
+        return $subscription->created_at->format('Y-m-d H:i:s');
+    }
+
+    public function isActive(Subscription $subscription): bool
+    {
+        return $subscription->active();
+    }
 }

--- a/graphql/schemas/Subscription/userSubscription.graphql
+++ b/graphql/schemas/Subscription/userSubscription.graphql
@@ -4,13 +4,17 @@ type UserSubscription {
     provider: String @field(resolver: "App\\GraphQL\\Subscription\\Types\\SubscriptionType@provider")
     stripe_id: ID!
     stripe_status: String!
+    status: String! @field(resolver: "App\\GraphQL\\Subscription\\Types\\SubscriptionType@status")
+    plan_name: String! @field(resolver: "App\\GraphQL\\Subscription\\Types\\SubscriptionType@planName")
     stripe_price: String
     items: [SubscriptionItem!]! @hasMany(relation: "items")
     quantity: Int!
     trial_ends_at: DateTime
     ends_at: DateTime
+    started_at: DateTime @field(resolver: "App\\GraphQL\\Subscription\\Types\\SubscriptionType@startedAt")
     created_at: String
     updated_at: String
+    is_active: Boolean! @field(resolver: "App\\GraphQL\\Subscription\\Types\\SubscriptionType@isActive")
 }
 
 extend type Query @guard {


### PR DESCRIPTION
This PR fixes a GraphQL schema issue where 'status', 'plan_name', 'started_at', and 'is_active' fields were missing from 'UserSubscription' type. I've added resolvers in 'SubscriptionType.php' and updated the schema.