### PR TITLE
fix: handle real ElevenLabs transcript payload format

### DIFF
--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsTranscriptWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsTranscriptWebhookJob.php
@@ -27,15 +27,19 @@ class ProcessElevenLabsTranscriptWebhookJob extends ProcessWebhookJob
     public function execute(): array
     {
         $payload = (array) $this->webhookRequest->payload;
-        $type = (string) ($payload['type'] ?? '');
-        $data = (array) ($payload['data'] ?? []);
 
-        return match ($type) {
-            'post_call_transcription' => $this->handleTranscription($data),
-            'post_call_audio' => $this->handleAudio($data),
-            'call_initiation_failure' => $this->handleCallFailure($data),
-            default => ['message' => 'Unknown webhook type: ' . $type],
-        };
+        $type = (string) ($payload['type'] ?? '');
+        $data = (array) ($payload['data'] ?? $payload);
+
+        if ($type === 'post_call_audio') {
+            return $this->handleAudio($data);
+        }
+
+        if ($type === 'call_initiation_failure') {
+            return $this->handleCallFailure($data);
+        }
+
+        return $this->handleTranscription($data);
     }
 
     protected function handleTranscription(array $data): array
@@ -44,9 +48,8 @@ class ProcessElevenLabsTranscriptWebhookJob extends ProcessWebhookJob
         $transcript = (array) ($data['transcript'] ?? []);
         $metadata = (array) ($data['metadata'] ?? []);
         $analysis = (array) ($data['analysis'] ?? []);
-        $phoneCall = (array) ($metadata['phone_call'] ?? []);
 
-        $phone = (string) ($phoneCall['from_number'] ?? $phoneCall['to_number'] ?? '');
+        $phone = $this->extractPhoneFromPayload($data);
         $lead = $this->findLeadByPhone($phone);
 
         if (! $lead) {
@@ -55,6 +58,8 @@ class ProcessElevenLabsTranscriptWebhookJob extends ProcessWebhookJob
                 'conversation_id' => $conversationId,
             ];
         }
+
+        $this->updateLeadPeopleFromAnalysis($lead, $analysis);
 
         $app = $this->receiver->app;
 
@@ -67,6 +72,7 @@ class ProcessElevenLabsTranscriptWebhookJob extends ProcessWebhookJob
         )->execute();
 
         $formattedTranscript = $this->formatTranscript($transcript);
+        $dataCollectionResults = (array) ($analysis['data_collection_results'] ?? []);
 
         $message = new CreateMessageAction(
             new MessageInput(
@@ -78,13 +84,14 @@ class ProcessElevenLabsTranscriptWebhookJob extends ProcessWebhookJob
                     'transcript' => $formattedTranscript,
                     'conversation_id' => $conversationId,
                     'agent_id' => $data['agent_id'] ?? null,
+                    'agent_name' => $data['agent_name'] ?? null,
                     'call_duration_secs' => $metadata['call_duration_secs'] ?? null,
                     'call_successful' => $analysis['call_successful'] ?? null,
                     'transcript_summary' => $analysis['transcript_summary'] ?? null,
-                    'phone_from' => $phoneCall['from_number'] ?? null,
-                    'phone_to' => $phoneCall['to_number'] ?? null,
+                    'call_summary_title' => $analysis['call_summary_title'] ?? null,
                     'termination_reason' => $metadata['termination_reason'] ?? null,
-                    'data_collection_results' => $analysis['data_collection_results'] ?? null,
+                    'data_collection_results' => $dataCollectionResults,
+                    'evaluation_criteria_results' => $analysis['evaluation_criteria_results'] ?? null,
                 ],
                 is_public: 1,
                 slug: 'elevenlabs-' . $conversationId,
@@ -99,6 +106,66 @@ class ProcessElevenLabsTranscriptWebhookJob extends ProcessWebhookJob
             'message_id' => $message->getId(),
             'lead_id' => $lead->getId(),
         ];
