### PR TITLE
Release 1.82.4

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -38,10 +38,10 @@ class Kernel extends ConsoleKernel
         $schedule->command(CheckExpiringOrdersCommand::class)->everyMinute();
         $schedule->command(ChargeLateOrdersCommand::class)->hourly();
         $schedule->command(CancelStalePaymentsCommand::class)->everyFiveMinutes();
-        /*         $schedule->command(CollectAgentTelemetryCommand::class)
-                    ->everyMinute()
-                    ->withoutOverlapping(5)
-                    ->runInBackground(); */
+        $schedule->command(CollectAgentTelemetryCommand::class)
+            ->everyTwoMinutes()
+            ->withoutOverlapping(5)
+            ->runInBackground();
         //$schedule->command(SendBookingRemindersCommand::class)->everyFiveMinutes();
         #$schedule->command(ScoutMessageReindexCommand::class, [env('MESSAGE_REINDEX_SCOUT_APP_ID', '13'), env('MESSAGE_REINDEX_SCOUT_MESSAGE_TYPES_ID', '572')])->everyTenMinutes();
         #$schedule->command(MailunregisteredUsersCampaignCommand::class)->weeklyOn(2, '2:30'); //@todo move this to normal cron

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -38,10 +38,10 @@ class Kernel extends ConsoleKernel
         $schedule->command(CheckExpiringOrdersCommand::class)->everyMinute();
         $schedule->command(ChargeLateOrdersCommand::class)->hourly();
         $schedule->command(CancelStalePaymentsCommand::class)->everyFiveMinutes();
-        $schedule->command(CollectAgentTelemetryCommand::class)
-            ->everyTwoMinutes()
-            ->withoutOverlapping(5)
-            ->runInBackground();
+        // $schedule->command(CollectAgentTelemetryCommand::class)
+        //     ->everyTwoMinutes()
+        //     ->withoutOverlapping(5)
+        //     ->runInBackground();
         //$schedule->command(SendBookingRemindersCommand::class)->everyFiveMinutes();
         #$schedule->command(ScoutMessageReindexCommand::class, [env('MESSAGE_REINDEX_SCOUT_APP_ID', '13'), env('MESSAGE_REINDEX_SCOUT_MESSAGE_TYPES_ID', '572')])->everyTenMinutes();
         #$schedule->command(MailunregisteredUsersCampaignCommand::class)->weeklyOn(2, '2:30'); //@todo move this to normal cron

--- a/app/GraphQL/Connector/OpenClaw/Mutations/AgentDeploymentMutation.php
+++ b/app/GraphQL/Connector/OpenClaw/Mutations/AgentDeploymentMutation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Connector\OpenClaw\Mutations;
 
+use Illuminate\Support\Facades\Cache;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\OpenClaw\Actions\CollectDeploymentUsageAction;
 use Kanvas\Connectors\OpenClaw\Actions\DispatchAgentDeploymentAction;
@@ -79,7 +80,9 @@ class AgentDeploymentMutation
         /** @var AgentDeployment $deployment */
         $deployment = AgentDeployment::getByIdFromCompanyApp((int) $request['deployment_id'], $company, $app);
 
-        return new GetAgentContainerLogsAction($deployment, $lines)->execute();
+        $cacheKey = 'openclaw:container-logs:' . $deployment->id . ':' . $lines;
+
+        return Cache::remember($cacheKey, 30, fn () => new GetAgentContainerLogsAction($deployment, $lines)->execute());
     }
 
     public function status(mixed $root, array $request): AgentDeployment
@@ -90,7 +93,12 @@ class AgentDeploymentMutation
         /** @var AgentDeployment $deployment */
         $deployment = AgentDeployment::getByIdFromCompanyApp((int) $request['deployment_id'], $company, $app);
 
-        return new GetAgentContainerStatusAction($deployment)->execute();
+        $cacheKey = 'openclaw:container-status:' . $deployment->id;
+
+        // Return cached status if fresh (30s). The background telemetry job also updates
+        // the deployment record, so the UI gets a live-enough view without an SSH call
+        // on every poll.
+        return Cache::remember($cacheKey, 30, fn () => new GetAgentContainerStatusAction($deployment)->execute());
     }
 
     public function collectUsage(mixed $root, array $request): AgentUsageSnapshot

--- a/app/GraphQL/Connector/OpenClaw/Queries/AgentDeploymentLogsQuery.php
+++ b/app/GraphQL/Connector/OpenClaw/Queries/AgentDeploymentLogsQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Connector\OpenClaw\Queries;
 
+use Illuminate\Support\Facades\Cache;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\OpenClaw\SshClient;
 use Kanvas\Intelligence\Agents\Models\AgentDeployment;
@@ -33,10 +34,14 @@ class AgentDeploymentLogsQuery
             return [];
         }
 
-        $ssh  = SshClient::fromMachine($deployment->machine);
-        $logs = $ssh->getDeploymentLogs($deployment->container_name, $deployment->agent->slug, $limit);
-        $ssh->disconnect();
+        $cacheKey = 'openclaw:deployment-logs:' . $deployment->id . ':' . $limit;
 
