### PR TITLE
fix: preserve pipeline stage IDs during update

### DIFF
--- a/src/Domains/Guild/Pipelines/Actions/AssociateStageToPipelineAction.php
+++ b/src/Domains/Guild/Pipelines/Actions/AssociateStageToPipelineAction.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Kanvas\Guild\Pipelines\Actions;
 
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Pipelines\Models\Pipeline as ModelsPipeline;
 use Kanvas\Guild\Pipelines\Models\PipelineStage;
 
@@ -17,38 +19,76 @@ class AssociateStageToPipelineAction
 
     public function execute(): void
     {
-        $incomingStageIds = collect($this->stages)
-            ->pluck('stages_id')
-            ->filter()
-            ->map(fn ($id) => (int) $id)
-            ->all();
+        $existingStages = $this->pipeline->stages()->orderBy('id')->get();
+        $existingStagesById = $existingStages->keyBy('id');
+        $existingStagesByName = $existingStages->keyBy('name');
+        $usedExistingIds = [];
+        $keepStageIds = [];
 
-        // Remove only stages that are no longer in the input
-        $deleteQuery = $this->pipeline->stages();
-        if (! empty($incomingStageIds)) {
-            $deleteQuery->whereNotIn('id', $incomingStageIds);
-        }
-        $deleteQuery->delete();
+        // Only use position fallback when no stage sends stages_id (frontend behavior)
+        $anyHasExplicitId = collect($this->stages)->contains(
+            fn ($s) => ! empty($s['stages_id'])
+        );
 
-        // Update existing stages or create new ones
-        foreach ($this->stages as $stage) {
+        foreach ($this->stages as $index => $stage) {
             $stageId = ! empty($stage['stages_id']) ? (int) $stage['stages_id'] : null;
             $attributes = [
                 'name' => $stage['name'],
                 'rotting_days' => $stage['rotting_days'],
-                'weight' => $stage['weight'],
+                'weight' => ! empty($stage['weight']) ? $stage['weight'] : $index,
                 'has_rotting_days' => 0,
                 'config' => $stage['config'] ?? null,
                 'pipelines_id' => $this->pipeline->id,
             ];
 
-            if ($stageId !== null) {
-                PipelineStage::where('id', $stageId)
-                    ->where('pipelines_id', $this->pipeline->id)
-                    ->update($attributes);
-            } else {
-                PipelineStage::create($attributes);
+            // Find existing stage: by explicit ID, then by name
+            $existingStage = null;
+            if ($stageId !== null && $existingStagesById->has($stageId)) {
+                $existingStage = $existingStagesById->get($stageId);
+            } elseif ($existingStagesByName->has($stage['name'])) {
+                $candidate = $existingStagesByName->get($stage['name']);
+                if (! in_array($candidate->id, $usedExistingIds)) {
+                    $existingStage = $candidate;
+                }
             }
+
+            // Position fallback only when frontend sends no stages_id at all
+            if ($existingStage === null && ! $anyHasExplicitId && isset($existingStages[$index])) {
+                $candidate = $existingStages[$index];
+                if (! in_array($candidate->id, $usedExistingIds)) {
+                    $existingStage = $candidate;
+                }
+            }
+
+            if ($existingStage !== null) {
+                $usedExistingIds[] = $existingStage->id;
+                $existingStage->update($attributes);
+                $keepStageIds[] = $existingStage->id;
+            } else {
+                $newStage = PipelineStage::create($attributes);
+                $keepStageIds[] = $newStage->id;
+            }
+        }
+
+        // Remove stages that are no longer in the input
+        $stageIdsToRemove = ! empty($keepStageIds)
+            ? $this->pipeline->stages()->whereNotIn('id', $keepStageIds)->pluck('id')
+            : $this->pipeline->stages()->pluck('id');
+
+        if ($stageIdsToRemove->isNotEmpty()) {
+            $leadsInRemovedStages = Lead::whereIn('pipeline_stage_id', $stageIdsToRemove)
+                ->where('apps_id', $this->pipeline->apps_id)
+                ->where('companies_id', $this->pipeline->companies_id)
+                ->where('is_deleted', 0)
+                ->exists();
+
+            if ($leadsInRemovedStages) {
+                throw new ValidationException(
+                    'Cannot remove pipeline stages that have active leads. Move leads to another stage first.'
+                );
+            }
+
+            PipelineStage::whereIn('id', $stageIdsToRemove)->delete();
         }
     }
 }

--- a/tests/GraphQL/Guild/PipelineTest.php
+++ b/tests/GraphQL/Guild/PipelineTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\GraphQL\Guild;
 
 use Illuminate\Testing\TestResponse;
+use Kanvas\Guild\Leads\Models\Lead;
 use Tests\TestCase;
 
 class PipelineTest extends TestCase
@@ -264,6 +265,223 @@ class PipelineTest extends TestCase
 
         // New stage should exist
         $this->assertEquals($newStageName, $stages[1]['name']);
+    }
+
+    public function testCannotRemoveStageWithActiveLeads()
+    {
+        $input = [
+            'name' => fake()->name(),
+            'weight' => 0,
+            'is_default' => false,
+            'stages' => [
+                ['name' => fake()->name(), 'rotting_days' => 1, 'weight' => 1],
+                ['name' => fake()->name(), 'rotting_days' => 2, 'weight' => 2],
+            ],
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: PipelineInput!) {
+                createPipeline(input: $input) {
+                    id
+                    stages { id name }
+                }
+            }
+        ', ['input' => $input]);
+
+        $pipelineId = $response->json('data.createPipeline.id');
+        $stage1Id = $response->json('data.createPipeline.stages.0.id');
+        $stage2Id = $response->json('data.createPipeline.stages.1.id');
+
+        // Create a lead on stage 2
+        $user = auth()->user();
+        $branch = $user->getCurrentBranch();
+
+        $this->graphQL('
+            mutation($input: LeadInput!) {
+                createLead(input: $input) { id }
+            }
+        ', [
+            'input' => [
+                'branch_id' => $branch->getId(),
+                'title' => fake()->title(),
+                'pipeline_stage_id' => (int) $stage2Id,
+                'people' => [
+                    'firstname' => fake()->firstName(),
+                    'lastname' => fake()->lastName(),
+                    'contacts' => [
+                        ['value' => fake()->email(), 'contacts_types_id' => 1, 'weight' => 0],
+                    ],
+                ],
+            ],
+        ])->assertSuccessful();
+
+        // Try to update pipeline removing stage 2 — should fail
+        $input['stages'] = [
+            ['stages_id' => $stage1Id, 'name' => $input['stages'][0]['name'], 'rotting_days' => 1, 'weight' => 1],
+        ];
+
+        $this->graphQL('
+            mutation($id: ID!, $input: PipelineInput!) {
+                updatePipeline(id: $id, input: $input) {
+                    id
+                    stages { id name }
+                }
+            }
+        ', ['id' => $pipelineId, 'input' => $input])
+        ->assertJsonFragment([
+            'message' => 'Cannot remove pipeline stages that have active leads. Move leads to another stage first.',
+        ]);
+    }
+
+    public function testUpdatePipelineStagesPreservesIdsWithoutStagesId()
+    {
+        $stageName1 = 'StageAlpha-' . fake()->uuid();
+        $stageName2 = 'StageBeta-' . fake()->uuid();
+        $input = [
+            'name' => fake()->name(),
+            'weight' => 0,
+            'is_default' => false,
+            'stages' => [
+                ['name' => $stageName1, 'rotting_days' => 1, 'weight' => 1],
+                ['name' => $stageName2, 'rotting_days' => 2, 'weight' => 2],
+            ],
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: PipelineInput!) {
+                createPipeline(input: $input) {
+                    id
+                    stages { id name }
+                }
+            }
+        ', ['input' => $input]);
+
+        $pipelineId = $response->json('data.createPipeline.id');
+        $stage1Id = $response->json('data.createPipeline.stages.0.id');
+        $stage2Id = $response->json('data.createPipeline.stages.1.id');
+
+        // Update WITHOUT stages_id — same as frontend behavior
+        $input['stages'] = [
+            ['name' => $stageName1, 'rotting_days' => 3, 'weight' => 1, 'pipeline_id' => $pipelineId],
+            ['name' => $stageName2, 'rotting_days' => 4, 'weight' => 2, 'pipeline_id' => $pipelineId],
+        ];
+
+        $updateResponse = $this->graphQL('
+            mutation($id: ID!, $input: PipelineInput!) {
+                updatePipeline(id: $id, input: $input) {
+                    id
+                    stages { id name rotting_days }
+                }
+            }
+        ', ['id' => $pipelineId, 'input' => $input])
+        ->assertSuccessful();
+
+        $updatedStages = $updateResponse->json('data.updatePipeline.stages');
+
+        $this->assertCount(2, $updatedStages);
+        $this->assertEquals($stage1Id, $updatedStages[0]['id'], 'Stage 1 ID must be preserved even without stages_id');
+        $this->assertEquals($stage2Id, $updatedStages[1]['id'], 'Stage 2 ID must be preserved even without stages_id');
+        $this->assertEquals(3, $updatedStages[0]['rotting_days'], 'Stage 1 rotting_days must be updated');
+        $this->assertEquals(4, $updatedStages[1]['rotting_days'], 'Stage 2 rotting_days must be updated');
+    }
+
+    public function testUpdatePipelineStagesPreservesIdsOnRename()
+    {
+        $input = [
+            'name' => fake()->name(),
+            'weight' => 0,
+            'is_default' => false,
+            'stages' => [
+                ['name' => 'Original-1', 'rotting_days' => 1, 'weight' => 1],
+                ['name' => 'Original-2', 'rotting_days' => 2, 'weight' => 2],
+            ],
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: PipelineInput!) {
+                createPipeline(input: $input) {
+                    id
+                    stages { id name }
+                }
+            }
+        ', ['input' => $input]);
+
+        $pipelineId = $response->json('data.createPipeline.id');
+        $stage1Id = $response->json('data.createPipeline.stages.0.id');
+        $stage2Id = $response->json('data.createPipeline.stages.1.id');
+
+        // Rename both stages WITHOUT sending stages_id — frontend behavior
+        $input['stages'] = [
+            ['name' => 'Renamed-1', 'rotting_days' => 1, 'weight' => 1, 'pipeline_id' => $pipelineId],
+            ['name' => 'Renamed-2', 'rotting_days' => 2, 'weight' => 2, 'pipeline_id' => $pipelineId],
+        ];
+
+        $updateResponse = $this->graphQL('
+            mutation($id: ID!, $input: PipelineInput!) {
+                updatePipeline(id: $id, input: $input) {
+                    id
+                    stages { id name }
+                }
+            }
+        ', ['id' => $pipelineId, 'input' => $input])
+        ->assertSuccessful();
+
+        $updatedStages = $updateResponse->json('data.updatePipeline.stages');
+
+        $this->assertCount(2, $updatedStages);
+        $this->assertEquals($stage1Id, $updatedStages[0]['id'], 'Stage 1 ID must be preserved after rename');
+        $this->assertEquals($stage2Id, $updatedStages[1]['id'], 'Stage 2 ID must be preserved after rename');
+        $this->assertEquals('Renamed-1', $updatedStages[0]['name']);
+        $this->assertEquals('Renamed-2', $updatedStages[1]['name']);
+    }
+
+    public function testUpdatePipelineStagesWeightFollowsPosition()
+    {
+        $input = [
+            'name' => fake()->name(),
+            'weight' => 0,
+            'is_default' => false,
+            'stages' => [
+                ['name' => 'First', 'rotting_days' => 1, 'weight' => 0],
+                ['name' => 'Second', 'rotting_days' => 1, 'weight' => 0],
+                ['name' => 'Third', 'rotting_days' => 1, 'weight' => 0],
+            ],
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: PipelineInput!) {
+                createPipeline(input: $input) {
+                    id
+                    stages { id name weight }
+                }
+            }
+        ', ['input' => $input]);
+
+        $pipelineId = $response->json('data.createPipeline.id');
+
+        // Reorder stages — frontend sends weight=0 for all (common pattern)
+        $input['stages'] = [
+            ['name' => 'Third', 'rotting_days' => 1, 'weight' => 0],
+            ['name' => 'First', 'rotting_days' => 1, 'weight' => 0],
+            ['name' => 'Second', 'rotting_days' => 1, 'weight' => 0],
+        ];
+
+        $updateResponse = $this->graphQL('
+            mutation($id: ID!, $input: PipelineInput!) {
+                updatePipeline(id: $id, input: $input) {
+                    id
+                    stages { id name weight }
+                }
+            }
+        ', ['id' => $pipelineId, 'input' => $input])
+        ->assertSuccessful();
+
+        $updatedStages = $updateResponse->json('data.updatePipeline.stages');
+
+        $this->assertCount(3, $updatedStages);
+        $this->assertEquals('Third', $updatedStages[0]['name']);
+        $this->assertEquals('First', $updatedStages[1]['name']);
+        $this->assertEquals('Second', $updatedStages[2]['name']);
     }
 
     public function testCreatePipeline()


### PR DESCRIPTION
## Summary
- Pipeline stage sync no longer deletes all stages and recreates them — only removes stages not in the input, updates existing ones in place, and creates new ones
- Matches existing stages by ID, name, or position (for frontend that doesn't send `stages_id`)
- Blocks removal of stages that have active leads (scoped by app + company)
- Weight uses sent value, falls back to array index when 0

## Test plan
- [x] `testUpdatePipelineWithStages` — update with `stages_id`
- [x] `testUpdatePipelineStagesPreservesExistingStageIds` — IDs preserved with `stages_id`
- [x] `testUpdatePipelineRemovesOnlyDeletedStages` — only omitted stages removed
- [x] `testCannotRemoveStageWithActiveLeads` — blocked when leads exist
- [x] `testUpdatePipelineStagesPreservesIdsWithoutStagesId` — IDs preserved by name match
- [x] `testUpdatePipelineStagesPreservesIdsOnRename` — IDs preserved by position on rename
- [x] `testUpdatePipelineStagesWeightFollowsPosition` — weight follows position order
- [x] Full suite: 17/17 tests, 44 assertions