### PR TITLE
MK-3227: Harden AI Prompts against Injection (V3)

### DIFF
--- a/src/Domains/Connectors/PromptMine/Actions/ModelWizardModelChooserAction.php
+++ b/src/Domains/Connectors/PromptMine/Actions/ModelWizardModelChooserAction.php
@@ -29,7 +29,9 @@ class ModelWizardModelChooserAction
         $modelWizardAnswers = $this->modelWizardAnswers;
 
         if (empty($modelWizardAnswers)) {
-            throw new InvalidArgumentException('Model wizard answers are required to execute the model chooser action.');
+            throw new InvalidArgumentException(
+                'Model wizard answers are required to execute the model chooser action.'
+            );
         }
 
         $productTypes = ProductsTypesRepository::getBySlug(self::LLM_MODELS_PRODUCT_TYPE_SLUG);

--- a/src/Domains/Connectors/PromptMine/Services/ImageFilterService.php
+++ b/src/Domains/Connectors/PromptMine/Services/ImageFilterService.php
@@ -239,7 +239,9 @@ class ImageFilterService
      */
     protected function getCompany(AppInterface $app, Model $entity): Companies
     {
-        $defaultAppCompanyBranch = $app->get(AppSettingsEnums::GLOBAL_USER_REGISTRATION_ASSIGN_GLOBAL_COMPANY->getValue());
+        $defaultAppCompanyBranch = $app->get(
+            AppSettingsEnums::GLOBAL_USER_REGISTRATION_ASSIGN_GLOBAL_COMPANY->getValue()
+        );
 
         try {
             $branch = CompaniesBranches::getById($defaultAppCompanyBranch);
@@ -284,11 +286,15 @@ class ImageFilterService
         if ($statusResponse['status'] !== 'COMPLETED') {
             $this->sendFailNotification(
                 $entity,
-                "Just a heads-up! Your last creation had a hiccup. Your credit wasn't used, feel free to try again.",
+                "Just a heads-up! Your last creation had a hiccup. " .
+                "Your credit wasn't used, feel free to try again.",
                 $params
             );
 
-            throw new Exception('Image processing did not complete successfully: ' . json_encode($statusResponse));
+            throw new Exception(
+                'Image processing did not complete successfully: ' .
+                json_encode($statusResponse)
+            );
         }
 
         // Step 3: Get the processed image result
@@ -296,7 +302,10 @@ class ImageFilterService
         $processedImageUrl = $this->extractImageUrl($resultResponse);
 
         if ($processedImageUrl === null) {
-            throw new Exception('Failed to extract image URL from response: ' . json_encode($resultResponse));
+            throw new Exception(
+                'Failed to extract image URL from response: ' .
+                json_encode($resultResponse)
+            );
         }
 
         $tempFilePath = ImageOptimizerService::optimizeImageFromUrl($processedImageUrl);
@@ -355,15 +364,22 @@ class ImageFilterService
                     $params['email_template'] = 'image-processing-failure-generic-error';
                     $this->sendFailNotification(
                         $entity,
-                        "Just a heads-up! Your last creation had a hiccup. Your credit wasn't used, feel free to try again.",
+                        "Just a heads-up! Your last creation had a hiccup. " .
+                        "Your credit wasn't used, feel free to try again.",
                         $params
                     );
 
-                    throw new Exception("Image processing failed after {$maxRetries} attempts: " . $e->getMessage());
+                    throw new Exception(
+                        "Image processing failed after {$maxRetries} attempts: " .
+                        $e->getMessage()
+                    );
                 }
 
                 // Log the retry attempt
-                report(new Exception("Image processing attempt {$attempt} failed: " . $e->getMessage() . ". Retrying in {$retryDelay} seconds."));
+                report(new Exception(
+                    "Image processing attempt {$attempt} failed: " . $e->getMessage() .
+                    ". Retrying in {$retryDelay} seconds."
+                ));
 
                 // Wait before retrying
                 sleep($retryDelay);
@@ -381,7 +397,8 @@ class ImageFilterService
             $errorProcessingImageNotification = new ImageProcessingPushNotification(
                 user: $entity->user,
                 entity: $entity,
-                message: "Your recent creation couldn't be completed as it didn't comply with the content provider’s policies.",
+                message: "Your recent creation couldn't be completed as it didn't comply with " .
+                    "the content provider’s policies.",
                 title: 'Error processing image',
                 via: $endViaList,
                 templates: [
@@ -449,7 +466,8 @@ class ImageFilterService
             $params['email_template'] = 'image-processing-failure-generic-error';
             $this->sendFailNotification(
                 $entity,
-                "Just a heads-up! Your last creation had a hiccup. Your credit wasn't used, feel free to try again.",
+                "Just a heads-up! Your last creation had a hiccup. " .
+                "Your credit wasn't used, feel free to try again.",
                 $params
             );
 
@@ -464,7 +482,10 @@ class ImageFilterService
         }
 
         if (! $processedImageUrl) {
-            throw new Exception('Failed to extract image URL from Gemini Banana response: ' . json_encode($responseData));
+            throw new Exception(
+                'Failed to extract image URL from Gemini Banana response: ' .
+                json_encode($responseData)
+            );
         }
 
         // Optimize and upload the processed image
@@ -515,7 +536,9 @@ class ImageFilterService
         // $isRemix = $entity->message['remix_parent_id'] ?? false;
         $user = Users::getById($entity->users_id);
         $user->set('images_generated', ($user->get('images_generated', 0) + 1), true);
-        $cdnImageUrl = $fileSystemRecord ? $entity->app->get('cloud-cdn') . '/' . $fileSystemRecord->path : $processedImageUrl;
+        $cdnImageUrl = $fileSystemRecord
+            ? $entity->app->get('cloud-cdn') . '/' . $fileSystemRecord->path
+            : $processedImageUrl;
 
         $endViaList = array_map(
             [NotificationChannelEnum::class, 'getNotificationChannelBySlug'],
@@ -625,9 +648,10 @@ class ImageFilterService
 
             $statusResponse = $response->json();
 
-            if ($statusResponse['status'] === 'COMPLETED' || isset($statusResponse['data']['images']) && ! empty($statusResponse['data']['images'])) {
-                break;
-            }
+        if ($statusResponse['status'] === 'COMPLETED'
+            || isset($statusResponse['data']['images']) && ! empty($statusResponse['data']['images'])) {
+            break;
+        }
 
             if ($statusResponse['status'] === 'FAILED') {
                 throw new Exception('Image processing failed for this request' . $requestId);

--- a/src/Domains/Connectors/PromptMine/Services/VideoProcessingService.php
+++ b/src/Domains/Connectors/PromptMine/Services/VideoProcessingService.php
@@ -247,7 +247,8 @@ class VideoProcessingService
                 if ($attempt >= $maxAttempts) {
                     return [
                         'status' => 'FAILED',
-                        'error' => 'Failed to check video status after ' . $maxAttempts . ' attempts: ' . $e->getMessage(),
+                        'error' => 'Failed to check video status after ' .
+                            $maxAttempts . ' attempts: ' . $e->getMessage(),
                     ];
                 }
                 sleep(2); // Wait before retry
@@ -328,7 +329,8 @@ class VideoProcessingService
         }
 
         $totalDelivery = 0;
-        $thumbnailImageUrl = $this->entity->getFiles()->first() ?? $this->generateThumbnailFromVideo($fileSystemRecord->url);
+        $thumbnailImageUrl = $this->entity->getFiles()->first()
+            ?? $this->generateThumbnailFromVideo($fileSystemRecord->url);
         $cdnThumbnailUrl = $this->entity->app->get('cloud-cdn') . '/' . $thumbnailImageUrl->path;
         // Create a new nugget message with the processed video
         $cdnVideoUrl = $this->entity->app->get('cloud-cdn') . '/' . $fileSystemRecord->path;
@@ -380,7 +382,10 @@ class VideoProcessingService
         }
 
         // Turn type to prompt
-        $this->entity->message_types_id = MessageType::fromApp($this->entity->app)->where('verb', 'prompt')->firstOrFail()->getId();
+        $this->entity->message_types_id = MessageType::fromApp($this->entity->app)
+            ->where('verb', 'prompt')
+            ->firstOrFail()
+            ->getId();
         $this->entity->update();
 
         return [

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -60,8 +60,10 @@ class LLMMessageResponseActivity extends KanvasActivity
                     ];
                 }
 
-                $isTypeImage = isset($message->message['type']) && $message->message['type'] === MessageTypeEnum::IMAGE_FORMAT->value;
-                $isTypeVideo = isset($message->message['type']) && $message->message['type'] === MessageTypeEnum::VIDEO_FORMAT->value;
+                $isTypeImage = isset($message->message['type'])
+                    && $message->message['type'] === MessageTypeEnum::IMAGE_FORMAT->value;
+                $isTypeVideo = isset($message->message['type'])
+                    && $message->message['type'] === MessageTypeEnum::VIDEO_FORMAT->value;
 
                 $promptChannel = $message->channels->first();
                 $totalMessagesInChannel = $promptChannel ? $promptChannel->messages()->count() : 0;
@@ -74,7 +76,10 @@ class LLMMessageResponseActivity extends KanvasActivity
                     $chatHistory = $result['chat_history'];
                     $messageTypeKey = 'nugget';
                     $isNotSafeForWork = $result['nsfw_flag'] ?? false;
-                } elseif ($isTypeImage && isset($message->message['ai_image']) && count($message->message['ai_image']) > 0) {
+                } elseif ($isTypeImage
+                    && isset($message->message['ai_image'])
+                    && count($message->message['ai_image']) > 0
+                ) {
                     $channel = $message->channels->first();
                     $channel->is_deleted = 1;
                     $channel->save();
@@ -117,7 +122,9 @@ class LLMMessageResponseActivity extends KanvasActivity
                     'message' => [
                         'title' => $this->generateTitleByPrompt($message->message['prompt']),
                         $messageTypeKey => $response,
-                        'type' => $isTypeImage ? MessageTypeEnum::IMAGE_FORMAT->value : MessageTypeEnum::TEXT_FORMAT->value,
+                        'type' => $isTypeImage
+                            ? MessageTypeEnum::IMAGE_FORMAT->value
+                            : MessageTypeEnum::TEXT_FORMAT->value,
                         'chat_history' => $chatHistory, // Include chat history
                         'nsfw_flag' => $isNotSafeForWork ?? false,
                         'error' => $error,
@@ -152,7 +159,11 @@ class LLMMessageResponseActivity extends KanvasActivity
                     ),
                 ))->execute();
 
