### PR TITLE
Hotfix(1.x): allow .mov uploads in WORK_FILES

### DIFF
--- a/src/Kanvas/Filesystem/Enums/AllowedFileExtensionEnum.php
+++ b/src/Kanvas/Filesystem/Enums/AllowedFileExtensionEnum.php
@@ -13,7 +13,7 @@ enum AllowedFileExtensionEnum
     {
         return match ($this) {
             self::ONLY_IMAGES => ['jpg', 'jpeg','tif', 'png', 'gif', 'svg', 'webp', 'json', 'pdf', 'txt', 'text', 'heic', 'heif'],
-            self::WORK_FILES => ['jpg', 'jpeg', 'png', 'gif', 'svg', 'webp', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'txt', 'pdf', 'csv', 'odt', 'ods', 'odp', 'json', 'heic', 'heif'],
+            self::WORK_FILES => ['jpg', 'jpeg', 'png', 'gif', 'svg', 'webp', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'txt', 'pdf', 'csv', 'odt', 'ods', 'odp', 'json', 'heic', 'heif', 'mov'],
         };
     }
 }


### PR DESCRIPTION
Hotfix: allow `.mov` uploads in `AllowedFileExtensionEnum::WORK_FILES` on the `1.x` branch.

Context:
- Production Sentry error: `Invalid file format mov` thrown from `HasMutationUploadFiles` during GraphQL file upload.
- `development` already includes broader video extensions, but `1.x` (prod) does not.

Change:
- Add `mov` to the WORK_FILES extension allowlist.
