### PR TITLE
fix: sync people addresses on update, remove orphans

### DIFF
--- a/src/Domains/Guild/Customers/Actions/UpdatePeopleAction.php
+++ b/src/Domains/Guild/Customers/Actions/UpdatePeopleAction.php
@@ -100,6 +100,7 @@ class UpdatePeopleAction
             })
             ->values();
 
+        $keepIds = [];
         $addresses = [];
 
         foreach ($deduplicatedAddresses as $address) {
@@ -136,11 +137,20 @@ class UpdatePeopleAction
                     'countries_id' => $address->country_id ?? $existingAddress->countries_id,
                     'address_type_id' => $address->address_type_id ?? AddressType::getByName(AddressTypeEnum::HOME->value, $this->people->app)->getId(),
                 ]);
+                $keepIds[] = $existingAddress->id;
             }
         }
 
         if (count($addresses) > 0) {
-            $this->people->address()->saveMany($addresses);
+            $savedAddresses = $this->people->address()->saveMany($addresses);
+            foreach ($savedAddresses as $saved) {
+                $keepIds[] = $saved->id;
+            }
+        }
+
+        // Remove addresses no longer in the input
+        if (! empty($keepIds)) {
+            $this->people->address()->whereNotIn('id', $keepIds)->delete();
         }
     }
 }

--- a/tests/GraphQL/Guild/PeopleTest.php
+++ b/tests/GraphQL/Guild/PeopleTest.php
@@ -1761,4 +1761,228 @@ class PeopleTest extends TestCase
                 ],
             ]);
     }
