### PR TITLE
fix(notifications): enforce KanvasDatabase channel (MK-3951)

### DIFF
--- a/src/Kanvas/Notifications/Notification.php
+++ b/src/Kanvas/Notifications/Notification.php
@@ -91,6 +91,10 @@ class Notification extends LaravelNotification implements EmailInterfaces, Shoul
             $channels = $this->filterEnabledChannels($channels, $notifiable);
         }
 
+        if (! in_array(\Kanvas\Notifications\Channels\KanvasDatabase::class, $channels)) {
+            $channels[] = \Kanvas\Notifications\Channels\KanvasDatabase::class;
+        }
+
         $this->setNotifiableData($notifiable);
 
         return $channels;


### PR DESCRIPTION
Ensures notifications are always persisted to the database by forcing KanvasDatabase channel in via(). Prevents data loss when other channels are disabled.