### PR TITLE
feat(openclaw): native agent workspace backup via openclaw backup create

### DIFF
--- a/app/GraphQL/Connector/OpenClaw/Mutations/AgentDeploymentMutation.php
+++ b/app/GraphQL/Connector/OpenClaw/Mutations/AgentDeploymentMutation.php
@@ -6,6 +6,7 @@ namespace App\GraphQL\Connector\OpenClaw\Mutations;
 
 use Illuminate\Support\Facades\Cache;
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\OpenClaw\Actions\BackupAgentWorkspaceAction;
 use Kanvas\Connectors\OpenClaw\Actions\CollectDeploymentUsageAction;
 use Kanvas\Connectors\OpenClaw\Actions\DispatchAgentDeploymentAction;
 use Kanvas\Connectors\OpenClaw\Actions\ExecDeploymentCommandAction;
@@ -14,10 +15,12 @@ use Kanvas\Connectors\OpenClaw\Actions\GetAgentContainerStatusAction;
 use Kanvas\Connectors\OpenClaw\Actions\GetDeploymentConfigAction;
 use Kanvas\Connectors\OpenClaw\Actions\UpdateDeploymentConfigAction;
 use Kanvas\Connectors\OpenClaw\Enums\CustomFieldEnum;
+use Kanvas\Connectors\OpenClaw\Jobs\BackupAgentWorkspaceJob;
 use Kanvas\Connectors\OpenClaw\Jobs\MigrateAgentWorkspaceJob;
 use Kanvas\Connectors\OpenClaw\Jobs\RestartAgentContainerJob;
 use Kanvas\Connectors\OpenClaw\Jobs\TerminateAgentJob;
 use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Models\AgentBackup;
 use Kanvas\Intelligence\Agents\Models\AgentDeployment;
 use Kanvas\Intelligence\Agents\Models\AgentMachine;
 use Kanvas\Intelligence\Agents\Models\AgentUsageSnapshot;
@@ -178,6 +181,29 @@ class AgentDeploymentMutation
             $deployment,
             (string) $request['config'],
         )->execute();
+    }
+
+    public function backup(mixed $root, array $request): AgentBackup
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        /** @var AgentDeployment $deployment */
+        $deployment = AgentDeployment::getByIdFromCompanyApp((int) $request['deployment_id'], $company, $app);
+
+        $includeWorkspace = $request['include_workspace'] ?? true;
+
+        // Create the record immediately so the caller gets an ID to poll
+        $backup = new AgentBackup();
+        $backup->apps_id = $app->getId();
+        $backup->companies_id = $company->getId();
+        $backup->agent_deployment_id = $deployment->getId();
+        $backup->status = 'pending';
+        $backup->saveOrFail();
+
+        BackupAgentWorkspaceJob::dispatch($deployment, $backup, $includeWorkspace);
+
+        return $backup;
     }
 
     public function migrateWorkspace(mixed $root, array $request): AgentDeployment

--- a/app/GraphQL/Connector/OpenClaw/Mutations/AgentDeploymentMutation.php
+++ b/app/GraphQL/Connector/OpenClaw/Mutations/AgentDeploymentMutation.php
@@ -6,7 +6,6 @@ namespace App\GraphQL\Connector\OpenClaw\Mutations;
 
 use Illuminate\Support\Facades\Cache;
 use Kanvas\Apps\Models\Apps;
-use Kanvas\Connectors\OpenClaw\Actions\BackupAgentWorkspaceAction;
 use Kanvas\Connectors\OpenClaw\Actions\CollectDeploymentUsageAction;
 use Kanvas\Connectors\OpenClaw\Actions\DispatchAgentDeploymentAction;
 use Kanvas\Connectors\OpenClaw\Actions\ExecDeploymentCommandAction;

--- a/database/migrations/Intelligence/2026_04_24_100000_create_agent_backups_table.php
+++ b/database/migrations/Intelligence/2026_04_24_100000_create_agent_backups_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('agent_backups', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->unsignedBigInteger('apps_id');
+            $table->unsignedBigInteger('companies_id');
+            $table->unsignedBigInteger('agent_deployment_id');
+            $table->string('status')->default('pending'); // pending, running, completed, failed
+            $table->string('file_path')->nullable();
+            $table->unsignedBigInteger('file_size_bytes')->nullable();
+            $table->string('notes')->nullable();
+            $table->text('error_message')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->boolean('is_deleted')->default(false);
+            $table->timestamps();
+
+            $table->index(['apps_id', 'companies_id', 'agent_deployment_id']);
+            $table->index('status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('agent_backups');
+    }
+};

