### PR TITLE
[dev] refact: add currentUserId to stateDelta in Google ADK chat requests

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -890,6 +890,41 @@ public static function search($query = '', $callback = null)
 
 **Placement:** Place the `search()` method at the **end of the class**, not at the top. Properties (`$table`, `$guarded`, `casts()`) and relationships should come first.
 
+## Notifications
+
+Always extend `Kanvas\Notifications\Notification` (not `\Illuminate\Notifications\Notification`) for all notification classes in this codebase.
+
+```php
+use Kanvas\Notifications\Notification;
+
+class MyNotification extends Notification
+{
+    public function __construct(
+        protected SomeModel $entity,
+        // ... other params
+        protected Apps $app,
+        protected Companies $company,
+        protected ?Users $fromUser = null,
+    ) {
+        parent::__construct($entity, [
+            'app' => $app,
+            'company' => $company,
+            'fromUser' => $fromUser,
+        ]);
+
+        // Set channels as slug strings; the base class maps them to channel classes via
+        // NotificationChannelEnum::getNotificationChannelBySlug() in via()
+        $this->channels = ['mail', 'sms', 'push'];
+    }
+}
+```
+
+**Key points:**
+- `Kanvas\Notifications\Notification` implements `ShouldQueue`, includes SMTP config, OneSignal, Expo, SMS, and storage traits
+- Set `$this->channels` with slug strings (`'mail'`, `'sms'`, `'push'`, `'expo'`, `'database'`) — the base `via()` maps them to channel classes automatically via `Kanvas\Notifications\Enums\NotificationChannelEnum::getNotificationChannelBySlug()`
+- Override `toMail()` and/or `toOneSignal()` only when you need notification-specific content that differs from the template-based defaults
+- Never use `\Illuminate\Notifications\Notification` directly
+
 ## Key Conventions
 
 ### No Inline Fully-Qualified Class Names

--- a/src/Domains/Connectors/SalesAssist/Actions/AIAssistAgentResponderAction.php
+++ b/src/Domains/Connectors/SalesAssist/Actions/AIAssistAgentResponderAction.php
@@ -67,7 +67,8 @@ class AIAssistAgentResponderAction extends BaseAgentResponderAction
                 $userId,
                 $sessionId,
                 $messageConversation,
-                $onChunk
+                $onChunk,
+                user: $this->message->user
             );
         } else {
             $question = $currentAgent->chat(new UserMessage($messageConversation));

--- a/src/Domains/Intelligence/Agents/Services/GoogleADKService.php
+++ b/src/Domains/Intelligence/Agents/Services/GoogleADKService.php
@@ -14,6 +14,7 @@ use GuzzleHttp\Exception\ServerException;
 use Illuminate\Support\Facades\Validator;
 use Kanvas\Exceptions\ValidationException;
 use Kanvas\Intelligence\Enums\ConfigurationEnum;
+use Kanvas\Users\Models\Users;
 
 class GoogleADKService
 {
@@ -105,7 +106,8 @@ class GoogleADKService
         string $sessionId,
         string $message,
         ?callable $onChunk = null,
-        int $maxRetries = 3
+        int $maxRetries = 3,
+        ?Users $user = null
     ): string {
         $attempt = 0;
 
@@ -115,7 +117,8 @@ class GoogleADKService
                     $userId,
                     $sessionId,
                     $message,
-                    $onChunk
+                    $onChunk,
+                    $user
                 );
             } catch (Exception $e) {
                 $attempt++;
@@ -131,7 +134,8 @@ class GoogleADKService
         string $userId,
         string $sessionId,
         string $message,
-        ?callable $onChunk = null
+        ?callable $onChunk = null,
+        ?Users $user = null
     ): string {
         $response = $this->client->post('/run_sse', [
             'headers' => [
@@ -145,7 +149,7 @@ class GoogleADKService
                     'role' => 'user',
                     'parts' => [['text' => $message]],
                     'stateDelta' => [
-                        'currentUserId' => auth()->user()?->id,
+                        'current_user_id' => $user ? $user->id : '',
                     ],
                 ],
             ],

--- a/src/Domains/Intelligence/Agents/Services/GoogleADKService.php
+++ b/src/Domains/Intelligence/Agents/Services/GoogleADKService.php
@@ -144,6 +144,9 @@ class GoogleADKService
                 'new_message' => [
                     'role' => 'user',
                     'parts' => [['text' => $message]],
+                    'stateDelta' => [
+                        'currentUserId' => auth()->user()?->id,
+                    ],
                 ],
             ],
             'stream' => true,
@@ -227,6 +230,9 @@ class GoogleADKService
                 'new_message' => [
                     'role' => 'user',
                     'parts' => [['text' => $message]],
+                    'stateDelta' => [
+                        'currentUserId' => auth()->user()?->id,
+                    ],
                 ],
             ],
         ]);

