### PR TITLE
feat: engagement update mutation

### DIFF
--- a/app/GraphQL/ActionEngine/Mutations/Engagements/EngagementMutation.php
+++ b/app/GraphQL/ActionEngine/Mutations/Engagements/EngagementMutation.php
@@ -6,7 +6,9 @@ namespace App\GraphQL\ActionEngine\Mutations\Engagements;
 
 use Kanvas\ActionEngine\Engagements\Actions\ContinueEngagementAction;
 use Kanvas\ActionEngine\Engagements\Actions\CreateEngagementAction;
+use Kanvas\ActionEngine\Engagements\Actions\UpdateEngagementAction;
 use Kanvas\ActionEngine\Engagements\DataTransferObject\Engagement as DataTransferObjectEngagement;
+use Kanvas\ActionEngine\Engagements\DataTransferObject\UpdateEngagement as UpdateEngagementData;
 use Kanvas\ActionEngine\Engagements\Models\Engagement;
 use Kanvas\ActionEngine\Enums\ActionStatusEnum;
 use Kanvas\Apps\Models\Apps;
@@ -16,9 +18,6 @@ use Kanvas\Guild\Leads\Models\Lead;
 
 class EngagementMutation
 {
-    /**
-     * @todo add test
-     */
     public function startEngagement(mixed $rootValue, array $request): Engagement
     {
         $app = app(Apps::class);
@@ -72,6 +71,33 @@ class EngagementMutation
                 $people,
                 $parentEngagement,
             )
+        )->execute();
+    }
+
+    public function update(mixed $rootValue, array $request): Engagement
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        /** @var \Kanvas\Companies\Models\Companies $company */
+        $company = $user->getCurrentCompany();
+        /** @var array $input */
+        $input = $request['input'];
+
+        /** @var Engagement $engagement */
+        $engagement = Engagement::getByUuidFromCompanyApp($request['uuid'], $company, $app);
+
+        if (! empty($input['status']) && ! ActionStatusEnum::validate($input['status'])) {
+            throw new ValidationException('Invalid Engagement Status');
+        }
+
+        return new UpdateEngagementAction(
+            engagement: $engagement,
+            data: new UpdateEngagementData(
+                data: $input['data'],
+                status: isset($input['status']) ? ActionStatusEnum::from($input['status']) : null,
+                description: $input['description'] ?? null,
+                via: $input['via'] ?? null,
+            ),
         )->execute();
     }
 }

--- a/graphql/schemas/ActionEngine/engagement.graphql
+++ b/graphql/schemas/ActionEngine/engagement.graphql
@@ -37,6 +37,13 @@ input EngagementFilterInput {
     status: String!
 }
 
