### PR TITLE
Merge pull request #9363 from bakaphp/hotfix/duplicate-checklist-items

### DIFF
--- a/src/Domains/Connectors/Elead/Actions/SyncLeadAction.php
+++ b/src/Domains/Connectors/Elead/Actions/SyncLeadAction.php
@@ -106,7 +106,7 @@ class SyncLeadAction
         if (! empty($eLeadOpportunity->tradeIns)) {
             $lead->set(
                 LeadCustomFieldEnum::TRADE_IN->value,
-                current($eLeadOpportunity->tradeIns)
+                end($eLeadOpportunity->tradeIns)
             );
         }
 

--- a/src/Domains/Connectors/Mailgun/Actions/CreateMessageFromEmailAction.php
+++ b/src/Domains/Connectors/Mailgun/Actions/CreateMessageFromEmailAction.php
@@ -7,6 +7,7 @@ namespace Kanvas\Connectors\Mailgun\Actions;
 use Baka\Support\Str;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadsEnumsConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Guild\Leads\Services\NotifyLeadStakeholdersService;
 use Kanvas\Intelligence\Sessions\Services\SessionChannelService;
 use Kanvas\Social\Channels\Actions\CreateChannelAction;
 use Kanvas\Social\Channels\DataTransferObject\Channel as ChannelDto;
@@ -104,6 +105,10 @@ class CreateMessageFromEmailAction
                 $this->webhookRequest->user,
                 $this->webhookRequest->company
             );
+
+            if ($this->lead instanceof Lead) {
+                new NotifyLeadStakeholdersService($this->lead)->onCustomerEngagement($newMessage);
+            }
 
             $channel->fireWorkflow(
                 WorkflowEnum::AFTER_ADDING_MESSAGE_TO_CHANNEL->value,

--- a/src/Domains/Connectors/Microsoft/Actions/CreateMessageFromMicrosoftEmailAction.php
+++ b/src/Domains/Connectors/Microsoft/Actions/CreateMessageFromMicrosoftEmailAction.php
@@ -9,6 +9,7 @@ use Baka\Contracts\CompanyInterface;
 use Baka\Users\Contracts\UserInterface;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadsConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Guild\Leads\Services\NotifyLeadStakeholdersService;
 use Kanvas\Intelligence\Sessions\Services\SessionChannelService;
 use Kanvas\Social\Channels\Actions\CreateChannelAction;
 use Kanvas\Social\Channels\DataTransferObject\Channel as ChannelDto;
@@ -213,6 +214,10 @@ class CreateMessageFromMicrosoftEmailAction
             $this->user,
             $this->company
         );
