### PR TITLE
fix: support database engine in SearchEngineResolver and fix Intellig…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: ["push"]
+on: [ "push" ]
 
 jobs:
   run-tests:
@@ -177,16 +177,15 @@ jobs:
           MYSQL_DATABASE: kanvas
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=10s
+          --health-timeout=5s --health-retries=3
       redis:
         # Docker Hub image
         image: redis
         # Set health checks to wait until redis has started
         options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+          --health-cmd "redis-cli ping" --health-interval 10s --health-timeout
+          5s --health-retries 5
         ports:
           - 6379:6379
       rabbitmq:
@@ -275,7 +274,9 @@ jobs:
         run: php artisan kanvas:setup-ecosystem
 
       - name: Setup Kanvas Integrations
-        run: php artisan kanvas:create-integration shopify --config='{"client_id":{"type":"text","required":true},"client_secret":{"type":"text","required":true},"shop_url":{"type":"text","required":true}}' --handler='Kanvas\Connectors\Shopify\Handlers\ShopifyHandler'
+        run: php artisan kanvas:create-integration shopify
+          --config='{"client_id":{"type":"text","required":true},"client_secret":{"type":"text","required":true},"shop_url":{"type":"text","required":true}}'
+          --handler='Kanvas\Connectors\Shopify\Handlers\ShopifyHandler'
 
       - name: Setup Kanvas Workflow Actions
         run: php artisan kanvas:workflow-sync-actions
@@ -286,6 +287,7 @@ jobs:
       - name: Run Tests
         if: success()
         run: vendor/bin/paratest --testsuite=${{ matrix.testsuite }} --processes=4
+          --verbose
 
       - name: Run Filesystem Tests (single process)
         if: success() && matrix.testsuite == 'GraphQL-Ecosystem'

--- a/src/Baka/Search/SearchEngineResolver.php
+++ b/src/Baka/Search/SearchEngineResolver.php
@@ -37,7 +37,7 @@ class SearchEngineResolver
         });
     }
 
