### PR TITLE
MK-3969: Longitudinal Usage Stats Endpoint

### DIFF
--- a/app/Http/Controllers/API/Users/UserStatsController.php
+++ b/app/Http/Controllers/API/Users/UserStatsController.php
@@ -43,6 +43,7 @@ class UserStatsController extends Controller
             ])
             ->groupBy('date')
             ->orderBy('date', 'ASC')
+            ->toBase()
             ->get()
             ->keyBy('date');
 

--- a/app/Http/Controllers/API/Users/UserStatsController.php
+++ b/app/Http/Controllers/API/Users/UserStatsController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\Users;
+
+use App\Http\Controllers\Controller;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Social\Messages\Models\Message;
+
+class UserStatsController extends Controller
+{
+    /**
+     * Get usage stats for the current user.
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $user = auth()->user();
+        $app = app(Apps::class);
+        $days = 7;
+
+        // Ensure we cover the last 7 days including today
+        $startDate = Carbon::now()->subDays($days - 1)->startOfDay();
+        $endDate = Carbon::now()->endOfDay();
+
+        // Get the counts grouped by date
+        // We use the social connection explicitly for the raw statement if needed, 
+        // but Eloquent handles the connection for the model.
+        $usageData = Message::fromApp($app)
+            ->where('users_id', $user->getId())
+            ->where('created_at', '>=', $startDate)
+            ->whereNull('parent_id') // Count only root messages (prompts/interactions)
+            ->select([
+                DB::raw('DATE(created_at) as date'),
+                DB::raw('count(*) as count')
+            ])
+            ->groupBy('date')
+            ->orderBy('date', 'ASC')
+            ->get()
+            ->keyBy('date');
+
+        // Fill in missing dates with 0
+        $stats = [];
+        $currentDate = clone $startDate;
+
+        while ($currentDate <= $endDate) {
+            $dateStr = $currentDate->format('Y-m-d');
+            $stats[] = [
+                'date' => $dateStr,
+                'count' => $usageData->has($dateStr) ? (int) $usageData[$dateStr]->count : 0,
+            ];
+            $currentDate->addDay();
+        }
+
+        return response()->json([
+            'data' => $stats
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,3 +9,7 @@ Route::get('/oauth/{uuid}', [\App\Http\Controllers\OAuthIntegrationController::c
 Route::get('/oauth/{uuid}/callback', [\App\Http\Controllers\OAuthIntegrationController::class, 'callback']);
 Route::get('/status', SimpleHealthCheckController::class);
 Route::middleware('auth')->get('/status/health', \Spatie\Health\Http\Controllers\HealthCheckJsonResultsController::class);
+
+Route::middleware('auth:api')->group(function () {
+    Route::get('/users/me/stats/usage', [\App\Http\Controllers\API\Users\UserStatsController::class, 'index']);
+});


### PR DESCRIPTION
## Description
Adds a new endpoint `/users/me/stats/usage` to retrieve usage statistics (message counts) for the logged-in user over the last 7 days. This data is intended for the Home Screen graph.

## Endpoint
`GET /users/me/stats/usage`

## Response
```json
{
  "data": [
    {"date": "2026-03-01", "count": 12},
    {"date": "2026-03-02", "count": 15},
    ...
  ]
}
```

## Implementation
- Added `UserStatsController` in `app/Http/Controllers/API/Users/`.
- Uses `Message::fromApp()` query scope.
- Groups by date and fills missing dates with 0.
- Registered route in `routes/api.php`.
