### PR TITLE
feat(deal): observer for default channels, notes, ai assistant

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -14,8 +14,6 @@ use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Customers\Models\PeopleEmploymentHistory;
 use Kanvas\Guild\Customers\Observers\PeopleEmploymentHistoryObserver;
 use Kanvas\Guild\Customers\Observers\PeopleObserver;
-use Kanvas\Guild\Deals\Models\Deal;
-use Kanvas\Guild\Deals\Observers\DealObserver;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Observers\LeadObserver;
 use Kanvas\Inventory\Attributes\Models\Attributes;
@@ -94,7 +92,6 @@ class EventServiceProvider extends ServiceProvider
         UserMessageActivity::observe(UserMessageActivityObserver::class);
         UserList::observe(UsersListsObserver::class);
         Lead::observe(LeadObserver::class);
-        Deal::observe(DealObserver::class);
         #UserMessage::observe(UserMessageObserver::class);
         Warehouses::observe(WarehouseObserver::class);
         Regions::observe(RegionObserver::class);

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -14,6 +14,8 @@ use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Customers\Models\PeopleEmploymentHistory;
 use Kanvas\Guild\Customers\Observers\PeopleEmploymentHistoryObserver;
 use Kanvas\Guild\Customers\Observers\PeopleObserver;
+use Kanvas\Guild\Deals\Models\Deal;
+use Kanvas\Guild\Deals\Observers\DealObserver;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Observers\LeadObserver;
 use Kanvas\Inventory\Attributes\Models\Attributes;
@@ -92,6 +94,7 @@ class EventServiceProvider extends ServiceProvider
         UserMessageActivity::observe(UserMessageActivityObserver::class);
         UserList::observe(UsersListsObserver::class);
         Lead::observe(LeadObserver::class);
+        Deal::observe(DealObserver::class);
         #UserMessage::observe(UserMessageObserver::class);
         Warehouses::observe(WarehouseObserver::class);
         Regions::observe(RegionObserver::class);