-        return $logs;
+        return Cache::remember($cacheKey, 30, function () use ($deployment, $limit) {
+            $ssh  = SshClient::fromMachine($deployment->machine);
+            $logs = $ssh->getDeploymentLogs($deployment->container_name, $deployment->agent->slug, $limit);
+            $ssh->disconnect();
+
+            return $logs;
+        });
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -17856,11 +17856,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.53",
+            "version": "2.1.54",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ef67586798c003274797b288a68b221e4270dca7",
-                "reference": "ef67586798c003274797b288a68b221e4270dca7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
                 "shasum": ""
             },
             "require": {
@@ -17905,7 +17905,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-28T16:09:00+00:00"
+            "time": "2026-04-29T13:31:09+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
-            "version": "4.42.0",
+            "version": "4.43.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/algolia/algoliasearch-client-php.git",
-                "reference": "61063d8473cf3f934ef807770ff5485acb1ea962"
+                "reference": "6a0f952909f334317838ae28bb85adb023ff11ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/61063d8473cf3f934ef807770ff5485acb1ea962",
-                "reference": "61063d8473cf3f934ef807770ff5485acb1ea962",
+                "url": "https://api.github.com/repos/algolia/algoliasearch-client-php/zipball/6a0f952909f334317838ae28bb85adb023ff11ed",
+                "reference": "6a0f952909f334317838ae28bb85adb023ff11ed",
                 "shasum": ""
             },
             "require": {
@@ -69,9 +69,9 @@
             ],
             "support": {
                 "issues": "https://github.com/algolia/algoliasearch-client-php/issues",
-                "source": "https://github.com/algolia/algoliasearch-client-php/tree/4.42.0"
+                "source": "https://github.com/algolia/algoliasearch-client-php/tree/4.43.0"
             },
-            "time": "2026-04-22T17:45:44+00:00"
+            "time": "2026-04-30T09:55:00+00:00"
         },
         {
             "name": "algolia/scout-extended",

--- a/src/Baka/Support/Str.php
+++ b/src/Baka/Support/Str.php
@@ -70,6 +70,25 @@ class Str extends IlluminateStr
         return $phone;
     }
 
+    /**
+     * Convert a phone number to strict E.164 (digits-only with leading '+').
+     * Assumes 10-digit numbers belong to the given default country code (US/DR by default).
+     */
+    public static function toE164(?string $phone, string $defaultCountryCode = '1'): string
+    {
+        $digits = self::digitsOnly($phone);
+
+        if ($digits === '') {
+            return '';
+        }
+
+        if (strlen($digits) === 10) {
+            return '+' . $defaultCountryCode . $digits;
+        }
+
+        return '+' . $digits;
+    }
+
     public static function sanitizeEmail(string $email): string
     {
         return str_replace(['@', '.'], ['-at-', '-dot-'], $email);

--- a/src/Domains/ActionEngine/Engagements/Traits/GeneratesChecklistEngagementUrls.php
+++ b/src/Domains/ActionEngine/Engagements/Traits/GeneratesChecklistEngagementUrls.php
@@ -11,6 +11,7 @@ use Kanvas\ActionEngine\Engagements\Actions\CreateEngagementAction;
 use Kanvas\ActionEngine\Engagements\DataTransferObject\Engagement;
 use Kanvas\ActionEngine\Engagements\Models\Engagement as EngagementModel;
 use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
 use Kanvas\Users\Models\Users;
 
 trait GeneratesChecklistEngagementUrls
@@ -23,7 +24,7 @@ trait GeneratesChecklistEngagementUrls
         ];
 
         $results = [];
