### PR TITLE
## General Description

### DIFF
--- a/src/Domains/Connectors/PromptMine/Webhooks/ModelWizardReceiverJob.php
+++ b/src/Domains/Connectors/PromptMine/Webhooks/ModelWizardReceiverJob.php
@@ -28,7 +28,6 @@ class ModelWizardReceiverJob extends ProcessWebhookJob
             ->where('users_id', $payload['users_id'])
             ->where('companies_id', 0)
             ->first();
-        
         if (! $userAssoc) {
             throw new InvalidArgumentException('User not found for the provided users_id in the payload.');
         }

--- a/src/Domains/Connectors/PromptMine/Webhooks/ModelWizardReceiverJob.php
+++ b/src/Domains/Connectors/PromptMine/Webhooks/ModelWizardReceiverJob.php
@@ -7,6 +7,7 @@ namespace Kanvas\Connectors\PromptMine\Webhooks;
 use InvalidArgumentException;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\PromptMine\Actions\ModelWizardModelChooserAction;
+use Kanvas\Users\Models\UsersAssociatedApps;
 use Kanvas\Workflow\Jobs\ProcessWebhookJob;
 use Override;
 
@@ -23,9 +24,18 @@ class ModelWizardReceiverJob extends ProcessWebhookJob
             throw new InvalidArgumentException('Model wizard answers and users_id are required to execute the model wizard receiver job.');
         }
 
+        $userAssoc = UsersAssociatedApps::fromApp($app)
+            ->where('users_id', $payload['users_id'])
+            ->where('companies_id', 0)
+            ->first();
+        
+        if (! $userAssoc) {
+            throw new InvalidArgumentException('User not found for the provided users_id in the payload.');
+        }
+
         return (new ModelWizardModelChooserAction(
             $payload['model_wizard_answers'],
-            $payload['users_id'],
+            $userAssoc->user,
             $app
         ))->execute();
     }


### PR DESCRIPTION


Validate user association during the execution of the ModelWizardReceiverJob. This change ensures that the job checks for a valid user associated with the provided user ID in the payload, improving error handling and data integrity.



## Related Issue



N/A



## Checklist



- [ ] I have performed a self-review of my code.

- [ ] I have added tests to cover my changes.

- [ ] I have updated the documentation (if needed).

- [ ] My changes generate no new warnings.

- [ ] My changes do not break any existing tests.



## Screenshots (if applicable)



N/A