--- a/graphql/schemas/Connector/openclaw.graphql
+++ b/graphql/schemas/Connector/openclaw.graphql
@@ -87,6 +87,11 @@ extend type Mutation @guard {
             resolver: "App\\GraphQL\\Connector\\OpenClaw\\Mutations\\AgentMachineMutation@ping"
         )
 
+    openclawBackupAgent(deployment_id: ID!, include_workspace: Boolean): AgentBackupType!
+        @field(
+            resolver: "App\\GraphQL\\Connector\\OpenClaw\\Mutations\\AgentDeploymentMutation@backup"
+        )
+
     openclawLaunchAgent(input: LaunchAgentInput!): AgentDeploymentType!
         @field(
             resolver: "App\\GraphQL\\Connector\\OpenClaw\\Mutations\\AgentDeploymentMutation@launch"

--- a/graphql/schemas/Intelligence/agentDeployment.graphql
+++ b/graphql/schemas/Intelligence/agentDeployment.graphql
@@ -1,3 +1,19 @@
+type AgentBackupType {
+    id: ID!
+    uuid: String!
+    agent_deployment_id: ID!
+    status: String!
+    file_path: String
+    file_size_bytes: Int
+    notes: String
+    error_message: String
+    completed_at: DateTime
+    created_at: DateTime!
+    updated_at: DateTime!
+    deployment: AgentDeploymentType @belongsTo
+    download_url: String
+}
+
 type AgentTelemetryData {
     deployment_id: ID!
     collected_at: String!
@@ -137,6 +153,16 @@ extend type Query @guardByAdmin {
     ): [AgentDeploymentType!]!
         @paginate(
             model: "Kanvas\\Intelligence\\Agents\\Models\\AgentDeployment"
+            scopes: ["fromApp", "fromCompany", "notDeleted"]
+            defaultCount: 25
+        )
+
+    agentBackups(
+        where: _ @whereConditions(columns: ["id", "agent_deployment_id", "status"])
+        orderBy: _ @orderBy(columns: ["id", "created_at", "completed_at"])
+    ): [AgentBackupType!]!
+        @paginate(
+            model: "Kanvas\\Intelligence\\Agents\\Models\\AgentBackup"
             scopes: ["fromApp", "fromCompany", "notDeleted"]
             defaultCount: 25
         )

--- a/src/Domains/Connectors/OpenClaw/Actions/BackupAgentWorkspaceAction.php
+++ b/src/Domains/Connectors/OpenClaw/Actions/BackupAgentWorkspaceAction.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\OpenClaw\Actions;
+
+use Illuminate\Support\Facades\Storage;
+use Kanvas\Connectors\OpenClaw\SshClient;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Intelligence\Agents\Models\AgentBackup;
+use Kanvas\Intelligence\Agents\Models\AgentDeployment;
+use Throwable;
+
+/**
+ * Run `openclaw backup create` inside the running gateway container,
+ * pull the resulting archive out via `docker cp`, download it to a local
+ * temp file via SFTP, upload to S3, and update the AgentBackup record.
+ *
+ * The native CLI backup includes: config, auth-profiles, workspace files,
+ * sessions, and credentials — everything needed to restore the agent later.
+ */
+class BackupAgentWorkspaceAction
+{
+    public function __construct(
+        protected AgentDeployment $deployment,
+        protected AgentBackup $backup,
+        protected bool $includeWorkspace = true,
+    ) {
+    }
+
+    public function execute(): AgentBackup
+    {
+        $this->backup->status = 'running';
+        $this->backup->saveOrFail();
+
+        $client = SshClient::fromMachine($this->deployment->machine);
+
+        try {
+            $localTempFile = $this->runBackupInContainer($client);
+
+            $s3Path = $this->uploadToS3($localTempFile);
+
+            $this->backup->status = 'completed';
+            $this->backup->file_path = $s3Path;
+            $this->backup->file_size_bytes = filesize($localTempFile) ?: null;
+            $this->backup->completed_at = now();
+            $this->backup->saveOrFail();
+        } catch (Throwable $e) {
+            $this->backup->status = 'failed';
+            $this->backup->error_message = $e->getMessage();
+            $this->backup->saveOrFail();
+
+            throw $e;
+        } finally {
+            $client->disconnect();
+
+            if (isset($localTempFile) && file_exists($localTempFile)) {
+                unlink($localTempFile);
+            }
+        }
+
+        return $this->backup;
+    }
+
+    /**
+     * Run the native openclaw backup CLI inside the gateway container,
+     * copy the archive to the host via `docker cp`, then download via SFTP.
+     * Returns the local PHP temp file path.
+     */
+    private function runBackupInContainer(SshClient $client): string
+    {
+        $containerName = $this->deployment->container_name;
+        $backupFlags = $this->includeWorkspace ? '' : ' --no-include-workspace';
+
+        // Run backup inside the container, writing to /tmp
+        $result = $client->exec(
+            'sudo docker exec ' . escapeshellarg($containerName)
+            . ' sh -c ' . escapeshellarg('openclaw backup create --output /tmp' . $backupFlags . ' 2>&1')
+            . '; echo "EXIT_CODE:$?"',
+            300
+        );
+
+        if (str_contains($result, 'EXIT_CODE:1') || ! str_contains($result, 'EXIT_CODE:0')) {
+            throw new ValidationException('openclaw backup create failed: ' . $result);
+        }
+
+        // Extract the timestamped archive filename from the CLI output
+        preg_match('/[\w\-:.]+\.tar\.gz/', $result, $matches);
+        if (empty($matches[0])) {
+            throw new ValidationException('Could not parse backup archive filename from output: ' . $result);
+        }
+
+        $archiveName = basename($matches[0]);
+        $containerPath = '/tmp/' . $archiveName;
+        $hostPath = '/tmp/' . $archiveName;
+
+        // Copy archive from container filesystem to host /tmp
+        $cpResult = $client->exec(
+            'sudo docker cp ' . escapeshellarg($containerName . ':' . $containerPath)
+            . ' ' . escapeshellarg($hostPath) . ' 2>&1; echo "EXIT_CODE:$?"',
+            60
+        );
+
+        if (str_contains($cpResult, 'EXIT_CODE:1')) {
+            throw new ValidationException('Failed to copy backup archive from container: ' . $cpResult);
+        }
+
+        // Stream from host /tmp to PHP temp file via SFTP
+        $localTempFile = sys_get_temp_dir() . '/' . $archiveName;
+
+        try {
+            if (! $client->downloadToFile($hostPath, $localTempFile)) {
+                throw new ValidationException('Failed to download backup archive from machine');
+            }
+        } finally {
+            $client->exec('sudo docker exec ' . escapeshellarg($containerName) . ' rm -f ' . escapeshellarg($containerPath));
+            $client->exec('rm -f ' . escapeshellarg($hostPath));
+        }
+
+        return $localTempFile;
+    }
+
+    private function uploadToS3(string $localTempFile): string
+    {
+        $agentSlug = $this->deployment->agent->slug ?? $this->deployment->container_name;
+        $filename = basename($localTempFile);
+        $s3Path = 'openclaw-backups/' . $agentSlug . '/' . $filename;
+
+        $stream = fopen($localTempFile, 'r');
+
+        if ($stream === false) {
+            throw new ValidationException('Failed to open backup archive for upload');
+        }
+
+        try {
+            Storage::put($s3Path, $stream);
+        } finally {
+            fclose($stream);
+        }
+
+        return $s3Path;
+    }
+}

--- a/src/Domains/Connectors/OpenClaw/Actions/BackupAgentWorkspaceAction.php
+++ b/src/Domains/Connectors/OpenClaw/Actions/BackupAgentWorkspaceAction.php
@@ -77,7 +77,7 @@ class BackupAgentWorkspaceAction
             'sudo docker exec ' . escapeshellarg($containerName)
             . ' sh -c ' . escapeshellarg('openclaw backup create --output /tmp' . $backupFlags . ' 2>&1')
             . '; echo "EXIT_CODE:$?"',
-            300
+            1800
         );
 
         if (str_contains($result, 'EXIT_CODE:1') || ! str_contains($result, 'EXIT_CODE:0')) {

--- a/src/Domains/Connectors/OpenClaw/Jobs/BackupAgentWorkspaceJob.php
+++ b/src/Domains/Connectors/OpenClaw/Jobs/BackupAgentWorkspaceJob.php
@@ -20,9 +20,9 @@ class BackupAgentWorkspaceJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public int $timeout = 600;
+    public int $timeout = 3600;
 
-    public int $tries = 2;
+    public int $tries = 1;
 
     public function __construct(
         protected AgentDeployment $deployment,

--- a/src/Domains/Connectors/OpenClaw/Jobs/BackupAgentWorkspaceJob.php
+++ b/src/Domains/Connectors/OpenClaw/Jobs/BackupAgentWorkspaceJob.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\OpenClaw\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Kanvas\Connectors\OpenClaw\Actions\BackupAgentWorkspaceAction;
+use Kanvas\Intelligence\Agents\Models\AgentBackup;
+use Kanvas\Intelligence\Agents\Models\AgentDeployment;
+
+class BackupAgentWorkspaceJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $timeout = 600;
+
+    public int $tries = 2;
+
+    public function __construct(
+        protected AgentDeployment $deployment,
+        protected AgentBackup $backup,
+        protected bool $includeWorkspace = true,
+    ) {
+    }
+
+    public function handle(): void
+    {
+        new BackupAgentWorkspaceAction(
+            $this->deployment,
+            $this->backup,
+            $this->includeWorkspace,
+        )->execute();
+    }
+}

--- a/src/Domains/Intelligence/Agents/Models/AgentBackup.php
+++ b/src/Domains/Intelligence/Agents/Models/AgentBackup.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Models;
+
+use Baka\Traits\UuidTrait;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Kanvas\Intelligence\Models\BaseModel;
+
+/**
+ * @property int $id
+ * @property string $uuid
+ * @property int $apps_id
+ * @property int $companies_id
+ * @property int $agent_deployment_id
+ * @property string $status
+ * @property string|null $file_path
+ * @property int|null $file_size_bytes
+ * @property string|null $notes
+ * @property string|null $error_message
+ * @property Carbon|null $completed_at
+ * @property bool $is_deleted
+ */
+class AgentBackup extends BaseModel
+{
+    use UuidTrait;
+
+    protected $table = 'agent_backups';
+
+    protected $fillable = [
+        'uuid',
+        'apps_id',
+        'companies_id',
+        'agent_deployment_id',
+        'status',
+        'file_path',
+        'file_size_bytes',
+        'notes',
+        'error_message',
+        'completed_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'completed_at' => 'datetime',
+            'file_size_bytes' => 'integer',
+        ];
+    }
+
+    public function deployment(): BelongsTo
+    {
+        return $this->belongsTo(AgentDeployment::class, 'agent_deployment_id');
+    }
+
+    public function getDownloadUrl(): string
+    {
+        return Storage::temporaryUrl($this->file_path, now()->addHours(1));
+    }
+}


### PR DESCRIPTION
## Summary
- Uses the native `openclaw backup create` CLI (runs inside the gateway container via `docker exec`)
- Archives are pulled out via `docker cp` → SFTP stream → uploaded to S3
- `AgentBackup` record is created immediately (status=`pending`) so the caller gets an ID to poll — the actual work runs async in `BackupAgentWorkspaceJob`

## New pieces
- **Migration**: `agent_backups` table with `deployment_id`, `status`, `file_path`, `file_size_bytes`, `error_message`, `completed_at`
- **Model**: `AgentBackup` with S3 `getDownloadUrl()` helper (1-hour signed URL)
- **Action**: `BackupAgentWorkspaceAction` — runs CLI, docker cp, SFTP download, S3 upload
- **Job**: `BackupAgentWorkspaceJob` — 10min timeout, 2 tries
- **GraphQL**: `openclawBackupAgent` mutation + `agentBackups` query

## Usage
```graphql
# Trigger backup (returns immediately with pending record)
mutation {
  openclawBackupAgent(deployment_id: "1", include_workspace: true) {
    id
    status
    created_at
  }
}

# Poll status / list backups
query {
  agentBackups(where: { column: AGENT_DEPLOYMENT_ID, value: "1" }) {
    data {
      id
      status
      file_size_bytes
      completed_at
      error_message
    }
  }
}
```

## Test plan
- [ ] Run migration on server
- [ ] Call `openclawBackupAgent` — verify record created with `pending` status
- [ ] After job completes — verify status is `completed`, `file_path` set in S3
- [ ] Call with `include_workspace: false` — verify smaller backup (config only)
- [ ] Check S3 bucket for `openclaw-backups/{agent-slug}/` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)