### PR TITLE
feat: clear unresponded lead cache when enabling FON

### DIFF
--- a/src/Domains/Connectors/Zoho/Workflows/ZohoAgentActivity.php
+++ b/src/Domains/Connectors/Zoho/Workflows/ZohoAgentActivity.php
@@ -64,8 +64,8 @@ class ZohoAgentActivity extends KanvasActivity implements WorkflowActivityInterf
                 if (empty($record->Member_Number) && $newAgent == null) {
                     return [
                         'error' => 'Error Member Number not found',
-                        'record' => $record,
-                        'newAgent' => $newAgent,
+                        'record' => $record->getData(),
+                        'newAgent' => $newAgent?->toArray(),
                     ];
                 }
 
@@ -112,7 +112,12 @@ class ZohoAgentActivity extends KanvasActivity implements WorkflowActivityInterf
                     'zohoId' => $zohoId,
                     'users_id' => $user->getId(),
                     'companies_id' => $company->getId(),
-                    'newAgentRecord' => $newAgentRecord ?? [],
+                    'newAgentRecord' => $newAgentRecord ? [
+                        'agent' => $newAgentRecord['agent']?->toArray(),
+                        'member_id' => $newAgentRecord['member_id'] ?? null,
+                        'zohoAgent' => $newAgentRecord['zohoAgent']?->getData(),
+                        'agentOwner' => $newAgentRecord['agentOwner']?->toArray(),
+                    ] : [],
                     'agentUpdateData' => $agentUpdateData ?? [],
                 ];
             },

--- a/src/Domains/Connectors/Zoho/Workflows/ZohoAgentActivity.php
+++ b/src/Domains/Connectors/Zoho/Workflows/ZohoAgentActivity.php
@@ -112,7 +112,8 @@ class ZohoAgentActivity extends KanvasActivity implements WorkflowActivityInterf
                     'zohoId' => $zohoId,
                     'users_id' => $user->getId(),
                     'companies_id' => $company->getId(),
-                    //'newAgentRecord' => $newAgentRecord ?? [],
+                    'newAgentRecord' => $newAgentRecord ?? [],
+                    'agentUpdateData' => $agentUpdateData ?? [],
                 ];
             },
             company: $company,

--- a/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
+++ b/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Triggers\Actions;
 
+use Exception;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\FollowUp\Enums\FollowUpValueEnum;
 use Kanvas\Intelligence\Services\LeadConfigurationService;
+use Kanvas\Intelligence\Support\UnrespondedLeadAgentMessageCache;
 use Kanvas\Intelligence\Triggers\Enums\TriggersEnum;
 use Kanvas\Social\Messages\Actions\CreateMessageAction;
 use Kanvas\Social\Messages\DataTransferObject\MessageInput;
 use Kanvas\Social\MessagesTypes\Actions\CreateMessageTypeAction;
 use Kanvas\Social\MessagesTypes\DataTransferObject\MessageTypeInput;
+
+use function Sentry\captureException;
 
 class ApplyLeadAiModeAction
 {
@@ -121,6 +125,14 @@ class ApplyLeadAiModeAction
         $this->lead->set(LeadConfigurationEnum::AI_MODE_IS_MANUAL->value, true);
         $this->setMode(IntelligenceModeEnum::FULL_ON->value);
         $this->setFollowUp(FollowUpValueEnum::ON());
+
+        try {
+            foreach ($this->lead->socialChannels as $channel) {
+                UnrespondedLeadAgentMessageCache::clear($this->lead, $channel);
+            }
+        } catch (Exception $e) {
+            captureException($e);
+        }
     }
 
     protected function setMode(string $aiMode): void

--- a/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeV1Action.php
+++ b/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeV1Action.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Triggers\Actions;
 
 use Carbon\Carbon;
+use Exception;
 use Kanvas\Companies\Enums\ConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Models\LeadStatus;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\FollowUp\Enums\FollowUpTypeEnum;
+use Kanvas\Intelligence\Support\UnrespondedLeadAgentMessageCache;
 use Kanvas\Intelligence\Triggers\Enums\TriggersEnum;
 use Kanvas\Social\Messages\Actions\CreateMessageAction;
 use Kanvas\Social\Messages\DataTransferObject\MessageInput;
 use Kanvas\Social\MessagesTypes\Actions\CreateMessageTypeAction;
 use Kanvas\Social\MessagesTypes\DataTransferObject\MessageTypeInput;
+
+use function Sentry\captureException;
 
 class ApplyLeadAiModeV1Action
 {
@@ -92,6 +96,14 @@ class ApplyLeadAiModeV1Action
             : FollowUpTypeEnum::LEAD_FOLLOW_UP;
 
         $this->lead->set(IntelligenceModeEnum::AI_FOLLOW_UP->value, $followUp->value);
+
+        try {
+            foreach ($this->lead->socialChannels as $channel) {
+                UnrespondedLeadAgentMessageCache::clear($this->lead, $channel);
+            }
+        } catch (Exception $e) {
+            captureException($e);
+        }
     }
 
     protected function setMode(string $aiMode, FollowUpTypeEnum $followUp): void

--- a/src/Domains/Souk/Referrals/Actions/GenerateReferralCodeAction.php
+++ b/src/Domains/Souk/Referrals/Actions/GenerateReferralCodeAction.php
@@ -99,7 +99,7 @@ class GenerateReferralCodeAction
     private function generateUniqueCode(): string
     {
         do {
-            $userPrefix = strtoupper(substr($this->user->firstname ?? 'USER', 0, 3));
+            $userPrefix = strtoupper(mb_substr(Str::ascii($this->user->firstname ?? 'USER'), 0, 3, 'UTF-8'));
             $randomSuffix = strtoupper(Str::random(4));
             $code = $userPrefix . $randomSuffix;
         } while (ReferralCode::where('code', $code)->fromApp($this->app)->exists());


### PR DESCRIPTION
## Summary
- When `applyManualFullOn()` flips a lead to FULL_ON AI mode, also clear the `UnrespondedLeadAgentMessageCache` for each social channel on the lead so the AI doesn't act on stale unresponded-message state from before the takeover.
- Wraps the cache clear in a try/catch + `Sentry\captureException` so a Redis hiccup can't block the mode change.

## Test plan
- [ ] Manually flip a lead to FON via the existing trigger flow and confirm the unresponded cache is cleared for each linked social channel.
- [ ] Verify Sentry captures the exception path if the cache layer is unavailable (no error surfaces to the user).