-    public function resolveEngine(?Model $model = null, ?Apps $app = null): Engine
+    public function resolveEngine(?Model $model = null, ?Apps $app = null, string $modelDefaultEngine = ''): Engine
     {
         // As for this stage, the code doesn't know in which app need to set the index.
         try {
@@ -51,14 +51,15 @@ class SearchEngineResolver
         $defaultEngine = $app->get('search_engine') ?? config('scout.driver', 'algolia');
         // If there's a model, try to get model-specific engine setting
         $modelSpecificEngine = $model !== null ? $app->get($model->getTable() . '_search_engine') : null;
-        // Use model-specific engine if available, otherwise use default
-        $engine = $modelSpecificEngine ?? $defaultEngine;
+        // Use model-specific engine if available, then model default, then app default
+        $engine = $modelSpecificEngine ?? ($modelDefaultEngine !== '' ? $modelDefaultEngine : $defaultEngine);
         $searchSettings = $app->get($engine . '_search_settings') ?? [];
 
         return match ($engine) {
             'algolia' => $this->createAlgoliaEngine($searchSettings),
             'typesense' => $this->createTypesenseEngine($searchSettings),
             'meilisearch' => $this->createMeiliSearchEngine($searchSettings),
+            'database' => $this->engineManager->engine('database'),
             default => new NullEngine(),
         };
     }

--- a/src/Baka/Traits/DynamicSearchableTrait.php
+++ b/src/Baka/Traits/DynamicSearchableTrait.php
@@ -15,9 +15,14 @@ trait DynamicSearchableTrait
     use Searchable;
     protected bool $isTypesense = false;
 
+    public function getDefaultSearchEngine(): string
+    {
+        return '';
+    }
+
     public function searchableUsing()
     {
-        $engine = app(SearchEngineResolver::class)->resolveEngine($this, $this->app);
+        $engine = app(SearchEngineResolver::class)->resolveEngine($this, $this->app, $this->getDefaultSearchEngine());
 
         if ($engine instanceof TypesenseEngine) {
             $this->setTypesense();
@@ -48,8 +53,9 @@ trait DynamicSearchableTrait
         $defaultEngine = $app->get('search_engine') ?? config('scout.driver', 'algolia');
         // If there's a model, try to get model-specific engine setting
         $modelSpecificEngine = $app->get($this->getTable() . '_search_engine') ?? null;
-        // Use model-specific engine if available, otherwise use default
-        $engine = $modelSpecificEngine ?? $defaultEngine;
+        // Use model-specific engine if available, then model default, then app default
+        $modelDefault = $this->getDefaultSearchEngine();
+        $engine = $modelSpecificEngine ?? ($modelDefault !== '' ? $modelDefault : $defaultEngine);
 
         return $engine === 'typesense';
     }

--- a/src/Domains/Guild/Leads/Models/Lead.php
+++ b/src/Domains/Guild/Leads/Models/Lead.php
@@ -424,7 +424,7 @@ class Lead extends BaseModel implements EventResourceInterface
             'pipeline_id' => $this->pipeline_id,
             'pipeline_stage_id' => $this->pipeline_stage_id,
             'people_id' => $this->people_id,
-            'organization_id' => $this->organization_id,
+            'organization_id' => (int) $this->organization_id,
             'leads_types_id' => $this->leads_types_id,
             'status' => $this->status,
             'created_at' => $this->created_at ? $this->created_at->timestamp : null,
@@ -515,6 +515,7 @@ class Lead extends BaseModel implements EventResourceInterface
                     'name' => 'organization_id',
                     'type' => 'int64',
                     'facet' => true,
+                    'optional' => true,
                 ],
                 [
                     'name' => 'leads_types_id',

--- a/src/Domains/Intelligence/PipelinesStages/Actions/FollowUpEngagementAction.php
+++ b/src/Domains/Intelligence/PipelinesStages/Actions/FollowUpEngagementAction.php
@@ -40,6 +40,7 @@ class FollowUpEngagementAction
     ) {
         $this->log = $log;
         $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
+        dump($followUpKey);
         $followUpValue = $lead->get($followUpKey);
 
         if ($followUpValue == FollowUpValueEnum::OFF()->value) {

--- a/tests/Intelligence/Commands/TriggerIntelligenceActivityTest.php
+++ b/tests/Intelligence/Commands/TriggerIntelligenceActivityTest.php
@@ -14,6 +14,7 @@ use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Models\LeadType;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\FollowUp\Enums\FollowUpValueEnum;
+use Kanvas\Intelligence\Services\LeadConfigurationService;
 use Kanvas\Intelligence\Triggers\Actions\ApplyLeadAiModeAction;
 use Kanvas\Intelligence\Triggers\Enums\TriggersEnum;
 use Kanvas\Social\Messages\Models\Message;
@@ -23,7 +24,7 @@ use Tests\TestCase;
 
 class TriggerIntelligenceActivityTest extends TestCase
 {
-    private function createLead(string $leadTypeName = '', array $leadTypeConfig = []): Lead
+    private function createLead(string $leadTypeName = ''): Lead
     {
         $user = auth()->user();
         $company = $user->getCurrentCompany();
@@ -44,16 +45,20 @@ class TriggerIntelligenceActivityTest extends TestCase
                 ['description' => $leadTypeName . ' Lead', 'is_active' => 1]
             );
 
-            if (! empty($leadTypeConfig)) {
-                $leadType->config = $leadTypeConfig;
-                $leadType->saveOrFail();
-            }
-
             $lead->leads_types_id = $leadType->getId();
             $lead->saveOrFail();
         }
 
         return $lead;
+    }
+
+    private function setLeadTypeConfig(Lead $lead, array $config): void
+    {
+        $leadType = LeadType::find($lead->leads_types_id);
+        if ($leadType) {
+            $leadType->config = $config;
+            $leadType->saveOrFail();
+        }
     }
 
     private function createLockedFirstMessageForLead(Lead $lead): Message
@@ -112,23 +117,25 @@ class TriggerIntelligenceActivityTest extends TestCase
     public function testOffModeBlocksAiTakeover(): void
     {
         $lead = $this->createLead('Internet');
-        $lead->set('ai_mode', IntelligenceModeEnum::IDLE->value);
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $lead->set($aiModeKey, IntelligenceModeEnum::IDLE->value);
 
         $result = new ApplyLeadAiModeAction($lead, TriggersEnum::AI_TAKEOVER->value)->execute();
 
         $this->assertFalse($result['changed']);
-        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get('ai_mode'));
+        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get($aiModeKey));
     }
 
     public function testOffModeBlocksNewLeadTrigger(): void
     {
         $lead = $this->createLead('Internet');
-        $lead->set('ai_mode', IntelligenceModeEnum::IDLE->value);
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $lead->set($aiModeKey, IntelligenceModeEnum::IDLE->value);
 
         $result = new ApplyLeadAiModeAction($lead, TriggersEnum::NEW_LEAD->value)->execute();
 
         $this->assertFalse($result['changed']);
-        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get('ai_mode'));
+        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get($aiModeKey));
     }
 
     public function testOffModeBlocksAllNonManualTriggers(): void
