### PR TITLE
fix: use IF() to guarantee JSON_VALID evaluates before JSON_CONTAINS

### DIFF
--- a/src/Domains/Guild/Leads/Services/LeadChannelFilesService.php
+++ b/src/Domains/Guild/Leads/Services/LeadChannelFilesService.php
@@ -213,7 +213,7 @@ class LeadChannelFilesService
         // Look for messages with status 'submitted'
         // Use JSON_VALID check to avoid errors on non-JSON message columns
         $lastMessage = Message::where('parent_id', $message->getId())
-            ->whereRaw('JSON_VALID(`message`) AND JSON_CONTAINS(`message`, \'"submitted"\', \'$."status"\')')
+            ->whereRaw('IF(JSON_VALID(`message`), JSON_CONTAINS(`message`, \'"submitted"\', \'$."status"\'), 0)')
             ->orderBy('id', 'desc')
             ->first();
 


### PR DESCRIPTION
MySQL optimizer can reorder AND conditions, so JSON_VALID guard wasn't guaranteed to short-circuit. IF() forces evaluation order.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
