### PR TITLE
fix(openclaw): fix metrics, logs, and events returning no data from agent machines

### DIFF
--- a/app/GraphQL/Connector/OpenClaw/Queries/AgentDeploymentLogsQuery.php
+++ b/app/GraphQL/Connector/OpenClaw/Queries/AgentDeploymentLogsQuery.php
@@ -34,7 +34,7 @@ class AgentDeploymentLogsQuery
         }
 
         $ssh  = SshClient::fromMachine($deployment->machine);
-        $logs = $ssh->getDeploymentLogs($deployment->system_user, $deployment->agent->slug, $limit);
+        $logs = $ssh->getDeploymentLogs($deployment->container_name, $deployment->agent->slug, $limit);
         $ssh->disconnect();
 
         return $logs;

--- a/src/Domains/Connectors/OpenClaw/Actions/CollectDeploymentUsageAction.php
+++ b/src/Domains/Connectors/OpenClaw/Actions/CollectDeploymentUsageAction.php
@@ -43,7 +43,7 @@ class CollectDeploymentUsageAction
         try {
             $rawOutput = $client->exec(
                 'docker exec ' . escapeshellarg($this->deployment->container_name)
-                . ' node /app/dist/index.js status --usage --json 2>&1',
+                . ' node /app/openclaw.mjs status --usage --json 2>&1',
                 60,
             );
         } finally {

--- a/src/Domains/Connectors/OpenClaw/Actions/GetAgentContainerStatusAction.php
+++ b/src/Domains/Connectors/OpenClaw/Actions/GetAgentContainerStatusAction.php
@@ -48,16 +48,42 @@ class GetAgentContainerStatusAction
             return;
         }
 
-        $decoded = json_decode($output, true);
+        // Docker Compose v2 outputs NDJSON — one JSON object per line.
+        // The compose stack has multiple services (gateway + socat-proxy), so we must
+        // find the line whose Name matches the deployment's container name rather than
+        // blindly taking the first line.
+        foreach (explode("\n", trim($output)) as $line) {
+            $line = trim($line);
 
-        if (is_array($decoded)) {
+            if ($line === '') {
+                continue;
+            }
+
+            $decoded = json_decode($line, true);
+
+            if (! is_array($decoded)) {
+                continue;
+            }
+
+            // Skip lines that belong to other containers in the stack.
+            $name = $decoded['Name'] ?? $decoded['name'] ?? '';
+
+            if ($name !== '' && $name !== $this->deployment->container_name) {
+                continue;
+            }
+
             $state = $decoded['State'] ?? $decoded['state'] ?? '';
 
             $this->deployment->status = match (true) {
                 $state === 'running' => DeploymentStatusEnum::RUNNING->value,
-                $state === 'exited' => DeploymentStatusEnum::STOPPED->value,
-                default => $this->deployment->status,
+                $state === 'exited'  => DeploymentStatusEnum::STOPPED->value,
+                default              => $this->deployment->status,
             };
+
+            return;
         }
+
+        // No line matched the deployment's container — mark as stopped.
+        $this->deployment->status = DeploymentStatusEnum::STOPPED->value;
     }
 }

