### PR TITLE
fix(openclaw): remove invalid skills install step from update sequence

### DIFF
--- a/src/Domains/Connectors/OpenClaw/Jobs/UpdateOpenClawForUserJob.php
+++ b/src/Domains/Connectors/OpenClaw/Jobs/UpdateOpenClawForUserJob.php
@@ -69,8 +69,6 @@ class UpdateOpenClawForUserJob implements ShouldQueue
             'docker build --no-cache -t openclaw-kanvas:latest /opt/openclaw-image 2>&1',
             'docker compose -f ' . escapeshellarg($composeFile)
                 . ' up -d --force-recreate 2>&1',
-            'docker compose -f ' . escapeshellarg($composeFile)
-                . ' --profile cli run --rm openclaw-cli skills install maximeprades/auto-updater 2>&1',
         ]);
 
         $output = $client->exec('sudo bash -c ' . escapeshellarg($script) . '; echo "EXIT_CODE:$?"', 1800);


### PR DESCRIPTION
## Summary
- Remove the `skills install maximeprades/auto-updater` step — the skill slug is invalid and was causing the entire update job to fail even though all containers had already been successfully pulled, rebuilt, and recreated

## Test plan
- [ ] Run `openclawUpdateMachineContainers` mutation
- [ ] Verify deployment status changes to `RUNNING` after update
- [ ] Verify containers are recreated with latest images

🤖 Generated with [Claude Code](https://claude.com/claude-code)