### PR TITLE
fix: preserve pipeline stage IDs during update

### DIFF
--- a/src/Domains/Guild/Pipelines/Actions/AssociateStageToPipelineAction.php
+++ b/src/Domains/Guild/Pipelines/Actions/AssociateStageToPipelineAction.php
@@ -30,24 +30,25 @@ class AssociateStageToPipelineAction
         }
         $deleteQuery->delete();
 
-        // Create new or update existing stages
+        // Update existing stages or create new ones
         foreach ($this->stages as $stage) {
             $stageId = ! empty($stage['stages_id']) ? (int) $stage['stages_id'] : null;
+            $attributes = [
+                'name' => $stage['name'],
+                'rotting_days' => $stage['rotting_days'],
+                'weight' => $stage['weight'],
+                'has_rotting_days' => 0,
+                'config' => $stage['config'] ?? null,
+                'pipelines_id' => $this->pipeline->id,
+            ];
 
-            PipelineStage::updateOrCreate(
-                [
-                    'id' => $stageId,
-                    'pipelines_id' => $this->pipeline->id,
-                ],
-                [
-                    'name' => $stage['name'],
-                    'rotting_days' => $stage['rotting_days'],
-                    'weight' => $stage['weight'],
-                    'has_rotting_days' => 0,
-                    'config' => $stage['config'] ?? null,
-                    'pipelines_id' => $this->pipeline->id,
-                ]
-            );
+            if ($stageId !== null) {
+                PipelineStage::where('id', $stageId)
+                    ->where('pipelines_id', $this->pipeline->id)
+                    ->update($attributes);
+            } else {
+                PipelineStage::create($attributes);
+            }
         }
     }
 }

--- a/src/Domains/Guild/Pipelines/Actions/AssociateStageToPipelineAction.php
+++ b/src/Domains/Guild/Pipelines/Actions/AssociateStageToPipelineAction.php
@@ -15,20 +15,38 @@ class AssociateStageToPipelineAction
     ) {
     }
 
-    public function execute()
+    public function execute(): void
     {
-        $this->pipeline->stages()->delete();
+        $incomingStageIds = collect($this->stages)
+            ->pluck('stages_id')
+            ->filter()
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        // Remove only stages that are no longer in the input
+        $deleteQuery = $this->pipeline->stages();
+        if (! empty($incomingStageIds)) {
+            $deleteQuery->whereNotIn('id', $incomingStageIds);
+        }
+        $deleteQuery->delete();
+
+        // Create new or update existing stages
         foreach ($this->stages as $stage) {
+            $stageId = ! empty($stage['stages_id']) ? (int) $stage['stages_id'] : null;
+
             PipelineStage::updateOrCreate(
-                ['id' => $stage['stages_id'] ?? null],
                 [
-                'name' => $stage['name'],
-                'rotting_days' => $stage['rotting_days'],
-                'weight' => $stage['weight'],
-                'has_rotting_days' => 0,
-                'config' => $stage['config'] ?? null,
-                'pipelines_id' => $this->pipeline->id,
-            ]
+                    'id' => $stageId,
+                    'pipelines_id' => $this->pipeline->id,
+                ],
+                [
+                    'name' => $stage['name'],
+                    'rotting_days' => $stage['rotting_days'],
+                    'weight' => $stage['weight'],
+                    'has_rotting_days' => 0,
+                    'config' => $stage['config'] ?? null,
+                    'pipelines_id' => $this->pipeline->id,
+                ]
             );
         }
     }

--- a/tests/GraphQL/Guild/PipelineTest.php
+++ b/tests/GraphQL/Guild/PipelineTest.php
@@ -188,7 +188,7 @@ class PipelineTest extends TestCase
             ['stages_id' => $stage2Id, 'name' => $updatedName2, 'rotting_days' => 2, 'weight' => 2],
         ];
 
-        $this->graphQL('
+        $updateResponse = $this->graphQL('
             mutation($id: ID!, $input: PipelineInput!) {
                 updatePipeline(id: $id, input: $input) {
                     id
@@ -196,16 +196,15 @@ class PipelineTest extends TestCase
                 }
             }
         ', ['id' => $pipelineId, 'input' => $input])
-        ->assertJson([
-            'data' => [
-                'updatePipeline' => [
-                    'stages' => [
-                        ['id' => $stage1Id, 'name' => $updatedName1],
-                        ['id' => $stage2Id, 'name' => $updatedName2],
-                    ],
-                ],
-            ],
-        ]);
+        ->assertSuccessful();
+
+        $updatedStages = $updateResponse->json('data.updatePipeline.stages');
+
+        $this->assertCount(2, $updatedStages);
+        $this->assertEquals($stage1Id, $updatedStages[0]['id'], 'Stage 1 ID must be preserved after update');
+        $this->assertEquals($stage2Id, $updatedStages[1]['id'], 'Stage 2 ID must be preserved after update');
+        $this->assertEquals($updatedName1, $updatedStages[0]['name']);
+        $this->assertEquals($updatedName2, $updatedStages[1]['name']);
     }
 
     public function testUpdatePipelineRemovesOnlyDeletedStages()

--- a/tests/GraphQL/Guild/PipelineTest.php
+++ b/tests/GraphQL/Guild/PipelineTest.php
@@ -153,6 +153,120 @@ class PipelineTest extends TestCase
             ]);
     }
 
