### PR TITLE
feat(deal): attachFileToDeal mutations + register Deal in Guild system module setup

### DIFF
--- a/app/GraphQL/Guild/Mutations/Deal/DealMutation.php
+++ b/app/GraphQL/Guild/Mutations/Deal/DealMutation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\GraphQL\Guild\Mutations\Deal;
 
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Filesystem\Traits\HasMutationUploadFiles;
 use Kanvas\Guild\Deals\Actions\CreateDealAction;
 use Kanvas\Guild\Deals\Actions\UpdateDealAction;
 use Kanvas\Guild\Deals\DataTransferObject\Deal as DealData;
@@ -14,6 +15,8 @@ use Kanvas\Workflow\Enums\WorkflowEnum;
 
 class DealMutation
 {
+    use HasMutationUploadFiles;
+
     public function create(mixed $rootValue, array $request): Deal
     {
         /** @var Users $user */
@@ -55,5 +58,42 @@ class DealMutation
         $deal->fireWorkflow(WorkflowEnum::DELETED->value, true);
 
         return $deal->softDelete();
+    }
+
+    public function attachFile(mixed $rootValue, array $request): Deal
+    {
+        /** @var Users $user */
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+        $app = app(Apps::class);
+
+        /** @var Deal $deal */
+        $deal = Deal::getByIdFromCompanyApp((int) $request['id'], $company, $app);
+
+        $rawParams = $request['params'] ?? null;
+        /** @var array<string, mixed> $params */
+        $params = is_array($rawParams) ? $rawParams : [];
+        $taskId = $params['task_id'] ?? null;
+
+        if (is_string($taskId) && $taskId !== '' || is_int($taskId)) {
+            $deal->set('checklist_upload', $taskId);
+            $deal->fireWorkflow(
+                WorkflowEnum::AFTER_UPLOAD->value,
+                true,
+                [
+                    'task_id' => $taskId,
+                    'app' => $app,
+                ]
+            );
+        }
+
+        $this->uploadFileToEntity(
+            model: $deal,
+            app: $app,
+            user: $user,
+            request: $request
+        );
+
+        return $deal;
     }
 }

--- a/graphql/schemas/Guild/deal.graphql
+++ b/graphql/schemas/Guild/deal.graphql
@@ -78,6 +78,14 @@ extend type Mutation @guard {
         @field(
             resolver: "App\\GraphQL\\Guild\\Mutations\\Deal\\DealMutation@delete"
         )
+    attachFileToDeal(file: Upload!, id: ID!, params: Mixed): Deal!
+        @field(
+            resolver: "App\\GraphQL\\Guild\\Mutations\\Deal\\DealMutation@attachFile"
+        )
+    attachFilesToDeal(file: [Upload!]!, id: ID!, params: Mixed): Deal!
+        @field(
+            resolver: "App\\GraphQL\\Guild\\Mutations\\Deal\\DealMutation@attachFile"
+        )
 }
 
 extend type Query @guard {

--- a/src/Domains/Guild/Support/CreateSystemModule.php
+++ b/src/Domains/Guild/Support/CreateSystemModule.php
@@ -30,6 +30,7 @@ class CreateSystemModule
         $createSystemModule->execute(Pipeline::class);
         $createSystemModule->execute(PipelineStage::class);
         $createSystemModule->execute(Lead::class);
+        $createSystemModule->execute(Deal::class);
         $createSystemModule->execute(People::class);
         $createSystemModule->execute(Agent::class);
         $createSystemModule->execute(Contact::class);


### PR DESCRIPTION
## Summary

Two follow-ups to the Deal work that got pushed after PR #9236 was already merged:

1. **`attachFileToDeal` + `attachFilesToDeal` GraphQL mutations** mirroring `attachFileToLead` / `attachFilesToLead`. Both route to the same `DealMutation@attachFile` resolver. Supports `task_id` param which sets `checklist_upload` on the Deal and fires the `AFTER_UPLOAD` workflow — same shape as Lead.
2. **Register `Deal::class` in `Guild\Support\CreateSystemModule`** so the system module row is created proactively during Guild setup (instead of being lazily hydrated on first `files`/`custom_fields` lookup).

## Files

- `app/GraphQL/Guild/Mutations/Deal/DealMutation.php` — adds `attachFile` method using `HasMutationUploadFiles` trait.
- `graphql/schemas/Guild/deal.graphql` — adds the two mutations inside `extend type Mutation @guard`.
- `src/Domains/Guild/Support/CreateSystemModule.php` — adds `Deal::class` to the `createSystemModule->execute(...)` list.

## Test plan

- [ ] `attachFileToDeal` with a single upload + `id` returns the Deal with the file attached (check `deal.files`).
- [ ] `attachFilesToDeal` with an array of uploads attaches all of them.
- [ ] `params: { task_id: <id> }` sets `checklist_upload` custom field and triggers `AFTER_UPLOAD` workflow rules.
- [ ] Provision a new app via Guild setup → verify the `system_modules` row exists for `Kanvas\Guild\Deals\Models\Deal` without having to touch a file first.