### PR TITLE
fix(openclaw): container update sequence and SSH hardening

### DIFF
--- a/src/Domains/Connectors/OpenClaw/Jobs/UpdateOpenClawForUserJob.php
+++ b/src/Domains/Connectors/OpenClaw/Jobs/UpdateOpenClawForUserJob.php
@@ -66,7 +66,7 @@ class UpdateOpenClawForUserJob implements ShouldQueue
         $script = implode(' && ', [
             'docker pull alpine/socat 2>&1',
             'docker pull ghcr.io/phioranex/openclaw-docker:latest 2>&1',
-            'sudo docker build --no-cache -t openclaw-kanvas:latest /opt/openclaw-image 2>&1',
+            'docker build --no-cache -t openclaw-kanvas:latest /opt/openclaw-image 2>&1',
             'docker compose -f ' . escapeshellarg($composeFile)
                 . ' up -d --force-recreate 2>&1',
             'docker compose -f ' . escapeshellarg($composeFile)

--- a/src/Domains/Connectors/OpenClaw/Jobs/UpdateOpenClawForUserJob.php
+++ b/src/Domains/Connectors/OpenClaw/Jobs/UpdateOpenClawForUserJob.php
@@ -68,8 +68,6 @@ class UpdateOpenClawForUserJob implements ShouldQueue
             'docker pull ghcr.io/phioranex/openclaw-docker:latest 2>&1',
             'sudo docker build --no-cache -t openclaw-kanvas:latest /opt/openclaw-image 2>&1',
             'docker compose -f ' . escapeshellarg($composeFile)
-                . ' build --no-cache 2>&1',
-            'docker compose -f ' . escapeshellarg($composeFile)
                 . ' up -d --force-recreate 2>&1',
             'docker compose -f ' . escapeshellarg($composeFile)
                 . ' --profile cli run --rm openclaw-cli skills install maximeprades/auto-updater 2>&1',

--- a/src/Domains/Connectors/OpenClaw/Jobs/UpdateOpenClawForUserJob.php
+++ b/src/Domains/Connectors/OpenClaw/Jobs/UpdateOpenClawForUserJob.php
@@ -64,7 +64,9 @@ class UpdateOpenClawForUserJob implements ShouldQueue
     private function runUpdate(SshClient $client, string $composeFile): void
     {
         $script = implode(' && ', [
-            'docker compose -f ' . escapeshellarg($composeFile) . ' pull --ignore-buildable 2>&1',
+            'docker pull alpine/socat 2>&1',
+            'docker pull ghcr.io/phioranex/openclaw-docker:latest 2>&1',
+            'sudo docker build --no-cache -t openclaw-kanvas:latest /opt/openclaw-image 2>&1',
             'docker compose -f ' . escapeshellarg($composeFile)
                 . ' build --no-cache 2>&1',
             'docker compose -f ' . escapeshellarg($composeFile)

--- a/src/Domains/Connectors/OpenClaw/Services/DockerComposeBuilder.php
+++ b/src/Domains/Connectors/OpenClaw/Services/DockerComposeBuilder.php
@@ -74,7 +74,7 @@ class DockerComposeBuilder
         $imageName = self::getSharedImageName($app);
 
         return str_replace(
-            ['{{CONTAINER_NAME}}', '{{OPENCLAW_DIR}}', '{{GATEWAY_PORT}}', '{{PROXY_PORT}}', '{{ENV_LINES}}', '{{IMAGE_NAME}}'],
+            ['{{CONTAINER_NAME}}', '{{OPENCLAW_DIR}}', '{{GATEWAY_PORT}}', '{{PROXY_PORT}}', '{{ENV_LINES}}', '{{IMAGE_NAME}}', '{{IMAGE_DIR}}'],
             [
                 $deployment->container_name,
                 $deployment->home_directory . '/.openclaw',
@@ -82,6 +82,7 @@ class DockerComposeBuilder
                 (string) $deployment->proxy_port,
                 $envLines,
                 $imageName,
+                self::getSharedImageDir($app),
             ],
             $template,
         );

--- a/src/Domains/Connectors/OpenClaw/Templates/docker-compose.yml
+++ b/src/Domains/Connectors/OpenClaw/Templates/docker-compose.yml
@@ -3,6 +3,8 @@ name: {{CONTAINER_NAME}}
 services:
   openclaw-gateway:
     image: {{IMAGE_NAME}}
+    build:
+      context: {{IMAGE_DIR}}
     container_name: {{CONTAINER_NAME}}
     restart: unless-stopped
     stdin_open: true


### PR DESCRIPTION
## Summary

- **Container update sequence**: replaced `docker compose pull` (which tried to pull `openclaw-kanvas:latest` from Docker Hub) with explicit pulls for external images + local rebuild of the gateway image from `/opt/openclaw-image` on the machine
- **docker-compose template**: added `build: context: {{IMAGE_DIR}}` to `openclaw-gateway` so future `--ignore-buildable` pulls work correctly on newly deployed agents
- **SSH hardening**: `setTimeout(60)` on phpseclib to cap the full SSH handshake; raised scan job timeout to 120s
- **sudo fix**: detect `mkdir` failure early; requires `NOPASSWD` + `!requiretty` for the SSH user on target machines
- **Schema**: resolved merge conflict with `development`, preserved `openclawSetTelegramToken`

## Update sequence (per agent user)
1. `docker pull alpine/socat`
2. `docker pull ghcr.io/phioranex/openclaw-docker:latest`
3. `docker build --no-cache -t openclaw-kanvas:latest /opt/openclaw-image`
4. `docker compose up -d --force-recreate`
5. `docker compose --profile cli run --rm openclaw-cli skills install maximeprades/auto-updater`

## Test plan

- [ ] Trigger `openclawUpdateMachineContainers` and confirm all steps complete without a Docker Hub pull error for `openclaw-kanvas`
- [ ] Confirm deployment status transitions: `updating` → `running` on success, `failed` on error
- [ ] Trigger against unreachable machine — confirm clean failure within ~60s

🤖 Generated with [Claude Code](https://claude.com/claude-code)