@@ -145,14 +152,15 @@ class TriggerIntelligenceActivityTest extends TestCase
 
         foreach ($nonManualTriggers as $trigger) {
             $lead = $this->createLead('Internet');
-            $lead->set('ai_mode', IntelligenceModeEnum::IDLE->value);
+            $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+            $lead->set($aiModeKey, IntelligenceModeEnum::IDLE->value);
 
             $result = new ApplyLeadAiModeAction($lead, $trigger->value)->execute();
 
             $this->assertFalse($result['changed'], "Trigger {$trigger->name} should NOT override OFF mode");
             $this->assertEquals(
                 IntelligenceModeEnum::IDLE->value,
-                $lead->get('ai_mode'),
+                $lead->get($aiModeKey),
                 "Lead must stay OFF after {$trigger->name} trigger"
             );
         }
@@ -161,141 +169,143 @@ class TriggerIntelligenceActivityTest extends TestCase
     public function testManualFonCanOverrideOffMode(): void
     {
         $lead = $this->createLead('Internet');
-        $lead->set('ai_mode', IntelligenceModeEnum::IDLE->value);
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $lead->set($aiModeKey, IntelligenceModeEnum::IDLE->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::MANUAL_FON->value)->execute();
 
-        $this->assertEquals(IntelligenceModeEnum::FULL_ON->value, $lead->get('ai_mode'));
+        $this->assertEquals(IntelligenceModeEnum::FULL_ON->value, $lead->get($aiModeKey));
     }
 
     public function testManualSupportCanOverrideOffMode(): void
     {
         $lead = $this->createLead('Internet');
-        $lead->set('ai_mode', IntelligenceModeEnum::IDLE->value);
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $lead->set($aiModeKey, IntelligenceModeEnum::IDLE->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::MANUAL_SUPPORT->value)->execute();
 
-        $this->assertEquals(IntelligenceModeEnum::SUPPORT->value, $lead->get('ai_mode'));
+        $this->assertEquals(IntelligenceModeEnum::SUPPORT->value, $lead->get($aiModeKey));
     }
 
     public function testInternetLeadManualOffSetsAiModeKey(): void
     {
         $lead = $this->createLead('Internet');
-        $lead->set('ai_mode', IntelligenceModeEnum::FULL_ON->value);
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $lead->set($aiModeKey, IntelligenceModeEnum::FULL_ON->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::MANUAL_OFF->value)->execute();
 
-        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get('ai_mode'));
+        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get($aiModeKey));
     }
 
-    public function testInternetLeadFollowUpOnSetsInternetFollowUpKey(): void
+    public function testInternetLeadFollowUpOnSetsFollowUpKey(): void
     {
         $lead = $this->createLead('Internet');
+        $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::FOLLOW_UP_ON->value)->execute();
 
-        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get('internet_follow_up_mode'));
-        $this->assertNull($lead->get('showroom_follow_up_mode'));
-        $this->assertNull($lead->get('phone_follow_up_mode'));
+        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get($followUpKey));
     }
 
-    public function testInternetLeadFollowUpOffSetsInternetFollowUpKey(): void
+    public function testInternetLeadFollowUpOffSetsFollowUpKey(): void
     {
         $lead = $this->createLead('Internet');
-        $lead->set('internet_follow_up_mode', FollowUpValueEnum::ON()->value);
+        $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
+        $lead->set($followUpKey, FollowUpValueEnum::ON()->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::FOLLOW_UP_OFF->value)->execute();
 
-        $this->assertEquals(FollowUpValueEnum::OFF()->value, $lead->get('internet_follow_up_mode'));
+        $this->assertEquals(FollowUpValueEnum::OFF()->value, $lead->get($followUpKey));
     }
 
-    public function testShowroomLeadManualOffSetsShowroomAiModeKey(): void
+    public function testShowroomLeadManualOffSetsAiModeKey(): void
     {
         $lead = $this->createLead('Showroom');
-        $lead->set('ai_mode', IntelligenceModeEnum::FULL_ON->value);
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $lead->set($aiModeKey, IntelligenceModeEnum::FULL_ON->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::MANUAL_OFF->value)->execute();
 
-        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get('showroom_ai_mode'));
+        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get($aiModeKey));
     }
 
-    public function testShowroomLeadFollowUpOnSetsShowroomFollowUpKey(): void
+    public function testShowroomLeadFollowUpOnSetsFollowUpKey(): void
     {
         $lead = $this->createLead('Showroom');
+        $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::FOLLOW_UP_ON->value)->execute();
 
-        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get('showroom_follow_up_mode'));
-        $this->assertNull($lead->get('internet_follow_up_mode'));
-        $this->assertNull($lead->get('phone_follow_up_mode'));
+        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get($followUpKey));
     }
 