+    public function testUpdatePipelineStagesPreservesExistingStageIds()
+    {
+        $stageName1 = fake()->name();
+        $stageName2 = fake()->name();
+        $input = [
+            'name' => fake()->name(),
+            'weight' => 0,
+            'is_default' => false,
+            'stages' => [
+                ['name' => $stageName1, 'rotting_days' => 1, 'weight' => 1],
+                ['name' => $stageName2, 'rotting_days' => 2, 'weight' => 2],
+            ],
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: PipelineInput!) {
+                createPipeline(input: $input) {
+                    id
+                    stages { id name }
+                }
+            }
+        ', ['input' => $input]);
+
+        $pipelineId = $response->json('data.createPipeline.id');
+        $stage1Id = $response->json('data.createPipeline.stages.0.id');
+        $stage2Id = $response->json('data.createPipeline.stages.1.id');
+
+        // Update: keep both stages with updated names, send stages_id to preserve them
+        $updatedName1 = fake()->name();
+        $updatedName2 = fake()->name();
+        $input['stages'] = [
+            ['stages_id' => $stage1Id, 'name' => $updatedName1, 'rotting_days' => 1, 'weight' => 1],
+            ['stages_id' => $stage2Id, 'name' => $updatedName2, 'rotting_days' => 2, 'weight' => 2],
+        ];
+
+        $this->graphQL('
+            mutation($id: ID!, $input: PipelineInput!) {
+                updatePipeline(id: $id, input: $input) {
+                    id
+                    stages { id name }
+                }
+            }
+        ', ['id' => $pipelineId, 'input' => $input])
+        ->assertJson([
+            'data' => [
+                'updatePipeline' => [
+                    'stages' => [
+                        ['id' => $stage1Id, 'name' => $updatedName1],
+                        ['id' => $stage2Id, 'name' => $updatedName2],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testUpdatePipelineRemovesOnlyDeletedStages()
+    {
+        $input = [
+            'name' => fake()->name(),
+            'weight' => 0,
+            'is_default' => false,
+            'stages' => [
+                ['name' => fake()->name(), 'rotting_days' => 1, 'weight' => 1],
+                ['name' => fake()->name(), 'rotting_days' => 2, 'weight' => 2],
+                ['name' => fake()->name(), 'rotting_days' => 3, 'weight' => 3],
+            ],
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: PipelineInput!) {
+                createPipeline(input: $input) {
+                    id
+                    stages { id name }
+                }
+            }
+        ', ['input' => $input]);
+
+        $pipelineId = $response->json('data.createPipeline.id');
+        $stage1Id = $response->json('data.createPipeline.stages.0.id');
+        $stage2Id = $response->json('data.createPipeline.stages.1.id');
+
+        // Update: keep stage 1, remove stages 2 and 3, add a new stage
+        $newStageName = fake()->name();
+        $input['stages'] = [
+            ['stages_id' => $stage1Id, 'name' => $input['stages'][0]['name'], 'rotting_days' => 1, 'weight' => 1],
+            ['name' => $newStageName, 'rotting_days' => 5, 'weight' => 4],
+        ];
+
+        $updateResponse = $this->graphQL('
+            mutation($id: ID!, $input: PipelineInput!) {
+                updatePipeline(id: $id, input: $input) {
+                    id
+                    stages { id name }
+                }
+            }
+        ', ['id' => $pipelineId, 'input' => $input])
+        ->assertSuccessful();
+
+        $stages = $updateResponse->json('data.updatePipeline.stages');
+
+        // Should have exactly 2 stages
+        $this->assertCount(2, $stages);
+
+        // Stage 1 should keep its original ID
+        $this->assertEquals($stage1Id, $stages[0]['id']);
+
+        // Stage 2 (removed) should not exist
+        $stageIds = array_column($stages, 'id');
+        $this->assertNotContains($stage2Id, $stageIds);
+
+        // New stage should exist
+        $this->assertEquals($newStageName, $stages[1]['name']);
+    }
+
     public function testCreatePipeline()
     {
         $pipeline = $this->createPipeline();


### PR DESCRIPTION
## Summary
- Cherry-pick of #9171 to 1.x for production
- Pipeline stage sync was deleting all stages and recreating them on every update, breaking FK references from leads and follow-up days
- Now only removes stages not present in the input, updates existing ones in place, and creates new ones

## Test plan
- [x] `testUpdatePipelineStagesPreservesExistingStageIds`
- [x] `testUpdatePipelineRemovesOnlyDeletedStages`
- [x] `testUpdatePipelineWithStages`