+
+        if ($this->lead instanceof Lead) {
+            new NotifyLeadStakeholdersService($this->lead)->onCustomerEngagement($message);
+        }
 
         $channel->fireWorkflow(
             WorkflowEnum::AFTER_ADDING_MESSAGE_TO_CHANNEL->value,

--- a/src/Domains/Connectors/RespondIO/Actions/ProcessIncomingMessageAction.php
+++ b/src/Domains/Connectors/RespondIO/Actions/ProcessIncomingMessageAction.php
@@ -13,6 +13,7 @@ use Kanvas\Connectors\RespondIO\Traits\HasChannelProcessing;
 use Kanvas\Connectors\RespondIO\Traits\HasLeadProcessing;
 use Kanvas\Connectors\RespondIO\Traits\HasMessageProcessing;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadsConfigurationEnum;
+use Kanvas\Guild\Leads\Services\NotifyLeadStakeholdersService;
 use Kanvas\Social\Messages\Actions\CreateMessageAction;
 use Kanvas\Social\Messages\DataTransferObject\MessageInput;
 use Kanvas\Social\Messages\Models\Message;
@@ -134,6 +135,8 @@ class ProcessIncomingMessageAction extends BaseRespondIOAction
         $message->addTag('engagement');
 
         $channel->addMessage($message);
+
+        new NotifyLeadStakeholdersService($lead)->onCustomerEngagement($message);
 
         $channel->addTags(
             ['respondio', 'ai-agent'],

--- a/src/Domains/Connectors/SalesAssist/Activities/BaseAddLeadCommentFromAgentMessageActivity.php
+++ b/src/Domains/Connectors/SalesAssist/Activities/BaseAddLeadCommentFromAgentMessageActivity.php
@@ -4,22 +4,13 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\SalesAssist\Activities;
 
-use Baka\Support\Url;
-use Illuminate\Support\Facades\Notification;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Guild\Leads\Models\Lead;
-use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
 use Kanvas\Intelligence\Sessions\Services\SessionChannelService;
-use Kanvas\Intelligence\Tools\CompanyWorkHoursTool;
-use Kanvas\Notifications\Channels\OneSignalNotificationChannel;
-use Kanvas\Notifications\Channels\TwilioSmsChannel;
-use Kanvas\Notifications\Templates\Blank;
 use Kanvas\Social\Enums\ChannelCategoryEnum;
 use Kanvas\Social\Messages\Models\Message;
-use Kanvas\Users\Repositories\UsersRepository;
 use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Kanvas\Workflow\KanvasActivity;
-use NotificationChannels\Expo\ExpoChannel;
 
 abstract class BaseAddLeadCommentFromAgentMessageActivity extends KanvasActivity
 {
@@ -50,15 +41,6 @@ abstract class BaseAddLeadCommentFromAgentMessageActivity extends KanvasActivity
     ): mixed;
 
     /**
-     * Get the enum key for tracking manager notification timestamp.
-     * Return null if not tracking notification timestamps.
-     */
-    protected function getManagerNotifiedAtKey(): ?string
-    {
-        return null;
-    }
-
-    /**
      * Whether to append AI chat link before adding the prefix.
      * Override to true for connectors that need link before prefix (e.g., Elead).
      */
@@ -83,7 +65,6 @@ abstract class BaseAddLeadCommentFromAgentMessageActivity extends KanvasActivity
             default => 'Customer',
         };
 
-        //return ($fromAgent ? $agentChannel . 'Sally: ' : 'Customer: ') . $note;
         return $fromWho . ': ' . $note;
     }
 
@@ -96,13 +77,6 @@ abstract class BaseAddLeadCommentFromAgentMessageActivity extends KanvasActivity
         if ($aiChatLink === null) {
             return $note;
         }
-
-        //$shortUrl = Url::getShortUrl($aiChatLink, $app) . '?openInSa=true';
-        //$linkText = "\nView Full Conversation here: {$shortUrl}";
-
-        //if (strlen($note) + strlen($linkText) > 200) {
-        //    return substr($note, 0, 200 - strlen($linkText) - 5) . '...' . $linkText;
-        //}
 
         return $note;
     }
@@ -185,179 +159,13 @@ abstract class BaseAddLeadCommentFromAgentMessageActivity extends KanvasActivity
 
                 $message->set('sent_to_crm', true);
 
-                // Notify managers
-                $notificationInfo = [];
-                if (! $fromAgent && $lead->company->get('ai_manager_notifications')) {
-                    $notificationInfo = $this->notifyManagers($message, $lead);
-                }
-
                 return [
                     'note' => $externalResult,
                     'from_agent' => $fromAgent,
                     'lead' => $lead->getId(),
-                    'sent_manager_notification' => ! empty($notificationInfo),
-                    'notification_info' => $notificationInfo,
                 ];
             },
             company: $company,
         );
