### PR TITLE
fix(hermes): load migrated secrets via env_file in compose template

### DIFF
--- a/src/Domains/Connectors/Hermes/Templates/docker-compose.yml
+++ b/src/Domains/Connectors/Hermes/Templates/docker-compose.yml
@@ -16,6 +16,9 @@ services:
     ports:
       - "{{GATEWAY_PORT}}:18789"
       - "{{PROXY_PORT}}:18790"
+    env_file:
+      - path: {{HERMES_DIR}}/.env
+        required: false
     environment:
 {{ENV_LINES}}
   socat-proxy:


### PR DESCRIPTION
## Summary

- `hermes claw migrate --migrate-secrets` writes API keys to `~/.hermes/.env` after migrating from OpenClaw
- The Hermes compose template only had hardcoded `environment:` vars sourced from Kanvas app settings
- Agents whose keys lived only in OpenClaw's `auth-profiles.json` (not in Kanvas app settings) ended up with no LLM API key after migration
- Add `env_file` pointing to `{{HERMES_DIR}}/.env` with `required: false` so migrated secrets are loaded as a fallback
- `environment:` section still takes precedence — existing deployments with Kanvas-managed keys are unaffected

## Test plan

- [ ] Migrate an OpenClaw agent to Hermes and verify the agent can call the LLM after migration
- [ ] Verify a fresh Hermes deployment (no `.env` file) still starts without errors (`required: false`)
- [ ] Verify that a key set in both Kanvas settings and `~/.hermes/.env` uses the Kanvas value (environment overrides env_file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)