--- a/src/Domains/Connectors/OpenClaw/Jobs/ExecDeploymentCommandJob.php
+++ b/src/Domains/Connectors/OpenClaw/Jobs/ExecDeploymentCommandJob.php
@@ -44,7 +44,7 @@ class ExecDeploymentCommandJob implements ShouldQueue
         try {
             $output = $client->exec(
                 'docker exec ' . escapeshellarg($this->deployment->container_name)
-                . ' node /app/dist/index.js ' . $this->command
+                . ' node /app/openclaw.mjs ' . $this->command
                 . ' 2>&1',
                 120,
             );

--- a/src/Domains/Connectors/OpenClaw/Services/AgentTelemetryService.php
+++ b/src/Domains/Connectors/OpenClaw/Services/AgentTelemetryService.php
@@ -60,8 +60,9 @@ class AgentTelemetryService
 
             // One SSH connection, one exec channel — all commands run in a single shell pipeline.
             // This is far gentler on the server's sshd than opening separate channels per command.
-            $ssh = SshClient::fromMachine($deployment->machine);
-            $sections = $ssh->getAllTelemetry();
+            // Commands run via `docker exec` because the openclaw CLI lives inside the container.
+            $ssh      = SshClient::fromMachine($deployment->machine);
+            $sections = $ssh->getAllTelemetryForContainer($deployment->container_name);
 
             // Per-agent tools: extract unique tool names from this agent's own session JSONL files.
             // Falls back to the machine-level skills list when no session data exists yet.

--- a/src/Domains/Connectors/OpenClaw/SshClient.php
+++ b/src/Domains/Connectors/OpenClaw/SshClient.php
@@ -292,12 +292,64 @@ class SshClient
      * Run all telemetry commands in a SINGLE exec channel to minimise SSH daemon load.
      *
      * Each section is wrapped by unique sentinel lines so the caller can split them.
-     * Returns an associative array keyed by section name (health, status, gateway,
-     * node, memory, os), each containing that command's raw stdout.
+     * Returns an associative array keyed by section name (health, version, gateway, memory),
+     * each containing that command's raw stdout.
      *
-     * One exec channel = one sshd fork on the server side, regardless of how many
-     * commands are piped together.
+     * Commands run via `docker exec` against the agent's container because the openclaw
+     * CLI lives inside the container, not on the host filesystem.
      *
+     * One exec channel = one sshd fork on the server side.
+     *
+     * @return array<string, string>
+     */
+    public function getAllTelemetryForContainer(string $containerName): array
+    {
+        $c   = escapeshellarg($containerName);
+        $cli = 'node /app/openclaw.mjs';
+
+        // Each command is wrapped with `timeout N` inside the container so a single
+        // hanging command cannot consume the entire exec budget.
+        // Individual budgets: health 10s, version 3s, gateway 15s (--deep adds service check), memory 15s.
+        // Worst-case total: ~43s. The outer exec timeout (70s) is the final safety net.
+        // Job timeout is 120s, giving ample headroom above the 70s outer cap.
+        //
+        // `node /app/openclaw.mjs` is used instead of the `openclaw` alias because
+        // the latter is not available in PATH inside the container.
+        $script = implode('; ', [
+            "echo '__SECTION__health'",
+            "docker exec {$c} timeout 10 {$cli} health --json 2>&1",
+            "echo '__SECTION__version'",
+            "docker exec {$c} timeout 3 {$cli} --version 2>/dev/null || echo unknown",
+            "echo '__SECTION__gateway'",
+            "docker exec {$c} timeout 15 {$cli} gateway status --json --deep 2>/dev/null",
+            "echo '__SECTION__memory'",
+            "docker exec {$c} timeout 15 {$cli} memory status 2>&1",
+        ]);
+
+        // Outer safety net: kill the channel if the whole script exceeds 70 s.
+        $raw = $this->exec($script, 70);
+
+        $sections = ['health' => '', 'version' => '', 'gateway' => '', 'memory' => ''];
+        $current  = null;
+
+        foreach (explode("\n", $raw) as $line) {
+            if (str_starts_with($line, '__SECTION__')) {
+                $current = substr($line, strlen('__SECTION__'));
+                $current = trim($current);
+
+                continue;
+            }
+
+            if ($current !== null && array_key_exists($current, $sections)) {
+                $sections[$current] .= $line . "\n";
+            }
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @deprecated Use getAllTelemetryForContainer() for Docker-deployed agents.
      * @return array<string, string>
      */
     public function getAllTelemetry(): array
@@ -360,12 +412,12 @@ class SshClient
         // actual JSONL conversation logs are written inside the container under
         // /home/node/.openclaw/agents/<slug>/sessions/.
         $sessionsDir = '/home/node/.openclaw/agents/' . $agentSlug . '/sessions';
-        $container   = $containerName;
 
-        $raw = $this->exec(
-            'docker exec ' . escapeshellarg($container)
-            . ' find ' . escapeshellarg($sessionsDir) . ' -name "*.jsonl" 2>/dev/null'
-            . ' | xargs -r cat 2>/dev/null',
+        // Run the entire find + cat pipeline inside the container so the host does not
+        // try to read container-internal paths (which would fail silently).
+        $inner = 'find ' . escapeshellarg($sessionsDir) . ' -name "*.jsonl" 2>/dev/null | xargs -r cat 2>/dev/null';
+        $raw   = $this->exec(
+            'docker exec ' . escapeshellarg($containerName) . ' bash -c ' . escapeshellarg($inner),
             15
         );
 
@@ -402,9 +454,13 @@ class SshClient
             }
         }
 
-        // ── Fallback: skills installed on this machine (eligible = installed + usable) ──
+        // ── Fallback: skills installed inside the container (eligible = installed + usable) ──
         // Used when the agent has no recorded session activity yet (e.g. heartbeat-only).
-        $skillsRaw = $this->exec('timeout 5 openclaw skills list --json 2>/dev/null', 10);
+        // `node /app/openclaw.mjs` is used because `openclaw` is not in PATH inside the container.
+        $skillsRaw = $this->exec(
+            'docker exec ' . escapeshellarg($containerName) . ' timeout 5 node /app/openclaw.mjs skills list --json 2>/dev/null',
+            10
+        );
 
         $start = strpos($skillsRaw, '{');
         $end   = strrpos($skillsRaw, '}');
@@ -435,12 +491,12 @@ class SshClient
      * Fetch the last N activity entries from a deployment's session JSONL files.
      *
      * Each deployment writes conversation events (messages, tool calls, model
-     * changes) to JSONL files at:
-     *   /home/<systemUser>/.openclaw/agents/<agentSlug>/sessions/*.jsonl
+     * changes) to JSONL files inside the Docker container at:
+     *   /home/node/.openclaw/agents/<agentSlug>/sessions/*.jsonl
      *
-     * We find the most recently modified session files, read the last $limit
-     * lines combined, and convert each event into a typed log entry. This
-     * requires no RPC auth and survives gateway restarts.
+     * We run the find + tail pipeline inside the container via `docker exec` so
+     * we read the actual files the agent writes. This requires no RPC auth and
+     * survives gateway restarts.
      *
      * Entry types mapped:
      *   session        → info  "Session started"
@@ -450,22 +506,25 @@ class SshClient
      *   model_change   → debug "Model changed to <modelId>"
      *   (other)        → debug "<type>"
      *
-     * @param  string  $systemUser  Linux user for the deployment (e.g. "agent-whitco")
-     * @param  string  $agentSlug   Openclaw agent slug matching the agents/ sub-dir
-     * @param  int     $limit       Max entries to return (default 100)
+     * @param  string  $containerName  Docker container name for the deployment
+     * @param  string  $agentSlug      Openclaw agent slug matching the agents/ sub-dir
+     * @param  int     $limit          Max entries to return (default 100)
      * @return array<int, array{ts:string,level:string,msg:string,meta:string|null}>
      */
-    public function getDeploymentLogs(string $systemUser, string $agentSlug, int $limit = 100): array
+    public function getDeploymentLogs(string $containerName, string $agentSlug, int $limit = 100): array
     {
-        $sessionsDir = '/home/' . $systemUser . '/.openclaw/agents/' . $agentSlug . '/sessions';
+        $sessionsDir = '/home/node/.openclaw/agents/' . $agentSlug . '/sessions';
 
-        // Find the 3 most recently modified session files, tail $limit lines total.
-        // -printf "%T@ %p\n" emits mtime as a unix timestamp so we can sort numerically.
+        // Run the entire find + tail pipeline inside the container so we read the
+        // actual session JSONL files the agent writes (not the host filesystem).
+        // find -printf "%T@ %p\n" emits mtime as a unix timestamp for sorting.
         // tail -q suppresses the "==> file <==" separators between files.
-        $raw = $this->exec(
-            'sudo find ' . escapeshellarg($sessionsDir) . ' -name "*.jsonl" -printf "%T@ %p\n" 2>/dev/null'
+        $inner = 'find ' . escapeshellarg($sessionsDir) . ' -name "*.jsonl" -printf "%T@ %p\n" 2>/dev/null'
             . ' | sort -rn | head -3 | awk \'{print $2}\''
-            . ' | xargs sudo tail -q -n ' . $limit . ' 2>/dev/null',
+            . ' | xargs tail -q -n ' . $limit . ' 2>/dev/null';
+
+        $raw = $this->exec(
+            'docker exec ' . escapeshellarg($containerName) . ' bash -c ' . escapeshellarg($inner),
             10
         );
 

--- a/src/Domains/Connectors/OpenClaw/Templates/docker-compose.yml
+++ b/src/Domains/Connectors/OpenClaw/Templates/docker-compose.yml
@@ -36,6 +36,6 @@ services:
       - {{OPENCLAW_DIR}}/workspace:/home/node/.openclaw/workspace
     environment:
       - NODE_ENV=production
-    entrypoint: ["node", "/app/dist/index.js"]
+    entrypoint: ["node", "/app/openclaw.mjs"]
     profiles:
       - cli

--- a/src/Domains/Connectors/OpenClaw/Templates/entrypoint.sh
+++ b/src/Domains/Connectors/OpenClaw/Templates/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 sudo service cron start
-exec node /app/dist/index.js "$@"
+exec node /app/openclaw.mjs "$@"


### PR DESCRIPTION
## Summary

- **Telemetry (metrics)**: All `health`, `version`, `gateway status`, and `memory status` commands were running on the host shell where `openclaw` is not installed. They now run via `docker exec {container} node /app/openclaw.mjs ...` through a new `getAllTelemetryForContainer()` method. The telemetry cache was never populated so the monitor always showed no data.
- **Logs**: `getDeploymentLogs()` read JSONL session files from the host filesystem (`/home/{systemUser}/.openclaw/...`), but the agent writes them inside the container (`/home/node/.openclaw/...`). The full `find | sort | tail` pipeline now runs inside the container via `docker exec bash -c`.
- **Container status**: `docker compose ps --format json` (Compose v2) outputs NDJSON — one JSON object per container per line. The code called `json_decode()` on the whole output (always null). Now iterates each NDJSON line and matches by container `Name` to pick the gateway, skipping the socat-proxy that shares the stack.
- **Agent tools**: `getAgentTools()` piped `docker exec find` output to `xargs cat` on the host, which tried to read container-internal paths that don't exist locally. Both the primary find+cat pipeline and the skills-list fallback now run entirely inside the container.
- **CLI path**: Replaced all remaining `node /app/dist/index.js` references with `node /app/openclaw.mjs` across all action/job/template files.

## Test plan

- [ ] Deploy to a machine with a running agent and verify the monitor shows telemetry (health, gateway, memory) within 60s
- [ ] Query `agentDeploymentLogs` for a deployment that has had sessions and confirm JSONL entries are returned
- [ ] Trigger `GetAgentContainerStatusAction` and confirm the deployment status syncs correctly for both running and stopped states
- [ ] Confirm `ExecDeploymentCommandJob` and `CollectDeploymentUsageAction` still work with the updated CLI path

🤖 Generated with [Claude Code](https://claude.com/claude-code)