--- a/src/Domains/Intelligence/Agents/Services/GoogleADKService.php
+++ b/src/Domains/Intelligence/Agents/Services/GoogleADKService.php
@@ -224,7 +224,7 @@ class GoogleADKService
      *
      * @throws GuzzleException
      */
-    public function chatSimple(string $userId, string $sessionId, string $message): array
+    public function chatSimple(string $userId, string $sessionId, string $message, ?Users $user): array
     {
         $response = $this->client->post('/run', [
             'json' => [
@@ -235,7 +235,7 @@ class GoogleADKService
                     'role' => 'user',
                     'parts' => [['text' => $message]],
                     'stateDelta' => [
-                        'currentUserId' => auth()->user()?->id,
+                        'current_user_id' => $user ? $user->id : '',
                     ],
                 ],
             ],

--- a/src/Domains/Intelligence/Notifications/LeadNotification.php
+++ b/src/Domains/Intelligence/Notifications/LeadNotification.php
@@ -6,7 +6,6 @@ namespace Kanvas\Intelligence\Notifications;
 
 use Baka\Users\Contracts\UserInterface;
 use Kanvas\Guild\Leads\Models\Lead;
-use Kanvas\Intelligence\Enums\NotificationChannelEnum;
 use Kanvas\Notifications\Notification;
 use Kanvas\Users\Models\Users;
 
@@ -23,7 +22,7 @@ class LeadNotification extends Notification
             'fromUser' => $fromUser,
         ]);
 
-        $this->channels = $this->filterChannels($enabledChannels);
+        $this->channels = $enabledChannels;
     }
 
     public function getNotificationTitle(): string
@@ -48,15 +47,5 @@ class LeadNotification extends Notification
                 'lead_id' => $this->lead->getId(),
             ],
         ];
-    }
-
-    private function filterChannels(array $enabledChannels): array
-    {
-        return array_values(
-            array_filter(
-                $enabledChannels,
-                fn ($channel) => NotificationChannelEnum::isSupported($channel)
-            )
-        );
     }
 }

--- a/src/Domains/Intelligence/Notifications/LeadNotification.php
+++ b/src/Domains/Intelligence/Notifications/LeadNotification.php
@@ -5,48 +5,50 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Notifications;
 
 use Baka\Users\Contracts\UserInterface;
-use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Mail\Mailable;
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Apps\Support\SmtpRuntimeConfiguration;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Enums\NotificationChannelEnum;
-use Kanvas\Notifications\Channels\OneSignalNotificationChannel;
-use Kanvas\Notifications\Channels\TwilioSmsChannel;
-use Kanvas\Notifications\Traits\NotificationSmsTrait;
+use Kanvas\Notifications\KanvasMailable;
+use Kanvas\Notifications\Notification;
 use Kanvas\Users\Models\Users;
 