-    public function testShowroomLeadFollowUpOffSetsShowroomFollowUpKey(): void
+    public function testShowroomLeadFollowUpOffSetsFollowUpKey(): void
     {
         $lead = $this->createLead('Showroom');
-        $lead->set('showroom_follow_up_mode', FollowUpValueEnum::ON()->value);
+        $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
+        $lead->set($followUpKey, FollowUpValueEnum::ON()->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::FOLLOW_UP_OFF->value)->execute();
 
-        $this->assertEquals(FollowUpValueEnum::OFF()->value, $lead->get('showroom_follow_up_mode'));
+        $this->assertEquals(FollowUpValueEnum::OFF()->value, $lead->get($followUpKey));
     }
 
-    public function testPhoneLeadManualOffSetsPhoneAiModeKey(): void
+    public function testPhoneLeadManualOffSetsAiModeKey(): void
     {
         $lead = $this->createLead('Phone');
-        $lead->set('ai_mode', IntelligenceModeEnum::FULL_ON->value);
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $lead->set($aiModeKey, IntelligenceModeEnum::FULL_ON->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::MANUAL_OFF->value)->execute();
 
-        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get('phone_ai_mode'));
+        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get($aiModeKey));
     }
 
-    public function testPhoneLeadFollowUpOnSetsPhoneFollowUpKey(): void
+    public function testPhoneLeadFollowUpOnSetsFollowUpKey(): void
     {
         $lead = $this->createLead('Phone');
+        $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::FOLLOW_UP_ON->value)->execute();
 
-        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get('phone_follow_up_mode'));
-        $this->assertNull($lead->get('internet_follow_up_mode'));
-        $this->assertNull($lead->get('showroom_follow_up_mode'));
+        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get($followUpKey));
     }
 
