### PR TITLE
refactor: extract bulk recharge logic into BulkRechargeOrderTagsAction

### DIFF
--- a/src/Domains/Connectors/Movipass/Actions/BulkRechargeOrderTagsAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/BulkRechargeOrderTagsAction.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Movipass\Actions;
+
+use Baka\Contracts\AppInterface;
+use Illuminate\Support\Facades\Log;
+use Kanvas\Connectors\EchoPay\Enums\CustomFieldEnum as EchoPayCustomFieldEnum;
+use Kanvas\Connectors\Movipass\Enums\OrderTypeEnum;
+use Kanvas\Connectors\PasoRapido\DataTransferObject\PaymentConfirmData;
+use Kanvas\Connectors\PasoRapido\Services\PasoRapidoService;
+use Kanvas\Souk\Orders\Models\Order;
+use Kanvas\Souk\Wallet\Actions\BuildWalletTransactionMetaAction;
+use Kanvas\Souk\Wallet\Enums\TransactionSourceEnum;
+use RuntimeException;
+use Throwable;
+
+class BulkRechargeOrderTagsAction
+{
+    public function __construct(
+        protected readonly Order $order,
+        protected readonly AppInterface $app,
+    ) {
+    }
+
+    public function execute(): array
+    {
+        $company = $this->order->company;
+        $wallet = $company->createAppWallet($this->app, ['name' => 'default']);
+
+        $creditMeta = new BuildWalletTransactionMetaAction(
+            source: TransactionSourceEnum::RECHARGE_MANUAL,
+            actorUserId: $this->order->users_id,
+            externalReference: $this->order->uuid,
+            reason: 'Corporate bulk recharge funding',
+            additional: [
+                'service' => OrderTypeEnum::PASO_RAPIDO->value,
+                'order_id' => $this->order->getId(),
+                'is_bulk_recharge' => true,
+            ],
+        )->execute();
+
+        $wallet->depositFloat((float) $this->order->total_gross_amount, $creditMeta);
+
+        $dni = (string) ($company->get('rnc') ?? '');
+        $bankTransaction = $this->resolveBankTransaction();
+
+        $service = null;
+        $serviceError = null;
+
+        try {
+            $service = new PasoRapidoService($this->app, $company);
+        } catch (Throwable $e) {
+            report($e);
+            $serviceError = $e->getMessage();
+        }
+
+        $results = [];
+
+        foreach ($this->order->items as $item) {
+            $tagNumber = (string) ($item->metadata['tag_number'] ?? '');
+
+            if ($tagNumber === '') {
+                continue;
+            }
+
+            $amount = (float) $item->unit_price_gross_amount;
+            $fiscalCredit = (bool) ($item->metadata['fiscal_credit'] ?? false);
+
+            if ($service === null) {
+                $results[$tagNumber] = [
+                    'status' => 'failed',
+                    'amount' => $amount,
+                    'error' => 'PasoRapido service unavailable: ' . $serviceError,
+                    'order_item_id' => $item->getId(),
+                ];
+
+                continue;
+            }
+
+            $withdrawn = false;
+
+            try {
+                $debitMeta = new BuildWalletTransactionMetaAction(
+                    source: TransactionSourceEnum::PAYMENT,
+                    actorUserId: $this->order->users_id,
+                    externalReference: "bulk:{$this->order->uuid}:{$tagNumber}",
+                    reason: "Corporate bulk recharge TAG {$tagNumber}",
+                    additional: [
+                        'service' => OrderTypeEnum::PASO_RAPIDO->value,
+                        'tag_number' => $tagNumber,
+                        'order_id' => $this->order->getId(),
+                        'order_item_id' => $item->getId(),
+                    ],
+                )->execute();
+
+                $wallet->withdrawFloat($amount, $debitMeta);
+                $withdrawn = true;
+
+                $confirmResponse = $service->confirmPayment(new PaymentConfirmData(
+                    reference: $tagNumber,
+                    bankTransaction: $bankTransaction,
+                    amount: $amount,
+                    fiscalCredit: $fiscalCredit,
+                    dni: $dni,
+                ));
+
+                if (! $confirmResponse->tag) {
+                    throw new RuntimeException('PasoRapido did not confirm TAG ' . $tagNumber);
+                }
+
+                $results[$tagNumber] = [
+                    'status' => 'success',
+                    'amount' => $amount,
+                    'order_item_id' => $item->getId(),
+                ];
+            } catch (Throwable $e) {
+                report($e);
+
+                if ($withdrawn) {
+                    try {
+                        $wallet->depositFloat($amount, [
+                            'source' => TransactionSourceEnum::REFUND_TECHNICAL->value,
+                            'reason' => 'Reversal: PasoRapido error for TAG ' . $tagNumber,
+                            'original_error' => $e->getMessage(),
+                            'tag_number' => $tagNumber,
+                            'order_id' => $this->order->getId(),
+                            'order_item_id' => $item->getId(),
+                        ]);
+                    } catch (Throwable $reversalEx) {
+                        report($reversalEx);
+                        Log::error('BulkRechargeOrderTagsAction: reversal failed — manual intervention required', [
+                            'tag' => $tagNumber,
+                            'amount' => $amount,
+                            'order_id' => $this->order->getId(),
+                            'order_item_id' => $item->getId(),
+                            'error' => $reversalEx->getMessage(),
+                        ]);
+                    }
+                }
+
+                $results[$tagNumber] = [
+                    'status' => 'failed',
+                    'amount' => $amount,
+                    'error' => $e->getMessage(),
+                    'order_item_id' => $item->getId(),
+                ];
+            }
+        }
+
+        $metadata = $this->order->metadata ?? [];
+        $metadata['corporate_recharge_results'] = $results;
+        $this->order->metadata = $metadata;
+        $this->order->saveOrFail();
+
+        $successCount = count(array_filter($results, fn ($r) => $r['status'] === 'success'));
+        $failCount = count($results) - $successCount;
+
+        return [
+            'result' => true,
+            'order_id' => $this->order->getId(),
+            'total' => count($results),
+            'success' => $successCount,
+            'failed' => $failCount,
+        ];
+    }
+
+    private function resolveBankTransaction(): string
+    {
+        $intentId = $this->order->get(EchoPayCustomFieldEnum::ECHO_PAY_PAYMENT_INTENT_ID->value);
+
+        if ($intentId) {
+            return explode(':', (string) $intentId)[1] ?? (string) $intentId;
+        }
+
+        return 'wallet_bulk_' . $this->order->uuid;
+    }
+}

