### PR TITLE
feat: clear unresponded lead cache when enabling FON

### DIFF
--- a/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
+++ b/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Triggers\Actions;
 
+use Exception;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\FollowUp\Enums\FollowUpValueEnum;
 use Kanvas\Intelligence\Services\LeadConfigurationService;
+use Kanvas\Intelligence\Support\UnrespondedLeadAgentMessageCache;
 use Kanvas\Intelligence\Triggers\Enums\TriggersEnum;
 use Kanvas\Social\Messages\Actions\CreateMessageAction;
 use Kanvas\Social\Messages\DataTransferObject\MessageInput;
 use Kanvas\Social\MessagesTypes\Actions\CreateMessageTypeAction;
 use Kanvas\Social\MessagesTypes\DataTransferObject\MessageTypeInput;
+
+use function Sentry\captureException;
 
 class ApplyLeadAiModeAction
 {
@@ -121,6 +125,14 @@ class ApplyLeadAiModeAction
         $this->lead->set(LeadConfigurationEnum::AI_MODE_IS_MANUAL->value, true);
         $this->setMode(IntelligenceModeEnum::FULL_ON->value);
         $this->setFollowUp(FollowUpValueEnum::ON());
+
+        try {
+            foreach ($this->lead->socialChannels as $channel) {
+                UnrespondedLeadAgentMessageCache::clear($this->lead, $channel);
+            }
+        } catch (Exception $e) {
+            captureException($e);
+        }
     }
 
     protected function setMode(string $aiMode): void

--- a/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeV1Action.php
+++ b/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeV1Action.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Triggers\Actions;
 
 use Carbon\Carbon;
+use Exception;
 use Kanvas\Companies\Enums\ConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Models\LeadStatus;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\FollowUp\Enums\FollowUpTypeEnum;
+use Kanvas\Intelligence\Support\UnrespondedLeadAgentMessageCache;
 use Kanvas\Intelligence\Triggers\Enums\TriggersEnum;
 use Kanvas\Social\Messages\Actions\CreateMessageAction;
 use Kanvas\Social\Messages\DataTransferObject\MessageInput;
 use Kanvas\Social\MessagesTypes\Actions\CreateMessageTypeAction;
 use Kanvas\Social\MessagesTypes\DataTransferObject\MessageTypeInput;
+
+use function Sentry\captureException;
 
 class ApplyLeadAiModeV1Action
 {
@@ -92,6 +96,14 @@ class ApplyLeadAiModeV1Action
             : FollowUpTypeEnum::LEAD_FOLLOW_UP;
 
         $this->lead->set(IntelligenceModeEnum::AI_FOLLOW_UP->value, $followUp->value);
+
+        try {
+            foreach ($this->lead->socialChannels as $channel) {
+                UnrespondedLeadAgentMessageCache::clear($this->lead, $channel);
+            }
+        } catch (Exception $e) {
+            captureException($e);
+        }
     }
 
     protected function setMode(string $aiMode, FollowUpTypeEnum $followUp): void


### PR DESCRIPTION
## Summary
- When `applyManualFullOn()` flips a lead to FULL_ON AI mode, also clear the `UnrespondedLeadAgentMessageCache` for each social channel on the lead so the AI doesn't act on stale unresponded-message state from before the takeover.
- Wraps the cache clear in a try/catch + `Sentry\captureException` so a Redis hiccup can't block the mode change.

## Test plan
- [ ] Manually flip a lead to FON via the existing trigger flow and confirm the unresponded cache is cleared for each linked social channel.
- [ ] Verify Sentry captures the exception path if the cache layer is unavailable (no error surfaces to the user).