### PR TITLE
feat(copic): notify admins when netsuite sync exhausts retries

### DIFF
--- a/src/Domains/Connectors/NetSuite/Workflow/PushOrderToNetsuiteActivity.php
+++ b/src/Domains/Connectors/NetSuite/Workflow/PushOrderToNetsuiteActivity.php
@@ -8,11 +8,14 @@ use Baka\Contracts\AppInterface;
 use Illuminate\Database\Eloquent\Model;
 use Kanvas\Connectors\NetSuite\Actions\PushOrderToNetSuiteQuoteAction;
 use Kanvas\Connectors\NetSuite\Enums\CustomFieldEnum;
+use Kanvas\Souk\Orders\Models\Order;
+use Kanvas\Users\Actions\SendUserNotificationAction;
 use Kanvas\Workflow\Contracts\WorkflowActivityInterface;
 use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Kanvas\Workflow\KanvasActivity;
 use Override;
 use RuntimeException;
+use Throwable;
 
 class PushOrderToNetsuiteActivity extends KanvasActivity implements WorkflowActivityInterface
 {
@@ -21,7 +24,7 @@ class PushOrderToNetsuiteActivity extends KanvasActivity implements WorkflowActi
     {
         $this->overwriteAppService($app);
 
-        $response = $this->executeIntegration(
+        return $this->executeIntegration(
             entity: $order,
             app: $app,
             integration: IntegrationsEnum::NETSUITE,
@@ -44,19 +47,47 @@ class PushOrderToNetsuiteActivity extends KanvasActivity implements WorkflowActi
                 ];
 
                 if ($result['success'] === false) {
+                    $errorMessage = $result['data']['error'] ?? $result['message'] ?? '';
+
+                    if ($this->isNetSuiteRateLimitError($errorMessage)) {
+                        throw new RuntimeException('NetSuite rate limit hit, retrying: ' . $errorMessage);
+                    }
+
                     return $this->failWorkflow($responseData);
                 }
 
                 return $responseData;
             },
             company: $order->company,
+            throwException: true,
         );
+    }
 
-        if ($this->isNetSuiteRateLimitError($response['error'] ?? $response['message'] ?? '')) {
-            throw new RuntimeException('NetSuite concurrent request limit exceeded. Retrying...');
+    #[Override]
+    public function failed(Throwable $throwable): void
+    {
+        [$order, $app] = $this->arguments + [null, null];
+
+        if ($order instanceof Order) {
+            report(new RuntimeException(sprintf(
+                'NetSuite order sync exhausted retries for order %d: %s',
+                $order->getId(),
+                $throwable->getMessage()
+            )));
         }
 
-        return $response;
+        if ($order instanceof Order && $app instanceof AppInterface) {
+            new SendUserNotificationAction(
+                $app,
+                $order->company,
+                $order->user
+            )->execute('netsuite-order-sync-failed', [
+                'order' => $order,
+                'error' => $throwable->getMessage(),
+            ]);
+        }
+
+        parent::failed($throwable);
     }
 
     protected function isNetSuiteRateLimitError(string $message): bool


### PR DESCRIPTION
Two changes to PushOrderToNetsuiteActivity:

1. Rate-limit detection moved inside the executeIntegration closure. The previous post-hoc check read the wrong response key ($response['error'] never existed at the top level) and let failWorkflow() flip integration status to FAILED on every transient retry. Now throws RuntimeException before failWorkflow() runs, so the integration history records a single proper FAILED entry per attempt. Passes throwException: true so Laravel-Workflow's queue layer sees the throw and retries per KanvasActivity::$tries = 3.

2. Added failed() override that fires once after retries exhaust:
   - Emits a distinct Sentry event ("NetSuite order sync exhausted retries for order N: ...") so an alert can fire on this without being drowned out by the per-retry rate-limit reports already emitted by executeIntegration's catch block.
   - Sends the netsuite-order-sync-failed email to OWNER-role users on the order's company via SendUserNotificationAction (same recipient resolution as B2BUpdateCompanyOrderActivity). Only B2B orders are pushed to NetSuite, so the action's B2B-company gate is a no-op in practice.
   - Calls parent::failed() so Laravel-Workflow's Exception signal still dispatches and the parent workflow can react.

Pre-deploy actions tracked in .planning/copic/changelog.md and full session detail in .planning/sessions/2026-05-01/.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
