### PR TITLE
feat: enable image support in neuron chat

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
@@ -10,6 +10,7 @@ use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Services\KanvasConversationStore;
 use Kanvas\Intelligence\Sessions\Models\Session;
 use Kanvas\Users\Models\Users;
+use NeuronAI\Agent\AgentHandler;
 use NeuronAI\Chat\Enums\SourceType;
 use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
 use NeuronAI\Chat\Messages\UserMessage;
@@ -51,7 +52,10 @@ class RunNeuronChatAction
             throw $e;
         }
 
-        $content = $responseContent->getContent() ?? '';
+        $message = $responseContent instanceof AgentHandler
+            ? $responseContent->getMessage()
+            : $responseContent;
+        $content = $message->getContent() ?? '';
         $response = ChatHelper::extractTextFromResponse($content);
         new KanvasConversationStore()->logTurn(
             userId: $this->user->getId(),

--- a/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
@@ -15,8 +15,6 @@ use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
 use NeuronAI\Chat\Messages\UserMessage;
 use Throwable;
 
-use function Illuminate\Log\log;
-
 class RunNeuronChatAction
 {
     public function __construct(
@@ -48,11 +46,8 @@ class RunNeuronChatAction
         try {
             $responseContent = $this->handler->chat($message);
         } catch (Throwable $e) {
-            dd($e->getMessage());
+            report($e);
         }
-        log('message', [
-            'message' => $responseContent->getMessage(),
-        ]);
         $response = ChatHelper::extractTextFromResponse($responseContent->getMessage()->getContent());
         new KanvasConversationStore()->logTurn(
             userId: $this->user->getId(),

--- a/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
@@ -7,12 +7,15 @@ namespace Kanvas\Intelligence\Agents\Actions\Chat;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Intelligence\Agents\Helpers\ChatHelper;
 use Kanvas\Intelligence\Agents\Models\Agent;
-use Kanvas\Intelligence\Agents\Types\ADKAgent;
 use Kanvas\Intelligence\Services\KanvasConversationStore;
 use Kanvas\Intelligence\Sessions\Models\Session;
 use Kanvas\Users\Models\Users;
-use NeuronAI\Agent\AgentHandler;
+use NeuronAI\Chat\Enums\SourceType;
+use NeuronAI\Chat\Messages\ContentBlocks\ImageContent;
 use NeuronAI\Chat\Messages\UserMessage;
+use Throwable;
+
+use function Illuminate\Log\log;
 
 class RunNeuronChatAction
 {
@@ -23,6 +26,7 @@ class RunNeuronChatAction
         protected readonly Apps $app,
         protected readonly Users $user,
         protected readonly mixed $handler,
+        protected readonly array $images = []
     ) {
     }
 
@@ -30,24 +34,26 @@ class RunNeuronChatAction
     {
         $sessionId = $this->session?->uuid ?? '';
 
-        $responseContent = $this->handler instanceof ADKAgent
-            ? $this->handler->chatSimple(
-                $this->app,
-                $this->agent->company,
-                (string) $this->user->getId(),
-                $sessionId,
-                $this->message
-            )
-            : $this->handler->chat(new UserMessage($this->message));
-
-        if ($this->handler instanceof ADKAgent) {
-            $response = $responseContent->getContent();
-        } elseif ($responseContent instanceof AgentHandler) {
-            $response = ChatHelper::extractTextFromResponse($responseContent->getMessage()->getContent());
-        } else {
-            $response = ChatHelper::extractTextFromResponse($responseContent->getContent());
+        $message = new UserMessage($this->message);
+        foreach ($this->images as $image) {
+            $message->addContent(
+                new ImageContent(
+                    content: base64_encode(file_get_contents($image)),
+                    sourceType: SourceType::BASE64,
+                    mediaType: 'image/png'
+                )
+            );
         }
 
+        try {
+            $responseContent = $this->handler->chat($message);
+        } catch (Throwable $e) {
+            dd($e->getMessage());
+        }
+        log('message', [
+            'message' => $responseContent->getMessage(),
+        ]);
+        $response = ChatHelper::extractTextFromResponse($responseContent->getMessage()->getContent());
         new KanvasConversationStore()->logTurn(
             userId: $this->user->getId(),
             sessionId: $sessionId,
@@ -56,6 +62,6 @@ class RunNeuronChatAction
             assistantResponse: $response,
         );
 
-        return $response;
+        return $responseContent->getMessage()->getContent();
     }
 }

--- a/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
@@ -47,8 +47,12 @@ class RunNeuronChatAction
             $responseContent = $this->handler->chat($message);
         } catch (Throwable $e) {
             report($e);
+
+            throw $e;
         }
-        $response = ChatHelper::extractTextFromResponse($responseContent->getMessage()->getContent());
+
+        $content = $responseContent->getContent() ?? '';
+        $response = ChatHelper::extractTextFromResponse($content);
         new KanvasConversationStore()->logTurn(
             userId: $this->user->getId(),
             sessionId: $sessionId,
@@ -57,6 +61,6 @@ class RunNeuronChatAction
             assistantResponse: $response,
         );
 
-        return $responseContent->getMessage()->getContent();
+        return $content;
     }
 }

--- a/src/Domains/Intelligence/Agents/Actions/ProcessAgentChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/ProcessAgentChatAction.php
@@ -101,6 +101,7 @@ class ProcessAgentChatAction
             app: $this->app,
             user: $this->user,
             handler: $handler,
+            images: $this->images
         )->execute();
     }
 

