### PR TITLE
hotfix: read AI_ENABLE setting from lead company instead of lead

### DIFF
--- a/src/Domains/Guild/Leads/Observers/LeadObserver.php
+++ b/src/Domains/Guild/Leads/Observers/LeadObserver.php
@@ -124,7 +124,7 @@ class LeadObserver
         LeadUpdateEvent::dispatch($lead);
         LeadCompanyUpdateEvent::dispatch($lead);
 
-        if ($lead->get(ConfigurationEnum::AI_ENABLE->value)) {
+        if ($lead->company->get(ConfigurationEnum::AI_ENABLE->value)) {
             new UpdateLeadSessionsAction($lead)->execute();
         }
 
@@ -160,7 +160,7 @@ class LeadObserver
             $channel->delete();
         }
 
-        if ($lead->get(ConfigurationEnum::AI_ENABLE->value)) {
+        if ($lead->company->get(ConfigurationEnum::AI_ENABLE->value)) {
             new DeleteSessionAction($lead)->execute();
         }
     }
@@ -173,7 +173,7 @@ class LeadObserver
             'updated_at' => now(),
         ]);
 
-        if ($lead->get(ConfigurationEnum::AI_ENABLE->value)) {
+        if ($lead->company->get(ConfigurationEnum::AI_ENABLE->value)) {
             new DeleteSessionAction($lead)->execute();
         }
     }


### PR DESCRIPTION
## Summary
- `AI_ENABLE` is a company-level configuration; reading it via `$lead->get(...)` looked up the wrong scope. Switch to `$lead->company->get(...)` in `updated`, `deleted`, and `softDeleted` so the AI session actions only fire when the lead's company has AI enabled.

## Test plan
- [ ] Update/delete a lead whose company has `AI_ENABLE` truthy → `UpdateLeadSessionsAction` / `DeleteSessionAction` runs
- [ ] Update/delete a lead whose company has `AI_ENABLE` unset/false → action is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)