--- a/src/Domains/Connectors/Movipass/Workflows/Activities/BulkRechargeTagsActivity.php
+++ b/src/Domains/Connectors/Movipass/Workflows/Activities/BulkRechargeTagsActivity.php
@@ -6,20 +6,13 @@ namespace Kanvas\Connectors\Movipass\Workflows\Activities;
 
 use Baka\Contracts\AppInterface;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Log;
-use Kanvas\Connectors\EchoPay\Enums\CustomFieldEnum as EchoPayCustomFieldEnum;
+use Kanvas\Connectors\Movipass\Actions\BulkRechargeOrderTagsAction;
 use Kanvas\Connectors\Movipass\Enums\OrderTypeEnum;
-use Kanvas\Connectors\PasoRapido\DataTransferObject\PaymentConfirmData;
-use Kanvas\Connectors\PasoRapido\Services\PasoRapidoService;
 use Kanvas\Souk\Orders\Models\Order;
-use Kanvas\Souk\Wallet\Actions\BuildWalletTransactionMetaAction;
-use Kanvas\Souk\Wallet\Enums\TransactionSourceEnum;
 use Kanvas\Workflow\Contracts\WorkflowActivityInterface;
 use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Kanvas\Workflow\KanvasActivity;
 use Override;
-use RuntimeException;
-use Throwable;
 
 class BulkRechargeTagsActivity extends KanvasActivity implements WorkflowActivityInterface
 {
@@ -53,162 +46,9 @@ class BulkRechargeTagsActivity extends KanvasActivity implements WorkflowActivit
                     return ['skipped' => true, 'reason' => 'already processed'];
                 }
 
-                return $this->processBulkRecharge($order, $app);
+                return new BulkRechargeOrderTagsAction($order, $app)->execute();
             },
             company: $entity->company,
         );
