### PR TITLE
feat: set lead preferred channel from company default when not defined

### DIFF
--- a/src/Domains/Connectors/SalesAssist/Actions/CreateSocialChannelsAfterPullAction.php
+++ b/src/Domains/Connectors/SalesAssist/Actions/CreateSocialChannelsAfterPullAction.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Kanvas\Connectors\SalesAssist\Actions;
 
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Enums\ConfigurationEnum as CompanyConfigurationEnum;
+use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadsConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Enums\ConfigurationEnum;
 
@@ -55,6 +57,21 @@ class CreateSocialChannelsAfterPullAction
                 $this->app,
                 $this->agentId,
             )->execute();
+        }
+
+        if (! $this->lead->get(LeadsConfigurationEnum::GUILD_PREFERRED_CHANNEL_UUID->value)) {
+            $defaultChannel = $this->lead->company->get(CompanyConfigurationEnum::DEFAULT_SELECTED_CHANNEL->value)
+                ?? $this->app->get(CompanyConfigurationEnum::DEFAULT_SELECTED_CHANNEL->value);
+
+            if ($defaultChannel) {
+                $matchedChannel = $this->lead->socialChannels()
+                    ->get()
+                    ->first(fn ($channel) => str_contains(strtolower($channel->name), strtolower($defaultChannel)));
+
+                if ($matchedChannel) {
+                    $this->lead->set(LeadsConfigurationEnum::GUILD_PREFERRED_CHANNEL_UUID->value, $matchedChannel->uuid);
+                }
+            }
         }
     }
 }

--- a/src/Kanvas/Companies/Enums/ConfigurationEnum.php
+++ b/src/Kanvas/Companies/Enums/ConfigurationEnum.php
@@ -23,4 +23,5 @@ enum ConfigurationEnum: string
     case DATE_ADK_AGENT_RESPONSES = 'date_adk_agent_responses';
     case CHANNEL_ORDER = 'guild_channel_order';
     case FOLLOW_UP_ON_IS_CONTACTED = 'follow_up_on_is_contacted';
+    case DEFAULT_SELECTED_CHANNEL = 'guild_default_selected_channel';
 }


### PR DESCRIPTION
## Summary

- Added `DEFAULT_SELECTED_CHANNEL` (`guild_default_selected_channel`) to `Companies\Enums\ConfigurationEnum`
- After social channels are created for a lead, if the lead has no `GUILD_PREFERRED_CHANNEL_UUID` set, the action now looks up the company (or app) default channel config and finds the matching social channel by name (e.g. `email`, `sms`, `whatsapp`), setting it as the preferred channel automatically

## Test plan

- [ ] Set `guild_default_selected_channel` on a company (e.g. `email`)
- [ ] Trigger lead pull/import so `CreateSocialChannelsAfterPullAction` runs
- [ ] Verify the lead's `guild_prefered_channel_uuid` is set to the matching channel's UUID
- [ ] Verify leads that already have `guild_prefered_channel_uuid` are not overwritten