### PR TITLE
feat: signup spam protection

### DIFF
--- a/app/GraphQL/Ecosystem/Mutations/Auth/AuthManagementMutation.php
+++ b/app/GraphQL/Ecosystem/Mutations/Auth/AuthManagementMutation.php
@@ -32,11 +32,10 @@ use Kanvas\Workflow\Enums\WorkflowEnum;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
-use function Sentry\captureMessage;
-
 use Sentry\Severity;
 use Sentry\State\Scope;
 
+use function Sentry\captureMessage;
 use function Sentry\withScope;
 
 class AuthManagementMutation

--- a/app/GraphQL/Ecosystem/Mutations/Auth/AuthManagementMutation.php
+++ b/app/GraphQL/Ecosystem/Mutations/Auth/AuthManagementMutation.php
@@ -7,8 +7,10 @@ namespace App\GraphQL\Ecosystem\Mutations\Auth;
 use Baka\Support\IPInfo;
 use Baka\Validations\PasswordValidation;
 use GraphQL\Type\Definition\ResolveInfo;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Validation\ValidationException;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Auth\Actions\RegisterUsersAction;
 use Kanvas\Auth\Actions\SocialLoginAction;
@@ -21,6 +23,7 @@ use Kanvas\Auth\Traits\AuthTrait;
 use Kanvas\Auth\Traits\TokenTrait;
 use Kanvas\Companies\Models\CompaniesBranches;
 use Kanvas\Enums\AppEnums;
+use Kanvas\Enums\AppSettingsEnums;
 use Kanvas\Sessions\Models\Sessions;
 use Kanvas\Users\Actions\SwitchCompanyBranchAction;
 use Kanvas\Users\Enums\UserConfigEnum;
@@ -28,10 +31,12 @@ use Kanvas\Users\Repositories\UsersRepository;
 use Kanvas\Workflow\Enums\WorkflowEnum;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+use function Sentry\captureMessage;
+
 use Sentry\Severity;
 use Sentry\State\Scope;
 
-use function Sentry\captureMessage;
 use function Sentry\withScope;
 
 class AuthManagementMutation
@@ -123,9 +128,6 @@ class AuthManagementMutation
         );
     }
 
-    /**
-     * @throws \Exception
-     */
     public function register(
         mixed $rootValue,
         array $request,
@@ -133,6 +135,8 @@ class AuthManagementMutation
         ?ResolveInfo $resolveInfo = null
     ): array {
         $app = app(Apps::class);
+
+        $this->enforceRegistrationRateLimit($app);
 
         Validator::make(
             $request['data'],
@@ -247,5 +251,34 @@ class AuthManagementMutation
         $user->reset($request['data']['new_password'], $request['data']['hash_key']);
 
         return true;
+    }
+
+    protected function enforceRegistrationRateLimit(Apps $app): void
+    {
+        $ip = IPInfo::getClientIp();
+        $key = 'register_attempt:' . $app->getId() . ':' . $ip;
+        $maxAttempts = (int) ($app->get(AppSettingsEnums::REGISTRATION_RATE_LIMIT->getValue()) ?: 10);
+
+        if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
+            $seconds = RateLimiter::availableIn($key);
+
+            withScope(function (Scope $scope) use ($app, $ip, $maxAttempts): void {
+                $scope->setLevel(Severity::warning());
+                $scope->setContext('registration_rate_limit', [
+                    'app_id' => $app->getId(),
+                    'app_name' => $app->name,
+                    'ip' => $ip,
+                    'max_attempts' => $maxAttempts,
+                    'user_agent' => request()->userAgent(),
+                ]);
+                captureMessage('Registration rate limit exceeded — possible spam signup attempt');
+            });
+
+            throw ValidationException::withMessages([
+                'email' => ["Too many registration attempts. Please try again in {$seconds} seconds."],
+            ]);
+        }
+
+        RateLimiter::hit($key, 60);
     }
 }

