### PR TITLE
fix(remix): atomic custom field increment (MK-3950)

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
@@ -115,30 +115,19 @@ class RemixCreationActivity extends KanvasActivity implements WorkflowActivityIn
                             $entity->parent->increment('total_children');
 
                             // Atomic custom field increment using pessimistic locking
-                            $customField = AppsCustomFields::firstOrNew([
-                                'companies_id' => $remixMessage->companies_id ?? AppEnums::GLOBAL_COMPANY_ID->getValue(),
-                                'model_name' => get_class($remixMessage),
-                                'entity_id' => $remixMessage->getKey(),
-                                'name' => 'remix_count',
-                            ]);
+                            $customField = $remixMessage->getCustomField('remix_count');
                             
-                            // If it exists, we lock it. If not, we set defaults.
-                            if ($customField->exists) {
+                            if ($customField) {
                                 // Reload with lock to prevent race conditions
                                 $customField = AppsCustomFields::where('id', $customField->id)->lockForUpdate()->first();
                                 $currentValue = (int) $customField->value;
                                 $customField->value = $currentValue + 1;
                                 $customField->save();
+                                $remixMessage->setInRedis('remix_count', $customField->value);
                             } else {
                                 // New record: set initial value
-                                $customField->users_id = $remixMessage->users_id ?? AppEnums::GLOBAL_USER_ID->getValue();
-                                $customField->label = 'remix_count';
-                                $customField->value = 1;
-                                $customField->save(); // Create is atomic-ish (unique constraint would fail if race, but unlikely for new)
+                                $remixMessage->set('remix_count', 1);
                             }
-
-                            // Sync redis cache if needed
-                            $remixMessage->setInRedis('remix_count', $customField->value);
                         });
                     }
                     $remixMessage->user->notify($newMessageNotification);

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
@@ -20,6 +20,10 @@ use Kanvas\Workflow\KanvasActivity;
 use Override;
 use Throwable;
 
+use Illuminate\Support\Facades\DB;
+use Kanvas\CustomFields\Models\AppsCustomFields;
+use Kanvas\Enums\AppEnums;
+
 class RemixCreationActivity extends KanvasActivity implements WorkflowActivityInterface
 {
     #[Override]
@@ -107,8 +111,35 @@ class RemixCreationActivity extends KanvasActivity implements WorkflowActivityIn
                         );
                     }
                     if ($entity->message_types_id == MessagesTypesRepository::getByVerb('memo', $entity->app)->getId()) {
-                        $entity->parent->increment('total_children');
-                        $remixMessage->set('remix_count', $remixMessage->childrenByType('memo')->count());
+                        DB::transaction(function () use ($entity, $remixMessage) {
+                            $entity->parent->increment('total_children');
+
+                            // Atomic custom field increment using pessimistic locking
+                            $customField = AppsCustomFields::firstOrNew([
+                                'companies_id' => $remixMessage->companies_id ?? AppEnums::GLOBAL_COMPANY_ID->getValue(),
+                                'model_name' => get_class($remixMessage),
+                                'entity_id' => $remixMessage->getKey(),
+                                'name' => 'remix_count',
+                            ]);
+                            
+                            // If it exists, we lock it. If not, we set defaults.
+                            if ($customField->exists) {
+                                // Reload with lock to prevent race conditions
+                                $customField = AppsCustomFields::where('id', $customField->id)->lockForUpdate()->first();
+                                $currentValue = (int) $customField->value;
+                                $customField->value = $currentValue + 1;
+                                $customField->save();
+                            } else {
+                                // New record: set initial value
+                                $customField->users_id = $remixMessage->users_id ?? AppEnums::GLOBAL_USER_ID->getValue();
+                                $customField->label = 'remix_count';
+                                $customField->value = 1;
+                                $customField->save(); // Create is atomic-ish (unique constraint would fail if race, but unlikely for new)
+                            }
+
+                            // Sync redis cache if needed
+                            $remixMessage->setInRedis('remix_count', $customField->value);
+                        });
                     }
                     $remixMessage->user->notify($newMessageNotification);
                 } catch (Throwable $th) {

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
@@ -111,16 +111,9 @@ class RemixCreationActivity extends KanvasActivity implements WorkflowActivityIn
                         );
                     }
                     if ($entity->message_types_id == MessagesTypesRepository::getByVerb('memo', $entity->app)->getId()) {
-                        DB::transaction(function () use ($entity, $remixMessage) {
-                            $entity->parent->increment('total_children');
-
-                            // Atomic custom field increment using set() to handle Redis and DB sync
-                            // We get the current value (from Redis or DB), increment it, and set it back.
-                            // Since we are in a transaction and this is a specific activity, this is safer than a raw DB increment
-                            // which would bypass Redis and potentially cause stale reads.
-                            $currentCount = (int) $remixMessage->get('remix_count', 0);
-                            $remixMessage->set('remix_count', $currentCount + 1);
-                        });
+                        $entity->parent->increment('total_children');
+                        $currentCount = (int) $remixMessage->get('remix_count', 0);
+                        $remixMessage->set('remix_count', $currentCount + 1);
                     }
                     $remixMessage->user->notify($newMessageNotification);
                 } catch (Throwable $th) {

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
@@ -20,10 +20,6 @@ use Kanvas\Workflow\KanvasActivity;
 use Override;
 use Throwable;
 
-use Illuminate\Support\Facades\DB;
-use Kanvas\CustomFields\Models\AppsCustomFields;
-use Kanvas\Enums\AppEnums;
-
 class RemixCreationActivity extends KanvasActivity implements WorkflowActivityInterface
 {
     #[Override]

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/RemixCreationActivity.php
@@ -114,20 +114,12 @@ class RemixCreationActivity extends KanvasActivity implements WorkflowActivityIn
                         DB::transaction(function () use ($entity, $remixMessage) {
                             $entity->parent->increment('total_children');
 
-                            // Atomic custom field increment using pessimistic locking
-                            $customField = $remixMessage->getCustomField('remix_count');
-                            
-                            if ($customField) {
-                                // Reload with lock to prevent race conditions
-                                $customField = AppsCustomFields::where('id', $customField->id)->lockForUpdate()->first();
-                                $currentValue = (int) $customField->value;
-                                $customField->value = $currentValue + 1;
-                                $customField->save();
-                                $remixMessage->setInRedis('remix_count', $customField->value);
-                            } else {
-                                // New record: set initial value
-                                $remixMessage->set('remix_count', 1);
-                            }
+                            // Atomic custom field increment using set() to handle Redis and DB sync
+                            // We get the current value (from Redis or DB), increment it, and set it back.
+                            // Since we are in a transaction and this is a specific activity, this is safer than a raw DB increment
+                            // which would bypass Redis and potentially cause stale reads.
+                            $currentCount = (int) $remixMessage->get('remix_count', 0);
+                            $remixMessage->set('remix_count', $currentCount + 1);
                         });
                     }
                     $remixMessage->user->notify($newMessageNotification);


### PR DESCRIPTION
Fixes remix count logic using Kanvas HasCustomFields trait for atomic updates.