### PR TITLE
refactor: track salesassist adf email integration history

### DIFF
--- a/src/Domains/Connectors/SalesAssist/Activities/SendLeadAdfByEmailActivity.php
+++ b/src/Domains/Connectors/SalesAssist/Activities/SendLeadAdfByEmailActivity.php
@@ -12,6 +12,7 @@ use Kanvas\Connectors\SalesAssist\Actions\BuildLeadAdfXmlAction;
 use Kanvas\Connectors\SalesAssist\Mail\LeadAdfXmlMailable;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Workflow\Contracts\WorkflowActivityInterface;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Kanvas\Workflow\KanvasActivity;
 use Override;
 
@@ -53,25 +54,34 @@ class SendLeadAdfByEmailActivity extends KanvasActivity implements WorkflowActiv
 
         $sendAsAttachment = (bool) ($params['send_as_attachment'] ?? false);
 
-        $this->sendAdfEmail(
-            lead: $lead,
+        return $this->executeIntegration(
+            entity: $lead,
             app: $app,
-            to: $to,
-            subject: (string) $subject,
-            xml: $xml,
-            attachmentName: $attachmentName,
-            sendAsAttachment: $sendAsAttachment,
-        );
+            integration: IntegrationsEnum::INTERNAL,
+            additionalParams: $params,
+            integrationOperation: function (Lead $lead, AppInterface $app, mixed $integrationCompany, array $additionalParams) use ($to, $subject, $xml, $attachmentName, $sendAsAttachment): array {
+                $this->sendAdfEmail(
+                    lead: $lead,
+                    app: $app,
+                    to: $to,
+                    subject: (string) $subject,
+                    xml: $xml,
+                    attachmentName: $attachmentName,
+                    sendAsAttachment: $sendAsAttachment,
+                );
 
-        return [
-            'success' => true,
-            'message' => 'ADF lead email sent successfully',
-            'lead_id' => $lead->getId(),
-            'to' => $to,
-            'subject' => $subject,
-            'attachment' => $sendAsAttachment ? $attachmentName : null,
-            'delivery_mode' => $sendAsAttachment ? 'attachment' : 'body',
-        ];
+                return [
+                    'success' => true,
+                    'message' => 'ADF lead email sent successfully',
+                    'lead_id' => $lead->getId(),
+                    'to' => $to,
+                    'subject' => $subject,
+                    'attachment' => $sendAsAttachment ? $attachmentName : null,
+                    'delivery_mode' => $sendAsAttachment ? 'attachment' : 'body',
+                ];
+            },
+            company: $lead->company,
+        );
     }
 
     protected function bootstrapAppService(AppInterface $app): void

--- a/tests/Unit/Connectors/SalesAssist/SendLeadAdfByEmailActivityTest.php
+++ b/tests/Unit/Connectors/SalesAssist/SendLeadAdfByEmailActivityTest.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Tests\Unit\Connectors\SalesAssist;
 
 use Baka\Contracts\AppInterface;
+use Illuminate\Database\Eloquent\Model;
+use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\SalesAssist\Actions\BuildLeadAdfXmlAction;
 use Kanvas\Connectors\SalesAssist\Activities\SendLeadAdfByEmailActivity;
 use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Regions\Models\Regions;
 use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Mockery;
 use PHPUnit\Framework\TestCase;
