### PR TITLE
refactor: capture exception in UpdateLeadSessionsAction

### DIFF
--- a/src/Domains/Intelligence/Sessions/Actions/UpdateLeadSessionsAction.php
+++ b/src/Domains/Intelligence/Sessions/Actions/UpdateLeadSessionsAction.php
@@ -8,8 +8,6 @@ use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Types\ADKAgent;
 use Throwable;
 
-use function Sentry\captureException;
-
 class UpdateLeadSessionsAction
 {
     public function __construct(
@@ -39,7 +37,7 @@ class UpdateLeadSessionsAction
                     $stateDelta,
                 );
             } catch (Throwable $e) {
-                captureException($e);
+                report($e);
             }
         }
     }

--- a/src/Domains/Intelligence/Sessions/Actions/UpdateLeadSessionsAction.php
+++ b/src/Domains/Intelligence/Sessions/Actions/UpdateLeadSessionsAction.php
@@ -8,6 +8,8 @@ use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Types\ADKAgent;
 use Throwable;
 
+use function Sentry\captureException;
+
 class UpdateLeadSessionsAction
 {
     public function __construct(
@@ -36,7 +38,8 @@ class UpdateLeadSessionsAction
                     $session->entity_id,
                     $stateDelta,
                 );
-            } catch (Throwable) {
+            } catch (Throwable $e) {
+                captureException($e);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Replace silent `catch (Throwable)` with `Sentry\captureException($e)` in `UpdateLeadSessionsAction::execute()` so swallowed errors are surfaced to Sentry instead of disappearing.

## Test plan
- [ ] Trigger a failure path inside the session update loop (e.g. force `ADKAgent::editStateBySessionId` to throw) and confirm the exception is reported in Sentry.
- [ ] Confirm the loop still continues processing remaining sessions after a thrown exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)