-    }
-
-    /**
-     * Notify managers about customer engagement.
-     */
-    protected function notifyManagers(Message $message, Lead $lead): array
-    {
-        $hoursTool = new CompanyWorkHoursTool($message)->execute();
-        if ($hoursTool['status'] !== 'work_hours') {
-            return ['skipped' => 'outside_work_hours'];
-        }
-
-        // Check if we should only notify once
-        $notifiedAtKey = $this->getManagerNotifiedAtKey();
-        if ($notifiedAtKey !== null
-            && $lead->company->get(IntelligenceConfigurationEnum::AI_ENGAGEMENT_MESSAGE_ONLY_ONE_NOTIFICATION->value)
-            && $lead->get($notifiedAtKey)) {
-            return ['skipped' => 'already_notified'];
-        }
-
-        $notification = new Blank(
-            templateName: 'agent-manager-notification',
-            data: [
-                'message' => $message,
-                'company' => $message->company,
-                'app' => $message->app,
-                'user' => $message->user,
-            ],
-            via: ['sms', 'push', 'expo', 'mail'],
-            entity: $message
-        );
-
-        $notification->setSubject($lead->people->name . ' Engaged with Sally');
-        $notification->setPushTemplateName('agent_manager_push_notification');
-        $notification->setSmsTemplateName('agent_manager_sms_notification');
-
-        $this->configureManagerNotificationChannels(
-            $notification,
-            $lead,
-            $message
-        );
-
-        // Get managers
-        $managers = UsersRepository::getCompanyAppUserByRole(
-            $message->company,
-            $message->app,
-            'BDCManager'
-        )->get();
-
-        // Include the lead owner in the notification recipients
-        $leadOwner = $lead->owner;
-        if ($leadOwner && ! $managers->contains('id', $leadOwner->getId())) {
-            $managers->push($leadOwner);
-        }
-
-        Notification::send($managers, $notification);
-
-        // Track notification timestamp if key is provided
-        if ($notifiedAtKey !== null) {
-            $lead->set($notifiedAtKey, date('Y-m-d H:i:s'));
-        }
-
-        $channel = $message->channels()->first();
-
-        return [
-            'channels' => $notification->channels,
-            'is_first_engagement' => $this->isFirstEngagement($lead, $message),
-            'channel_id' => $channel?->getId(),
-            'channel_name' => $channel?->name,
-            'channel_slug' => $channel?->slug,
-            'manager_count' => $managers->count(),
-            'manager_ids' => $managers->pluck('id')->toArray(),
-            'first_engagement_config' => $lead->company->get(IntelligenceConfigurationEnum::FIRST_ENGAGEMENT_NOTIFICATION_CHANNELS->value),
-            'engagement_config' => $lead->company->get(IntelligenceConfigurationEnum::ENGAGEMENT_NOTIFICATION_CHANNELS->value),
-        ];
-    }
-
-    protected function configureManagerNotificationChannels(Blank $notification, Lead $lead, Message $message): void
-    {
-        $engagementChannels = $this->getEngagementNotificationChannels($lead, $message);
-        if ($engagementChannels !== null) {
-            $notification->channels = $engagementChannels;
-
-            return;
-        }
-
-        $onlySms = (bool) $lead->company->get('ai_manager_notification_only_sms');
-        $onlyMail = (bool) $lead->company->get('ai_manager_notification_only_mail');
-        $onlyPush = (bool) $lead->company->get('ai_manager_notification_only_push');
-
-        if ($onlySms) {
-            $notification->channels = [TwilioSmsChannel::class];
-        } elseif ($onlyMail) {
-            $notification->channels = ['mail'];
-        } elseif ($onlyPush) {
-            $notification->channels = [
-                OneSignalNotificationChannel::class,
-                ExpoChannel::class,
-            ];
-        }
-    }
-
-    protected function getEngagementNotificationChannels(Lead $lead, Message $message): ?array
-    {
-        $firstEngagementChannels = (array) ($lead->company->get(IntelligenceConfigurationEnum::FIRST_ENGAGEMENT_NOTIFICATION_CHANNELS->value) ?? []);
-        $subsequentEngagementChannels = (array) ($lead->company->get(IntelligenceConfigurationEnum::ENGAGEMENT_NOTIFICATION_CHANNELS->value) ?? []);
-
-        if (empty($firstEngagementChannels) && empty($subsequentEngagementChannels)) {
-            return null;
-        }
-
-        $isFirst = $this->isFirstEngagement($lead, $message);
-        $selectedChannels = $isFirst
-            ? $firstEngagementChannels
-            : $subsequentEngagementChannels;
-
-        if (empty($selectedChannels)) {
-            return null;
-        }
-
-        return $this->mapNotificationChannelSlugs($selectedChannels);
-    }
-
-    protected function isFirstEngagement(Lead $lead, Message $message): bool
-    {
-        $channel = $message->channels()->first();
-
-        if ($channel === null) {
-            return true;
-        }
-
-        $previousInboundCount = $channel->messages()
-            ->whereRaw("JSON_EXTRACT(messages.message, '$.from_me') = false")
-            ->where('messages.is_deleted', 0)
-            ->where('messages.id', '!=', $message->getId())
-            ->count();
-
-        return $previousInboundCount === 0;
-    }
-
-    protected function mapNotificationChannelSlugs(array $slugs): array
-    {
-        $channelMap = [
-            'sms' => TwilioSmsChannel::class,
-            'push' => OneSignalNotificationChannel::class,
-            'expo' => ExpoChannel::class,
-            'mail' => 'mail',
-            'email' => 'mail',
-        ];
-
-        $mapped = [];
-        foreach ($slugs as $slug) {
-            if (isset($channelMap[$slug])) {
-                $mapped[] = $channelMap[$slug];
-            }
-        }
-
-        return $mapped;
     }
 }