-class LeadNotification extends \Illuminate\Notifications\Notification
+class LeadNotification extends Notification
 {
-    use NotificationSmsTrait;
-    public array $channels = [];
-
     public function __construct(
         protected Lead $lead,
         protected string $message,
         protected array $enabledChannels,
-        protected Apps $app,
-        protected Companies $company,
-        protected ?Users $fromUser = null
+        Apps $app,
+        Companies $company,
+        ?Users $fromUser = null
     ) {
-        $this->channels = $this->mapChannels($enabledChannels);
+        parent::__construct($lead, [
+            'app' => $app,
+            'company' => $company,
+            'fromUser' => $fromUser,
+        ]);
+
+        $this->channels = $this->filterChannels($enabledChannels);
     }
 
-    public function via(object $notifiable): array
+    public function toMail($notifiable): Mailable
     {
-        return $this->channels;
-    }
+        $smtpConfig = new SmtpRuntimeConfiguration($this->app, $this->company);
+        $mailConfig = $smtpConfig->loadSmtpSettings();
+        $fromMail = $smtpConfig->getFromEmail();
 
-    public function toMail(object $notifiable): MailMessage
-    {
         $toEmail = $notifiable instanceof UserInterface ? $notifiable->email : $notifiable->routes['mail'];
 
-        return (new MailMessage())
-            ->subject('Lead Notification - ' . $this->lead->people->name)
-            ->line($this->message)
-            ->line('Lead: ' . $this->lead->people->name);
+        return (new KanvasMailable($mailConfig, $this->message))
+            ->from($fromMail['address'], $fromMail['name'])
+            ->to($toEmail)
+            ->subject('Lead Notification - ' . $this->lead->people->name);
     }
 
-    public function toOneSignal(object $notifiable): array
+    public function toOneSignal($notifiable): array
     {
         return [
             'user_id' => $notifiable instanceof UserInterface ? $notifiable->getId() : null,
@@ -60,25 +62,13 @@ class LeadNotification extends \Illuminate\Notifications\Notification
         ];
     }
 
-    private function mapChannels(array $enabledChannels): array
+    private function filterChannels(array $enabledChannels): array
     {
-        $channelMap = [
-            NotificationChannelEnum::SMS->value => TwilioSmsChannel::class,
-            NotificationChannelEnum::EMAIL->value => 'mail',
-            NotificationChannelEnum::PUSH->value => OneSignalNotificationChannel::class,
-        ];
-
-        $channels = [];
-        foreach ($enabledChannels as $channel) {
-            if (! NotificationChannelEnum::isSupported($channel)) {
-                continue;
-            }
-
-            if (isset($channelMap[$channel])) {
-                $channels[] = $channelMap[$channel];
-            }
-        }
-
-        return $channels;
+        return array_values(
+            array_filter(
+                $enabledChannels,
+                fn ($channel) => NotificationChannelEnum::isSupported($channel)
+            )
+        );
     }
 }

--- a/src/Domains/Intelligence/Notifications/LeadNotification.php
+++ b/src/Domains/Intelligence/Notifications/LeadNotification.php
@@ -12,10 +12,12 @@ use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Enums\NotificationChannelEnum;
 use Kanvas\Notifications\Channels\OneSignalNotificationChannel;
 use Kanvas\Notifications\Channels\TwilioSmsChannel;
+use Kanvas\Notifications\Traits\NotificationSmsTrait;
 use Kanvas\Users\Models\Users;
 
 class LeadNotification extends \Illuminate\Notifications\Notification
 {
+    use NotificationSmsTrait;
     public array $channels = [];
 
     public function __construct(
@@ -42,24 +44,6 @@ class LeadNotification extends \Illuminate\Notifications\Notification
             ->subject('Lead Notification - ' . $this->lead->people->name)
             ->line($this->message)
             ->line('Lead: ' . $this->lead->people->name);
-    }
-
-    public function toSms(object $notifiable): array
-    {
-        $phone = null;
-        if ($notifiable instanceof UserInterface) {
-            $appProfile = $notifiable->getAppProfile($this->app);
-            $phone = $appProfile?->phone ?? $notifiable->phone;
-        }
-
-        return [
-            'user_id' => $notifiable instanceof UserInterface ? $notifiable->getId() : null,
-            'phone' => $phone,
-            'content' => $this->message,
-            'title' => 'Lead Notification',
-            'app' => $this->app,
-            'company' => $this->company,
-        ];
     }
 
     public function toOneSignal(object $notifiable): array

--- a/src/Domains/Intelligence/Notifications/LeadNotification.php
+++ b/src/Domains/Intelligence/Notifications/LeadNotification.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Notifications;
 
 use Baka\Users\Contracts\UserInterface;
-use Illuminate\Mail\Mailable;
 use Kanvas\Apps\Models\Apps;
-use Kanvas\Apps\Support\SmtpRuntimeConfiguration;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Enums\NotificationChannelEnum;
-use Kanvas\Notifications\KanvasMailable;
 use Kanvas\Notifications\Notification;
 use Kanvas\Users\Models\Users;
 
@@ -34,18 +31,14 @@ class LeadNotification extends Notification
         $this->channels = $this->filterChannels($enabledChannels);
     }
 