@@ -88,7 +91,7 @@ class SendLeadAdfByEmailActivityTest extends TestCase
     public function testSendLeadAdfByEmailActivitySendsUsingWorkflowParams(): void
     {
         $lead = Mockery::mock(Lead::class);
-        $company = Mockery::mock(\Kanvas\Companies\Models\Companies::class);
+        $company = Mockery::mock(Companies::class);
 
         $lead->shouldReceive('getId')->andReturn(88);
         $lead->shouldReceive('getAttribute')->with('people')->andReturn(new \stdClass());
@@ -114,13 +117,13 @@ class SendLeadAdfByEmailActivityTest extends TestCase
             }
 
             public function executeIntegration(
-                \Illuminate\Database\Eloquent\Model $entity,
+                Model $entity,
                 AppInterface $app,
                 IntegrationsEnum $integration,
                 callable $integrationOperation,
                 array $additionalParams = [],
-                ?\Kanvas\Regions\Models\Regions $region = null,
-                ?\Kanvas\Companies\Models\Companies $company = null,
+                ?Regions $region = null,
+                ?Companies $company = null,
                 bool $throwException = false
             ): array {
                 $this->usedIntegrationWrapper = true;
@@ -163,7 +166,7 @@ class SendLeadAdfByEmailActivityTest extends TestCase
     public function testSendLeadAdfByEmailActivityCanSendAsAttachment(): void
     {
         $lead = Mockery::mock(Lead::class);
-        $company = Mockery::mock(\Kanvas\Companies\Models\Companies::class);
+        $company = Mockery::mock(Companies::class);
 
         $lead->shouldReceive('getId')->andReturn(89);
         $lead->shouldReceive('getAttribute')->with('people')->andReturn(new \stdClass());
@@ -187,13 +190,13 @@ class SendLeadAdfByEmailActivityTest extends TestCase
             }
 
             public function executeIntegration(
-                \Illuminate\Database\Eloquent\Model $entity,
+                Model $entity,
                 AppInterface $app,
                 IntegrationsEnum $integration,
                 callable $integrationOperation,
                 array $additionalParams = [],
-                ?\Kanvas\Regions\Models\Regions $region = null,
-                ?\Kanvas\Companies\Models\Companies $company = null,
+                ?Regions $region = null,
+                ?Companies $company = null,
                 bool $throwException = false
             ): array {
                 $this->usedIntegrationWrapper = true;

--- a/tests/Unit/Connectors/SalesAssist/SendLeadAdfByEmailActivityTest.php
+++ b/tests/Unit/Connectors/SalesAssist/SendLeadAdfByEmailActivityTest.php
@@ -8,6 +8,7 @@ use Baka\Contracts\AppInterface;
 use Kanvas\Connectors\SalesAssist\Actions\BuildLeadAdfXmlAction;
 use Kanvas\Connectors\SalesAssist\Activities\SendLeadAdfByEmailActivity;
 use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Workflow\Models\StoredWorkflow;
@@ -87,8 +88,11 @@ class SendLeadAdfByEmailActivityTest extends TestCase
     public function testSendLeadAdfByEmailActivitySendsUsingWorkflowParams(): void
     {
         $lead = Mockery::mock(Lead::class);
+        $company = Mockery::mock(\Kanvas\Companies\Models\Companies::class);
+
         $lead->shouldReceive('getId')->andReturn(88);
         $lead->shouldReceive('getAttribute')->with('people')->andReturn(new \stdClass());
+        $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
 
         $app = Mockery::mock(AppInterface::class);
         $storedWorkflow = Mockery::mock(StoredWorkflow::class);
@@ -97,6 +101,7 @@ class SendLeadAdfByEmailActivityTest extends TestCase
         $activity = new class (1, '2026-04-02T00:00:00+00:00', $storedWorkflow) extends SendLeadAdfByEmailActivity {
             public bool $bootstrapped = false;
             public bool $sent = false;
+            public bool $usedIntegrationWrapper = false;
 
             protected function bootstrapAppService(AppInterface $app): void
             {
@@ -106,6 +111,21 @@ class SendLeadAdfByEmailActivityTest extends TestCase
             protected function buildAdfXml(Lead $lead, array $params): string
             {
                 return '<adf></adf>';
+            }
+
+            public function executeIntegration(
+                \Illuminate\Database\Eloquent\Model $entity,
+                AppInterface $app,
+                IntegrationsEnum $integration,
+                callable $integrationOperation,
+                array $additionalParams = [],
+                ?\Kanvas\Regions\Models\Regions $region = null,
+                ?\Kanvas\Companies\Models\Companies $company = null,
+                bool $throwException = false
+            ): array {
+                $this->usedIntegrationWrapper = true;
+
+                return $integrationOperation($entity, $app, null, $additionalParams);
             }
 
             protected function sendAdfEmail(
@@ -132,6 +152,7 @@ class SendLeadAdfByEmailActivityTest extends TestCase
         ]);
 
         $this->assertTrue($activity->bootstrapped);
+        $this->assertTrue($activity->usedIntegrationWrapper);
         $this->assertTrue($activity->sent);
         $this->assertTrue($response['success']);
         $this->assertSame('adf@example.com', $response['to']);
@@ -142,8 +163,11 @@ class SendLeadAdfByEmailActivityTest extends TestCase
     public function testSendLeadAdfByEmailActivityCanSendAsAttachment(): void
     {
         $lead = Mockery::mock(Lead::class);
+        $company = Mockery::mock(\Kanvas\Companies\Models\Companies::class);
+
         $lead->shouldReceive('getId')->andReturn(89);
         $lead->shouldReceive('getAttribute')->with('people')->andReturn(new \stdClass());
+        $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
 
         $app = Mockery::mock(AppInterface::class);
         $storedWorkflow = Mockery::mock(StoredWorkflow::class);
@@ -151,6 +175,7 @@ class SendLeadAdfByEmailActivityTest extends TestCase
 
         $activity = new class (1, '2026-04-02T00:00:00+00:00', $storedWorkflow) extends SendLeadAdfByEmailActivity {
             public bool $sent = false;
+            public bool $usedIntegrationWrapper = false;
 
             protected function bootstrapAppService(AppInterface $app): void
             {
@@ -159,6 +184,21 @@ class SendLeadAdfByEmailActivityTest extends TestCase
             protected function buildAdfXml(Lead $lead, array $params): string
             {
                 return '<adf></adf>';
+            }
+
+            public function executeIntegration(
+                \Illuminate\Database\Eloquent\Model $entity,
+                AppInterface $app,
+                IntegrationsEnum $integration,
+                callable $integrationOperation,
+                array $additionalParams = [],
+                ?\Kanvas\Regions\Models\Regions $region = null,
+                ?\Kanvas\Companies\Models\Companies $company = null,
+                bool $throwException = false
+            ): array {
+                $this->usedIntegrationWrapper = true;
+
+                return $integrationOperation($entity, $app, null, $additionalParams);
             }
 
             protected function sendAdfEmail(
@@ -181,6 +221,7 @@ class SendLeadAdfByEmailActivityTest extends TestCase
             'send_as_attachment' => true,
         ]);
 
+        $this->assertTrue($activity->usedIntegrationWrapper);
         $this->assertTrue($activity->sent);
         $this->assertSame('lead-89.xml', $response['attachment']);
         $this->assertSame('attachment', $response['delivery_mode']);


### PR DESCRIPTION
## Summary
- route `SendLeadAdfByEmailActivity` through `executeIntegration(...)`
- keep the existing Sales Assist ADF email behavior and response payload
- update the focused unit test to verify the integration wrapper/UI-trace path

## Validation
- php artisan test tests/Unit/Connectors/SalesAssist/SendLeadAdfByEmailActivityTest.php
- 4 tests passing, 18 assertions
