### PR TITLE
feat(MK-3964): Add IncrementPromptUsageActivity

### DIFF
--- a/app/Console/Commands/Workflows/KanvasWorkflowSynActionCommand.php
+++ b/app/Console/Commands/Workflows/KanvasWorkflowSynActionCommand.php
@@ -72,6 +72,7 @@ use Kanvas\Connectors\PlateRecognizer\Workflows\ProcessVehicleImageActivity;
 use Kanvas\Connectors\PromptMine\Webhooks\ModelWizardReceiverJob;
 use Kanvas\Connectors\PromptMine\Webhooks\PremiumPromptApprovalWebhookJob;
 use Kanvas\Connectors\PromptMine\Workflows\Activities\CheckNuggetGenerationCountActivity;
+use Kanvas\Connectors\PromptMine\Workflows\Activities\IncrementPromptUsageActivity;
 use Kanvas\Connectors\PromptMine\Workflows\Activities\LLMMessageResponseActivity;
 use Kanvas\Connectors\PromptMine\Workflows\Activities\PremiumPromptFlagActivity;
 use Kanvas\Connectors\PromptMine\Workflows\Activities\PromptIAPOrderActivity;
@@ -344,6 +345,7 @@ class KanvasWorkflowSynActionCommand extends Command
             ProcessAppleSubscriptionWebhookJob::class,
             ProcessGoogleSubscriptionWebhookJob::class,
             ModelWizardReceiverJob::class,
+            IncrementPromptUsageActivity::class,
         ];
 
         $createdActions = [];

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/IncrementPromptUsageActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/IncrementPromptUsageActivity.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\PromptMine\Workflows\Activities;
+
+use Baka\Contracts\AppInterface;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Workflow\Contracts\WorkflowActivityInterface;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\KanvasActivity;
+use Override;
+
+class IncrementPromptUsageActivity extends KanvasActivity implements WorkflowActivityInterface
+{
+    #[Override]
+    public function execute(Message $message, AppInterface $app, array $params): array
+    {
+        $this->overwriteAppService($app);
+
+        return $this->executeIntegration(
+            entity: $message,
+            app: $app,
+            integration: IntegrationsEnum::PROMPT_MINE,
+            integrationOperation: function ($message, $app, $integrationCompany, $additionalParams) {
+                // $message is the *Result Message* (Nugget) created from the Prompt.
+                // We need to find the *Parent Prompt*.
+
+                $parent = null;
+
+                // 1. Check parent_id (Standard Reply/Thread)
+                if ($message->parent_id) {
+                    $parent = Message::getById($message->parent_id, $app);
+                }
+                // 2. Check remix_parent_id (Common in PromptMine for remixes)
+                elseif (isset($message->message['remix_parent_id'])) {
+                    $parentId = (int) $message->message['remix_parent_id'];
+                    $parent = Message::getById($parentId, $app);
+                }
+
+                if (! $parent) {
+                    // No parent found? Nothing to increment.
+                    return [
+                        'result' => false,
+                        'message' => 'No parent prompt found to increment usage.',
+                        'entity_id' => $message->getId(),
+                    ];
+                }
+
+                // Increment Usage Count
+                // Using set() from HasCustomFields trait on the Parent Message
+                $currentCount = (int) $parent->get('usage_count', 0);
+                $parent->set('usage_count', $currentCount + 1);
+
+                // Update Last Used At
+                $parent->set('last_used_at', now()->toDateTimeString());
+
+                return [
+                    'result' => true,
+                    'message' => 'Prompt usage incremented successfully.',
+                    'parent_id' => $parent->getId(),
+                    'new_count' => $currentCount + 1,
+                    'last_used_at' => $parent->get('last_used_at'),
+                ];
+            },
+            company: $message->company,
+            integrationParams: $params,
+        );
+    }
+}


### PR DESCRIPTION
## Description\n\nAdds `IncrementPromptUsageActivity` to track `usage_count` and `last_used_at` custom fields for Prompts (Parent Messages).\n\n## Ticket\n\nMK-3964: Backend - Expose Usage Data in API\n\n## Logic\n\n- Checks `parent_id` or `remix_parent_id` to find the parent prompt.\n- Increments `usage_count` via `HasCustomFields`.\n- Updates `last_used_at`.\n\n## Integration\n\nThis activity should be added to `PromptMine` workflows (e.g., after image generation).\n\n## Note\n\nThis is a clean PR recreating #8535.