+input UpdateEngagementInput {
+    status: String
+    data: Mixed!
+    description: String
+    via: String
+}
+
 input CreateEngagementInput {
     lead_id: ID!
     request_id: ID!
@@ -60,6 +67,10 @@ extend type Mutation @guard {
     continueLeadEngagement(input: CreateEngagementInput!): Engagement!
         @field(
             resolver: "App\\GraphQL\\ActionEngine\\Mutations\\Engagements\\EngagementMutation@continueEngagement"
+        )
+    updateEngagement(uuid: ID!, input: UpdateEngagementInput!): Engagement!
+        @field(
+            resolver: "App\\GraphQL\\ActionEngine\\Mutations\\Engagements\\EngagementMutation@update"
         )
 }
 

--- a/src/Domains/ActionEngine/Engagements/Actions/UpdateEngagementAction.php
+++ b/src/Domains/ActionEngine/Engagements/Actions/UpdateEngagementAction.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\ActionEngine\Engagements\Actions;
+
+use Illuminate\Support\Facades\DB;
+use Kanvas\ActionEngine\Engagements\DataTransferObject\UpdateEngagement as UpdateEngagementData;
+use Kanvas\ActionEngine\Engagements\Models\Engagement;
+use Kanvas\ActionEngine\Pipelines\Models\Pipeline;
+use Kanvas\Social\Messages\Models\Message;
+
+class UpdateEngagementAction
+{
+    public function __construct(
+        protected readonly Engagement $engagement,
+        protected readonly UpdateEngagementData $data,
+    ) {
+    }
+
+    public function execute(): Engagement
+    {
+        return DB::connection('action_engine')->transaction(function () {
+            if ($this->data->status !== null) {
+                $pipeline = Pipeline::getBySlug($this->engagement->slug, $this->engagement->app, $this->engagement->company);
+                $stage = $pipeline->stages()->where('slug', $this->data->status->value)->firstOrFail();
+                $this->engagement->pipelines_stages_id = $stage->getId();
+            }
+
+            /** @var Message|null $message */
+            $message = $this->engagement->message;
+
+            if ($message) {
+                $messageData = is_array($message->message) ? $message->message : [];
+                $existingData = is_array($messageData['data'] ?? null) ? $messageData['data'] : [];
+                $messageData['data'] = array_merge($existingData, $this->data->data);
+
+                if ($this->data->description !== null) {
+                    $messageData['description'] = $this->data->description;
+                }
+
+                if ($this->data->via !== null) {
+                    $messageData['via'] = $this->data->via;
+                }
+
+                $message->message = $messageData;
+                $message->saveOrFail();
+            }
+
+            $this->engagement->saveOrFail();
+
+            return $this->engagement;
+        });
+    }
+}

--- a/src/Domains/ActionEngine/Engagements/DataTransferObject/UpdateEngagement.php
+++ b/src/Domains/ActionEngine/Engagements/DataTransferObject/UpdateEngagement.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\ActionEngine\Engagements\DataTransferObject;
+
+use Kanvas\ActionEngine\Enums\ActionStatusEnum;
+use Spatie\LaravelData\Data;
+
+class UpdateEngagement extends Data
+{
+    public function __construct(
+        public readonly array $data,
+        public readonly ?ActionStatusEnum $status = null,
+        public readonly ?string $description = null,
+        public readonly ?string $via = null,
+    ) {
+    }
+}

--- a/src/Domains/ActionEngine/Engagements/Observers/EngagementObserver.php
+++ b/src/Domains/ActionEngine/Engagements/Observers/EngagementObserver.php
@@ -11,11 +11,11 @@ class EngagementObserver
 {
     public function updated(Engagement $engagement): void
     {
-        if (! $engagement->wasChanged('message_id')) {
+        if (! $engagement->wasChanged('message_id') && ! $engagement->wasChanged('pipelines_stages_id')) {
             return;
         }
 
-        $message = $engagement->message; // assuming relationship exists
+        $message = $engagement->message;
         if (! $message) {
             return;
         }

--- a/tests/GraphQL/ActionEngine/EngagementUpdateTest.php
+++ b/tests/GraphQL/ActionEngine/EngagementUpdateTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\GraphQL\ActionEngine;
+
+use Kanvas\ActionEngine\Support\Setup;
+use Kanvas\Apps\Actions\SyncEmailTemplateAction;
+use Kanvas\Apps\Models\Apps;
+use Tests\TestCase;
+
+class EngagementUpdateTest extends TestCase
+{
+    protected function createEngagement(): array
+    {
+        $lead = $this->createLeadAndGetResponse();
+        $leadId = $lead['data']['createLead']['id'];
+        $peopleId = $lead['data']['createLead']['people']['id'];
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        new SyncEmailTemplateAction($app, $user)->execute();
+
+        $actions = [[
+            'id' => 7,
+            'name' => 'credit-app',
+            'description' => 'Credit App',
+            'title' => 'Credit App',
+            'enable' => true,
+            'icon' => '',
+            'reasonEn' => 'apply for financing',
+            'reasonEs' => 'apply for financing',
+            'form_fields' => '{"personal":{"type":"object","required":1}}',
+            'form_config' => '{"require_credit-app_signature":true}',
+        ]];
+
+        new Setup($app, $user, $company, $actions)->run();
+
+        $response = $this->graphQL('
+            mutation($input: CreateEngagementInput!) {
+                startLeadEngagement(input: $input) {
+                    id
+                    uuid
+                    slug
+                    stage {
+                        id
+                        name
+                    }
+                    message {
+                        id
+                        message
+                    }
+                }
+            }
+        ', [
+            'input' => [
+                'lead_id' => $leadId,
+                'people_id' => $peopleId,
+                'request_id' => fake()->uuid(),
+                'source' => 'kanvas-ai',
+                'status' => 'sent',
+                'action' => 'credit-app',
+                'data' => [],
+            ],
+        ]);
+
+        $json = $response->json();
+        if (! empty($json['errors'])) {
+            $this->fail('GraphQL errors in createEngagement: ' . json_encode($json['errors']));
+        }
+
+        $response->assertSuccessful();
+
+        return $response->json('data.startLeadEngagement');
+    }
+
+    protected function createLeadAndGetResponse(array $input = [])
+    {
+        $user = auth()->user();
+        $branch = $user->getCurrentBranch();
+
+        if (empty($input)) {
+            $input = [
+                'branch_id' => $branch->getId(),
+                'title' => fake()->title(),
+                'pipeline_stage_id' => 0,
+                'people' => [
+                    'firstname' => fake()->firstName(),
+                    'lastname' => fake()->lastName(),
+                    'contacts' => [
+                        [
+                            'value' => fake()->email(),
+                            'contacts_types_id' => 1,
+                            'weight' => 0,
+                        ],
+                    ],
+                    'address' => [
+                        [
+                            'address' => fake()->address(),
+                            'city' => fake()->city(),
+                            'state' => fake()->state(),
+                            'country' => fake()->country(),
+                            'zip' => fake()->postcode(),
+                        ],
+                    ],
+                ],
+                'custom_fields' => [],
+                'files' => [],
+            ];
+        }
+
+        return $this->graphQL('
+            mutation($input: LeadInput!) {
+                createLead(input: $input) {
+                    id
+                    uuid
+                    people {
+                        id
+                    }
+                }
+            }
+        ', ['input' => $input])->json();
+    }
+
+    public function testUpdateEngagementStatus(): void
+    {
+        $engagement = $this->createEngagement();
+
+        $response = $this->graphQL('
+            mutation($uuid: ID!, $input: UpdateEngagementInput!) {
+                updateEngagement(uuid: $uuid, input: $input) {
+                    id
+                    uuid
+                    stage {
+                        id
+                        name
+                    }
+                }
+            }
+        ', [
+            'uuid' => $engagement['uuid'],
+            'input' => [
+                'status' => 'opened',
+                'data' => ['updated' => true],
+            ],
+        ]);
+
+        $json = $response->json();
+        if (! empty($json['errors'])) {
+            $this->fail('GraphQL errors: ' . json_encode($json['errors']));
+        }
+
+        $response->assertSuccessful();
+        $updated = $response->json('data.updateEngagement');
+        $this->assertEquals($engagement['id'], $updated['id']);
+        $this->assertNotEquals($engagement['stage']['id'], $updated['stage']['id']);
+    }
+
+    public function testUpdateEngagementMessageData(): void
+    {
+        $engagement = $this->createEngagement();
+
+        $response = $this->graphQL('
+            mutation($uuid: ID!, $input: UpdateEngagementInput!) {
+                updateEngagement(uuid: $uuid, input: $input) {
+                    id
+                    uuid
+                    message {
+                        message
+                    }
+                }
+            }
+        ', [
+            'uuid' => $engagement['uuid'],
+            'input' => [
+                'data' => ['custom_key' => 'custom_value'],
+                'description' => 'Updated engagement description',
+                'via' => 'sms',
+            ],
+        ]);
+
+        $json = $response->json();
+        if (! empty($json['errors'])) {
+            $this->fail('GraphQL errors: ' . json_encode($json['errors']));
+        }
+
+        $response->assertSuccessful();
+        $updated = $response->json('data.updateEngagement');
+        $this->assertEquals($engagement['id'], $updated['id']);
+
+        $messageData = $updated['message']['message'];
+        $this->assertEquals('Updated engagement description', $messageData['description']);
+        $this->assertEquals('sms', $messageData['via']);
+        $this->assertEquals('custom_value', $messageData['data']['custom_key']);
+    }
+
+    public function testUpdateEngagementAll(): void
+    {
+        $engagement = $this->createEngagement();
+
+        $response = $this->graphQL('
+            mutation($uuid: ID!, $input: UpdateEngagementInput!) {
+                updateEngagement(uuid: $uuid, input: $input) {
+                    id
+                    uuid
+                    stage {
+                        name
+                    }
+                    message {
+                        message
+                    }
+                }
+            }
+        ', [
+            'uuid' => $engagement['uuid'],
+            'input' => [
+                'status' => 'submitted',
+                'data' => ['result' => 'approved'],
+                'description' => 'Final submission',
+                'via' => 'email',
+            ],
+        ]);
+
+        $json = $response->json();
+        if (! empty($json['errors'])) {
+            $this->fail('GraphQL errors: ' . json_encode($json['errors']));
+        }
+
+        $response->assertSuccessful();
+        $updated = $response->json('data.updateEngagement');
+        $this->assertEquals($engagement['id'], $updated['id']);
+
+        $messageData = $updated['message']['message'];
+        $this->assertEquals('Final submission', $messageData['description']);
+        $this->assertEquals('email', $messageData['via']);
+        $this->assertEquals('approved', $messageData['data']['result']);
+    }
+
+    public function testUpdateEngagementNotFound(): void
+    {
+        $response = $this->graphQL('
+            mutation($uuid: ID!, $input: UpdateEngagementInput!) {
+                updateEngagement(uuid: $uuid, input: $input) {
+                    id
+                }
+            }
+        ', [
+            'uuid' => fake()->uuid(),
+            'input' => [
+                'status' => 'opened',
+                'data' => [],
+            ],
+        ]);
+
+        $this->assertNotEmpty($response->json('errors'));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `updateEngagement` mutation with `UpdateEngagementAction` and `UpdateEngagement` DTO
- Update `EngagementObserver` to handle updated events
- Add comprehensive test coverage for engagement updates

Cherry-picked from development (`bc9de9eec`).

## Test plan
- [ ] Run ActionEngine test suite
- [ ] Verify `updateEngagement` mutation works in staging