--- a/graphql/schemas/Guild/deal.graphql
+++ b/graphql/schemas/Guild/deal.graphql
@@ -13,6 +13,10 @@ type Deal {
     pipeline: LeadPipeline @belongsTo(relation: "pipeline")
     stage: LeadPipelineStage @belongsTo(relation: "pipelineStage")
     status: LeadStatus @belongsTo(relation: "leadStatus")
+    channels: [SocialChannel]! @hasMany(relation: "socialChannels")
+    notes: SocialChannel @hasOne(relation: "notes")
+    ai_session: [AIAgentSession!]!
+        @hasMany(relation: "aiSession", type: PAGINATOR)
     tags: [Tag!]
         @paginate(
             defaultCount: 25

--- a/src/Domains/Guild/Deals/Models/Deal.php
+++ b/src/Domains/Guild/Deals/Models/Deal.php
@@ -7,12 +7,14 @@ namespace Kanvas\Guild\Deals\Models;
 use Baka\Traits\DatabaseSearchableTrait;
 use Baka\Traits\UuidTrait;
 use Baka\Users\Contracts\UserInterface;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\CompaniesBranches;
 use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Deals\Observers\DealObserver;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Models\LeadStatus;
 use Kanvas\Guild\Models\BaseModel;
@@ -47,6 +49,7 @@ use Override;
  * @property string|null $description
  * @property int $is_deleted
  */
+#[ObservedBy([DealObserver::class])]
 class Deal extends BaseModel
 {
     use UuidTrait;

--- a/src/Domains/Guild/Deals/Models/Deal.php
+++ b/src/Domains/Guild/Deals/Models/Deal.php
@@ -8,6 +8,8 @@ use Baka\Traits\DatabaseSearchableTrait;
 use Baka\Traits\UuidTrait;
 use Baka\Users\Contracts\UserInterface;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\CompaniesBranches;
 use Kanvas\Guild\Customers\Models\People;
@@ -17,7 +19,11 @@ use Kanvas\Guild\Models\BaseModel;
 use Kanvas\Guild\Organizations\Models\Organization;
 use Kanvas\Guild\Pipelines\Models\Pipeline;
 use Kanvas\Guild\Pipelines\Models\PipelineStage;
+use Kanvas\Intelligence\Sessions\Models\Session;
+use Kanvas\Social\Channels\Enums\ChannelNameEnum;
+use Kanvas\Social\Channels\Models\Channel;
 use Kanvas\Social\Tags\Traits\HasTagsTrait;
+use Kanvas\SystemModules\Models\SystemModules;
 use Kanvas\Users\Models\Users;
 use Kanvas\Workflow\Traits\CanUseWorkflow;
 use Override;
@@ -68,12 +74,6 @@ class Deal extends BaseModel
         return $this->belongsTo(Lead::class, 'leads_id', 'id');
     }
 
-    #[Override]
-    public function user(): BelongsTo
-    {
-        return $this->belongsTo(Users::class, 'users_id', 'id');
-    }
-
     public function owner(): BelongsTo
     {
         return $this->belongsTo(Users::class, 'owner_id', 'id');
@@ -97,6 +97,37 @@ class Deal extends BaseModel
     public function leadStatus(): BelongsTo
     {
         return $this->belongsTo(LeadStatus::class, 'status_id', 'id');
+    }
+
+    public function getStringIdAttribute(): string
+    {
+        return (string) $this->id;
+    }
+
+    public function socialChannels(): HasMany
+    {
+        return $this->hasMany(Channel::class, 'entity_id', 'string_id')
+            ->whereIn(
+                'entity_namespace',
+                [
+                    self::class,
+                    SystemModules::getLegacyNamespace(self::class),
+                ]
+            )
+            ->where('is_deleted', 0);
+    }
+
+    public function notes(): HasOne
+    {
+        return $this->hasOne(Channel::class, 'entity_id', 'string_id')
+            ->where('entity_namespace', self::class)
+            ->where('name', ChannelNameEnum::NOTES->value);
+    }
+
+    public function aiSession(): HasMany
+    {
+        return $this->hasMany(Session::class, 'entity_id', 'string_id')
+            ->where('entity_namespace', self::class);
     }
 
     public function searchableAs(): string

--- a/src/Domains/Guild/Deals/Observers/DealObserver.php
+++ b/src/Domains/Guild/Deals/Observers/DealObserver.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Deals\Observers;
+
+use Baka\Support\Str;
+use Kanvas\Guild\Deals\Models\Deal;
+use Kanvas\Guild\Leads\Models\LeadStatus;
+use Kanvas\Guild\Pipelines\Models\Pipeline;
+use Kanvas\Intelligence\Sessions\Models\Session;
+use Kanvas\Social\Channels\Actions\CreateChannelAction;
+use Kanvas\Social\Channels\DataTransferObject\Channel as ChannelData;
+use Kanvas\Social\Channels\Enums\ChannelNameEnum;
+
+class DealObserver
+{
+    public function creating(Deal $deal): void
+    {
+        if ($deal->title === null || $deal->title === '') {
+            $deal->title = 'Deal ' . ($deal->uuid ?? Str::uuid()->toString());
+        }
+
+        if (! $deal->status_id) {
+            $deal->status_id = LeadStatus::getDefault($deal->app)->getId();
+        }
+
+        if (! $deal->pipeline_id) {
+            $pipeline = Pipeline::where('companies_id', $deal->companies_id)
+                ->where('is_deleted', 0)
+                ->where('apps_id', $deal->apps_id)
+                ->orderBy('is_default', 'desc')
+                ->first();
+
+            if ($pipeline) {
+                $deal->pipeline_id = $pipeline->id;
+                $deal->pipeline_stage_id = $pipeline->stages->first()?->id ?? 0;
+            }
+        }
+    }
+
+    public function created(Deal $deal): void
+    {
+        if (! $deal->user) {
+            return;
+        }
+
+        $description = $deal->description;
+        $channelDescription = ($description === null || $description === '')
+            ? $deal->uuid
+            : $description;
+
+        new CreateChannelAction(
+            new ChannelData(
+                $deal->app,
+                $deal->company,
+                $deal->user,
+                (string) $deal->getKey(),
+                Deal::class,
+                ChannelNameEnum::DEFAULT->value,
+                $channelDescription,
+                $deal->uuid
+            )
+        )->execute();
+
+        if ($deal->company->get('enable_ai_notes_channel', false)) {
+            $channel = new CreateChannelAction(
+                new ChannelData(
+                    $deal->app,
+                    $deal->company,
+                    $deal->user,
+                    (string) $deal->getKey(),
+                    Deal::class,
+                    ChannelNameEnum::NOTES->value,
+                    'AI Notes Channel',
+                    Str::uuid()->toString()
+                )
+            )->execute();
+
+            $channel->addCategory(
+                'ai-agent',
+                $deal->app,
+                $deal->user,
+                $deal->company
+            );
+        }
+    }
+
+    public function deleted(Deal $deal): void
+    {
+        $this->cleanupRelatedChannelsAndSessions($deal);
+    }
+
+    public function softDeleted(Deal $deal): void
+    {
+        $this->cleanupRelatedChannelsAndSessions($deal);
+    }
+
+    protected function cleanupRelatedChannelsAndSessions(Deal $deal): void
+    {
+        foreach ($deal->socialChannels as $channel) {
+            $channel->delete();
+        }
+
+        Session::where('entity_namespace', Deal::class)
+            ->where('entity_id', $deal->getId())
+            ->get()
+            ->each(fn (Session $session) => $session->delete());
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #9234. Brings Deal to feature parity with Lead for collaboration features — comments, notes, and the AI assistant channel — so the admin UI can render the same activity feed / notes / AI session panels on a Deal detail page that Lead already has.

Everything else in the original PR (Deal CRUD, Lendflow connector, Zoho webhook, Str::digitsOnly, index migration, DTO factory, branch fallback, status relation, @cacheRedis, etc.) was already merged with #9234.

## What's in this PR

- **`DealObserver`** mirrors `LeadObserver`:
  - `creating` — sets default `status_id` (first LeadStatus) and default pipeline + first stage if unset.
  - `created` — creates the Default social channel for comments/activity feed. If the company has `enable_ai_notes_channel` enabled, also creates a Notes channel categorized as `ai-agent`.
  - `deleted` / `softDeleted` — deletes related social channels and Intelligence sessions.
- **Observer registered via Laravel 11+ attribute** — `#[ObservedBy([DealObserver::class])]` on the Deal model. No `EventServiceProvider` change needed (matches the pattern used by `Engagement`, `Agent`, `TaskEngagementItem` elsewhere in the codebase).
- **Deal model gains relations** used by the observer and GraphQL:
  - `stringId` accessor (matches Lead — needed because social channels join on a string entity_id).
  - `socialChannels()` HasMany → `Channel` (all channels for this Deal).
  - `notes()` HasOne → the `Notes` channel.
  - `aiSession()` HasMany → Intelligence `Session`.
- **GraphQL type** exposes `channels`, `notes`, `ai_session` — same shape as Lead. Frontend can query them directly.

## Test plan

- [ ] Create a Deal via `createDeal` mutation; verify a default social channel appears in `deal.channels`.
- [ ] Enable `enable_ai_notes_channel` on the company, create a Deal, verify the Notes channel shows up in `deal.notes` with the `ai-agent` category.
- [ ] Delete a Deal; verify its channels and any Intelligence sessions are cleaned up.
- [ ] Create a Deal without providing `status_id` or `pipeline_id`; verify the observer fills in the company defaults.