--- a/src/Domains/Connectors/Twilio/Webhooks/ProcessTwilioWebhookJob.php
+++ b/src/Domains/Connectors/Twilio/Webhooks/ProcessTwilioWebhookJob.php
@@ -27,6 +27,7 @@ use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadsEnumsConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Models\LeadType;
 use Kanvas\Guild\Leads\Repositories\LeadsRepository;
+use Kanvas\Guild\Leads\Services\NotifyLeadStakeholdersService;
 use Kanvas\Guild\LeadSources\Actions\CreateLeadSourceAction;
 use Kanvas\Guild\LeadSources\DataTransferObject\LeadSource;
 use Kanvas\Intelligence\Enums\ConfigurationEnum;
@@ -173,6 +174,10 @@ class ProcessTwilioWebhookJob extends ProcessWebhookJob
             }
         }
         $lead->set(LeadsEnumsConfigurationEnum::AGENT_COMMUNICATION_CHANNEL->value, 'sms');
+
+        if (! $isFromMe) {
+            new NotifyLeadStakeholdersService($lead)->onCustomerEngagement($message);
+        }
 
         $workflowJobKey = "workflow_job:{$batchKey}";
 

--- a/src/Domains/Connectors/Twilio/Workflows/HumanAgentChannelResponseActivity.php
+++ b/src/Domains/Connectors/Twilio/Workflows/HumanAgentChannelResponseActivity.php
@@ -10,6 +10,7 @@ use Kanvas\Guild\Leads\Enums\ConfigurationEnum;
 use Kanvas\Guild\Leads\Enums\LeadCommunicationChannelEnum;
 use Kanvas\Guild\Leads\Enums\LeadGroupStatusEnum;
 use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Guild\Leads\Services\NotifyLeadStakeholdersService;
 use Kanvas\Intelligence\Triggers\Enums\TriggersEnum;
 use Kanvas\Social\Channels\Models\Channel;
 use Kanvas\Social\Enums\ChannelCategoryEnum;
@@ -131,6 +132,7 @@ class HumanAgentChannelResponseActivity extends KanvasActivity
                 );
 
                 new MarkLeadMessagesAsRespondedAction($lead, $message)->execute();
+                new NotifyLeadStakeholdersService($lead)->onAgentReply($message, isHuman: true);
 
                 return $result;
             },

--- a/src/Domains/Connectors/VinSolution/Workflow/AddLeadCommentFromAgentMessageActivity.php
+++ b/src/Domains/Connectors/VinSolution/Workflow/AddLeadCommentFromAgentMessageActivity.php
@@ -34,12 +34,6 @@ class AddLeadCommentFromAgentMessageActivity extends BaseAddLeadCommentFromAgent
     }
 
     #[Override]