+
+    public function testUpdatePeopleContactsSyncPreservesIds(): void
+    {
+        $email = fake()->unique()->email();
+        $input = [
+            'firstname' => fake()->firstName(),
+            'lastname' => fake()->lastName(),
+            'contacts' => [
+                ['value' => $email, 'contacts_types_id' => 1, 'weight' => 0],
+            ],
+            'address' => [],
+            'custom_fields' => [],
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: PeopleInput!) {
+                createPeople(input: $input) {
+                    id
+                    firstname
+                    lastname
+                    contacts { id value }
+                }
+            }
+        ', ['input' => $input]);
+
+        $peopleId = $response['data']['createPeople']['id'];
+        $contactId = $response['data']['createPeople']['contacts'][0]['id'];
+
+        // Update: keep contact, change email value
+        $newEmail = fake()->unique()->email();
+        $updateInput = [
+            'firstname' => $input['firstname'],
+            'lastname' => $input['lastname'],
+            'contacts' => [
+                ['id' => (int) $contactId, 'value' => $newEmail, 'contacts_types_id' => 1, 'weight' => 0],
+            ],
+            'address' => [],
+            'custom_fields' => [],
+        ];
+
+        $updateResponse = $this->graphQL('
+            mutation($id: ID!, $input: PeopleInput!) {
+                updatePeople(id: $id, input: $input) {
+                    id
+                    contacts { id value }
+                }
+            }
+        ', ['id' => $peopleId, 'input' => $updateInput])
+        ->assertSuccessful();
+
+        $contacts = $updateResponse->json('data.updatePeople.contacts');
+        $this->assertCount(1, $contacts);
+        $this->assertEquals($contactId, $contacts[0]['id'], 'Contact ID must be preserved');
+        $this->assertEquals($newEmail, $contacts[0]['value'], 'Contact value must be updated');
+    }
+
+    public function testUpdatePeopleContactsSyncRemovesDeleted(): void
+    {
+        $email1 = fake()->unique()->email();
+        $email2 = fake()->unique()->email();
+        $input = [
+            'firstname' => fake()->firstName(),
+            'lastname' => fake()->lastName(),
+            'contacts' => [
+                ['value' => $email1, 'contacts_types_id' => 1, 'weight' => 0],
+                ['value' => $email2, 'contacts_types_id' => 1, 'weight' => 1],
+            ],
+            'address' => [],
+            'custom_fields' => [],
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: PeopleInput!) {
+                createPeople(input: $input) {
+                    id
+                    firstname
+                    lastname
+                    contacts { id value }
+                }
+            }
+        ', ['input' => $input]);
+
+        $peopleId = $response['data']['createPeople']['id'];
+        $contact1Id = $response['data']['createPeople']['contacts'][0]['id'];
+
+        // Update: keep only first email, remove second
+        $updateInput = [
+            'firstname' => $input['firstname'],
+            'lastname' => $input['lastname'],
+            'contacts' => [
+                ['id' => (int) $contact1Id, 'value' => $email1, 'contacts_types_id' => 1, 'weight' => 0],
+            ],
+            'address' => [],
+            'custom_fields' => [],
+        ];
+
+        $updateResponse = $this->graphQL('
+            mutation($id: ID!, $input: PeopleInput!) {
+                updatePeople(id: $id, input: $input) {
+                    id
+                    contacts { id value }
+                }
+            }
+        ', ['id' => $peopleId, 'input' => $updateInput])
+        ->assertSuccessful();
+
+        $contacts = $updateResponse->json('data.updatePeople.contacts');
+        $this->assertCount(1, $contacts, 'Only the kept contact should remain');
+        $this->assertEquals($contact1Id, $contacts[0]['id']);
+    }
+
+    public function testUpdatePeopleAddressSyncPreservesIds(): void
+    {
+        $address1 = fake()->unique()->streetAddress();
+        $address2 = fake()->unique()->streetAddress();
+        $input = [
+            'firstname' => fake()->firstName(),
+            'lastname' => fake()->lastName(),
+            'contacts' => [
+                ['value' => fake()->unique()->email(), 'contacts_types_id' => 1, 'weight' => 0],
+            ],
+            'address' => [
+                ['address' => $address1, 'city' => 'CityA', 'state' => 'StateA', 'zip' => '10001'],
+                ['address' => $address2, 'city' => 'CityB', 'state' => 'StateB', 'zip' => '20002'],
+            ],
+            'custom_fields' => [],
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: PeopleInput!) {
+                createPeople(input: $input) {
+                    id
+                    address { id address city }
+                }
+            }
+        ', ['input' => $input]);
+
+        $peopleId = $response->json('data.createPeople.id');
+        $addr1Id = $response->json('data.createPeople.address.0.id');
+        $addr2Id = $response->json('data.createPeople.address.1.id');
+
+        // Update: keep both addresses, change city on first
+        $updateInput = [
+            'firstname' => $input['firstname'],
+            'lastname' => $input['lastname'],
+            'contacts' => $input['contacts'],
+            'address' => [
+                ['id' => (int) $addr1Id, 'address' => $address1, 'city' => 'NewCityA', 'state' => 'StateA', 'zip' => '10001'],
+                ['id' => (int) $addr2Id, 'address' => $address2, 'city' => 'CityB', 'state' => 'StateB', 'zip' => '20002'],
+            ],
+            'custom_fields' => [],
+        ];
+
+        $updateResponse = $this->graphQL('
+            mutation($id: ID!, $input: PeopleInput!) {
+                updatePeople(id: $id, input: $input) {
+                    id
+                    address { id address city }
+                }
+            }
+        ', ['id' => $peopleId, 'input' => $updateInput])
+        ->assertSuccessful();
+
+        $addresses = $updateResponse->json('data.updatePeople.address');
+        $this->assertCount(2, $addresses);
+        $this->assertEquals($addr1Id, $addresses[0]['id'], 'Address 1 ID must be preserved');
+        $this->assertEquals('NewCityA', $addresses[0]['city']);
+        $this->assertEquals($addr2Id, $addresses[1]['id'], 'Address 2 ID must be preserved');
+    }
+
+    public function testUpdatePeopleAddressSyncRemovesDeleted(): void
+    {
+        $address1 = fake()->unique()->streetAddress();
+        $address2 = fake()->unique()->streetAddress();
+        $input = [
+            'firstname' => fake()->firstName(),
+            'lastname' => fake()->lastName(),
+            'contacts' => [
+                ['value' => fake()->unique()->email(), 'contacts_types_id' => 1, 'weight' => 0],
+            ],
+            'address' => [
+                ['address' => $address1, 'city' => 'CityA', 'state' => 'StateA', 'zip' => '10001'],
+                ['address' => $address2, 'city' => 'CityB', 'state' => 'StateB', 'zip' => '20002'],
+            ],
+            'custom_fields' => [],
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: PeopleInput!) {
+                createPeople(input: $input) {
+                    id
+                    address { id address }
+                }
+            }
+        ', ['input' => $input]);
+
+        $peopleId = $response->json('data.createPeople.id');
+        $addr1Id = $response->json('data.createPeople.address.0.id');
+
+        // Update: keep only first address, remove second
+        $updateInput = [
+            'firstname' => $input['firstname'],
+            'lastname' => $input['lastname'],
+            'contacts' => $input['contacts'],
+            'address' => [
+                ['id' => (int) $addr1Id, 'address' => $address1, 'city' => 'CityA', 'state' => 'StateA', 'zip' => '10001'],
+            ],
+            'custom_fields' => [],
+        ];
+
+        $updateResponse = $this->graphQL('
+            mutation($id: ID!, $input: PeopleInput!) {
+                updatePeople(id: $id, input: $input) {
+                    id
+                    address { id address }
+                }
+            }
+        ', ['id' => $peopleId, 'input' => $updateInput])
+        ->assertSuccessful();
+
+        $addresses = $updateResponse->json('data.updatePeople.address');
+        $this->assertCount(1, $addresses, 'Only the kept address should remain');
+        $this->assertEquals($addr1Id, $addresses[0]['id']);
+    }
 }

--- a/tests/GraphQL/Guild/PeopleTest.php
+++ b/tests/GraphQL/Guild/PeopleTest.php
@@ -1844,7 +1844,10 @@ class PeopleTest extends TestCase
         ', ['input' => $input]);
 
         $peopleId = $response['data']['createPeople']['id'];
-        $contact1Id = $response['data']['createPeople']['contacts'][0]['id'];
+        $createdContacts = $response['data']['createPeople']['contacts'];
+        $this->assertCount(2, $createdContacts, 'Both contacts must be created');
+        $contact1Id = $createdContacts[0]['id'];
+        $contact2Id = $createdContacts[1]['id'];
 
         // Update: keep only first email, remove second
         $updateInput = [
@@ -1869,7 +1872,9 @@ class PeopleTest extends TestCase
 
         $contacts = $updateResponse->json('data.updatePeople.contacts');
         $this->assertCount(1, $contacts, 'Only the kept contact should remain');
-        $this->assertEquals($contact1Id, $contacts[0]['id']);
+        $this->assertEquals($contact1Id, $contacts[0]['id'], 'Kept contact ID must be preserved');
+        $contactIds = array_column($contacts, 'id');
+        $this->assertNotContains($contact2Id, $contactIds, 'Removed contact must be deleted');
     }
 
     public function testUpdatePeopleAddressSyncPreservesIds(): void
@@ -1952,13 +1957,18 @@ class PeopleTest extends TestCase
             mutation($input: PeopleInput!) {
                 createPeople(input: $input) {
                     id
+                    firstname
+                    lastname
                     address { id address }
                 }
             }
         ', ['input' => $input]);
 
-        $peopleId = $response->json('data.createPeople.id');
-        $addr1Id = $response->json('data.createPeople.address.0.id');
+        $peopleId = $response['data']['createPeople']['id'];
+        $createdAddresses = $response['data']['createPeople']['address'];
+        $this->assertCount(2, $createdAddresses, 'Both addresses must be created');
+        $addr1Id = $createdAddresses[0]['id'];
+        $addr2Id = $createdAddresses[1]['id'];
 
         // Update: keep only first address, remove second
         $updateInput = [
@@ -1983,6 +1993,8 @@ class PeopleTest extends TestCase
 
         $addresses = $updateResponse->json('data.updatePeople.address');
         $this->assertCount(1, $addresses, 'Only the kept address should remain');
-        $this->assertEquals($addr1Id, $addresses[0]['id']);
+        $this->assertEquals($addr1Id, $addresses[0]['id'], 'Kept address ID must be preserved');
+        $addressIds = array_column($addresses, 'id');
+        $this->assertNotContains($addr2Id, $addressIds, 'Removed address must be deleted');
     }
 }


### PR DESCRIPTION
## Summary
- Address sync in `UpdatePeopleAction` now removes addresses no longer in the input (previously they were left as orphans)
- Contacts already had proper sync — added tests to validate both patterns
- Matches the same sync approach used for pipeline stages

## Test plan
- [x] `testUpdatePeopleContactsSyncPreservesIds` — contact ID preserved on update
- [x] `testUpdatePeopleContactsSyncRemovesDeleted` — removed contacts are deleted
- [x] `testUpdatePeopleAddressSyncPreservesIds` — address ID preserved on update
- [x] `testUpdatePeopleAddressSyncRemovesDeleted` — removed addresses are deleted