-    }
-
-    private function processBulkRecharge(Order $order, AppInterface $app): array
-    {
-        $company = $order->company;
-        $wallet = $company->createAppWallet($app, ['name' => 'default']);
-
-        $creditMeta = (new BuildWalletTransactionMetaAction(
-            source: TransactionSourceEnum::RECHARGE_MANUAL,
-            actorUserId: $order->users_id,
-            externalReference: $order->uuid,
-            reason: 'Corporate bulk recharge funding',
-            additional: [
-                'service' => OrderTypeEnum::PASO_RAPIDO->value,
-                'order_id' => $order->getId(),
-                'is_bulk_recharge' => true,
-            ],
-        ))->execute();
-
-        $wallet->depositFloat((float) $order->total_gross_amount, $creditMeta);
-
-        $dni = (string) ($company->get('rnc') ?? '');
-        $bankTransaction = $this->resolveBankTransaction($order);
-
-        $service = null;
-        $serviceError = null;
-
-        try {
-            $service = new PasoRapidoService($app, $company);
-        } catch (Throwable $e) {
-            report($e);
-            $serviceError = $e->getMessage();
-        }
-
-        $results = [];
-
-        foreach ($order->items as $item) {
-            $tagNumber = (string) ($item->metadata['tag_number'] ?? '');
-
-            if ($tagNumber === '') {
-                continue;
-            }
-
-            $amount = (float) $item->unit_price_gross_amount;
-            $fiscalCredit = (bool) ($item->metadata['fiscal_credit'] ?? false);
-
-            if ($service === null) {
-                $results[$tagNumber] = [
-                    'status' => 'failed',
-                    'amount' => $amount,
-                    'error' => 'PasoRapido service unavailable: ' . $serviceError,
-                    'order_item_id' => $item->getId(),
-                ];
-
-                continue;
-            }
-
-            $withdrawn = false;
-
-            try {
-                $debitMeta = (new BuildWalletTransactionMetaAction(
-                    source: TransactionSourceEnum::PAYMENT,
-                    actorUserId: $order->users_id,
-                    externalReference: "bulk:{$order->uuid}:{$tagNumber}",
-                    reason: "Corporate bulk recharge TAG {$tagNumber}",
-                    additional: [
-                        'service' => OrderTypeEnum::PASO_RAPIDO->value,
-                        'tag_number' => $tagNumber,
-                        'order_id' => $order->getId(),
-                        'order_item_id' => $item->getId(),
-                    ],
-                ))->execute();
-
-                $wallet->withdrawFloat($amount, $debitMeta);
-                $withdrawn = true;
-
-                $confirmResponse = $service->confirmPayment(new PaymentConfirmData(
-                    reference: $tagNumber,
-                    bankTransaction: $bankTransaction,
-                    amount: $amount,
-                    fiscalCredit: $fiscalCredit,
-                    dni: $dni,
-                ));
-
-                if (! $confirmResponse->tag) {
-                    throw new RuntimeException('PasoRapido did not confirm TAG ' . $tagNumber);
-                }
-
-                $results[$tagNumber] = [
-                    'status' => 'success',
-                    'amount' => $amount,
-                    'order_item_id' => $item->getId(),
-                ];
-            } catch (Throwable $e) {
-                report($e);
-
-                if ($withdrawn) {
-                    try {
-                        $wallet->depositFloat($amount, [
-                            'source' => TransactionSourceEnum::REFUND_TECHNICAL->value,
-                            'reason' => 'Reversal: PasoRapido error for TAG ' . $tagNumber,
-                            'original_error' => $e->getMessage(),
-                            'tag_number' => $tagNumber,
-                            'order_id' => $order->getId(),
-                            'order_item_id' => $item->getId(),
-                        ]);
-                    } catch (Throwable $reversalEx) {
-                        report($reversalEx);
-                        Log::error('BulkRechargeTagsActivity: reversal failed — manual intervention required', [
-                            'tag' => $tagNumber,
-                            'amount' => $amount,
-                            'order_id' => $order->getId(),
-                            'order_item_id' => $item->getId(),
-                            'error' => $reversalEx->getMessage(),
-                        ]);
-                    }
-                }
-
-                $results[$tagNumber] = [
-                    'status' => 'failed',
-                    'amount' => $amount,
-                    'error' => $e->getMessage(),
-                    'order_item_id' => $item->getId(),
-                ];
-            }
-        }
-
-        $metadata = $order->metadata ?? [];
-        $metadata['corporate_recharge_results'] = $results;
-        $order->metadata = $metadata;
-        $order->saveOrFail();
-
-        $successCount = count(array_filter($results, fn ($r) => $r['status'] === 'success'));
-        $failCount = count($results) - $successCount;
-
-        return [
-            'result' => true,
-            'order_id' => $order->getId(),
-            'total' => count($results),
-            'success' => $successCount,
-            'failed' => $failCount,
-        ];
-    }
-
-    private function resolveBankTransaction(Order $order): string
-    {
-        $intentId = $order->get(EchoPayCustomFieldEnum::ECHO_PAY_PAYMENT_INTENT_ID->value);
-
-        if ($intentId) {
-            return explode(':', (string) $intentId)[1] ?? (string) $intentId;
-        }
-
-        return 'wallet_bulk_' . $order->uuid;
     }
 }


### PR DESCRIPTION
Move processBulkRecharge + resolveBankTransaction out of BulkRechargeTagsActivity into a dedicated Action so the recharge logic is reusable from controllers/jobs/CLI without dragging the workflow runtime. Activity keeps only the gates + executeIntegration delegation. Public shape of the activity (execute signature + return) is unchanged so the existing integration test still applies.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