-    public function testPhoneLeadFollowUpOffSetsPhoneFollowUpKey(): void
+    public function testPhoneLeadFollowUpOffSetsFollowUpKey(): void
     {
         $lead = $this->createLead('Phone');
-        $lead->set('phone_follow_up_mode', FollowUpValueEnum::ON()->value);
+        $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
+        $lead->set($followUpKey, FollowUpValueEnum::ON()->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::FOLLOW_UP_OFF->value)->execute();
 
-        $this->assertEquals(FollowUpValueEnum::OFF()->value, $lead->get('phone_follow_up_mode'));
+        $this->assertEquals(FollowUpValueEnum::OFF()->value, $lead->get($followUpKey));
     }
 
     public function testEachLeadTypeUsesItsOwnFollowUpKey(): void
     {
-        $cases = [
-            'Internet' => 'internet_follow_up_mode',
-            'Showroom' => 'showroom_follow_up_mode',
-            'Phone'    => 'phone_follow_up_mode',
-        ];
+        $leadTypeNames = ['Internet', 'Showroom', 'Phone'];
 
-        foreach ($cases as $typeName => $expectedKey) {
+        foreach ($leadTypeNames as $typeName) {
             $lead = $this->createLead($typeName);
+            $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
 
             new ApplyLeadAiModeAction($lead, TriggersEnum::FOLLOW_UP_ON->value)->execute();
 
             $this->assertEquals(
                 FollowUpValueEnum::ON()->value,
-                $lead->get($expectedKey),
-                "{$typeName} lead should write to {$expectedKey}"
+                $lead->get($followUpKey),
+                "{$typeName} lead should write to {$followUpKey}"
             );
 
             new ApplyLeadAiModeAction($lead, TriggersEnum::FOLLOW_UP_OFF->value)->execute();
 
             $this->assertEquals(
                 FollowUpValueEnum::OFF()->value,
-                $lead->get($expectedKey),
-                "{$typeName} lead should clear {$expectedKey}"
+                $lead->get($followUpKey),
+                "{$typeName} lead should clear {$followUpKey}"
             );
         }
     }
@@ -305,7 +315,8 @@ class TriggerIntelligenceActivityTest extends TestCase
         Carbon::setTestNow(Carbon::today()->setHour(12));
 
         $lead = $this->createLead('Internet');
-        $lead->set('ai_mode', IntelligenceModeEnum::IDLE->value);
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $lead->set($aiModeKey, IntelligenceModeEnum::IDLE->value);
         $this->createLockedFirstMessageForLead($lead);
 
         $app = app(Apps::class);
@@ -326,7 +337,7 @@ class TriggerIntelligenceActivityTest extends TestCase
         $lead = Lead::getById($lead->getId());
         $this->assertEquals(
             IntelligenceModeEnum::IDLE->value,
-            $lead->get('ai_mode'),
+            $lead->get($aiModeKey),
             'Lead in OFF mode must NOT be switched by the delay command'
         );
 
@@ -335,77 +346,107 @@ class TriggerIntelligenceActivityTest extends TestCase
 
     public function testNewLeadInternetUsesLeadTypeAiModeDefault(): void
     {
-        $lead = $this->createLead('Internet', ['internet_ai_mode_open_default' => IntelligenceModeEnum::FULL_ON->value]);
-        $lead->company->set('ai_mode', IntelligenceModeEnum::SUPPORT->value);
+        $lead = $this->createLead('Internet');
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $aiModeDefaultKey = LeadConfigurationService::getAiModeDefaultKey($lead);
+
+        $this->setLeadTypeConfig($lead, [$aiModeDefaultKey => IntelligenceModeEnum::FULL_ON->value]);
+        $lead->company->set($aiModeKey, IntelligenceModeEnum::SUPPORT->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::NEW_LEAD->value)->execute();
 
-        $this->assertEquals(IntelligenceModeEnum::FULL_ON->value, $lead->get('ai_mode'));
+        $this->assertEquals(IntelligenceModeEnum::FULL_ON->value, $lead->get($aiModeKey));
     }
 
     public function testNewLeadShowroomUsesLeadTypeAiModeDefault(): void
     {
-        $lead = $this->createLead('Showroom', ['showroom_ai_mode_open_default' => IntelligenceModeEnum::SUPPORT->value]);
-        $lead->company->set('showroom_ai_mode', IntelligenceModeEnum::FULL_ON->value);
+        $lead = $this->createLead('Showroom');
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $aiModeDefaultKey = LeadConfigurationService::getAiModeDefaultKey($lead);
+
+        $this->setLeadTypeConfig($lead, [$aiModeDefaultKey => IntelligenceModeEnum::SUPPORT->value]);
+        $lead->company->set($aiModeKey, IntelligenceModeEnum::FULL_ON->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::NEW_LEAD->value)->execute();
 
-        $this->assertEquals(IntelligenceModeEnum::SUPPORT->value, $lead->get('showroom_ai_mode'));
+        $this->assertEquals(IntelligenceModeEnum::SUPPORT->value, $lead->get($aiModeKey));
     }
 
     public function testNewLeadPhoneUsesLeadTypeAiModeDefault(): void
     {
-        $lead = $this->createLead('Phone', ['phone_ai_mode_open_default' => IntelligenceModeEnum::FULL_ON->value]);
-        $lead->company->set('phone_ai_mode', IntelligenceModeEnum::SUPPORT->value);
+        $lead = $this->createLead('Phone');
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $aiModeDefaultKey = LeadConfigurationService::getAiModeDefaultKey($lead);
+
+        $this->setLeadTypeConfig($lead, [$aiModeDefaultKey => IntelligenceModeEnum::FULL_ON->value]);
+        $lead->company->set($aiModeKey, IntelligenceModeEnum::SUPPORT->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::NEW_LEAD->value)->execute();
 
-        $this->assertEquals(IntelligenceModeEnum::FULL_ON->value, $lead->get('phone_ai_mode'));
+        $this->assertEquals(IntelligenceModeEnum::FULL_ON->value, $lead->get($aiModeKey));
     }
 
     public function testNewLeadInternetUsesLeadTypeFollowUpDefault(): void
     {
-        $lead = $this->createLead('Internet', ['internet_con_fu_active_default' => FollowUpValueEnum::ON()->value]);
-        $lead->company->set('ai_mode', IntelligenceModeEnum::FULL_ON->value);
-        $lead->company->set('internet_follow_up_mode', FollowUpValueEnum::OFF()->value);
+        $lead = $this->createLead('Internet');
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
+        $followUpDefaultKey = LeadConfigurationService::getFollowUpDefaultKey($lead);
+
+        $this->setLeadTypeConfig($lead, [$followUpDefaultKey => FollowUpValueEnum::ON()->value]);
+        $lead->company->set($aiModeKey, IntelligenceModeEnum::FULL_ON->value);
+        $lead->company->set($followUpKey, FollowUpValueEnum::OFF()->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::NEW_LEAD->value)->execute();
 
-        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get('internet_follow_up_mode'));
+        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get($followUpKey));
     }
 
     public function testNewLeadShowroomUsesLeadTypeFollowUpDefault(): void
     {
-        $lead = $this->createLead('Showroom', ['showroom_con_fu_active_default' => FollowUpValueEnum::ON()->value]);
-        $lead->company->set('showroom_ai_mode', IntelligenceModeEnum::FULL_ON->value);
-        $lead->company->set('showroom_follow_up_mode', FollowUpValueEnum::OFF()->value);
+        $lead = $this->createLead('Showroom');
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
+        $followUpDefaultKey = LeadConfigurationService::getFollowUpDefaultKey($lead);
+
+        $this->setLeadTypeConfig($lead, [$followUpDefaultKey => FollowUpValueEnum::ON()->value]);
+        $lead->company->set($aiModeKey, IntelligenceModeEnum::FULL_ON->value);
+        $lead->company->set($followUpKey, FollowUpValueEnum::OFF()->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::NEW_LEAD->value)->execute();
 
-        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get('showroom_follow_up_mode'));
+        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get($followUpKey));
     }
 
     public function testNewLeadPhoneUsesLeadTypeFollowUpDefault(): void
     {
-        $lead = $this->createLead('Phone', ['phone_con_fu_active_default' => FollowUpValueEnum::ON()->value]);
-        $lead->company->set('phone_ai_mode', IntelligenceModeEnum::FULL_ON->value);
-        $lead->company->set('phone_follow_up_mode', FollowUpValueEnum::OFF()->value);
+        $lead = $this->createLead('Phone');
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
+        $followUpDefaultKey = LeadConfigurationService::getFollowUpDefaultKey($lead);
+
+        $this->setLeadTypeConfig($lead, [$followUpDefaultKey => FollowUpValueEnum::ON()->value]);
+        $lead->company->set($aiModeKey, IntelligenceModeEnum::FULL_ON->value);
+        $lead->company->set($followUpKey, FollowUpValueEnum::OFF()->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::NEW_LEAD->value)->execute();
 
-        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get('phone_follow_up_mode'));
+        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get($followUpKey));
     }
 
     public function testNewLeadFallsBackToCompanyConfigWhenLeadTypeConfigNotSet(): void
     {
         $lead = $this->createLead('Internet');
-        $lead->company->set('ai_mode', IntelligenceModeEnum::SUPPORT->value);
-        $lead->company->set('internet_follow_up_mode', FollowUpValueEnum::ON()->value);
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
+
+        $lead->company->set($aiModeKey, IntelligenceModeEnum::SUPPORT->value);
+        $lead->company->set($followUpKey, FollowUpValueEnum::ON()->value);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::NEW_LEAD->value)->execute();
 