-        $aiAgentUserId = (int) $lead->company->get('ai-agent-user-id');
+        $aiAgentUserId = (int) $lead->company->get(IntelligenceConfigurationEnum::AI_AGENT_USER_ID->value);
         $user = $aiAgentUserId ? Users::getById($aiAgentUserId) : $lead->user;
 
         foreach ($actions as $key => $action) {

--- a/src/Domains/Connectors/Elead/Actions/PullLeadAction.php
+++ b/src/Domains/Connectors/Elead/Actions/PullLeadAction.php
@@ -35,9 +35,13 @@ class PullLeadAction
 
     public function execute(array $request, ?ModelsLead $lead = null): array
     {
-        $phone = $request['phone']['cell'] ?? $request['phone']['home'] ?? $request['phone']['work'] ?? null;
-        //$emails = $request['emails'] ?? [];
+        $cellPhone = $request['phone']['cell'] ?? null;
+        $homePhone = $request['phone']['home'] ?? null;
+        $workPhone = $request['phone']['work'] ?? null;
+        $phone = $cellPhone ?? $homePhone ?? $workPhone;
+
         $email = $request['email'] ?? null;
+        $secondEmail = $request['emails'][1]['value'] ?? $request['emails'][1]['address'] ?? null;
         $dob = $request['birthday'] ?? null;
         $firstname = $request['firstname'] ?? null;
         $lastname = $request['lastname'] ?? null;
@@ -222,7 +226,20 @@ class PullLeadAction
 
                         /** @var People $matchedPerson */
                         foreach ($allMatchedPeople as $matchedPerson) {
-                            $nameRank = $this->calculateNameRank($firstname, $lastname, $matchedPerson, $phone, $email);
+                            $nameRank = $this->calculateNameRank(
+                                $firstname,
+                                $lastname,
+                                $matchedPerson,
+                                [
+                                    $cellPhone ?? null,
+                                    $homePhone ?? null,
+                                    $workPhone ?? null,
+                                ],
+                                [
+                                    $email ?? null,
+                                    $secondEmail ?? null,
+                                ]
+                            );
                             $closedLeads = LeadsRepository::getPeopleClosedLeads($matchedPerson)->get();
 
                             if ($closedLeads->isEmpty()) {
@@ -280,16 +297,16 @@ class PullLeadAction
         ?string $eLeadFirstname,
         ?string $eLeadLastname,
         People $person,
-        ?string $searchPhone = null,
-        ?string $searchEmail = null
+        array $searchPhones = [],
+        array $searchEmails = []
     ): float {
         $totalFields = 0;
         $matchedFields = 0;
 
         $hasFirst = $eLeadFirstname !== null && $eLeadFirstname !== '';
         $hasLast = $eLeadLastname !== null && $eLeadLastname !== '';
-        $hasPhone = $searchPhone !== null && $searchPhone !== '';
-        $hasEmail = $searchEmail !== null && $searchEmail !== '';
+        $searchPhones = array_filter(array_map('trim', $searchPhones));
+        $searchEmails = array_filter(array_map('trim', $searchEmails));
 
         if ($hasFirst) {
             $totalFields++;
@@ -319,23 +336,22 @@ class PullLeadAction
             }
         }
 
-        if ($hasPhone) {
+        foreach ($searchPhones as $searchPhone) {
             $totalFields++;
             $personPhones = $person->getAllPhones()->pluck('value')->map(fn ($v) => preg_replace('/\D/', '', (string) $v))->toArray();
             $normalizedSearch = preg_replace('/\D/', '', $searchPhone);
             foreach ($personPhones as $personPhone) {
                 if ($personPhone === $normalizedSearch) {
                     $matchedFields++;
-
                     break;
                 }
             }
         }
 
-        if ($hasEmail) {
+        foreach ($searchEmails as $searchEmail) {
             $totalFields++;
             $personEmails = $person->getEmails()->pluck('value')->map(fn ($v) => strtolower(trim((string) $v)))->toArray();
-            if (in_array(strtolower(trim($searchEmail)), $personEmails, true)) {
+            if (in_array(strtolower($searchEmail), $personEmails, true)) {
                 $matchedFields++;
             }
         }

--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsCalendarEventWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsCalendarEventWebhookJob.php
@@ -34,7 +34,7 @@ class ProcessElevenLabsCalendarEventWebhookJob extends ProcessElevenLabsWebhookJ
 
         $app = $this->receiver->app;
         $company = $this->receiver->company;
-        $user = $this->receiver->user;
+        $user = $this->resolveUser();
         $timezone = $company->get('timezone') ?? $company->timezone ?? 'UTC';
 
         $date = DateHelper::normalizeDate($rawDate, $timezone);

--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsProductShareWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsProductShareWebhookJob.php
@@ -49,7 +49,7 @@ class ProcessElevenLabsProductShareWebhookJob extends ProcessElevenLabsWebhookJo
         $engagementDto = EngagementData::from(
             app: $app,
             company: $company,
-            user: $company->user,
+            user: $this->resolveUser(),
             lead: $lead,
             request: [
                 'action' => 'view-vehicle',

--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsSendMessageWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsSendMessageWebhookJob.php
@@ -7,6 +7,7 @@ namespace Kanvas\Connectors\ElevenLabs\Webhooks;
 use Kanvas\Connectors\Twilio\Enums\ConfigurationEnum as TwilioConfigurationEnum;
 use Kanvas\Guild\Leads\Actions\SendMessageToLeadAction;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadsConfigurationEnum;
+use Kanvas\Guild\Leads\Enums\LeadCommunicationChannelEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Override;
 use Throwable;
@@ -36,9 +37,15 @@ class ProcessElevenLabsSendMessageWebhookJob extends ProcessElevenLabsWebhookJob
 
         $lead = $this->resolveLeadByPhone($phone);
 
-        $channel = isset($payload['channel']) && (string) $payload['channel'] !== ''
+        $requestedChannel = isset($payload['channel']) && (string) $payload['channel'] !== ''
             ? strtolower((string) $payload['channel'])
             : $this->resolveLeadChannel($lead);
+
+        // Phone is always present, so SMS is always attempted; add the requested channel if different.
+        $channels = [LeadCommunicationChannelEnum::SMS->value];
+        if ($requestedChannel !== LeadCommunicationChannelEnum::SMS->value) {
+            $channels[] = $requestedChannel;
+        }
 
         $title = isset($payload['title']) && (string) $payload['title'] !== ''
             ? (string) $payload['title']
@@ -50,23 +57,25 @@ class ProcessElevenLabsSendMessageWebhookJob extends ProcessElevenLabsWebhookJob
         $sendMessage = new SendMessageToLeadAction($lead);
         $sent = [];
 
-        try {
-            $sendMessage->execute(
-                $channel,
-                $message,
-                (string) ($fromPhone ?? ''),
-                $title,
-            );
-            $sent[] = ['channel' => $channel, 'success' => true];
-        } catch (Throwable $e) {
-            $sent[] = ['channel' => $channel, 'success' => false, 'error' => $e->getMessage()];
+        foreach ($channels as $channel) {
+            try {
+                $sendMessage->execute(
+                    $channel,
+                    $message,
+                    (string) ($fromPhone ?? ''),
+                    $title,
+                );
+                $sent[] = ['channel' => $channel, 'success' => true];
+            } catch (Throwable $e) {
+                $sent[] = ['channel' => $channel, 'success' => false, 'error' => $e->getMessage()];
+            }
         }
 
         return [
             'message' => 'Message processed',
             'lead_id' => $lead->getId(),
             'lead_uuid' => $lead->uuid,
-            'channel_used' => $channel,
+            'channels_used' => $channels,
             'sent' => $sent,
         ];
     }

--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsTranscriptWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsTranscriptWebhookJob.php
@@ -15,7 +15,6 @@ use Kanvas\Social\Messages\DataTransferObject\MessageInput;
 use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Social\MessagesTypes\Actions\CreateMessageTypeAction;
 use Kanvas\Social\MessagesTypes\DataTransferObject\MessageTypeInput;
-use Kanvas\Users\Models\Users;
 use Override;
 
 class ProcessElevenLabsTranscriptWebhookJob extends ProcessElevenLabsWebhookJob
@@ -76,7 +75,7 @@ class ProcessElevenLabsTranscriptWebhookJob extends ProcessElevenLabsWebhookJob
             new MessageInput(
                 app: $app,
                 company: $this->receiver->company,
-                user: $this->receiver->user,
+                user: $this->resolveUser(),
                 type: $messageType,
                 message: [
                     'transcript' => $formattedTranscript,
@@ -221,7 +220,7 @@ class ProcessElevenLabsTranscriptWebhookJob extends ProcessElevenLabsWebhookJob
         file_put_contents($tempFile, base64_decode($audioBase64));
 
         try {
-            $user = Users::getById($this->receiver->users_id);
+            $user = $this->resolveUser();
             $filesystem = new FilesystemServices($this->receiver->app);
             $file = $filesystem->upload(
                 new UploadedFile(

--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsWebhookJob.php
@@ -21,11 +21,20 @@ use Kanvas\Guild\Leads\Models\LeadType;
 use Kanvas\Guild\Leads\Repositories\LeadsRepository;
 use Kanvas\Guild\LeadSources\Actions\CreateLeadSourceAction;
 use Kanvas\Guild\LeadSources\DataTransferObject\LeadSource;
+use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
+use Kanvas\Users\Models\Users;
 use Kanvas\Workflow\Jobs\ProcessWebhookJob;
 use Spatie\LaravelData\DataCollection;
 
 abstract class ProcessElevenLabsWebhookJob extends ProcessWebhookJob
 {
+    protected function resolveUser(): Users
+    {
+        $agentUserId = (int) $this->receiver->company->get(IntelligenceConfigurationEnum::AI_AGENT_USER_ID->value);
+
+        return $agentUserId ? Users::getById($agentUserId) : $this->receiver->user;
+    }
+
     protected function resolveLeadByPhone(string $phone): Lead
     {
         $normalizedPhone = Str::normalizePhoneNumber($phone);
@@ -67,7 +76,7 @@ abstract class ProcessElevenLabsWebhookJob extends ProcessWebhookJob
         $peopleDto = new PeopleDto(
             app: $this->receiver->app,
             branch: $this->receiver->company->defaultBranch,
-            user: $this->receiver->user,
+            user: $this->resolveUser(),
             firstname: $phone,
             contacts: Contact::collect($contactData, DataCollection::class),
             address: Address::collect([], DataCollection::class),
@@ -88,6 +97,8 @@ abstract class ProcessElevenLabsWebhookJob extends ProcessWebhookJob
             ->where('name', 'Warm')
             ->firstOrFail();
 
+        $user = $this->resolveUser();
+
         $leadSource = new CreateLeadSourceAction(
             new LeadSource(
                 $people->app,
@@ -103,8 +114,8 @@ abstract class ProcessElevenLabsWebhookJob extends ProcessWebhookJob
             new LeadReceiver(
                 app: $people->app,
                 branch: $people->company->defaultBranch,
-                user: $people->user,
-                agent: $people->user,
+                user: $user,
+                agent: $user,
                 name: 'ElevenLabs Agent',
                 source: 'ElevenLabs Voice Agent',
                 isDefault: false,
@@ -116,13 +127,13 @@ abstract class ProcessElevenLabsWebhookJob extends ProcessWebhookJob
         $leadData = new LeadData(
             app: $people->app,
             branch: $people->company->defaultBranch,
-            user: $people->user,
+            user: $user,
             title: $people->name . ' ElevenLabs Opp',
             pipeline_stage_id: 0,
             people: new PeopleDto(
                 $people->app,
                 $people->company->defaultBranch,
-                $people->user,
+                $user,
                 (string) $people->firstname,
                 Contact::collect($people->contacts()->get()->toArray(), DataCollection::class),
                 Address::collect([], DataCollection::class),

--- a/src/Domains/Connectors/OpenClaw/Jobs/CollectMachineTelemetryJob.php
+++ b/src/Domains/Connectors/OpenClaw/Jobs/CollectMachineTelemetryJob.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\OpenClaw\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Kanvas\Connectors\OpenClaw\Services\AgentTelemetryService;
+use Kanvas\Intelligence\Agents\Models\AgentMachine;
+
+/**
+ * Collect telemetry for all running deployments on a single machine.
+ *
+ * One job per machine instead of one per deployment. A single SSH connection
+ * is opened, all containers are queried sequentially, then the connection is
+ * closed — preventing concurrent SSH hammering when a machine hosts multiple
+ * agents.
+ *
+ * Timeout accounts for the worst case: each deployment runs a 70s pipeline
+ * + a 15s tools exec, so 5 deployments ≈ 425s max. We cap at 300s which
+ * handles the realistic case (1-3 deployments) with headroom to spare.
+ *
+ * ShouldBeUnique ensures a second run for the same machine cannot queue
+ * while the first is still in progress.
+ */
+class CollectMachineTelemetryJob implements ShouldQueue, ShouldBeUnique
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $timeout = 300;
+
+    public int $uniqueFor = 290;
+
+    public function __construct(public readonly int $machineId)
+    {
+        $this->onQueue('openclaw');
+    }
+
+    public function uniqueId(): string
+    {
+        return 'machine-' . $this->machineId;
+    }
+
+    public function handle(AgentTelemetryService $service): void
+    {
+        $machine = AgentMachine::find($this->machineId);
+
+        if ($machine === null) {
+            return;
+        }
+
+        $service->collectForMachine($machine);
+    }
+}

--- a/src/Domains/Connectors/OpenClaw/Services/AgentTelemetryService.php
+++ b/src/Domains/Connectors/OpenClaw/Services/AgentTelemetryService.php
@@ -12,10 +12,11 @@ use Illuminate\Support\Facades\Mail;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\OpenClaw\Enums\ConfigurationEnum;
 use Kanvas\Connectors\OpenClaw\Events\AgentTelemetryUpdated;
-use Kanvas\Connectors\OpenClaw\Jobs\CollectAgentTelemetryJob;
+use Kanvas\Connectors\OpenClaw\Jobs\CollectMachineTelemetryJob;
 use Kanvas\Connectors\OpenClaw\SshClient;
 use Kanvas\Intelligence\Agents\Models\AgentDeployment;
 use Kanvas\Intelligence\Agents\Models\AgentDeploymentEvent;
+use Kanvas\Intelligence\Agents\Models\AgentMachine;
 use Nuwave\Lighthouse\Subscriptions\Contracts\BroadcastsSubscriptions;
 use Swoole\Timer;
 use Throwable;
@@ -38,47 +39,88 @@ class AgentTelemetryService
         Cache::put('openclaw:telemetry:worker', getmypid(), 65);
 
         try {
-            $deployments = AgentDeployment::where('status', 'running')
-                ->with('machine')
-                ->get();
+            // Group by machine so we dispatch ONE job per machine instead of one per deployment.
+            // Each machine job opens a single SSH connection and collects all its deployments
+            // sequentially — dramatically reducing sshd load on busy machines.
+            $machineIds = AgentDeployment::where('status', 'running')
+                ->distinct()
+                ->pluck('agent_machine_id');
         } catch (Throwable $e) {
             Log::warning('OpenClaw telemetry: failed to fetch deployments — ' . $e->getMessage());
 
             return;
         }
 
-        foreach ($deployments as $deployment) {
-            CollectAgentTelemetryJob::dispatch($deployment->id);
+        foreach ($machineIds as $machineId) {
+            CollectMachineTelemetryJob::dispatch((int) $machineId);
         }
     }
 
-    public function collectForDeployment(AgentDeployment $deployment): void
+    /**
+     * Collect telemetry for all running deployments on a machine using a single SSH connection.
+     *
+     * Opening one connection per machine (instead of one per deployment) prevents concurrent
+     * SSH hammering when multiple agents share the same host.
+     */
+    public function collectForMachine(AgentMachine $machine): void
+    {
+        $deployments = AgentDeployment::where('agent_machine_id', $machine->id)
+            ->where('status', 'running')
+            ->with('agent')
+            ->get();
+
+        if ($deployments->isEmpty()) {
+            return;
+        }
+
+        try {
+            $ssh = SshClient::fromMachine($machine);
+        } catch (Throwable $e) {
+            Log::warning("OpenClaw telemetry: SSH connection failed for machine {$machine->id} — {$e->getMessage()}");
+
+            foreach ($deployments as $deployment) {
+                try {
+                    AgentDeploymentEvent::record($deployment->id, AgentDeploymentEvent::AGENT_UNREACHABLE, [
+                        'error' => $e->getMessage(),
+                    ]);
+                    $this->sendSlackAlert($deployment, AgentDeploymentEvent::AGENT_UNREACHABLE, $e->getMessage());
+                } catch (Throwable) {
+                }
+            }
+
+            return;
+        }
+
+        try {
+            foreach ($deployments as $deployment) {
+                $this->collectDeploymentOnConnection($deployment, $ssh);
+            }
+        } finally {
+            $ssh->disconnect();
+        }
+    }
+
+    /**
+     * Collect telemetry for a single deployment using an already-open SSH connection.
+     * All docker exec commands run over the shared connection — no open/close overhead.
+     */
+    protected function collectDeploymentOnConnection(AgentDeployment $deployment, SshClient $ssh): void
     {
         try {
-            // Ensure both relations are loaded — machine for SSH creds, agent for slug (tools lookup).
-            $deployment->loadMissing(['machine', 'agent']);
+            $deployment->loadMissing('agent');
 
-            // One SSH connection, one exec channel — all commands run in a single shell pipeline.
-            // This is far gentler on the server's sshd than opening separate channels per command.
-            // Commands run via `docker exec` because the openclaw CLI lives inside the container.
-            $ssh      = SshClient::fromMachine($deployment->machine);
             $sections = $ssh->getAllTelemetryForContainer($deployment->container_name);
 
-            // Per-agent tools: extract unique tool names from this agent's own session JSONL files.
-            // Falls back to the machine-level skills list when no session data exists yet.
-            // Uses a separate exec call after getAllTelemetry so it doesn't inflate the pipeline timeout.
-            $agentSlug = $deployment->agent?->slug;
+            $agentSlug     = $deployment->agent?->slug;
             $containerName = $deployment->container_name;
-            $tools = ($agentSlug && $containerName)
+            $tools         = ($agentSlug && $containerName)
                 ? $ssh->getAgentTools($containerName, $agentSlug)
                 : null;
 
-            $ssh->disconnect();
-
-            $health = $this->parseJson($sections['health']);
+            $health        = $this->parseJson($sections['health']);
             $gatewayStatus = $this->parseJson($sections['gateway']);
-            $memoryStats = $this->parseMemoryStatus($sections['memory']);
-            $version = $this->parseVersion(trim($sections['version']));
+            $memoryStats   = $this->parseMemoryStatus($sections['memory']);
+            $version       = $this->parseVersion(trim($sections['version']));
 
             if ($health === null) {
                 return;
@@ -113,8 +155,29 @@ class AgentTelemetryService
                 ]);
                 $this->sendSlackAlert($deployment, AgentDeploymentEvent::AGENT_UNREACHABLE, $e->getMessage());
             } catch (Throwable) {
-                // Don't let event recording swallow the original warning
             }
+        }
+    }
+
+    /**
+     * @deprecated Use collectForMachine() — kept for backward compatibility with CollectAgentTelemetryJob.
+     */
+    public function collectForDeployment(AgentDeployment $deployment): void
+    {
+        $deployment->loadMissing(['machine', 'agent']);
+
+        try {
+            $ssh = SshClient::fromMachine($deployment->machine);
+        } catch (Throwable $e) {
+            Log::warning("OpenClaw telemetry: SSH failed for deployment {$deployment->id} — {$e->getMessage()}");
+
+            return;
+        }
+
+        try {
+            $this->collectDeploymentOnConnection($deployment, $ssh);
+        } finally {
+            $ssh->disconnect();
         }
     }
 

--- a/src/Domains/Connectors/Twilio/Actions/AgentChannelResponderAction.php
+++ b/src/Domains/Connectors/Twilio/Actions/AgentChannelResponderAction.php
@@ -65,16 +65,7 @@ class AgentChannelResponderAction extends BaseAgentResponderAction
             );
         }
 
-        $to = Str::replace('twilio-', '', $this->channel->slug);
-        $to = Str::replace('+', '', $to); // Strip any existing +
-
-        // Add country code if needed (assuming +1 for 10-digit numbers)
-        if (strlen($to) === 10) {
-            $to = "+1{$to}";
-        } else {
-            $to = "+{$to}";
-        }
-        //if its missing a +1 add it
+        $to = Str::toE164(Str::replace('twilio-', '', $this->channel->slug));
         $to = $this->hijackMessagePhone($to);
 
         $client = Client::getInstanceByCompany($this->message->company);

--- a/src/Domains/Connectors/Twilio/Actions/DownloadMessageFileAction.php
+++ b/src/Domains/Connectors/Twilio/Actions/DownloadMessageFileAction.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Http;
 use InvalidArgumentException;
 use Kanvas\Connectors\Twilio\Client;
 use Kanvas\Filesystem\Services\FilesystemServices;
+use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
 use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Users\Models\Users;
 
@@ -61,7 +62,7 @@ class DownloadMessageFileAction
         $tempPath = sys_get_temp_dir() . '/' . $filename;
         file_put_contents($tempPath, $response->body());
 
-        $agentUser = $this->message->company->get('ai-agent-user-id');
+        $agentUser = $this->message->company->get(IntelligenceConfigurationEnum::AI_AGENT_USER_ID->value);
         if ($agentUser !== null) {
             $user = Users::getById($agentUser);
         } else {

--- a/src/Domains/Connectors/VoiceBridge/Jobs/SaveCallRecordingJob.php
+++ b/src/Domains/Connectors/VoiceBridge/Jobs/SaveCallRecordingJob.php
@@ -17,6 +17,7 @@ use Kanvas\Connectors\Twilio\Client as TwilioClient;
 use Kanvas\Connectors\VoiceBridge\Actions\FetchCallRecordingAction;
 use Kanvas\Filesystem\Services\FilesystemServices;
 use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
 use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Users\Models\Users;
 use Throwable;
@@ -54,7 +55,7 @@ class SaveCallRecordingJob implements ShouldQueue
 
             $filesystemService = new FilesystemServices($app, $this->lead->company);
 
-            $agentUserId = $this->lead->company->get('ai-agent-user-id');
+            $agentUserId = $this->lead->company->get(IntelligenceConfigurationEnum::AI_AGENT_USER_ID->value);
             $user = $agentUserId !== null
                 ? Users::getById((int) $agentUserId)
                 : Users::getById($this->lead->users_id);

--- a/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
@@ -264,6 +264,7 @@ class SendMessageToLeadAction
         }
 
         $cellphone = $this->hijackPhoneNumber($cellphone, 'twilio-');
+        $cellphone = Str::toE164($cellphone);
 
         $engagementUrls = array_filter(array_column($this->videoEngagements, 'url'));
         $fullMessage = $message;

--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
@@ -12,6 +12,7 @@ use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Services\NotifyLeadStakeholdersService;
 use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\Services\LeadConfigurationService;
 use Kanvas\Intelligence\Sessions\Models\Session;
@@ -79,7 +80,7 @@ class BaseAgentResponderAction
         ?string $from = null
     ): Message {
         $user = $message->user;
-        $agentUser = $this->channel->company->get('ai-agent-user-id');
+        $agentUser = $this->channel->company->get(IntelligenceConfigurationEnum::AI_AGENT_USER_ID->value);
         if ($agentUser !== null) {
             $user = Users::getById((int) $agentUser);
         }

--- a/src/Domains/Intelligence/Enums/ConfigurationEnum.php
+++ b/src/Domains/Intelligence/Enums/ConfigurationEnum.php
@@ -27,6 +27,7 @@ enum ConfigurationEnum: string
     case LAST_MESSAGE_TIME = 'last_message_time';
     case LAST_MESSAGE = 'last_message';
     case MUTE_AI_AGENT = 'ai_control';
+    case AI_AGENT_USER_ID = 'ai-agent-user-id';
     case FIRST_MESSAGE_ONLY_DURING_BUSINESS_HOURS = 'ai_agent_first_message_only_during_business_hours';
     case FIRST_MESSAGE_ONLY_DURING_OFF_BUSINESS_HOURS = 'ai_agent_first_message_only_during_off_business_hours';
     case AI_ENGAGEMENT_MESSAGE_ONLY_ONE_NOTIFICATION = 'ai_engagement_message_only_one_notification';

--- a/src/Domains/Intelligence/PipelinesStages/Actions/CreateMessageFollowUpAction.php
+++ b/src/Domains/Intelligence/PipelinesStages/Actions/CreateMessageFollowUpAction.php
@@ -15,6 +15,7 @@ use Kanvas\Guild\Leads\Models\Lead as ModelsLead;
 use Kanvas\Guild\Pipelines\Models\PipelineStage;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Enums\AgentEnum;
+use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
 use Kanvas\Intelligence\FollowUp\Models\FollowUpLog;
 use Kanvas\Intelligence\Sessions\Actions\CreateContentSessionAction;
 use Kanvas\Intelligence\Sessions\Models\Session;
@@ -104,7 +105,7 @@ class CreateMessageFollowUpAction
             $this->getMessageTypeVerb()
         );
 
-        $agentUser = $this->lead->company->get('ai-agent-user-id');
+        $agentUser = $this->lead->company->get(IntelligenceConfigurationEnum::AI_AGENT_USER_ID->value);
         if ($agentUser !== null) {
             $user = Users::getById($agentUser);
         } else {

--- a/src/Domains/Intelligence/Workflows/LeadAgentFirstMessageOutreachActivity.php
+++ b/src/Domains/Intelligence/Workflows/LeadAgentFirstMessageOutreachActivity.php
@@ -428,7 +428,7 @@ class LeadAgentFirstMessageOutreachActivity extends KanvasActivity
         bool $runWorkflow = true,
     ): Message {
         $user = $lead->user;
-        $agentUser = $lead->company->get('ai-agent-user-id');
+        $agentUser = $lead->company->get(EnumsConfigurationEnum::AI_AGENT_USER_ID->value);
         if ($agentUser !== null) {
             $user = Users::getById((int) $agentUser);
         }

--- a/tests/Baka/Unit/StrPhoneTest.php
+++ b/tests/Baka/Unit/StrPhoneTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Baka\Unit;
+
+use Baka\Support\Str;
+use Tests\TestCaseUnit;
+
+final class StrPhoneTest extends TestCaseUnit
+{
+    public function testToE164PrependsPlusOneFor10DigitUsNumber(): void
+    {
+        $this->assertSame('+14047907130', Str::toE164('4047907130'));
+    }
+
+    public function testToE164PreservesUsNumberWithCountryCode(): void
+    {
+        $this->assertSame('+14047907130', Str::toE164('14047907130'));
+    }
+
+    public function testToE164KeepsExistingE164(): void
+    {
+        $this->assertSame('+14047907130', Str::toE164('+14047907130'));
+    }
+
+    public function testToE164StripsDashesAndParens(): void
+    {
+        $this->assertSame('+14047907130', Str::toE164('(404) 790-7130'));
+        $this->assertSame('+14047907130', Str::toE164('404-790-7130'));
+        $this->assertSame('+14047907130', Str::toE164('+1 (404) 790-7130'));
+    }
+
+    public function testToE164StripsSpaces(): void
+    {
+        $this->assertSame('+14047907130', Str::toE164(' 404 790 7130 '));
+    }
+
+    public function testToE164SupportsDominicanAreaCodes(): void
+    {
+        $this->assertSame('+18098646241', Str::toE164('8098646241'));
+        $this->assertSame('+18298646241', Str::toE164('829-864-6241'));
+        $this->assertSame('+18498646241', Str::toE164('+1 849 864 6241'));
+    }
+
+    public function testToE164InternationalNumberKeepsCountryCodeAndAddsPlus(): void
+    {
+        $this->assertSame('+442012345678', Str::toE164('442012345678'));
+        $this->assertSame('+442012345678', Str::toE164('+44 20 1234 5678'));
+    }
+
+    public function testToE164ReturnsEmptyStringForEmptyOrNullInput(): void
+    {
+        $this->assertSame('', Str::toE164(null));
+        $this->assertSame('', Str::toE164(''));
+        $this->assertSame('', Str::toE164('---'));
+    }
+
+    public function testToE164RespectsCustomDefaultCountryCode(): void
+    {
+        $this->assertSame('+525512345678', Str::toE164('5512345678', '52'));
+        // 11+ digit input ignores the default; the digits already imply a country code.
+        $this->assertSame('+525512345678', Str::toE164('525512345678', '1'));
+    }
+
+    public function testToE164NeverDoublesPlusOnAlreadyPrefixedShortInput(): void
+    {
+        // `+` plus 10 digits — `digitsOnly` strips the +, then the 10-digit branch adds +1.
+        $this->assertSame('+14047907130', Str::toE164('+4047907130'));
+    }
+}

--- a/tests/Intelligence/Leads/LeadContextCreationTest.php
+++ b/tests/Intelligence/Leads/LeadContextCreationTest.php
@@ -176,7 +176,7 @@ final class LeadContextCreationTest extends TestCase
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
-        $company->set('ai-agent-user-id', $user->getId());
+        $company->set(EnumsConfigurationEnum::AI_AGENT_USER_ID->value, $user->getId());
         $setupInventory = new Setup($app, $user, $company);
         $setupInventory->run();
 


### PR DESCRIPTION
## Summary

Patch release carved out of `release/1.83.0` (PR #9407) excluding the NervousSystem work, so we can ship Elead + AI agent fixes without holding for the new domain.

**Included:**
- PR #9393 — Elead lead matching rate improvement (multiple phones/emails)
- PR #9396 — OpenClaw: reduce SSH load on agent machines
- PR #9399 — Bump `algolia/algoliasearch-client-php` 4.42.0 → 4.43.0
- PR #9400 — Bump `phpstan/phpstan` 2.1.53 → 2.1.54 (dev)
- `decf098ed` — ElevenLabs webhook agent-id updates (cherry-picked from `release/1.83.0`)
- PR #9408 — Twilio phone hotfix

**Excluded (deferred to 1.83):**
- All `feat/nervous-system*` commits and the NervousSystem domain
- Two `Lead.php` hotfixes that only added the `EmitsNervousSystemEvents` trait

## Test plan

- [ ] CI green on this PR
- [ ] Smoke-test Elead lead matching against a known multi-phone/email lead
- [ ] Verify OpenClaw telemetry job runs without spamming SSH
- [ ] Verify ElevenLabs webhooks process with the updated agent id resolution
- [ ] Tag `v1.82.4` after merge
