### PR TITLE
MK-3922: Do not mutate model prefixes for image-to-image

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -59,7 +59,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
         $this->app = $app;
         $this->apiUrl = $entity->app->get('PROMPT_IMAGE_API_URL');
         $this->openaiApiUrl = $entity->app->get('PROMPT_IMAGE_API_URL_OPENAI');
-        $imageFilter = Str::of($entity->message['ai_model']['value'] ?? 'cartoonify')->replace('fal-ai/', '')->toString();
+        $imageFilter = Str::of($entity->message['ai_model']['value'] ?? 'cartoonify')->toString();
         $imageFilterName = $entity->message['ai_model']['name'] ?? 'cartoonify';
 
         $isOpenAi = Str::contains($imageFilter, 'gpt');
@@ -273,8 +273,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
     protected function processImageWithFalAi(string $fileUrl, string $imageFilter, Model $entity, array $params): array
     {
         // Step 1: Submit the image for processing
-        $model = 'fal-ai/';
-        $submitResponse = $this->submitImage($this->apiUrl, $fileUrl, $imageFilter, $entity->message['prompt'] ?? '', $model, $params)->json();
+        $submitResponse = $this->submitImage($this->apiUrl, $fileUrl, $imageFilter, $entity->message['prompt'] ?? '', '', $params)->json();
 
         if (! isset($submitResponse['request_id'])) {
             throw new Exception('Failed to submit image for processing: ' . json_encode($submitResponse));
@@ -640,7 +639,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
         ])->timeout(120)->post($apiUrl, [
             'operation' => 'submit',
             'image_url' => $imageUrl,
-            'model' => $model . $imageFilter,
+            'model' => $imageFilter,
             'prompt' => $prompt,
         ]);
 
@@ -661,7 +660,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
             ])->timeout(120)->post($this->apiUrl, [
                 'operation' => 'status',
                 'requestId' => $requestId,
-                'model' => 'fal-ai/' . $imageFilter,
+                'model' => $imageFilter,
                 'logs' => true,
             ]);
 
@@ -701,7 +700,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
         ])->timeout(120)->post($this->apiUrl, [
             'operation' => 'result',
             'requestId' => $requestId,
-            'model' => 'fal-ai/' . $imageFilter,
+            'model' => $imageFilter,
         ]);
 
         return $response->json();

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -273,7 +273,8 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
     protected function processImageWithFalAi(string $fileUrl, string $imageFilter, Model $entity, array $params): array
     {
         // Step 1: Submit the image for processing
-        $submitResponse = $this->submitImage($this->apiUrl, $fileUrl, $imageFilter, $entity->message['prompt'] ?? '', '', $params)->json();
+        $falModel = $this->normalizeFalModel($imageFilter);
+        $submitResponse = $this->submitImage($this->apiUrl, $fileUrl, $falModel, $entity->message['prompt'] ?? '', $params)->json();
 
         if (! isset($submitResponse['request_id'])) {
             throw new Exception('Failed to submit image for processing: ' . json_encode($submitResponse));
@@ -463,7 +464,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
         $apiUrl = str_replace('api/image/fal-ai/image-to-image', '', $this->apiUrl);
         $apiUrl = rtrim($apiUrl, '/') . '/api/image/Gemini-Nano-Banana/i2i';
 
-        $response = $this->submitImage($apiUrl, $imageUrl, $imageFilter, $prompt, '', $params);
+        $response = $this->submitImage($apiUrl, $imageUrl, $imageFilter, $prompt, $params);
         $responseData = $response->json();
 
         if (! $response->successful()) {
@@ -628,18 +629,49 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
     /**
      * Submit an image for processing
      */
-    protected function submitImage(string $apiUrl, string $imageUrl, string $imageFilter, string $prompt, string $model, array $params): Response
+    /**
+     * MK-3922: Normalize fal model identifiers.
+     * - If the model already includes a known provider prefix (e.g. xai/..., fal-ai/...), pass through as-is.
+     * - Otherwise, treat it as a bare fal model key and prefix with `fal-ai/`.
+     */
+    protected function normalizeFalModel(string $model): string
     {
+        $model = trim($model);
+
+        if ($model === '') {
+            return 'fal-ai/cartoonify';
+        }
+
+        $knownPrefixes = [
+            'fal-ai/',
+            'xai/',
+            'openai/',
+            'stability-ai/',
+            'google/',
+            'replicate/',
+            'anthropic/',
+        ];
+
+        if (Str::startsWith($model, $knownPrefixes)) {
+            return $model;
+        }
+
+        return 'fal-ai/' . ltrim($model, '/');
+    }
+
+    protected function submitImage(string $apiUrl, string $imageUrl, string $model, string $prompt, array $params): Response
+    { 
         if (isset($params['additional_images']) && ! empty($params['additional_images'])) {
             $params['additional_images'][] = $imageUrl;
             $imageUrl = array_values($params['additional_images']);
         }
+
         $response = Http::withHeaders([
             'Content-Type' => 'application/json',
         ])->timeout(120)->post($apiUrl, [
             'operation' => 'submit',
             'image_url' => $imageUrl,
-            'model' => $imageFilter,
+            'model' => $model,
             'prompt' => $prompt,
         ]);
 
@@ -660,7 +692,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
             ])->timeout(120)->post($this->apiUrl, [
                 'operation' => 'status',
                 'requestId' => $requestId,
-                'model' => $imageFilter,
+                'model' => $this->normalizeFalModel($imageFilter),
                 'logs' => true,
             ]);
 
@@ -700,7 +732,7 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
         ])->timeout(120)->post($this->apiUrl, [
             'operation' => 'result',
             'requestId' => $requestId,
-            'model' => $imageFilter,
+            'model' => $this->normalizeFalModel($imageFilter),
         ]);
 
         return $response->json();

--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/PromptImageFilterActivity.php
@@ -627,9 +627,6 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
     }
 
     /**
-     * Submit an image for processing
-     */
-    /**
      * MK-3922: Normalize fal model identifiers.
      * - If the model already includes a known provider prefix (e.g. xai/..., fal-ai/...), pass through as-is.
      * - Otherwise, treat it as a bare fal model key and prefix with `fal-ai/`.
@@ -659,8 +656,16 @@ class PromptImageFilterActivity extends KanvasActivity implements WorkflowActivi
         return 'fal-ai/' . ltrim($model, '/');
     }
 
-    protected function submitImage(string $apiUrl, string $imageUrl, string $model, string $prompt, array $params): Response
-    { 
+    /**
+     * Submit an image for processing.
+     */
+    protected function submitImage(
+        string $apiUrl,
+        string $imageUrl,
+        string $model,
+        string $prompt,
+        array $params
+    ): Response {
         if (isset($params['additional_images']) && ! empty($params['additional_images'])) {
             $params['additional_images'][] = $imageUrl;
             $imageUrl = array_values($params['additional_images']);


### PR DESCRIPTION
Fixes MK-3922.

Problem:
- Requests routed to `/api/image/fal-ai/image-to-image` were mutating model identifiers by prepending `fal-ai/`.
- When the client sends a model with a different provider prefix (e.g. `xai/...`), the backend produced `fal-ai/xai/...`, which is invalid.

Changes:
- Treat the model string as an opaque identifier and forward it as-is.
- Remove `fal-ai/` stripping at the entrypoint and remove forced `fal-ai/` prefixing in submit/status/result calls.

Expected:
- `xai/grok-imagine-image/edit` stays exactly that through the proxy call.