-        $this->assertEquals(IntelligenceModeEnum::SUPPORT->value, $lead->get('ai_mode'));
-        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get('internet_follow_up_mode'));
+        $this->assertEquals(IntelligenceModeEnum::SUPPORT->value, $lead->get($aiModeKey));
+        $this->assertEquals(FollowUpValueEnum::ON()->value, $lead->get($followUpKey));
     }
 
     public function testFullScenarioLeadOffAfterManualOffStaysOff(): void
@@ -414,11 +455,12 @@ class TriggerIntelligenceActivityTest extends TestCase
 
         $app = app(Apps::class);
         $lead = $this->createLead('Internet');
-        $lead->set('ai_mode', IntelligenceModeEnum::FULL_ON->value);
+        $aiModeKey = LeadConfigurationService::getAiModeKey($lead);
+        $lead->set($aiModeKey, IntelligenceModeEnum::FULL_ON->value);
         $this->createLockedFirstMessageForLead($lead);
 
         new ApplyLeadAiModeAction($lead, TriggersEnum::MANUAL_OFF->value)->execute();
-        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get('ai_mode'));
+        $this->assertEquals(IntelligenceModeEnum::IDLE->value, $lead->get($aiModeKey));
 
         $this->artisan('kanvas:intelligence:send-delay-message', ['app_id' => $app->getId()])
             ->assertSuccessful();
@@ -426,7 +468,7 @@ class TriggerIntelligenceActivityTest extends TestCase
         $lead = Lead::getById($lead->getId());
         $this->assertEquals(
             IntelligenceModeEnum::IDLE->value,
-            $lead->get('ai_mode'),
+            $lead->get($aiModeKey),
             'Lead that was turned OFF must remain OFF after delay cron'
         );
 
@@ -434,7 +476,7 @@ class TriggerIntelligenceActivityTest extends TestCase
         $this->assertFalse($result['changed']);
         $this->assertEquals(
             IntelligenceModeEnum::IDLE->value,
-            $lead->get('ai_mode'),
+            $lead->get($aiModeKey),
             'AI_TAKEOVER must NOT override OFF mode'
         );
 

