### PR TITLE
Clarify model selection criteria in ModelWizardModelChooserAction

### DIFF
--- a/src/Domains/Connectors/PromptMine/Actions/ModelWizardModelChooserAction.php
+++ b/src/Domains/Connectors/PromptMine/Actions/ModelWizardModelChooserAction.php
@@ -51,7 +51,7 @@ class ModelWizardModelChooserAction
             . ", identify the best AI model for this user. Return the sku of the model only.Take into account the type of model as well. 
             If the user data indicates that they need a text-based model, prioritize models with type 'text'. 
             If the user data indicates that they need an image-based model, prioritize models with type 'image'. 
-            If the user data does not indicate a preference, choose the best overall model based on the user data.";
+            If the user data does not indicate a preference, choose the best overall model based on the user data. ASNWER WITH THE SKU OF THE CHOSEN MODEL ONLY.";
 
         try {
             $chosenModelSku = Prism::text()


### PR DESCRIPTION
## General Description

Update the prompt in the ModelWizardModelChooserAction to clarify the criteria for model selection. This change aims to enhance user understanding by specifying that the SKU of the chosen model should be returned, particularly when no user preference is indicated.

## Related Issue

N/A

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

N/A