-    public function toMail($notifiable): Mailable
+    public function getNotificationTitle(): string
     {
-        $smtpConfig = new SmtpRuntimeConfiguration($this->app, $this->company);
-        $mailConfig = $smtpConfig->loadSmtpSettings();
-        $fromMail = $smtpConfig->getFromEmail();
+        return 'Lead Notification - ' . $this->lead->people->name;
+    }
 
-        $toEmail = $notifiable instanceof UserInterface ? $notifiable->email : $notifiable->routes['mail'];
-
-        return (new KanvasMailable($mailConfig, $this->message))
-            ->from($fromMail['address'], $fromMail['name'])
-            ->to($toEmail)
-            ->subject('Lead Notification - ' . $this->lead->people->name);
+    public function getEmailContent(): string
+    {
+        return $this->message;
     }
 
     public function toOneSignal($notifiable): array

--- a/src/Domains/Intelligence/Notifications/LeadNotification.php
+++ b/src/Domains/Intelligence/Notifications/LeadNotification.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Notifications;
 
 use Baka\Users\Contracts\UserInterface;
-use Kanvas\Apps\Models\Apps;
-use Kanvas\Companies\Models\Companies;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Enums\NotificationChannelEnum;
 use Kanvas\Notifications\Notification;
@@ -18,13 +16,10 @@ class LeadNotification extends Notification
         protected Lead $lead,
         protected string $message,
         protected array $enabledChannels,
-        Apps $app,
-        Companies $company,
         ?Users $fromUser = null
     ) {
         parent::__construct($lead, [
-            'app' => $app,
-            'company' => $company,
+            'company' => $lead->company,
             'fromUser' => $fromUser,
         ]);
 

--- a/src/Domains/Intelligence/Workflows/SendNotificationActivity.php
+++ b/src/Domains/Intelligence/Workflows/SendNotificationActivity.php
@@ -7,7 +7,6 @@ namespace Kanvas\Intelligence\Workflows;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Enums\ConfigurationEnum;
-use Kanvas\Intelligence\Enums\NotificationChannelEnum;
 use Kanvas\Intelligence\Notifications\LeadNotification;
 use Kanvas\Users\Models\Users;
 use Kanvas\Workflow\Enums\IntegrationsEnum;
@@ -88,9 +87,6 @@ class SendNotificationActivity extends KanvasActivity
             $configuredChannels = json_decode($configuredChannels, true) ?? [];
         }
 
-        return array_filter(
-            $configuredChannels,
-            fn ($channel) => NotificationChannelEnum::isSupported($channel)
-        );
+        return $configuredChannels;
     }
 }

--- a/src/Domains/Intelligence/Workflows/SendNotificationActivity.php
+++ b/src/Domains/Intelligence/Workflows/SendNotificationActivity.php
@@ -57,9 +57,7 @@ class SendNotificationActivity extends KanvasActivity
                 $notification = new LeadNotification(
                     lead: $lead,
                     message: $text,
-                    enabledChannels: $enabledChannels,
-                    app: $app,
-                    company: $company
+                    enabledChannels: $enabledChannels
                 );
 
                 $user->notify($notification);


### PR DESCRIPTION
## Summary
- Add `stateDelta.currentUserId` to the `new_message` payload in `executeChat` and `chatSimple` methods
- Uses nullsafe operator `auth()->user()?->id` to handle unauthenticated contexts gracefully

## Test plan
- [ ] Verify chat requests include `stateDelta.currentUserId` when a user is authenticated
- [ ] Verify no errors when called without an authenticated user (value is `null`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)