### PR TITLE
Fix Movipass vehicle plate reference on 1.x

### DIFF
--- a/app/Console/Commands/Souk/OrderFinishExpiredCommand.php
+++ b/app/Console/Commands/Souk/OrderFinishExpiredCommand.php
@@ -201,7 +201,7 @@ class OrderFinishExpiredCommand extends Command
         $config = ConfigurationEnum::SEND_EXPIRED_ORDER_FINISHED_NOTIFICATION->value;
 
         return $this->enabled($order->app?->get($config))
-            && $this->enabled($order->company?->get($config));
+            || $this->enabled($order->company?->get($config));
     }
 
     protected function shouldSendExpiringOrderNotification(Order $order): bool
@@ -209,7 +209,7 @@ class OrderFinishExpiredCommand extends Command
         $config = ConfigurationEnum::SEND_EXPIRING_ORDER_NOTIFICATION->value;
 
         return $this->enabled($order->app?->get($config))
-            && $this->enabled($order->company?->get($config));
+            || $this->enabled($order->company?->get($config));
     }
 
     protected function getExpiringOrderNotificationMinutes(Order $order): int

--- a/src/Domains/Connectors/Movipass/Workflows/Activities/SyncMovipassActivity.php
+++ b/src/Domains/Connectors/Movipass/Workflows/Activities/SyncMovipassActivity.php
@@ -53,7 +53,9 @@ class SyncMovipassActivity extends KanvasActivity implements WorkflowActivityInt
 
                 if ($eventName === WorkflowEnum::CREATED->value) {
                     if ($order->reference && ! str_contains($order->reference, '#' . $order->order_number)) {
-                        $order->reference = $order->reference . ' ' . $order->metadata['data']['vehiclePlate'] ?? '' . ' - #' . $order->order_number;
+                        $vehiclePlate = $order->metadata['data']['vehiclePlate'] ?? '';
+                        $referenceParts = array_filter([$vehiclePlate, '#' . $order->order_number]);
+                        $order->reference = $order->reference . ' ' . implode(' - ', $referenceParts);
                     }
 
                     $qrHost = $app->get(ConfigurationEnum::QR_CODE_HOST->value) ?? 'https://go-parking-web.vercel.app';

--- a/tests/Connectors/Integration/Movipass/SyncMovipassActivityTest.php
+++ b/tests/Connectors/Integration/Movipass/SyncMovipassActivityTest.php
@@ -164,7 +164,7 @@ final class SyncMovipassActivityTest extends TestCase
         $activity = new SyncMovipassActivity(
             0,
             now()->toDateTimeString(),
-            StoredWorkflow::make(),
+            new StoredWorkflow(),
             []
         );
 
@@ -197,7 +197,7 @@ final class SyncMovipassActivityTest extends TestCase
         $activity = new SyncMovipassActivity(
             0,
             now()->toDateTimeString(),
-            StoredWorkflow::make(),
+            new StoredWorkflow(),
             []
         );
 
@@ -222,7 +222,7 @@ final class SyncMovipassActivityTest extends TestCase
         $activity = new SyncMovipassActivity(
             0,
             now()->toDateTimeString(),
-            StoredWorkflow::make(),
+            new StoredWorkflow(),
             []
         );
 
@@ -236,5 +236,32 @@ final class SyncMovipassActivityTest extends TestCase
         $this->assertEquals(0, $order->orderDiscounts()->count());
         $this->assertNull($order->discount_name);
         $this->assertNull($order->voucher_id);
+    }
+
+    public function testCreatedOrderWithoutVehiclePlateUpdatesReference(): void
+    {
+        $app = app(Apps::class);
+
+        $order = $this->createMovipassOrder($app);
+        $metadata = $order->metadata;
+        unset($metadata['data']['vehiclePlate']);
+        $order->metadata = $metadata;
+        $order->saveQuietly();
+
+        $activity = new SyncMovipassActivity(
+            0,
+            now()->toDateTimeString(),
+            new StoredWorkflow(),
+            []
+        );
+
+        $result = $activity->execute($order, $app, [
+            'currentEventTypeName' => WorkflowEnum::CREATED->value,
+        ]);
+
+        $order->refresh();
+
+        $this->assertEquals('success', $result['status']);
+        $this->assertSame('Movipass parking test #' . $order->order_number, $order->reference);
     }
 }


### PR DESCRIPTION
## Summary
- Fix Movipass reference generation when `metadata.data.vehiclePlate` is missing
- Add a regression test for created Movipass orders without a vehicle plate
- Allow expired/expiring order notifications when either app or company config is enabled

## Validation
- `php -l app/Console/Commands/Souk/OrderFinishExpiredCommand.php`
- `php -l src/Domains/Connectors/Movipass/Workflows/Activities/SyncMovipassActivity.php`
- `php -l tests/Connectors/Integration/Movipass/SyncMovipassActivityTest.php`

PHPStan could not bootstrap Laravel in the separate 1.x worktree because the local app container failed resolving `Silber\Bouncer\Contracts\Clipboard`.