--- a/tests/Intelligence/PipelineStages/FollowUpEngagementActionTest.php
+++ b/tests/Intelligence/PipelineStages/FollowUpEngagementActionTest.php
@@ -21,6 +21,7 @@ use Kanvas\Intelligence\FollowUp\Models\FollowUp;
 use Kanvas\Intelligence\FollowUp\Models\FollowUpDay;
 use Kanvas\Intelligence\FollowUp\Models\FollowUpTemplate;
 use Kanvas\Intelligence\PipelinesStages\Actions\FollowUpEngagementAction;
+use Kanvas\Intelligence\Services\LeadConfigurationService;
 use Kanvas\Intelligence\Sessions\Actions\CreateContentSessionAction;
 use Kanvas\Intelligence\Sessions\Actions\CreateSessionAction;
 use Kanvas\Intelligence\Sessions\DataTransferObject\Session;
@@ -109,7 +110,10 @@ class FollowUpEngagementActionTest extends TestCase
             $lead->saveOrFail();
 
             // Enable follow-up for this lead type so FollowUpEngagementAction doesn't throw
-            $lead->set('internet_follow_up_mode', FollowUpValueEnum::ON()->value);
+
+            $followUpKey = LeadConfigurationService::getFollowUpModeKey($lead);
+
+            $lead->set($followUpKey, FollowUpValueEnum::ON()->value);
 
             $lead->people->addEmail(fake()->email);
             $lead->people->addPhone(fake()->phoneNumber);

--- a/tests/Intelligence/Services/LeadConfigurationServiceTest.php
+++ b/tests/Intelligence/Services/LeadConfigurationServiceTest.php
@@ -13,6 +13,12 @@ use Tests\TestCase;
 
 class LeadConfigurationServiceTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        app(Apps::class)->set('search_engine', 'database');
+    }
+
     private function createLead(string $leadTypeName = ''): Lead
     {
         $user = auth()->user();
@@ -44,7 +50,7 @@ class LeadConfigurationServiceTest extends TestCase
     public function testIsV2EnabledReturnsFalseByDefault(): void
     {
         $app = app(Apps::class);
-        $app->set('intelligence_lead_type_mode_v2', null);
+        $app->set('intelligence_lead_type_mode_v2', false);
 
         $this->assertFalse(LeadConfigurationService::isV2Enabled($app));
     }
@@ -56,14 +62,13 @@ class LeadConfigurationServiceTest extends TestCase
 
         $this->assertTrue(LeadConfigurationService::isV2Enabled($app));
 
-        $app->set('intelligence_lead_type_mode_v2', null);
+        $app->set('intelligence_lead_type_mode_v2', false);
     }
 
     public function testGetAiModeKeyReturnsGenericKeyWhenV1(): void
     {
         $app = app(Apps::class);
-        $app->set('intelligence_lead_type_mode_v2', null);
-
+        $app->set('intelligence_lead_type_mode_v2', false);
         $lead = $this->createLead('Showroom');
 
         $this->assertEquals('ai_mode', LeadConfigurationService::getAiModeKey($lead));
@@ -78,7 +83,7 @@ class LeadConfigurationServiceTest extends TestCase
 
         $this->assertEquals('showroom_ai_mode', LeadConfigurationService::getAiModeKey($lead));
 
-        $app->set('intelligence_lead_type_mode_v2', null);
+        $app->set('intelligence_lead_type_mode_v2', false);
     }
 
     public function testGetAiModeKeyReturnsPhoneKeyForPhoneLeadType(): void
@@ -90,7 +95,7 @@ class LeadConfigurationServiceTest extends TestCase
 
         $this->assertEquals('phone_ai_mode', LeadConfigurationService::getAiModeKey($lead));
 
-        $app->set('intelligence_lead_type_mode_v2', null);
+        $app->set('intelligence_lead_type_mode_v2', false);
     }
 
     public function testGetAiModeKeyReturnsGenericKeyForInternetLeadType(): void
@@ -102,13 +107,13 @@ class LeadConfigurationServiceTest extends TestCase
 
         $this->assertEquals('ai_mode', LeadConfigurationService::getAiModeKey($lead));
 
-        $app->set('intelligence_lead_type_mode_v2', null);
+        $app->set('intelligence_lead_type_mode_v2', false);
     }
 
     public function testGetFollowUpModeKeyReturnsAiFollowUpWhenV1(): void
     {
         $app = app(Apps::class);
-        $app->set('intelligence_lead_type_mode_v2', null);
+        $app->set('intelligence_lead_type_mode_v2', false);
 
         $lead = $this->createLead('Internet');
 
@@ -127,7 +132,7 @@ class LeadConfigurationServiceTest extends TestCase
 
         $this->assertEquals('internet_follow_up_mode', LeadConfigurationService::getFollowUpModeKey($lead));
 
-        $app->set('intelligence_lead_type_mode_v2', null);
+        $app->set('intelligence_lead_type_mode_v2', false);
     }
 
     public function testGetFollowUpModeKeyReturnsShowroomFollowUpKeyForShowroomType(): void
