### PR TITLE
fix(event): allow multiple bookings without slug collision

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -22,10 +22,17 @@ Guidelines for working with the Kanvas Ecosystem API codebase.
       'photo'
   );
   ```
-- **PHP-CS-Fixer enforced** — always follow these formatting rules:
+- **PHP-CS-Fixer enforced** — config lives at `.php-cs-fixer.php`. **Run it on every save and before every commit/push** so the code matches house style and doesn't bounce back in review:
+  ```bash
+  vendor/bin/php-cs-fixer fix <file-or-dir>
+  ```
+  Apply it to every PHP file you touch (the fixer is idempotent — running it on files you didn't change is a no-op). If the binary isn't installed in the current environment, match the same rules by hand:
   - Anonymous classes: `new class () extends Foo {` (parentheses + space before brace, brace on same line)
   - Multi-line closures passed as method arguments: place the closure on a new line, e.g. `->whereHas('rel', fn ($q) => ...)` becomes `->whereHas(\n    'rel',\n    fn ($q) => ...\n)`
-  - `use` imports: alphabetical order within each namespace group (e.g. `Enums\` before `Models\`)
+  - `use` imports: alphabetical order **across the entire use block** (not just within each namespace group) — e.g. `Connectors\Zoho\...` must come after `Connectors\WooCommerce\...`
+  - No superfluous phpdoc tags (strip `@var mixed $x` style annotations when the var is already typed by assignment; see `no_superfluous_phpdoc_tags` with `allow_mixed: true` — applies only when the variable is named)
+  - No trailing blank line before the closing `}` of a class
+  - `no_empty_comment`, `single_quote`, `array_syntax: short`, `trailing_comma_in_multiline`, and the other rules in `.php-cs-fixer.php`
 - **Email rendering note**: `KanvasMailable` is HTML-first and uses `resources/views/emails/layout.blade.php`. If a feature needs true plain-text body delivery (for example raw ADF/XML in the body with no escaping/wrapping), use a dedicated plain-text view such as `resources/views/emails/plain.blade.php` instead of routing through the HTML layout.
 
 ## Domain CRUD Pattern

--- a/src/Domains/Event/Events/Actions/CreateEventAction.php
+++ b/src/Domains/Event/Events/Actions/CreateEventAction.php
@@ -6,7 +6,6 @@ namespace Kanvas\Event\Events\Actions;
 
 use Baka\Support\Str;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Validator;
 use Kanvas\Currencies\Models\Currencies;
 use Kanvas\Event\Events\DataTransferObject\Event;
 use Kanvas\Event\Events\DataTransferObject\EventVersion;
@@ -58,7 +57,6 @@ class CreateEventAction
                 $slug = $slug . '-' . $this->metadata['slug_suffix'];
             }
 
-            // $this->validateSlug($slug);
             $event = ModelsEvent::updateOrCreate([
                 'slug' => $slug,
                 'apps_id' => $this->event->app->getId(),
@@ -168,31 +166,6 @@ class CreateEventAction
         $this->runWorkflow = false;
 
         return $this;
-    }
-
-    protected function validateSlug(string $slug): void
-    {
-        Validator::make(
-            ['slug' => $slug],
-            [
-                'slug' => [
-                    'required',
-                    // Custom rule using DB to specify the connection and validate uniqueness.
-                    function ($attribute, $value, $fail) {
-                        $exists = DB::connection('event') // Replace with your DB connection name.
-                            ->table('events')
-                            ->where('slug', $value)
-                            ->where('apps_id', $this->event->app->getId())
-                            ->where('companies_id', $this->event->company->getId())
-                            ->exists();
-
-                        if ($exists) {
-                            $fail('The ' . $attribute . ' has already been taken.');
-                        }
-                    },
-                ],
-            ]
-        )->validate();
     }
 
     protected function createEventOrder(ModelsEventVersion $eventVersion, array $orderItemsData = []): void

--- a/src/Domains/Event/Events/Actions/CreateEventVersionAction.php
+++ b/src/Domains/Event/Events/Actions/CreateEventVersionAction.php
@@ -6,8 +6,6 @@ namespace Kanvas\Event\Events\Actions;
 
 use Baka\Support\Str;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Validator;
 use Kanvas\Event\Events\DataTransferObject\EventVersion;
 use Kanvas\Event\Events\Models\EventVersion as ModelsEventVersion;
 
@@ -20,11 +18,10 @@ class CreateEventVersionAction
 
     public function execute(): ModelsEventVersion
     {
-        $slug = $this->eventVersion->slug ?? Str::slug($this->eventVersion->name);
+        $baseSlug = $this->eventVersion->slug ?? Str::slug($this->eventVersion->name);
+        $appId = $this->eventVersion->event->app->getId();
+        $companyId = $this->eventVersion->event->company->getId();
 
-        // $this->validateSlug($slug);
-
-        // Calculate start_at and end_at from dates
         $startAt = null;
         $endAt = null;
 
@@ -36,51 +33,37 @@ class CreateEventVersionAction
             $endAt = Carbon::parse($lastDate->date->format('Y-m-d') . ' ' . $lastDate->end_time);
         }
 
-        $eventVersion = ModelsEventVersion::updateOrCreate([
-            'apps_id' => $this->eventVersion->event->app->getId(),
-            'companies_id' => $this->eventVersion->event->company->getId(),
-            'users_id' => $this->eventVersion->user->getId(),
-            'event_id' => $this->eventVersion->event->getId(),
-            'currency_id' => $this->eventVersion->currency->getId(),
-            'time_slot_id' => $this->eventVersion->timeSlotId,
-            'name' => $this->eventVersion->name,
-            'version' => $this->eventVersion->version,
-            'description' => $this->eventVersion->description,
-            'price_per_ticket' => $this->eventVersion->pricePerTicket,
-            'agenda' => $this->eventVersion->agenda ?? null,
-            'metadata' => $this->eventVersion->metadata ?? null,
-            'slug' => $slug,
-            'start_at' => $startAt,
-            'end_at' => $endAt,
-        ]);
+        $highestVersion = (int) ModelsEventVersion::where('apps_id', $appId)
+            ->where('companies_id', $companyId)
+            ->where(function ($query) use ($baseSlug) {
+                $query->where('slug', $baseSlug)
+                    ->orWhere('slug', 'like', $baseSlug . '-%');
+            })
+            ->max('version');
+
+        $version = $highestVersion > 0 ? $highestVersion + 1 : (int) $this->eventVersion->version;
+        $slug = $highestVersion > 0 ? $baseSlug . '-' . $version : $baseSlug;
+
+        $eventVersion = new ModelsEventVersion();
+        $eventVersion->apps_id = $appId;
+        $eventVersion->companies_id = $companyId;
+        $eventVersion->users_id = $this->eventVersion->user->getId();
+        $eventVersion->event_id = $this->eventVersion->event->getId();
+        $eventVersion->currency_id = $this->eventVersion->currency->getId();
+        $eventVersion->time_slot_id = $this->eventVersion->timeSlotId;
+        $eventVersion->name = $this->eventVersion->name;
+        $eventVersion->version = $version;
+        $eventVersion->description = $this->eventVersion->description;
+        $eventVersion->price_per_ticket = $this->eventVersion->pricePerTicket;
+        $eventVersion->agenda = $this->eventVersion->agenda ?? null;
+        $eventVersion->metadata = $this->eventVersion->metadata ?? null;
+        $eventVersion->slug = $slug;
+        $eventVersion->start_at = $startAt;
+        $eventVersion->end_at = $endAt;
+        $eventVersion->saveOrFail();
 
         $eventVersion->addDates($this->eventVersion->dates);
 
         return $eventVersion;
-    }
-
-    protected function validateSlug(string $slug): void
-    {
-        Validator::make(
-            ['slug' => $slug],
-            [
-                'slug' => [
-                    'required',
-                    // Custom rule using DB to specify the connection and validate uniqueness.
-                    function ($attribute, $value, $fail) {
-                        $exists = DB::connection('event') // Replace with your DB connection name.
-                            ->table('event_versions')
-                            ->where('slug', $value)
-                            ->where('apps_id', $this->eventVersion->event->app->getId())
-                            ->where('companies_id', $this->eventVersion->event->company->getId())
-                            ->exists();
-
-                        if ($exists) {
-                            $fail('The ' . $attribute . ' has already been taken.');
-                        }
-                    },
-                ],
-            ]
-        )->validate();
     }
 }

--- a/tests/GraphQL/Event/EventTest.php
+++ b/tests/GraphQL/Event/EventTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\GraphQL\Event;
 
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Event\Events\Models\Event;
 use Kanvas\Event\Events\Models\EventCategory;
 use Kanvas\Event\Events\Models\EventType;
 use Kanvas\Event\Support\Setup;
@@ -182,6 +183,119 @@ class EventTest extends TestCase
                     }
                 }
             }')->assertSee('eventVersions');
+    }
+
+    public function testCreateEventDoesNotDuplicateEventOnSameSlug(): void
+    {
+        $user = auth()->user();
+        $app = app(Apps::class);
+        $company = $user->getCurrentCompany();
+
+        $setup = new Setup($app, $user, $company);
+        $setup->run();
+
+        $eventName = 'Reused Event ' . uniqid();
+        $input = [
+            'name' => $eventName,
+            'description' => 'Tests Event-level upsert',
+            'category_id' => EventCategory::fromCompany($company)->fromApp($app)->first()->getId(),
+            'type_id' => EventType::fromCompany($company)->fromApp($app)->first()->getId(),
+            'dates' => [
+                [
+                    'date' => date('Y-m-d'),
+                    'start_time' => '08:00',
+                    'end_time' => '09:00',
+                ],
+            ],
+        ];
+
+        $mutation = '
+            mutation($input: EventInput!) {
+                createEvent(input: $input) {
+                    id
+                    slug
+                }
+            }
+        ';
+
+        $first = $this->graphQL($mutation, ['input' => $input])->assertSuccessful();
+        $second = $this->graphQL($mutation, ['input' => $input])->assertSuccessful();
+        $third = $this->graphQL($mutation, ['input' => $input])->assertSuccessful();
+
+        $eventId = $first->json('data.createEvent.id');
+        $slug = $first->json('data.createEvent.slug');
+
+        $this->assertSame($eventId, $second->json('data.createEvent.id'));
+        $this->assertSame($eventId, $third->json('data.createEvent.id'));
+        $this->assertSame($slug, $second->json('data.createEvent.slug'));
+        $this->assertSame($slug, $third->json('data.createEvent.slug'));
+
+        $this->assertSame(
+            1,
+            Event::where('slug', $slug)
+                ->where('apps_id', $app->getId())
+                ->where('companies_id', $company->getId())
+                ->count(),
+            'Event::updateOrCreate must reuse the existing row, not insert duplicates',
+        );
+    }
+
+    public function testCreateEventCreatesVersionedSlugOnDuplicate(): void
+    {
+        $user = auth()->user();
+        $app = app(Apps::class);
+        $company = $user->getCurrentCompany();
+
+        $setup = new Setup($app, $user, $company);
+        $setup->run();
+
+        $input = [
+            'name' => 'Duplicate Slug Event ' . uniqid(),
+            'description' => 'Tests slug versioning on duplicate booking',
+            'category_id' => EventCategory::fromCompany($company)->fromApp($app)->first()->getId(),
+            'type_id' => EventType::fromCompany($company)->fromApp($app)->first()->getId(),
+            'dates' => [
+                [
+                    'date' => date('Y-m-d'),
+                    'start_time' => '09:00',
+                    'end_time' => '10:00',
+                ],
+            ],
+        ];
+
+        $mutation = '
+            mutation($input: EventInput!) {
+                createEvent(input: $input) {
+                    id
+                    versions {
+                        data {
+                            slug
+                            version
+                        }
+                    }
+                }
+            }
+        ';
+
+        $firstEventId = $this->graphQL($mutation, ['input' => $input])
+            ->assertSuccessful()
+            ->json('data.createEvent.id');
+
+        $secondResponse = $this->graphQL($mutation, ['input' => $input])->assertSuccessful();
+
+        $this->assertSame($firstEventId, $secondResponse->json('data.createEvent.id'));
+
+        $versions = $secondResponse->json('data.createEvent.versions.data');
+        $this->assertGreaterThanOrEqual(2, count($versions));
+
+        $slugs = array_column($versions, 'slug');
+        $versionNumbers = array_map('intval', array_column($versions, 'version'));
+
+        $this->assertContains(1, $versionNumbers);
+        $this->assertContains(2, $versionNumbers);
+
+        sort($slugs);
+        $this->assertSame($slugs[0] . '-2', $slugs[1]);
     }
 
     public function testCreateEventWithConfig(): void


### PR DESCRIPTION
CreateEventVersionAction was passing all 15 fields as updateOrCreate match keys, so the lookup almost never matched and every retry hit the unique constraint on (slug, apps_id, companies_id). Switched to a single SELECT for max(version) on slugs starting with the base slug, then create with an auto-incremented `-N` suffix and `version` number. Dead validateSlug helpers removed from both actions. CLAUDE.md updated with PHP-CS-Fixer guidance.
