### PR TITLE
fix(MK-3947): handle empty previousImageUrl after background generation

### DIFF
--- a/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
+++ b/src/Domains/Connectors/PromptMine/Workflows/Activities/LLMMessageResponseActivity.php
@@ -535,14 +535,20 @@ class LLMMessageResponseActivity extends KanvasActivity
         }
 
         try {
-            $generateImage = $previousChatResponse === null ? $promptClient->generateImage(
+            // MK-3947: If we do not have a valid previous image URL, do NOT call continueImageChat.
+            // Passing an empty string was causing downstream services to misclassify the request
+            // and trigger false content-warning flows on the next attempt.
+            $previousImageUrl = $params['previousImageUrl'] ?? null;
+            $canContinueImageChat = $previousChatResponse !== null && is_string($previousImageUrl) && $previousImageUrl !== '';
+
+            $generateImage = ! $canContinueImageChat ? $promptClient->generateImage(
                 provider: $provider,
                 model: $model,
                 prompt: $prompt,
                 params: $params
             ) : $promptClient->continueImageChat(
                 //provider: $provider,
-                previousImageUrl: $params['previousImageUrl'] ?? '',
+                previousImageUrl: $previousImageUrl,
                 previousPrompts: $params['previousPrompts'] ?? [],
                 //model: $model,
                 model: $this->app->get('default-image-edit-model') ?? 'fal-ai/flux-kontext/dev',


### PR DESCRIPTION
## Summary
Fixes a bug where returning to the app after an image generation completes could leave previousImageUrl empty. Passing an empty string into continueImageChat could trigger incorrect downstream classification and lead to false content warnings on the next attempt.

## Changes
- In LLMMessageResponseActivity, only call continueImageChat when previousImageUrl is a non-empty string.
- Otherwise fall back to generateImage.

## Acceptance Criteria
- Returning to app after background generation does not produce false content warnings.
- Empty previousImageUrl is handled gracefully (not treated as content violation).
- User can retry generation normally.

## Testing
- Simulate a message thread where a prior response exists but no valid child image can be resolved.
- Confirm request uses generateImage instead of continueImageChat when previousImageUrl is empty.