--- a/app/GraphQL/Ecosystem/Mutations/Auth/AuthManagementMutation.php
+++ b/app/GraphQL/Ecosystem/Mutations/Auth/AuthManagementMutation.php
@@ -31,7 +31,6 @@ use Kanvas\Users\Repositories\UsersRepository;
 use Kanvas\Workflow\Enums\WorkflowEnum;
 use Nuwave\Lighthouse\Exceptions\AuthorizationException;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
-
 use Sentry\Severity;
 use Sentry\State\Scope;
 

--- a/src/Kanvas/Auth/Actions/CreateUserAction.php
+++ b/src/Kanvas/Auth/Actions/CreateUserAction.php
@@ -105,12 +105,15 @@ class CreateUserAction
 
     protected function validateEmail(): void
     {
+        $emailRule = $this->app->get(AppSettingsEnums::VALIDATE_EMAIL_DNS->getValue())
+            ? 'required|email:rfc,dns'
+            : 'required|email';
+
         $validator = Validator::make(
             ['email' => $this->data->email],
-            ['email' => 'required|email']
+            ['email' => $emailRule]
         );
 
-        // This is the second time that we need get user data without an exception.
         if ($validator->fails()) {
             throw new ValidationException($validator);
         }

--- a/src/Kanvas/Enums/AppSettingsEnums.php
+++ b/src/Kanvas/Enums/AppSettingsEnums.php
@@ -47,6 +47,8 @@ enum AppSettingsEnums implements EnumsInterface
     case ENABLE_GLOBAL_MERGE_FILESYSTEM;
 
     case DATE_ADK_AGENT_RESPONSES;
+    case REGISTRATION_RATE_LIMIT;
+    case VALIDATE_EMAIL_DNS;
 
     #[Override]
     public function getValue(): mixed
@@ -88,7 +90,9 @@ enum AppSettingsEnums implements EnumsInterface
             self::ALLOW_RESET_PASSWORD_WITH_DISPLAYNAME => 'allow_reset_password_with_displayname',
             self::OPEN_AI_EMBEDDING_KEY => 'open_ai_embedding_key',
             self::ENABLE_GLOBAL_MERGE_FILESYSTEM => 'enable_global_merge_filesystem',
-            self::DATE_ADK_AGENT_RESPONSES => 'date_adk_agent_responses'
+            self::DATE_ADK_AGENT_RESPONSES => 'date_adk_agent_responses',
+            self::REGISTRATION_RATE_LIMIT => 'registration_rate_limit',
+            self::VALIDATE_EMAIL_DNS => 'validate_email_dns',
         };
     }
 }

