### PR TITLE
fix: remove timestamp from Sally Mode system notes

### DIFF
--- a/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
+++ b/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Triggers\Actions;
 
-use Carbon\Carbon;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
@@ -140,8 +139,7 @@ class ApplyLeadAiModeAction
             return;
         }
 
-        $carbon = Carbon::now($this->lead->company->timezone);
-        $noteContent = $carbon->format('Y-m-d H:i:s') . ' Sally Mode set to ' . $newMode;
+        $noteContent = 'Sally Mode set to ' . $newMode;
 
         $messageType = new CreateMessageTypeAction(
             new MessageTypeInput(


### PR DESCRIPTION
## Summary
- Removes the timestamp prefix from the Sally Mode system notes in `ApplyLeadAiModeAction`
- Removes the unused `Carbon` import

## Test plan
- [ ] Verify Sally Mode change notes are created without a timestamp prefix
- [ ] Confirm no regression in lead AI mode trigger behavior

🤖 Generated with [Claude Code](https://claude.ai/claude-code)