--- a/src/Domains/Intelligence/Agents/Neuron/BaseKanvasAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/BaseKanvasAgent.php
@@ -48,9 +48,13 @@ class BaseKanvasAgent extends NeuronAIAgent
     #[Override]
     protected function provider(): AIProviderInterface
     {
+        $config = $this->agent->config ?? [];
+        $key = $config['key'] ?? $this->app->get(ConfigurationEnum::GEMINI_KEY->value);
+        $model = $config['model'] ?? $this->app->get(ConfigurationEnum::GEMINI_MODEL->value) ?? 'gemini-2.5-pro';
+
         return new Gemini(
-            key: $this->app->get(ConfigurationEnum::GEMINI_KEY->value),
-            model: $this->app->get(ConfigurationEnum::GEMINI_MODEL->value) ?? 'gemini-2.5-pro',
+            key: $key,
+            model: $model,
         );
     }
 

--- a/src/Domains/Intelligence/Workflows/LeadAgentFirstMessageOutreachActivity.php
+++ b/src/Domains/Intelligence/Workflows/LeadAgentFirstMessageOutreachActivity.php
@@ -316,7 +316,7 @@ class LeadAgentFirstMessageOutreachActivity extends KanvasActivity
 
                 $canRunVoice = $lead->get(VoiceBridgeConfigurationEnum::API_KEY->value, 0)
                     ?? $lead->company->get(VoiceBridgeConfigurationEnum::API_KEY->value, 0);
-                    //?? $app->get(VoiceBridgeConfigurationEnum::API_KEY->value, 0);
+                //?? $app->get(VoiceBridgeConfigurationEnum::API_KEY->value, 0);
 
                 if ($totalSentMessages > 0 && ! empty($canRunVoice)) {
                     $delayMinutes = (int) (


### PR DESCRIPTION
## Summary
- RunNeuronChatAction now accepts an `images` array and forwards each as an `ImageContent` block on the `UserMessage` (base64 PNG).
- ProcessAgentChatAction passes its `images` through to RunNeuronChatAction.
- Simplifies the response-extraction path (drops the ADKAgent branch in this action).

## Test plan
- [ ] Send a chat to a neuron agent with one image attached → verify the agent receives it.
- [ ] Send a chat without images → existing text-only flow still works.
- [ ] Verify the stored conversation turn includes the assistant response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)