### PR TITLE
fix: read AI_ENABLE setting from lead company instead of lead

### DIFF
--- a/src/Domains/Guild/Leads/Observers/LeadObserver.php
+++ b/src/Domains/Guild/Leads/Observers/LeadObserver.php
@@ -124,7 +124,7 @@ class LeadObserver
         LeadUpdateEvent::dispatch($lead);
         LeadCompanyUpdateEvent::dispatch($lead);
 
-        if ($lead->get(ConfigurationEnum::AI_ENABLE->value)) {
+        if ($lead->company->get(ConfigurationEnum::AI_ENABLE->value)) {
             new UpdateLeadSessionsAction($lead)->execute();
         }
 

--- a/src/Domains/Guild/Leads/Observers/LeadObserver.php
+++ b/src/Domains/Guild/Leads/Observers/LeadObserver.php
@@ -160,7 +160,7 @@ class LeadObserver
             $channel->delete();
         }
 
-        if ($lead->get(ConfigurationEnum::AI_ENABLE->value)) {
+        if ($lead->company->get(ConfigurationEnum::AI_ENABLE->value)) {
             new DeleteSessionAction($lead)->execute();
         }
     }
@@ -173,7 +173,7 @@ class LeadObserver
             'updated_at' => now(),
         ]);
 
-        if ($lead->get(ConfigurationEnum::AI_ENABLE->value)) {
+        if ($lead->company->get(ConfigurationEnum::AI_ENABLE->value)) {
             new DeleteSessionAction($lead)->execute();
         }
     }


### PR DESCRIPTION
## Summary
- `AI_ENABLE` is a company-level configuration; reading it from `$lead->get(...)` looked up the wrong scope. Switch to `$lead->company->get(...)` so the AI session update only fires when the lead's company has AI enabled.

## Test plan
- [ ] Update a lead whose company has `AI_ENABLE` set to truthy → `UpdateLeadSessionsAction` runs
- [ ] Update a lead whose company has `AI_ENABLE` unset/false → action is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)