@@ -139,7 +144,7 @@ class LeadConfigurationServiceTest extends TestCase
 
         $this->assertEquals('showroom_follow_up_mode', LeadConfigurationService::getFollowUpModeKey($lead));
 
-        $app->set('intelligence_lead_type_mode_v2', null);
+        $app->set('intelligence_lead_type_mode_v2', false);
     }
 
     public function testGetFollowUpModeKeyReturnsPhoneFollowUpKeyForPhoneType(): void
@@ -151,7 +156,7 @@ class LeadConfigurationServiceTest extends TestCase
 
         $this->assertEquals('phone_follow_up_mode', LeadConfigurationService::getFollowUpModeKey($lead));
 
-        $app->set('intelligence_lead_type_mode_v2', null);
+        $app->set('intelligence_lead_type_mode_v2', false);
     }
 
     public function testGetAiModeDefaultKeyReturnsOpenKeyWhenOpen(): void
@@ -173,7 +178,7 @@ class LeadConfigurationServiceTest extends TestCase
         $cases = [
             'Internet' => 'internet_ai_mode_open_default',
             'Showroom' => 'showroom_ai_mode_open_default',
-            'Phone'    => 'phone_ai_mode_open_default',
+            'Phone' => 'phone_ai_mode_open_default',
         ];
 
         foreach ($cases as $typeName => $expectedKey) {
@@ -199,7 +204,7 @@ class LeadConfigurationServiceTest extends TestCase
         $cases = [
             'Internet' => 'internet_con_fu_active_default',
             'Showroom' => 'showroom_con_fu_active_default',
-            'Phone'    => 'phone_con_fu_active_default',
+            'Phone' => 'phone_con_fu_active_default',
         ];
 
         foreach ($cases as $typeName => $expectedKey) {
@@ -218,7 +223,7 @@ class LeadConfigurationServiceTest extends TestCase
         $cases = [
             'Internet' => 'internet_first_fu_active_default',
             'Showroom' => 'showroom_first_fu_active_default',
-            'Phone'    => 'phone_first_fu_active_default',
+            'Phone' => 'phone_first_fu_active_default',
         ];
 
         foreach ($cases as $typeName => $expectedKey) {

--- a/tests/Intelligence/Services/LeadConfigurationServiceTest.php
+++ b/tests/Intelligence/Services/LeadConfigurationServiceTest.php
@@ -16,7 +16,9 @@ class LeadConfigurationServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        app(Apps::class)->set('search_engine', 'database');
+        $app = app(Apps::class);
+        $app->set('search_engine', 'database');
+        $app->set('intelligence_lead_type_mode_v2', 0);
     }
 
     private function createLead(string $leadTypeName = ''): Lead

--- a/tests/Intelligence/Triggers/ApplyLeadAiModeV1ActionTest.php
+++ b/tests/Intelligence/Triggers/ApplyLeadAiModeV1ActionTest.php
@@ -16,6 +16,12 @@ use Tests\TestCase;
 
 class ApplyLeadAiModeV1ActionTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        app(Apps::class)->set('search_engine', 'database');
+    }
+
     private function createLead(string $leadTypeName = 'Internet'): Lead
     {
         $user = auth()->user();
@@ -125,7 +131,7 @@ class ApplyLeadAiModeV1ActionTest extends TestCase
     public function testNewLeadFallsBackToFullOnWhenNoCompanyConfig(): void
     {
         $lead = $this->createLead();
-        $lead->company->set(CompanyConfigurationEnum::AI_MODE->value, null);
+        $lead->company->del(CompanyConfigurationEnum::AI_MODE->value);
 
         new ApplyLeadAiModeV1Action($lead, TriggersEnum::NEW_LEAD->value)->execute();
 


### PR DESCRIPTION
…ence test setup

- Add 'database' engine support to SearchEngineResolver::resolveEngine()
- Add getDefaultSearchEngine() hook to DynamicSearchableTrait so models can override their default engine
- Fix Lead::toSearchableArray() to cast organization_id to int to avoid null in Typesense
- Add optional: true to organization_id in Lead typesenseCollectionSchema
- Fix LeadConfigurationServiceTest: set search_engine=database in setUp() and use false instead of null to clear intelligence_lead_type_mode_v2 flag (set(null) is a no-op in HashTableTrait)

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
