### PR TITLE
Fix updateMessage to accept is_locked

### DIFF
--- a/app/GraphQL/Social/Mutations/Messages/MessageManagementMutation.php
+++ b/app/GraphQL/Social/Mutations/Messages/MessageManagementMutation.php
@@ -163,6 +163,7 @@ class MessageManagementMutation
                 is_public: $input['is_public'] ?? $message->is_public,
                 tags: $input['tags'] ?? [],
                 categories: $input['categories'] ?? [],
+                is_locked: $input['is_locked'] ?? $message->is_locked,
             ),
         )->execute();
     }

--- a/graphql/schemas/Social/message.graphql
+++ b/graphql/schemas/Social/message.graphql
@@ -90,6 +90,7 @@ input MessageUpdateInput {
     message: Mixed
     message_verb: ID
     is_public: Int
+    is_locked: Int
     is_deleted: Int
     tags: [TagInput!]
     categories: [CategoryInput!]

--- a/src/Domains/Social/Messages/Actions/UpdateMessageAction.php
+++ b/src/Domains/Social/Messages/Actions/UpdateMessageAction.php
@@ -22,6 +22,7 @@ class UpdateMessageAction
             $this->message->message = $this->data->message;
             $this->message->message_types_id = $this->data->type->getId();
             $this->message->is_public = (int) $this->data->is_public;
+            $this->message->is_locked = (int) $this->data->is_locked;
             $this->message->saveOrFail();
 
             if (count($this->data->tags)) {

--- a/tests/GraphQL/Social/MessageTest.php
+++ b/tests/GraphQL/Social/MessageTest.php
@@ -142,7 +142,7 @@ class MessageTest extends TestCase
             'data' => [
                 'updateMessage' => [
                     'message' => $newMessage,
-                'tags' => [
+                    'tags' => [
                         'data' => [
                             [
                                 'name' => 'tag1',
@@ -152,6 +152,52 @@ class MessageTest extends TestCase
                 ],
             ],
         ]);
+    }
+
+    public function testUpdateMessageWithIsLocked(): void
+    {
+        $messageType = MessageType::factory()->create();
+        $createResponse = $this->graphQL('{
+            mutation($input: MessageInput!) {
+                createMessage(input: $input) {
+                    id
+                    is_locked
+                }
+            }
+        ', [
+            'input' => [
+                'message' => fake()->text(),
+                'message_verb' => $messageType->verb,
+            ],
+        ])->assertSuccessful();
+
+        $id = $createResponse->json('data.createMessage.id');
+
+        $this->graphQL('{
+            mutation($id: ID!, $input: MessageUpdateInput!) {
+                updateMessage(id: $id, input: $input) {
+                    id
+                    is_locked
+                }
+            }
+        ', [
+            'id' => $id,
+            'input' => [
+                'is_locked' => 1,
+            ],
+        ])
+        ->assertSuccessful()
+        ->assertJson([
+            'data' => [
+                'updateMessage' => [
+                    'id' => $id,
+                    'is_locked' => 1,
+                ],
+            ],
+        ]);
+
+        $message = Message::getById((int) $id, app(Apps::class));
+        $this->assertSame(1, (int) $message->is_locked);
     }
 
     public function testUpdateMessageAddTags(): void


### PR DESCRIPTION
Fixes GraphQL error: `Field "is_locked" is not defined by type "MessageUpdateInput"`.

Changes:
- Add `is_locked: Int` to `MessageUpdateInput` in `graphql/schemas/Social/message.graphql`
- Pass `is_locked` through `MessageManagementMutation@update` into `MessageInput`
- Persist `is_locked` in `UpdateMessageAction`

This allows clients to call:

```
mutation($id: ID!, $input: MessageUpdateInput!) {
  updateMessage(id: $id, input: $input) { id }
}
```

with `input.is_locked` without schema validation errors.