-    protected function getManagerNotifiedAtKey(): ?string
-    {
-        return ConfigurationEnum::MANAGER_NOTIFIED_AT->value;
-    }
-
-    #[Override]
     protected function addNoteToExternalSystem(
         Lead $lead,
         string $note,

--- a/src/Domains/Connectors/WaSender/Webhooks/ProcessWaSenderWebhookJob.php
+++ b/src/Domains/Connectors/WaSender/Webhooks/ProcessWaSenderWebhookJob.php
@@ -28,6 +28,7 @@ use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Models\LeadReceiver as LeadReceiverModel;
 use Kanvas\Guild\Leads\Models\LeadType;
 use Kanvas\Guild\Leads\Repositories\LeadsRepository;
+use Kanvas\Guild\Leads\Services\NotifyLeadStakeholdersService;
 use Kanvas\Guild\LeadSources\Actions\CreateLeadSourceAction;
 use Kanvas\Guild\LeadSources\DataTransferObject\LeadSource;
 use Kanvas\Guild\Pipelines\Models\Pipeline;
@@ -283,6 +284,10 @@ class ProcessWaSenderWebhookJob extends ProcessWebhookJob
             // Associate message with channel
             $channel->addMessage($message);
             $lastMessageParent = $lastMessage->parent ?? null;
+
+            if ($isFromMe === false && isset($lead)) {
+                new NotifyLeadStakeholdersService($lead)->onCustomerEngagement($message);
+            }
 
             //get the previous msg before this that was of type document and is not process by me , to check
 

--- a/src/Domains/Guild/Leads/Services/NotifyLeadStakeholdersService.php
+++ b/src/Domains/Guild/Leads/Services/NotifyLeadStakeholdersService.php
@@ -4,16 +4,37 @@ declare(strict_types=1);
 
 namespace Kanvas\Guild\Leads\Services;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Notification;
 use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
+use Kanvas\Intelligence\Tools\CompanyWorkHoursTool;
 use Kanvas\Notifications\Notification as NotificationsNotification;
+use Kanvas\Notifications\Templates\Blank;
+use Kanvas\Social\Channels\Models\Channel;
+use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Users\Models\Users;
+use Kanvas\Users\Repositories\UsersRepository;
 
 class NotifyLeadStakeholdersService
 {
+    public const string LAST_MANAGER_NOTIFICATION_AT = 'lead_last_manager_notification_at';
+    public const string NOTIFY_ON_AGENT_REPLY = 'ai_manager_notify_on_agent_reply';
+    public const string NOTIFY_ON_HUMAN_REPLY = 'ai_manager_notify_on_human_reply';
+    public const string NOTIFY_ON_INBOUND = 'ai_manager_notifications';
+    public const string MANAGER_ROLE = 'BDCManager';
+
+    public const string LAST_AGENT_REPLY_NOTIFICATION_AT = 'last_agent_reply_notification_at';
+    public const string AGENT_REPLY_DEDUPE_SECONDS_KEY = 'agent_reply_notification_dedupe_seconds';
+    public const int AGENT_REPLY_DEDUPE_SECONDS_DEFAULT = 5;
+
+    public const string LAST_CUSTOMER_ENGAGEMENT_NOTIFICATION_AT = 'last_customer_engagement_notification_at';
+    public const string CUSTOMER_ENGAGEMENT_DEDUPE_SECONDS_KEY = 'customer_engagement_notification_dedupe_seconds';
+    public const int CUSTOMER_ENGAGEMENT_DEDUPE_SECONDS_DEFAULT = 1;
+
     public function __construct(
         protected Lead $lead,
-        protected NotificationsNotification $notification,
+        protected ?NotificationsNotification $notification = null,
     ) {
     }
 
@@ -26,13 +47,21 @@ class NotifyLeadStakeholdersService
 
     public function owner(): void
     {
+        if ($this->notification === null) {
+            return;
+        }
+
         if ($this->lead->owner) {
             $this->lead->owner->notify($this->notification);
         }
     }
 
-    public function managers(?string $emailContent = null): void
+    public function managers(): void
     {
+        if ($this->notification === null) {
+            return;
+        }
+
         $companyManagers = $this->lead->company->get('company_manager');
 
         if ($this->lead->get('sent_email_notification_to_manager')) {
@@ -42,7 +71,6 @@ class NotifyLeadStakeholdersService
         if ($companyManagers && is_array($companyManagers)) {
             $this->lead->set('sent_email_notification_to_manager', 1);
 
-            // Get all users in one query and send bulk notification
             $users = Users::whereIn('id', $companyManagers)->get();
 
             Notification::send($users, $this->notification);
@@ -51,7 +79,10 @@ class NotifyLeadStakeholdersService
 
     public function followers(): void
     {
-        //notify followers
+        if ($this->notification === null) {
+            return;
+        }
+
         if ($this->lead->getTotalFollowers($this->lead->app) === 0) {
             return;
         }
@@ -60,5 +91,270 @@ class NotifyLeadStakeholdersService
                 $follower->notify($this->notification);
             }
         }
+    }
+
+    /**
+     * Notify lead owner + BDC managers when a customer engages on a channel.
+     *
+     * Honors company config:
+     * - ai_manager_notifications (off → skip entirely)
+     * - first_engagement_notification_channels / engagement_notification_channels (slug list)
+     * - ai_manager_notification_only_sms / _only_mail / _only_push (legacy fallbacks)
+     * - ai_engagement_message_only_one_notification (dedupe via lead_last_manager_notification_at)
+     * - work hours via CompanyWorkHoursTool
+     *
+     * Channel slugs ('sms', 'push', 'expo', 'mail', 'database') flow straight to
+     * $notification->channels — the base Notification::via() resolves them via
+     * NotificationChannelEnum::getNotificationChannelBySlug(). No service-level
+     * slug-to-class mapping.
+     */
+    public function onCustomerEngagement(Message $message, bool $includeOwner = true): array
+    {
+        if (! $this->lead->company->get(self::NOTIFY_ON_INBOUND)) {
+            return ['skipped' => 'inbound_notifications_disabled'];
+        }
+
+        $hoursTool = new CompanyWorkHoursTool($message)->execute();
+        if ($hoursTool['status'] !== 'work_hours') {
+            return ['skipped' => 'outside_work_hours'];
+        }
+
+        if ($this->lead->company->get(IntelligenceConfigurationEnum::AI_ENGAGEMENT_MESSAGE_ONLY_ONE_NOTIFICATION->value)
+            && $this->lead->get(self::LAST_MANAGER_NOTIFICATION_AT)) {
+            return ['skipped' => 'already_notified'];
+        }
+
+        /** @var Channel|null $channel */
+        $channel = $message->channels()->first();
+        if ($channel instanceof Channel && $this->isWithinCustomerEngagementDedupeWindow($channel)) {
+            return ['skipped' => 'already_notified_within_window'];
+        }
+
+        $isFirst = $this->isFirstEngagement($message);
+        $channels = $this->resolveEngagementChannels($isFirst);
+        if (empty($channels)) {
+            return ['skipped' => 'no_channels_configured'];
+        }
+
+        $notification = new Blank(
+            templateName: 'agent-manager-notification',
+            data: [
+                'message' => $message,
+                'company' => $message->company,
+                'app' => $message->app,
+                'user' => $message->user,
+            ],
+            via: $channels,
+            entity: $message
+        );
+
+        $peopleName = (string) ($this->lead->people->name ?? '');
+        $notification->setSubject($peopleName . ' Engaged with Sally');
+        $notification->setPushTemplateName('agent_manager_push_notification');
+        $notification->setSmsTemplateName('agent_manager_sms_notification');
+
+        $recipients = $this->collectManagerRecipients($message, $includeOwner);
+
+        if ($recipients->isEmpty()) {
+            return ['skipped' => 'no_recipients'];
+        }
+
+        Notification::send($recipients, $notification);
+
+        $this->lead->set(self::LAST_MANAGER_NOTIFICATION_AT, date('Y-m-d H:i:s'));
+
+        if ($channel instanceof Channel) {
+            $channel->set(self::LAST_CUSTOMER_ENGAGEMENT_NOTIFICATION_AT, date('Y-m-d H:i:s'));
+        }
+
+        return [
+            'channels' => $channels,
+            'is_first_engagement' => $isFirst,
+            'channel_id' => $channel?->getId(),
+            'channel_name' => $channel?->name,
+            'channel_slug' => $channel?->slug,
+            'manager_count' => $recipients->count(),
+            'manager_ids' => $recipients->pluck('id')->toArray(),
+        ];
+    }
+
+    /**
+     * Notify lead owner + BDC managers when an agent (AI or human) replies to a customer.
+     *
+     * Internal-only by default: 'database' channel — recipients see it in the in-app feed
+     * without getting SMS/email/push spam every time the agent answers.
+     *
+     * Gated by separate company flags from inbound:
+     * - ai_manager_notify_on_agent_reply (AI replies, default off)
+     * - ai_manager_notify_on_human_reply (human replies, default off)
+     */
+    public function onAgentReply(
+        Message $message,
+        bool $isHuman = false,
+        bool $includeOwner = true
+    ): array {
+        $flag = $isHuman ? self::NOTIFY_ON_HUMAN_REPLY : self::NOTIFY_ON_AGENT_REPLY;
+
+        if (! $this->lead->company->get($flag)) {
+            return ['skipped' => $flag . '_disabled'];
+        }
+
+        /** @var Channel|null $channel */
+        $channel = $message->channels()->first();
+        if ($channel instanceof Channel && $this->isWithinAgentReplyDedupeWindow($channel)) {
+            return ['skipped' => 'already_notified_within_window'];
+        }
+
+        $channels = ['database'];
+
+        $notification = new Blank(
+            templateName: 'agent-reply-manager-notification',
+            data: [
+                'message' => $message,
+                'company' => $message->company,
+                'app' => $message->app,
+                'user' => $message->user,
+                'is_human' => $isHuman,
+            ],
+            via: $channels,
+            entity: $message
+        );
+
+        $peopleName = (string) ($this->lead->people->name ?? '');
+        $notification->setSubject(
+            ($isHuman ? 'Agent ' : 'Sally ') . 'replied to ' . $peopleName
+        );
+
+        $recipients = $this->collectManagerRecipients($message, $includeOwner);
+
+        if ($recipients->isEmpty()) {
+            return ['skipped' => 'no_recipients'];
+        }
+
+        Notification::send($recipients, $notification);
+
+        if ($channel !== null) {
+            $channel->set(self::LAST_AGENT_REPLY_NOTIFICATION_AT, date('Y-m-d H:i:s'));
+        }
+
+        return [
+            'channels' => $channels,
+            'is_human' => $isHuman,
+            'channel_id' => $channel?->getId(),
+            'channel_name' => $channel?->name,
+            'channel_slug' => $channel?->slug,
+            'manager_count' => $recipients->count(),
+            'manager_ids' => $recipients->pluck('id')->toArray(),
+        ];
+    }
+
+    protected function isWithinAgentReplyDedupeWindow(Channel $channel): bool
+    {
+        return $this->isWithinDedupeWindow(
+            $channel,
+            self::LAST_AGENT_REPLY_NOTIFICATION_AT,
+            self::AGENT_REPLY_DEDUPE_SECONDS_KEY,
+            self::AGENT_REPLY_DEDUPE_SECONDS_DEFAULT
+        );
+    }
+
+    protected function isWithinCustomerEngagementDedupeWindow(Channel $channel): bool
+    {
+        return $this->isWithinDedupeWindow(
+            $channel,
+            self::LAST_CUSTOMER_ENGAGEMENT_NOTIFICATION_AT,
+            self::CUSTOMER_ENGAGEMENT_DEDUPE_SECONDS_KEY,
+            self::CUSTOMER_ENGAGEMENT_DEDUPE_SECONDS_DEFAULT
+        );
+    }
+
+    /**
+     * Window dedupe: returns true if a notification was fired on this channel
+     * within `now - $windowSeconds`. Window is read from company config when set,
+     * otherwise the default. Setting the company config to 0 disables dedupe.
+     */
+    protected function isWithinDedupeWindow(
+        Channel $channel,
+        string $timestampKey,
+        string $windowConfigKey,
+        int $windowDefault
+    ): bool {
+        $configured = $this->lead->company->get($windowConfigKey);
+        $window = is_numeric($configured) ? (int) $configured : $windowDefault;
+
+        if ($window <= 0) {
+            return false;
+        }
+
+        $lastAt = $channel->get($timestampKey);
+
+        if (empty($lastAt)) {
+            return false;
+        }
+
+        return strtotime((string) $lastAt) > (time() - $window);
+    }
+
+    /**
+     * Pick the slug list for first-vs-subsequent engagement, falling back to legacy
+     * ai_manager_notification_only_* flags when neither engagement list is configured.
+     */
+    protected function resolveEngagementChannels(bool $isFirst): array
+    {
+        $firstEngagementChannels = (array) ($this->lead->company->get(IntelligenceConfigurationEnum::FIRST_ENGAGEMENT_NOTIFICATION_CHANNELS->value) ?? []);
+        $subsequentEngagementChannels = (array) ($this->lead->company->get(IntelligenceConfigurationEnum::ENGAGEMENT_NOTIFICATION_CHANNELS->value) ?? []);
+
+        if (! empty($firstEngagementChannels) || ! empty($subsequentEngagementChannels)) {
+            return $isFirst ? $firstEngagementChannels : $subsequentEngagementChannels;
+        }
+
+        $onlySms = (bool) $this->lead->company->get('ai_manager_notification_only_sms');
+        $onlyMail = (bool) $this->lead->company->get('ai_manager_notification_only_mail');
+        $onlyPush = (bool) $this->lead->company->get('ai_manager_notification_only_push');
+
+        return match (true) {
+            $onlySms => ['sms'],
+            $onlyMail => ['mail'],
+            $onlyPush => ['push', 'expo'],
+            default => ['mail'],
+        };
+    }
+
+    protected function isFirstEngagement(Message $message): bool
+    {
+        $channel = $message->channels()->first();
+
+        if ($channel === null) {
+            return true;
+        }
+
+        $previousInboundCount = $channel->messages()
+            ->whereRaw("JSON_EXTRACT(messages.message, '$.from_me') = false")
+            ->where('messages.is_deleted', 0)
+            ->where('messages.id', '!=', $message->getId())
+            ->count();
+
+        return $previousInboundCount === 0;
+    }
+
+    /**
+     * BDC managers + lead owner, deduped by user id.
+     */
+    protected function collectManagerRecipients(Message $message, bool $includeOwner): Collection
+    {
+        $managers = UsersRepository::getCompanyAppUserByRole(
+            $message->company,
+            $message->app,
+            self::MANAGER_ROLE
+        )->get();
+
+        if ($includeOwner) {
+            $owner = $this->lead->owner;
+            if ($owner && ! $managers->contains('id', $owner->getId())) {
+                $managers->push($owner);
+            }
+        }
+
+        return $managers;
     }
 }

--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
@@ -10,6 +10,7 @@ use InvalidArgumentException;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Guild\Leads\Services\NotifyLeadStakeholdersService;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\Services\LeadConfigurationService;
@@ -27,7 +28,7 @@ use Kanvas\Workflow\Enums\WorkflowEnum;
 class BaseAgentResponderAction
 {
     protected string $messageTypeVerb = 'text';
-    protected string $communicationChannel;
+    protected string $communicationChannel = '';
 
     public function __construct(
         protected Channel $channel,
@@ -134,6 +135,7 @@ class BaseAgentResponderAction
         $lead = $message->entity();
         if ($lead instanceof Lead) {
             new MarkLeadMessagesAsRespondedAction($lead, $newMessage)->execute();
+            new NotifyLeadStakeholdersService($lead)->onAgentReply($newMessage, isHuman: false);
         }
 
         return $newMessage;


### PR DESCRIPTION
## Summary
- **Decouple manager/owner notifications from the CRM-comment activity.** Notifications now fire when the message lands in the system (after `$channel->addMessage()` in each connector's receiver), not as a side-effect of pushing the note to Elead/VinSolution/DealerSocket. This fixes the prod case where companies without a CRM connector got nothing, and where notifications dropped on every guard the comment activity had (locked, private, `sent_to_crm`, CRM API failure).
- **Three new firing points:** customer-engagement (inbound), AI-agent reply, human-agent reply. Each gated by separate company flags so operators can opt in independently. AI/human reply notifications default to `'database'` channel (in-app feed only) so managers don't get push/SMS spam every time Sally answers.
- **Channel-level time-window dedupe** on both methods, configurable per company. Default 1s for inbound (effectively no dedupe — only catches duplicate webhook deliveries), 60s for outbound (kills ADK streaming chunks and `HumanAgentChannelResponseActivity` retries cleanly).
- **Drop the duplicate slug→class map** in `BaseAddLeadCommentFromAgentMessageActivity::mapNotificationChannelSlugs()`. Slugs (`'push'`, `'expo'`, `'sms'`, `'mail'`, `'database'`) flow straight into `$notification->channels` and the base `Notification::via()` resolves them through the central `NotificationChannelEnum`. Aligns with the existing notification-channel dedup direction.