### PR TITLE
feat(social): add has_replies and last_reply_date to Message

### DIFF
--- a/graphql/schemas/Social/message.graphql
+++ b/graphql/schemas/Social/message.graphql
@@ -20,6 +20,8 @@ type Message {
     total_view: Int
     total_children: Int
     total_purchase: Int
+    has_replies: Boolean
+    last_reply_date: DateTime
     parent: Message @cacheRedis
     user: User!
     children: [Message!] @hasMany(type: PAGINATOR)

--- a/src/Domains/Social/Messages/Models/Message.php
+++ b/src/Domains/Social/Messages/Models/Message.php
@@ -15,6 +15,7 @@ use Carbon\Carbon;
 use Dyrynda\Database\Support\CascadeSoftDeletes;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -650,6 +651,22 @@ class Message extends BaseModel
             'default_sorting_field' => 'created_at',
             'enable_nested_fields' => true,
         ];
+    }
+
+    protected function lastReplyDate(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->total_children > 0
+                ? $this->children()->orderByDesc('created_at')->value('created_at')
+                : null,
+        );
+    }
+
+    protected function hasReplies(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => $this->total_children > 0,
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

- Added `has_replies` boolean attribute to `Message` model — returns `true` if the message has child replies (`total_children > 0`), no extra query
- Added `last_reply_date` DateTime attribute to `Message` model — returns the `created_at` of the most recent child message, `null` if none
- Exposed both fields in the `Message` GraphQL type

## Test plan

- [ ] Query a message with replies: `has_replies` should return `true`, `last_reply_date` should return the timestamp of the latest child
- [ ] Query a message without replies: `has_replies` should return `false`, `last_reply_date` should return `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)