+    }
+
+    protected function extractPhoneFromPayload(array $data): string
+    {
+        $metadata = (array) ($data['metadata'] ?? []);
+        $phoneCall = $metadata['phone_call'] ?? null;
+
+        if (is_array($phoneCall) && ! empty($phoneCall)) {
+            $phone = (string) ($phoneCall['from_number'] ?? $phoneCall['to_number'] ?? '');
+            if ($phone !== '') {
+                return $phone;
+            }
+        }
+
+        $analysis = (array) ($data['analysis'] ?? []);
+        $dataCollection = (array) ($analysis['data_collection_results'] ?? []);
+
+        if (isset($dataCollection['caller_phone_number']['value'])) {
+            $phone = (string) $dataCollection['caller_phone_number']['value'];
+            if ($phone !== '') {
+                return $phone;
+            }
+        }
+
+        return '';
+    }
+
+    protected function updateLeadPeopleFromAnalysis(Lead $lead, array $analysis): void
+    {
+        $dataCollection = (array) ($analysis['data_collection_results'] ?? []);
+
+        $callerName = isset($dataCollection['caller_name']['value'])
+            ? (string) $dataCollection['caller_name']['value']
+            : null;
+
+        if ($callerName === null || $callerName === '') {
+            return;
+        }
+
+        /** @var \Kanvas\Guild\Customers\Models\People $people */
+        $people = $lead->people;
+        $nameParts = explode(' ', $callerName, 2);
+        $firstname = $nameParts[0];
+        $lastname = $nameParts[1] ?? '';
+
+        $updated = false;
+
+        if ($people->firstname === '' || $people->firstname === $people->contacts()->first()?->value) {
+            $people->firstname = $firstname;
+            $updated = true;
+        }
+
+        if ($lastname !== '' && ($people->lastname === '' || $people->lastname === null)) {
+            $people->lastname = $lastname;
+            $updated = true;
+        }
+
+        if ($updated) {
+            $people->saveOrFail();
+        }
     }
 
     protected function handleAudio(array $data): array
@@ -224,6 +291,7 @@ class ProcessElevenLabsTranscriptWebhookJob extends ProcessWebhookJob
                 'time_in_call_secs' => $turn['time_in_call_secs'] ?? 0,
                 'tool_calls' => $turn['tool_calls'] ?? null,
                 'tool_results' => $turn['tool_results'] ?? null,
+                'source_medium' => $turn['source_medium'] ?? null,
             ];
         }, $transcript);
     }

--- a/tests/Connectors/Integration/ElevenLabs/ProcessElevenLabsWebhookJobTest.php
+++ b/tests/Connectors/Integration/ElevenLabs/ProcessElevenLabsWebhookJobTest.php
@@ -76,17 +76,16 @@ class ProcessElevenLabsWebhookJobTest extends TestCase
         $this->markTestSkipped('Requires voiceOutreachAgent and VoiceBridge configuration');
     }
 
