### PR TITLE
fix(openclaw): SSH hardening, sudo fix, and container update improvements

### DIFF
--- a/src/Domains/Connectors/OpenClaw/Actions/LaunchAgentOnMachineAction.php
+++ b/src/Domains/Connectors/OpenClaw/Actions/LaunchAgentOnMachineAction.php
@@ -116,7 +116,10 @@ class LaunchAgentOnMachineAction
             return;
         }
 
-        $client->exec('sudo mkdir -p ' . escapeshellarg($imageDir));
+        $mkdirResult = $client->exec('sudo mkdir -p ' . escapeshellarg($imageDir) . ' 2>&1; echo "EXIT_CODE:$?"');
+        if (! str_contains($mkdirResult, 'EXIT_CODE:0')) {
+            throw new ValidationException('Failed to create shared image directory ' . $imageDir . ': ' . $mkdirResult);
+        }
 
         $client->writeFileAsUser(
             $imageDir . '/Dockerfile',

--- a/src/Domains/Connectors/OpenClaw/Jobs/UpdateOpenClawForUserJob.php
+++ b/src/Domains/Connectors/OpenClaw/Jobs/UpdateOpenClawForUserJob.php
@@ -64,9 +64,9 @@ class UpdateOpenClawForUserJob implements ShouldQueue
     private function runUpdate(SshClient $client, string $composeFile): void
     {
         $script = implode(' && ', [
-            'docker compose -f ' . escapeshellarg($composeFile) . ' pull 2>&1',
+            'docker compose -f ' . escapeshellarg($composeFile) . ' pull --ignore-buildable 2>&1',
             'docker compose -f ' . escapeshellarg($composeFile)
-                . ' build --no-cache openclaw-gateway 2>&1',
+                . ' build --no-cache 2>&1',
             'docker compose -f ' . escapeshellarg($composeFile)
                 . ' up -d --force-recreate 2>&1',
             'docker compose -f ' . escapeshellarg($composeFile)


### PR DESCRIPTION
## Summary

- **SSH handshake timeout**: bound phpseclib handshake with `setTimeout(60)` to prevent indefinite hangs on slow connections
- **sudo without TTY**: detect `mkdir` failures early with exit-code checking; requires `NOPASSWD` + `!requiretty` for the SSH user in sudoers on the target machine
- **Container update**: pull only external images (`--ignore-buildable`), rebuild `openclaw-kanvas:latest` locally on the machine via `build --no-cache` instead of trying to pull it from Docker Hub
- **Schema fix**: resolved merge conflict with `development` — `openclawSetTelegramToken` preserved alongside new mutations

## Test plan

- [ ] Trigger `openclawUpdateMachineContainers` and confirm containers rebuild from the local Dockerfile without a Docker Hub pull error
- [ ] Trigger `openclawUpdateMachineContainers` against an unreachable machine and confirm it fails cleanly within ~60 s
- [ ] Confirm `sudo mkdir -p /opt/openclaw-image` failure surfaces as a clear `ValidationException` instead of a cryptic `cd: No such file or directory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)