--- a/tests/GraphQL/Ecosystem/RegistrationSpamProtectionTest.php
+++ b/tests/GraphQL/Ecosystem/RegistrationSpamProtectionTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\GraphQL\Ecosystem;
+
+use Illuminate\Support\Facades\RateLimiter;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Enums\AppSettingsEnums;
+use Tests\TestCase;
+
+class RegistrationSpamProtectionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        $app = app(Apps::class);
+        $app->del(AppSettingsEnums::VALIDATE_EMAIL_DNS->getValue());
+
+        parent::tearDown();
+    }
+
+    public function testRegistrationRateLimitByIp(): void
+    {
+        $app = app(Apps::class);
+
+        RateLimiter::clear('register_attempt:' . $app->getId() . ':127.0.0.1');
+
+        for ($i = 0; $i < 10; $i++) {
+            $email = fake()->unique()->safeEmail();
+            $password = fake()->password(9);
+
+            $this->graphQL(/** @lang GraphQL */ '
+                mutation register($data: RegisterInput!) {
+                    register(data: $data) {
+                        user { email }
+                        token { token }
+                    }
+                }
+            ', [
+                'data' => [
+                    'email' => $email,
+                    'password' => $password,
+                    'password_confirmation' => $password,
+                ],
+            ])->assertSuccessful();
+        }
+
+        $email = fake()->unique()->safeEmail();
+        $password = fake()->password(9);
+
+        $response = $this->graphQL(/** @lang GraphQL */ '
+            mutation register($data: RegisterInput!) {
+                register(data: $data) {
+                    user { email }
+                    token { token }
+                }
+            }
+        ', [
+            'data' => [
+                'email' => $email,
+                'password' => $password,
+                'password_confirmation' => $password,
+            ],
+        ]);
+
+        $errors = $response->json('errors');
+        $this->assertNotNull($errors, 'Expected rate limit error but got none');
+        $this->assertStringContainsString(
+            'Too many registration attempts',
+            $errors[0]['message'] ?? $errors[0]['extensions']['debugMessage'] ?? ''
+        );
+
+        RateLimiter::clear('register_attempt:' . $app->getId() . ':127.0.0.1');
+    }
+
+    public function testRegistrationWithDnsEmailValidationRejectsInvalidDomain(): void
+    {
+        $app = app(Apps::class);
+        $app->set(AppSettingsEnums::VALIDATE_EMAIL_DNS->getValue(), true);
+
+        RateLimiter::clear('register_attempt:' . $app->getId() . ':127.0.0.1');
+
+        $password = fake()->password(9);
+
+        $response = $this->graphQL(/** @lang GraphQL */ '
+            mutation register($data: RegisterInput!) {
+                register(data: $data) {
+                    user { email }
+                    token { token }
+                }
+            }
+        ', [
+            'data' => [
+                'email' => 'test@thisisnotarealdomainthatexists999.com',
+                'password' => $password,
+                'password_confirmation' => $password,
+            ],
+        ]);
+
+        $errors = $response->json('errors');
+        $this->assertNotNull($errors, 'Expected validation error for invalid DNS domain');
+
+        RateLimiter::clear('register_attempt:' . $app->getId() . ':127.0.0.1');
+    }
+
+    public function testRegistrationWithoutDnsValidationAcceptsAnyEmailFormat(): void
+    {
+        $app = app(Apps::class);
+        $app->del(AppSettingsEnums::VALIDATE_EMAIL_DNS->getValue());
+
+        RateLimiter::clear('register_attempt:' . $app->getId() . ':127.0.0.1');
+
+        $password = fake()->password(9);
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation register($data: RegisterInput!) {
+                register(data: $data) {
+                    user { email }
+                    token { token }
+                }
+            }
+        ', [
+            'data' => [
+                'email' => 'validformat@anydomain.xyz',
+                'password' => $password,
+                'password_confirmation' => $password,
+            ],
+        ])->assertSuccessful();
+
+        RateLimiter::clear('register_attempt:' . $app->getId() . ':127.0.0.1');
+    }
+
+    public function testRegistrationDnsValidationDisabledByDefault(): void
+    {
+        $app = app(Apps::class);
+        $app->del(AppSettingsEnums::VALIDATE_EMAIL_DNS->getValue());
+
+        RateLimiter::clear('register_attempt:' . $app->getId() . ':127.0.0.1');
+
+        $email = fake()->unique()->safeEmail();
+        $password = fake()->password(9);
+
+        $this->graphQL(/** @lang GraphQL */ '
+            mutation register($data: RegisterInput!) {
+                register(data: $data) {
+                    user { email }
+                    token { token }
+                }
+            }
+        ', [
+            'data' => [
+                'email' => $email,
+                'password' => $password,
+                'password_confirmation' => $password,
+            ],
+        ])->assertSuccessful();
+
+        RateLimiter::clear('register_attempt:' . $app->getId() . ':127.0.0.1');
+    }
+}


### PR DESCRIPTION
## Summary
- Add IP-based rate limiting on registration (default 10 attempts/min, configurable per app via `registration_rate_limit` setting)
- Report rate limit violations to Sentry for spam monitoring
- Add optional DNS email validation (`validate_email_dns` app setting) to reject emails with invalid MX records

## Test plan
- [x] Rate limit blocks 11th registration attempt from same IP
- [x] DNS validation rejects emails with non-existent domains when enabled
- [x] DNS validation is off by default (no breaking change)
- [x] Existing auth tests still pass