-    public function testTranscriptWebhookSavesTranscription(): void
+    public function testTranscriptWebhookWithPhoneCallMetadata(): void
     {
         $this->createTestLeadWithPhone();
 
         $result = $this->dispatchJob(
             ProcessElevenLabsTranscriptWebhookJob::class,
             [
-                'type' => 'post_call_transcription',
-                'event_timestamp' => time(),
                 'data' => [
                     'agent_id' => 'agent_123',
+                    'agent_name' => 'Sally',
                     'conversation_id' => 'conv_' . Str::random(10),
                     'status' => 'done',
                     'transcript' => [
@@ -94,11 +93,13 @@ class ProcessElevenLabsWebhookJobTest extends TestCase
                             'role' => 'agent',
                             'message' => 'Hello, how can I help you?',
                             'time_in_call_secs' => 0,
+                            'source_medium' => null,
                         ],
                         [
                             'role' => 'user',
                             'message' => 'I want to schedule a test drive.',
                             'time_in_call_secs' => 3,
+                            'source_medium' => 'audio',
                         ],
                     ],
                     'metadata' => [
@@ -114,6 +115,7 @@ class ProcessElevenLabsWebhookJobTest extends TestCase
                     'analysis' => [
                         'call_successful' => 'success',
                         'transcript_summary' => 'Customer called to schedule a test drive.',
+                        'call_summary_title' => 'Test Drive Scheduling',
                     ],
                 ],
             ]
@@ -125,6 +127,105 @@ class ProcessElevenLabsWebhookJobTest extends TestCase
         $this->assertEquals($this->testLead->getId(), $result['lead_id']);
     }
 
+    public function testTranscriptWebhookWithDataCollectionPhone(): void
+    {
+        $this->createTestLeadWithPhone();
+        $phoneDigits = preg_replace('/[^0-9]/', '', $this->testPhone);
+
+        $result = $this->dispatchJob(
+            ProcessElevenLabsTranscriptWebhookJob::class,
+            [
+                'data' => [
+                    'agent_id' => 'agent_123',
+                    'agent_name' => 'Sally',
+                    'conversation_id' => 'conv_dc_' . Str::random(10),
+                    'status' => 'done',
+                    'transcript' => [
+                        [
+                            'role' => 'agent',
+                            'message' => 'Thank you for calling, this is Sally.',
+                            'time_in_call_secs' => 0,
+                        ],
+                        [
+                            'role' => 'user',
+                            'message' => 'I want a showroom appointment.',
+                            'time_in_call_secs' => 3,
+                            'source_medium' => 'audio',
+                        ],
+                    ],
+                    'metadata' => [
+                        'call_duration_secs' => 76,
+                        'termination_reason' => 'end_call tool was called.',
+                        'phone_call' => null,
+                    ],
+                    'analysis' => [
+                        'call_successful' => 'failure',
+                        'transcript_summary' => 'Customer booked a showroom appointment.',
+                        'call_summary_title' => 'Showroom Appointment Booking',
+                        'data_collection_results' => [
+                            'caller_phone_number' => [
+                                'value' => $phoneDigits,
+                                'data_collection_id' => 'caller_phone_number',
+                            ],
+                            'caller_name' => [
+                                'value' => 'Geraldie Miguel de la Rosa Hernandez',
+                                'data_collection_id' => 'caller_name',
+                            ],
+                            'call_intent' => [
+                                'value' => 'sales',
+                                'data_collection_id' => 'call_intent',
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertIsArray($result);
+        $this->assertEquals('Transcript saved', $result['message']);
+        $this->assertEquals($this->testLead->getId(), $result['lead_id']);
+    }
+
+    public function testTranscriptWebhookUpdatesPeopleNameFromAnalysis(): void
+    {
+        $this->createTestLeadWithPhone();
+        $phoneDigits = preg_replace('/[^0-9]/', '', $this->testPhone);
+
+        $this->dispatchJob(
+            ProcessElevenLabsTranscriptWebhookJob::class,
+            [
+                'data' => [
+                    'agent_id' => 'agent_123',
+                    'conversation_id' => 'conv_name_' . Str::random(10),
+                    'status' => 'done',
+                    'transcript' => [],
+                    'metadata' => [
+                        'call_duration_secs' => 30,
+                        'termination_reason' => 'end_call',
+                        'phone_call' => null,
+                    ],
+                    'analysis' => [
+                        'call_successful' => 'success',
+                        'transcript_summary' => 'Quick call.',
+                        'data_collection_results' => [
+                            'caller_phone_number' => [
+                                'value' => $phoneDigits,
+                            ],
+                            'caller_name' => [
+                                'value' => 'Maria Santos',
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->testLead->refresh();
+        $people = $this->testLead->people;
+        $this->assertEquals('Maria', $people->firstname);
+        $this->assertEquals('Santos', $people->lastname);
+    }
+
     public function testTranscriptWebhookHandlesCallFailure(): void
     {
         $this->createTestLeadWithPhone();
@@ -133,7 +234,6 @@ class ProcessElevenLabsWebhookJobTest extends TestCase
             ProcessElevenLabsTranscriptWebhookJob::class,
             [
                 'type' => 'call_initiation_failure',
-                'event_timestamp' => time(),
                 'data' => [
                     'agent_id' => 'agent_123',
                     'conversation_id' => 'conv_fail_' . Str::random(10),
@@ -155,18 +255,22 @@ class ProcessElevenLabsWebhookJobTest extends TestCase
         $this->assertEquals('busy', $result['failure_reason']);
     }
 
-    public function testTranscriptWebhookHandlesUnknownType(): void
+    public function testTranscriptWebhookNoPhoneReturnsNotFound(): void
     {
         $result = $this->dispatchJob(
             ProcessElevenLabsTranscriptWebhookJob::class,
             [
-                'type' => 'unknown_type',
-                'data' => [],
+                'data' => [
+                    'conversation_id' => 'conv_nophone_' . Str::random(10),
+                    'transcript' => [],
+                    'metadata' => ['phone_call' => null],
+                    'analysis' => ['data_collection_results' => []],
+                ],
             ]
         );
 
         $this->assertIsArray($result);
-        $this->assertStringContainsString('Unknown webhook type', $result['message']);
+        $this->assertStringContainsString('No lead found', $result['message']);
     }
 
     public function testCalendarEventWebhookCreatesEvent(): void


### PR DESCRIPTION
- Default to transcript handling when type field is missing (real payloads come as { data: {...} } without post_call_transcription envelope)
- Extract phone from data_collection_results.caller_phone_number.value when metadata.phone_call is null (web SDK calls)
- Auto-update lead people name from data_collection_results.caller_name
- Store agent_name, call_summary_title, evaluation_criteria_results

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
