### PR TITLE
fix(elevenlabs): SMS/WhatsApp to payload phone, not lead cellphone

### DIFF
--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsProductShareWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsProductShareWebhookJob.php
@@ -86,7 +86,12 @@ class ProcessElevenLabsProductShareWebhookJob extends ProcessElevenLabsWebhookJo
 
         try {
             if ($fromPhone) {
-                $sendMessage->execute('sms', $smsMessage, (string) $fromPhone);
+                $sendMessage->execute(
+                    channel: 'sms',
+                    message: $smsMessage,
+                    from: (string) $fromPhone,
+                    to: $phone,
+                );
                 $smsSent = true;
             }
         } catch (Throwable $e) {

--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsSendMessageWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsSendMessageWebhookJob.php
@@ -60,10 +60,11 @@ class ProcessElevenLabsSendMessageWebhookJob extends ProcessElevenLabsWebhookJob
         foreach ($channels as $channel) {
             try {
                 $sendMessage->execute(
-                    $channel,
-                    $message,
-                    (string) ($fromPhone ?? ''),
-                    $title,
+                    channel: $channel,
+                    message: $message,
+                    from: (string) ($fromPhone ?? ''),
+                    title: $title,
+                    to: $phone,
                 );
                 $sent[] = ['channel' => $channel, 'success' => true];
             } catch (Throwable $e) {

--- a/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
@@ -44,7 +44,8 @@ class SendMessageToLeadAction
         ?string $from = '',
         ?string $title = null,
         bool $signature = true,
-        ?Collection $files = null
+        ?Collection $files = null,
+        ?string $to = null
     ): array {
         if ($files !== null && $files->isNotEmpty()) {
             $this->processedFiles = $this->prepareFiles($files);
@@ -52,8 +53,8 @@ class SendMessageToLeadAction
         }
 
         return match ($channel) {
-            LeadCommunicationChannelEnum::WHATSAPP->value => $this->sendWhatsAppMessage($message),
-            LeadCommunicationChannelEnum::SMS->value => $this->sendSmsMessage($from, $message),
+            LeadCommunicationChannelEnum::WHATSAPP->value => $this->sendWhatsAppMessage($message, $to),
+            LeadCommunicationChannelEnum::SMS->value => $this->sendSmsMessage((string) $from, $message, $to),
             LeadCommunicationChannelEnum::EMAIL->value => $this->sendEmailMessage($message, $title, $signature),
             LeadCommunicationChannelEnum::VOICE->value => $this->sendVoiceMessage($message),
             default => throw new InvalidArgumentException('Unsupported communication channel ' . $channel),
@@ -194,7 +195,7 @@ class SendMessageToLeadAction
         return $this->videoEngagements;
     }
 
-    protected function sendWhatsAppMessage(string $message): array
+    protected function sendWhatsAppMessage(string $message, ?string $to = null): array
     {
         $isFromWhatsapp = (bool) $this->lead->get(ConfigurationEnum::IS_FROM_WHATSAPP->value);
         $hasOutboundConfigured = ! empty($this->lead->app->get(WaSenderConfigurationEnum::BASE_URL_OUTBOUND->value));
@@ -205,12 +206,14 @@ class SendMessageToLeadAction
             outbound: ! $isFromWhatsapp && $hasOutboundConfigured
         );
 
-        $cellphone = $this->lead->people->getCellPhones()->first()?->value;
+        $cellphone = ($to !== null && $to !== '')
+            ? $to
+            : $this->lead->people->getCellPhones()->first()?->value;
 
-        if (! $cellphone) {
+        if ($cellphone === null || $cellphone === '') {
             throw new InvalidArgumentException('Lead does not have a cellphone number');
         }
-        $cellphone = $this->hijackPhoneNumber($cellphone, '@s.whatsapp.net');
+        $cellphone = $this->hijackPhoneNumber((string) $cellphone, '@s.whatsapp.net');
 
         $this->sendWhatsAppMediaFiles($whatsAppMessageService, $cellphone);
 
@@ -253,17 +256,19 @@ class SendMessageToLeadAction
         }
     }
 
-    protected function sendSmsMessage(string $from, string $message): array
+    protected function sendSmsMessage(string $from, string $message, ?string $to = null): array
     {
         $client = Client::getInstanceByCompany($this->lead->company);
 
-        $cellphone = $this->lead->people->getCellPhones()->first()?->value;
+        $cellphone = ($to !== null && $to !== '')
+            ? $to
+            : $this->lead->people->getCellPhones()->first()?->value;
 
-        if (! $cellphone) {
+        if ($cellphone === null || $cellphone === '') {
             throw new InvalidArgumentException('Lead does not have a cellphone number');
         }
 
-        $cellphone = $this->hijackPhoneNumber($cellphone, 'twilio-');
+        $cellphone = $this->hijackPhoneNumber((string) $cellphone, 'twilio-');
         $cellphone = Str::toE164($cellphone);
 
         $engagementUrls = array_filter(array_column($this->videoEngagements, 'url'));


### PR DESCRIPTION
## Summary

Follow-up to #9410. Two ElevenLabs webhooks were silently failing or surfacing `"Lead does not have a cellphone number"` when the matched lead's phone was stored as `PHONE` (or any non-`CELLPHONE` ContactType).

- **`ProcessElevenLabsProductShareWebhookJob`** — silently swallowed the error, returned `sms_sent: false` while the engagement still got created.
- **`ProcessElevenLabsSendMessageWebhookJob`** — surfaced the error explicitly:
  ```json
  { "error": "Lead does not have a cellphone number", "channel": "sms", "success": false }
  ```

Both webhooks already have a verified phone in the payload — that's the number the agent used to reach the lead in the first place. We should send to that number, not to whatever the lead's `getCellPhones()->first()` resolves to.

## Changes

- `SendMessageToLeadAction::execute()` — adds an optional `?string $to = null` parameter (last position).
- `sendSmsMessage()` and `sendWhatsAppMessage()` — use `$to` when provided, otherwise fall back to the existing `getCellPhones()->first()` lookup. Throws only when neither is available.
- `ProcessElevenLabsProductShareWebhookJob` and `ProcessElevenLabsSendMessageWebhookJob` — pass the payload `phone` as `to`.

Fully backwards-compatible — every existing caller of `SendMessageToLeadAction::execute()` keeps working unchanged. Only the two ElevenLabs webhooks opt in to the explicit recipient.

## Test plan

- [ ] Trigger product-share webhook with the failing payload (`phone: 4047907130, variant_id: 465403`); confirm `sms_sent: true` and the SMS arrives at that number
- [ ] Trigger send-message webhook with the same lead; confirm `sent[].success: true` for the `sms` channel
- [ ] Smoke-test a normal lead path that does have a `CELLPHONE` contact (no regression on the fallback path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)