### PR TITLE
feat: add dealership_name and company_language to ElevenLabs init

### DIFF
--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsConversationInitiationWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsConversationInitiationWebhookJob.php
@@ -32,6 +32,8 @@ class ProcessElevenLabsConversationInitiationWebhookJob extends ProcessElevenLab
             'elevenlabs_agent_id' => isset($payload['agent_id']) ? (string) $payload['agent_id'] : '',
             'current_date' => $currentDate,
             'timezone' => (string) $timezone,
+            'dealership_name' => $company->name,
+            'company_language' => $company->language,
             'contact_exists' => false,
             'has_open_opportunity' => false,
             'customer_name' => '',


### PR DESCRIPTION
## Summary
- Adds `dealership_name` (company name) and `company_language` to the dynamic variables passed to ElevenLabs on the conversation initiation webhook.

## Test plan
- [ ] Trigger an ElevenLabs conversation initiation webhook and verify the new variables are present in the payload sent to the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)