-                if ($promptChannel && empty($promptChannel->title) && isset($message->message['title']) && ! empty($message->message['title'])) {
+                if ($promptChannel
+                    && empty($promptChannel->title)
+                    && isset($message->message['title'])
+                    && ! empty($message->message['title'])
+                ) {
                     $channelName = $this->cleanChannelTitle($message->message['title']);
                     $promptChannel->name = $channelName;
                     $promptChannel->title = $channelName;
@@ -265,7 +276,9 @@ class LLMMessageResponseActivity extends KanvasActivity
             $errorProcessingImageNotification = new ImageProcessingPushNotification(
                 user: $message->user,
                 entity: $message,
-                message: $isNotSafeForWork ? 'Your image prompt was flagged as not safe for work and could not be processed.' : 'We could not process your prompt at this time, please try again.',
+                message: $isNotSafeForWork
+                    ? 'Your image prompt was flagged as not safe for work and could not be processed.'
+                    : 'We could not process your prompt at this time, please try again.',
                 title: 'Image Processing Error',
                 via: $endViaList,
                 templates: [
@@ -283,7 +296,9 @@ class LLMMessageResponseActivity extends KanvasActivity
 
             //return [$isNotSafeForWork ? $message->app->get('NSFW_IMAGE_URL') : ''];
             return [
-                'response' => $isNotSafeForWork ? 'Your prompt was flagged as not safe for work and could not be processed.' : 'We could not process your prompt at this time, please try again.',
+                'response' => $isNotSafeForWork
+                    ? 'Your prompt was flagged as not safe for work and could not be processed.'
+                    : 'We could not process your prompt at this time, please try again.',
                 'chat_history' => [],
                 'message' => Str::isJson($errorBody) ? json_decode($errorBody, true) : $errorBody,
                 'nsfw_flag' => true,
@@ -324,7 +339,9 @@ class LLMMessageResponseActivity extends KanvasActivity
             $errorProcessingImageNotification = new ImageProcessingPushNotification(
                 user: $message->user,
                 entity: $message,
-                message: $isNotSafeForWork ? 'Your image prompt was flagged as not safe for work and could not be processed.' : 'We could not process your prompt at this time, please try again.',
+                message: $isNotSafeForWork
+                    ? 'Your image prompt was flagged as not safe for work and could not be processed.'
+                    : 'We could not process your prompt at this time, please try again.',
                 title: 'Image Processing Error',
                 via: $endViaList,
                 templates: [
@@ -341,11 +358,15 @@ class LLMMessageResponseActivity extends KanvasActivity
             $message->user->notify($errorProcessingImageNotification);
 
             //return [$isNotSafeForWork ? $message->app->get('NSFW_IMAGE_URL') : ''];
-            $placeHolderText = urlencode('We could not process your prompt at this time'); // . '\n' . urlencode($errorBody);
+            $placeHolderText = urlencode('We could not process your prompt at this time');
 
             return [
-                'response' => $isNotSafeForWork ? $message->app->get('NSFW_IMAGE_URL') : (string) $message->app->get('PLACE_HOLDER_IMAGE_URL') . '?text=' . $placeHolderText,
-                'image_url' => $isNotSafeForWork ? $message->app->get('NSFW_IMAGE_URL') : (string) $message->app->get('PLACE_HOLDER_IMAGE_URL') . '?text=' . $placeHolderText,
+                'response' => $isNotSafeForWork
+                    ? $message->app->get('NSFW_IMAGE_URL')
+                    : (string) $message->app->get('PLACE_HOLDER_IMAGE_URL') . '?text=' . $placeHolderText,
+                'image_url' => $isNotSafeForWork
+                    ? $message->app->get('NSFW_IMAGE_URL')
+                    : (string) $message->app->get('PLACE_HOLDER_IMAGE_URL') . '?text=' . $placeHolderText,
                 'chat_history' => [],
                 'flag' => true,
                 'message' => 'You have reached your daily image generation limit.',
@@ -421,7 +442,10 @@ class LLMMessageResponseActivity extends KanvasActivity
         // Check if previous message has children and if the first child has chat history
         $firstChild = $previousMessage->children()->first();
 
-        if ($firstChild && isset($firstChild->message['chat_history']) && is_array($firstChild->message['chat_history'])) {
+        if ($firstChild
+            && isset($firstChild->message['chat_history'])
+            && is_array($firstChild->message['chat_history'])
+        ) {
             return $firstChild->message['chat_history'];
         }
 
@@ -433,8 +457,11 @@ class LLMMessageResponseActivity extends KanvasActivity
      * Find a valid previous image response by skipping NSFW or error responses.
      * Looks back up to maxAttempts messages to find a valid one.
      */
-    private function findValidPreviousImageResponse(?Message $currentMessage, ?Channel $channel, int $maxAttempts = 3): ?Message
-    {
+    private function findValidPreviousImageResponse(
+        ?Message $currentMessage,
+        ?Channel $channel,
+        int $maxAttempts = 3
+    ): ?Message {
         if ($currentMessage === null) {
             return null;
         }
@@ -506,8 +533,14 @@ class LLMMessageResponseActivity extends KanvasActivity
             $initialPreviousResponse = $channel !== null ? $channel->getPreviousMessage($message) : null;
             $previousChatResponse = $this->findValidPreviousImageResponse($initialPreviousResponse, $channel);
 
-            if ($previousChatResponse instanceof Message && ($previousChatResponse->isRoot() || isset($previousChatResponse->message['remix_parent_id']))) {
-                if (array_key_exists('is_regeneration', $message->message) && $message->message['is_regeneration'] && ! empty($chatHistory) && end($chatHistory)['role'] === 'assistant') {
+            if ($previousChatResponse instanceof Message
+                && ($previousChatResponse->isRoot() || isset($previousChatResponse->message['remix_parent_id']))
+            ) {
+                if (array_key_exists('is_regeneration', $message->message)
+                    && $message->message['is_regeneration']
+                    && ! empty($chatHistory)
+                    && end($chatHistory)['role'] === 'assistant'
+                ) {
                     $previousChatResponseMessage = $message->message['prompt'];
                     $previousChatImage = null;
                     if (count($chatHistory) > 1) {
@@ -517,11 +550,15 @@ class LLMMessageResponseActivity extends KanvasActivity
                         $previousChatImage = end($chatHistory);
                         array_pop($chatHistory); //remove current assistant message
                     }
-                    $params['previousImageUrl'] = $previousChatImage && array_key_exists('content', $previousChatImage) ? $previousChatImage['content'] : null;
+                    $params['previousImageUrl'] = $previousChatImage && array_key_exists('content', $previousChatImage)
+                        ? $previousChatImage['content']
+                        : null;
                 } else {
                     $previousChatResponseMessage = $previousChatResponse->message['prompt'] ?? null;
                     $previousChatMessageChildren = $previousChatResponse->children()?->first();
-                    $params['previousImageUrl'] = $previousChatMessageChildren instanceof Message ? $previousChatMessageChildren->message['image'] : null;
+                    $params['previousImageUrl'] = $previousChatMessageChildren instanceof Message
+                        ? $previousChatMessageChildren->message['image']
+                        : null;
                 }
 
                 $params['previousPrompts'] = $previousChatResponseMessage ? [$previousChatResponseMessage] : [];
@@ -563,7 +600,9 @@ class LLMMessageResponseActivity extends KanvasActivity
             $errorProcessingImageNotification = new ImageProcessingPushNotification(
                 user: $message->user,
                 entity: $message,
-                message: $isNotSafeForWork ? 'Your image prompt was flagged as not safe for work and could not be processed.' : 'Your image prompt could not be processed. Please try again.',
+                message: $isNotSafeForWork
+                    ? 'Your image prompt was flagged as not safe for work and could not be processed.'
+                    : 'Your image prompt could not be processed. Please try again.',
                 title: 'Image Processing Error',
                 via: $endViaList,
                 templates: [
@@ -580,7 +619,7 @@ class LLMMessageResponseActivity extends KanvasActivity
             $message->user->notify($errorProcessingImageNotification);
 
             //return [$isNotSafeForWork ? $message->app->get('NSFW_IMAGE_URL') : ''];
-            $placeHolderText = urlencode('We could not process your prompt at this time'); // . '\n' . urlencode($errorBody);
+            $placeHolderText = urlencode('We could not process your prompt at this time');
 
             if ($message->isRoot() && $isNotSafeForWork) {
                 /* $channel->is_deleted = 1;
@@ -588,7 +627,9 @@ class LLMMessageResponseActivity extends KanvasActivity
             }
 
             return [
-                'response' => $isNotSafeForWork ? $message->app->get('NSFW_IMAGE_URL') : (string) $message->app->get('PLACE_HOLDER_IMAGE_URL') . '?text=' . $placeHolderText,
+                'response' => $isNotSafeForWork
+                    ? $message->app->get('NSFW_IMAGE_URL')
+                    : (string) $message->app->get('PLACE_HOLDER_IMAGE_URL') . '?text=' . $placeHolderText,
                 'chat_history' => $chatHistory,
                 'message' => Str::isJson($errorBody) ? json_decode($errorBody, true) : $errorBody,
                 'nsfw_flag' => true,
@@ -672,7 +713,8 @@ class LLMMessageResponseActivity extends KanvasActivity
             //$useOnlyImageResponse = (bool) ($message->app->get('use_only_image_response') ?? false);
 
             return [
-                'response' => (string) $message->app->get('PLACE_HOLDER_IMAGE_URL') . '?text=You have reached your daily image generation limit.',
+                'response' => (string) $message->app->get('PLACE_HOLDER_IMAGE_URL') .
+                    '?text=You have reached your daily image generation limit.',
                 'image_url' => $message->app->get('LIMIT_IMAGE_URL') ?? '',
                 'chat_history' => [],
                 'limit' => $message->app->get('message-post-limit') ?? 0,
@@ -705,7 +747,9 @@ class LLMMessageResponseActivity extends KanvasActivity
      */
     protected function getCompany(AppInterface $app, Model $entity): Companies
     {
-        $defaultAppCompanyBranch = $app->get(AppSettingsEnums::GLOBAL_USER_REGISTRATION_ASSIGN_GLOBAL_COMPANY->getValue());
+        $defaultAppCompanyBranch = $app->get(
+            AppSettingsEnums::GLOBAL_USER_REGISTRATION_ASSIGN_GLOBAL_COMPANY->getValue()
+        );
 
         try {
             $branch = CompaniesBranches::getById($defaultAppCompanyBranch);

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -59,7 +59,9 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
         $this->app = $app;
         $this->apiUrl = $entity->app->get('PROMPT_IMAGE_API_URL');
         $this->openaiApiUrl = $entity->app->get('PROMPT_IMAGE_API_URL_OPENAI');
-        $imageFilter = Str::of($entity->message['ai_model']['value'] ?? 'cartoonify')->replace('fal-ai/', '')->toString();
+        $imageFilter = Str::of($entity->message['ai_model']['value'] ?? 'cartoonify')
+            ->replace('fal-ai/', '')
+            ->toString();
         $imageFilterName = $entity->message['ai_model']['name'] ?? 'cartoonify';
 
         $isOpenAi = Str::contains($imageFilter, 'gpt');
@@ -71,7 +73,12 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
             entity: $entity,
             app: $app,
             integration: IntegrationsEnum::PROMPT_MINE,
-            integrationOperation: function ($entity, $app, $integrationCompany, $additionalParams) use ($messageFiles, $params, $imageFilter, $isOpenAi, $isGeminiBanana) {
+            integrationOperation: function (
+                $entity,
+                $app,
+                $integrationCompany,
+                $additionalParams
+            ) use ($messageFiles, $params, $imageFilter, $isOpenAi, $isGeminiBanana) {
                 $entity->setPrivate();
 
                 if (! empty($this->validateImageLimit($entity, $params))) {
@@ -106,13 +113,20 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
 
                 if ($messageFiles->count() > 1) {
                     //lets add them to params since this is optional
-                    $params['additional_images'] = $messageFiles->slice(1)->map(fn ($file) => $file->url)->toArray();
+                    $params['additional_images'] = $messageFiles->slice(1)
+                        ->map(fn ($file) => $file->url)
+                        ->toArray();
                 }
 
                 try {
                     // Process image based on the model type
                     if ($isOpenAi) {
-                        $fileSystemRecord = $this->processImageWithOpenAI($fileUrl, $entity->message['prompt'], $entity, $params);
+                        $fileSystemRecord = $this->processImageWithOpenAI(
+                            $fileUrl,
+                            $entity->message['prompt'],
+                            $entity,
+                            $params
+                        );
                         if ($fileSystemRecord === null) {
                             return $this->failWorkflow([
                                 'result' => false,
@@ -122,7 +136,13 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
                         }
                     } elseif ($isGeminiBanana) {
                         // Process with Gemini-Nano-Banana
-                        $fileSystemRecord = $this->processImageWithGeminiBanana($fileUrl, $entity->message['prompt'] ?? '', $entity, $imageFilter, $params);
+                        $fileSystemRecord = $this->processImageWithGeminiBanana(
+                            $fileUrl,
+                            $entity->message['prompt'] ?? '',
+                            $entity,
+                            $imageFilter,
+                            $params
+                        );
                         if ($fileSystemRecord === null) {
                             return $this->failWorkflow([
                                 'result' => false,
@@ -254,7 +274,9 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
      */
     protected function getCompany(AppInterface $app, Model $entity): Companies
     {
-        $defaultAppCompanyBranch = $app->get(AppSettingsEnums::GLOBAL_USER_REGISTRATION_ASSIGN_GLOBAL_COMPANY->getValue());
+        $defaultAppCompanyBranch = $app->get(
+            AppSettingsEnums::GLOBAL_USER_REGISTRATION_ASSIGN_GLOBAL_COMPANY->getValue()
+        );
 
         try {
             $branch = CompaniesBranches::getById($defaultAppCompanyBranch);
@@ -274,7 +296,14 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
     {
         // Step 1: Submit the image for processing
         $model = 'fal-ai/';
-        $submitResponse = $this->submitImage($this->apiUrl, $fileUrl, $imageFilter, $entity->message['prompt'] ?? '', $model, $params)->json();
+        $submitResponse = $this->submitImage(
+            $this->apiUrl,
+            $fileUrl,
+            $imageFilter,
+            $entity->message['prompt'] ?? '',
+            $model,
+            $params
+        )->json();
 
         if (! isset($submitResponse['request_id'])) {
             throw new Exception('Failed to submit image for processing: ' . json_encode($submitResponse));
@@ -326,8 +355,12 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
     /**
      * Process image with OpenAI
      */
-    protected function processImageWithOpenAI(string $imageUrl, string $prompt, Model $entity, array $params = []): ?Filesystem
-    {
+    protected function processImageWithOpenAI(
+        string $imageUrl,
+        string $prompt,
+        Model $entity,
+        array $params = []
+    ): ?Filesystem {
         // Download the image file
         $imageContents = file_get_contents($imageUrl);
         $filename = basename(parse_url($imageUrl, PHP_URL_PATH));
@@ -376,7 +409,8 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
                     $params['email_template'] = 'image-processing-failure-generic-error';
                     $this->sendFailNotification(
                         $entity,
-                        "Just a heads-up! Your last creation had a hiccup. Your credit wasn't used, feel free to try again.",
+                        "Just a heads-up! Your last creation had a hiccup. " .
+                        "Your credit wasn't used, feel free to try again.",
                         $params
                     );
 
@@ -384,7 +418,10 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
                 }
 
                 // Log the retry attempt
-                report(new Exception("Image processing attempt {$attempt} failed: " . $e->getMessage() . ". Retrying in {$retryDelay} seconds."));
+                report(new Exception(
+                    "Image processing attempt {$attempt} failed: " . $e->getMessage() .
+                    ". Retrying in {$retryDelay} seconds."
+                ));
 
                 // Wait before retrying
                 sleep($retryDelay);
@@ -405,7 +442,8 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
             $errorProcessingImageNotification = new ImageProcessingPushNotification(
                 user: $entity->user,
                 entity: $entity,
-                message: "Your recent creation couldn't be completed as it didn't comply with the content provider’s policies.",
+                message: "Your recent creation couldn't be completed as it didn't comply with " .
+                    "the content provider’s policies.",
                 title: 'Error processing image',
                 via: $endViaList,
                 templates: [
@@ -459,8 +497,13 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
     /**
      * Process image with Gemini-Nano-Banana
      */
-    protected function processImageWithGeminiBanana(string $imageUrl, string $prompt, Model $entity, string $imageFilter, array $params): ?Filesystem
-    {
+    protected function processImageWithGeminiBanana(
+        string $imageUrl,
+        string $prompt,
+        Model $entity,
+        string $imageFilter,
+        array $params
+    ): ?Filesystem {
         $apiUrl = str_replace('api/image/fal-ai/image-to-image', '', $this->apiUrl);
         $apiUrl = rtrim($apiUrl, '/') . '/api/image/Gemini-Nano-Banana/i2i';
 
@@ -486,7 +529,10 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
         }
 
         if (! $processedImageUrl) {
-            throw new Exception('Failed to extract image URL from Gemini Banana response: ' . json_encode($responseData));
+            throw new Exception(
+                'Failed to extract image URL from Gemini Banana response: ' .
+                json_encode($responseData)
+            );
         }
 
         // Optimize and upload the processed image
@@ -629,8 +675,14 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
     /**
      * Submit an image for processing
      */
-    protected function submitImage(string $apiUrl, string $imageUrl, string $imageFilter, string $prompt, string $model, array $params): Response
-    {
+    protected function submitImage(
+        string $apiUrl,
+        string $imageUrl,
+        string $imageFilter,
+        string $prompt,
+        string $model,
+        array $params
+    ): Response {
         if (isset($params['additional_images']) && ! empty($params['additional_images'])) {
             $params['additional_images'][] = $imageUrl;
             $imageUrl = array_values($params['additional_images']);


### PR DESCRIPTION
## Description
Redo of PR #8560 on a clean branch from latest development.
Implements XML delimiting and sandwich defense across core AI templates to prevent prompt injection attacks.

## Changes
- Hardened **GeminiTagService** (Summarizer)
- Hardened **CalculateCustomTaxAction** (Commerce)
- Hardened **ModelWizardModelChooserAction** (Code Assistant equivalent)
- Hardened **VideoProcessingService**, **ImageFilterService**, **PromptImageFilterActivity** (Content Generation)
- Hardened **PromptCreatorAgentCommand**, **PromptAgentEngagerCommand** (Agents)

## Verification
- Style issues (line length) resolved.
- CI triggered on fresh branch.
