### PR TITLE
fix: disable auto-set of lead preferred channel

### DIFF
--- a/app/Console/Commands/Intelligence/SendDelayMessageCommand.php
+++ b/app/Console/Commands/Intelligence/SendDelayMessageCommand.php
@@ -236,13 +236,13 @@ class SendDelayMessageCommand extends Command
         Message $message,
         string $communicationChannel
     ): void {
-        if (! $lead->get(LeadsEnumsConfigurationEnum::PREFERRED_CHANNEL->value)) {
-            $lead->set(LeadsEnumsConfigurationEnum::PREFERRED_CHANNEL->value, $communicationChannel);
-        }
+        // if (! $lead->get(LeadsEnumsConfigurationEnum::PREFERRED_CHANNEL->value)) {
+        //     $lead->set(LeadsEnumsConfigurationEnum::PREFERRED_CHANNEL->value, $communicationChannel);
+        // }
 
-        if ($lead->get(LeadsEnumsConfigurationEnum::GUILD_PREFERRED_CHANNEL_UUID->value)) {
-            return;
-        }
+        // if ($lead->get(LeadsEnumsConfigurationEnum::GUILD_PREFERRED_CHANNEL_UUID->value)) {
+        //     return;
+        // }
 
         $communicationChannelNumber = $message->message['chat_jid'] ?? null;
         if (! $communicationChannelNumber) {

--- a/src/Domains/Connectors/SalesAssist/Actions/CreateSocialChannelForContactAction.php
+++ b/src/Domains/Connectors/SalesAssist/Actions/CreateSocialChannelForContactAction.php
@@ -74,12 +74,12 @@ class CreateSocialChannelForContactAction
         $session = $result['session'];
         $isNewChannel = $channel->wasRecentlyCreated;
 
-        if (! $lead->get(LeadsConfigurationEnum::PREFERRED_CHANNEL->value)) {
-            $lead->set(LeadsConfigurationEnum::PREFERRED_CHANNEL->value, $communicationChannel);
-        }
-        if (! $lead->get(LeadsConfigurationEnum::GUILD_PREFERRED_CHANNEL_UUID->value)) {
-            $lead->set(LeadsConfigurationEnum::GUILD_PREFERRED_CHANNEL_UUID->value, $channel->uuid);
-        }
+        // if (! $lead->get(LeadsConfigurationEnum::PREFERRED_CHANNEL->value)) {
+        //     $lead->set(LeadsConfigurationEnum::PREFERRED_CHANNEL->value, $communicationChannel);
+        // }
+        // if (! $lead->get(LeadsConfigurationEnum::GUILD_PREFERRED_CHANNEL_UUID->value)) {
+        //     $lead->set(LeadsConfigurationEnum::GUILD_PREFERRED_CHANNEL_UUID->value, $channel->uuid);
+        // }
 
         if (! empty($this->params['create_whatsapp'])) {
             $whatsappResult = $this->createChannelAndSession(


### PR DESCRIPTION
## Summary
- Comment out the logic in `SendDelayMessageCommand::setPreferredChannel` that auto-assigns `PREFERRED_CHANNEL` and short-circuits on `GUILD_PREFERRED_CHANNEL_UUID`.
- Comment out the equivalent auto-set of `PREFERRED_CHANNEL` and `GUILD_PREFERRED_CHANNEL_UUID` in `CreateSocialChannelForContactAction::execute`.
- The lead's preferred channel is no longer overwritten by message delivery or social-channel creation flows.

## Test plan
- [ ] Trigger a delayed message via `SendDelayMessageCommand` for a lead without a preferred channel and verify the channel is NOT auto-set on the lead.
- [ ] Create a new social channel for a contact via `CreateSocialChannelForContactAction` and verify `PREFERRED_CHANNEL` / `GUILD_PREFERRED_CHANNEL_UUID` are not written to the lead.
- [ ] Confirm downstream messaging still resolves a channel correctly when no preferred channel is set on the lead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)