### PR TITLE
chore(echopay): mock client infrastructure for new portal processor

### DIFF
--- a/src/Domains/Connectors/EchoPay/Client.php
+++ b/src/Domains/Connectors/EchoPay/Client.php
@@ -8,11 +8,12 @@ use Baka\Contracts\AppInterface;
 use Baka\Contracts\CompanyInterface;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\RequestException;
+use Kanvas\Connectors\EchoPay\Contracts\ClientInterface;
 use Kanvas\Connectors\EchoPay\Enums\ConfigurationEnum;
 use Kanvas\Connectors\EchoPay\Exceptions\EchoPayException;
 use Kanvas\Exceptions\ValidationException;
 
-class Client
+class Client implements ClientInterface
 {
     protected string $baseUrl;
     protected string $appToken;

--- a/src/Domains/Connectors/EchoPay/Contracts/ClientInterface.php
+++ b/src/Domains/Connectors/EchoPay/Contracts/ClientInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\EchoPay\Contracts;
+
+interface ClientInterface
+{
+    public function get(string $endpoint): array;
+
+    public function post(string $endpoint, array $data, ?int $timeout = null): array;
+
+    public function patch(string $endpoint, array $data): array;
+
+    public function delete(string $endpoint, array $data = []): array;
+}

--- a/src/Domains/Connectors/EchoPay/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/EchoPay/Enums/ConfigurationEnum.php
@@ -19,6 +19,7 @@ enum ConfigurationEnum: string
     case SANDBOX_URL = 'https://api-test.portall.com.do:2053';
     case BYPASS_ECI = 'ECHO_PAY_BYPASS_ECI';
     case CAPTURE_TIMEOUT = 'ECHO_PAY_CAPTURE_TIMEOUT';
+    case USE_MOCK = 'ECHO_PAY_USE_MOCK';
 
     case AUTHORIZATION_PATH = '/api/v2/auth/token';
     case CONSULT_SERVICE_PATH = '/api/v2/echo-pay/service';

--- a/src/Domains/Connectors/EchoPay/Handlers/EchoPayHandler.php
+++ b/src/Domains/Connectors/EchoPay/Handlers/EchoPayHandler.php
@@ -7,6 +7,7 @@ namespace Kanvas\Connectors\EchoPay\Handlers;
 use Kanvas\Connectors\Contracts\BaseIntegration;
 use Kanvas\Connectors\EchoPay\Client;
 use Kanvas\Connectors\EchoPay\Enums\ConfigurationEnum;
+use Kanvas\Connectors\EchoPay\Services\EchoPayService;
 use Override;
 
 class EchoPayHandler extends BaseIntegration
@@ -33,6 +34,10 @@ class EchoPayHandler extends BaseIntegration
         $this->app->set(ConfigurationEnum::MERCHANT_KEY->value, $merchantKey);
         $this->app->set(ConfigurationEnum::MERCHANT_SECRET->value, $merchantSecret);
         $this->app->set(ConfigurationEnum::REDIRECT_URL->value, $redirectUrl);
+
+        if (EchoPayService::shouldUseMock($this->app)) {
+            return true;
+        }
 
         $client = new Client($this->app, $this->company);
 

--- a/src/Domains/Connectors/EchoPay/MockClient.php
+++ b/src/Domains/Connectors/EchoPay/MockClient.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\EchoPay;
+
+use Baka\Contracts\AppInterface;
+use Baka\Contracts\CompanyInterface;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Kanvas\Connectors\EchoPay\Contracts\ClientInterface;
+use Kanvas\Connectors\EchoPay\Enums\ConfigurationEnum;
+use Kanvas\Connectors\EchoPay\Enums\PaymentStatusEnum;
+
+class MockClient implements ClientInterface
+{
+    public function __construct(
+        protected AppInterface $app,
+        protected CompanyInterface $company,
+        protected array $config = []
+    ) {
+    }
+
+    public function get(string $endpoint): array
+    {
+        $this->logCall('GET', $endpoint);
+        $path = $this->stripQuery($endpoint);
+
+        if (str_starts_with($path, ConfigurationEnum::CONSULT_SERVICE_PATH->value)) {
+            return $this->ok($this->consultServicePayload());
+        }
+
+        return $this->ok([]);
+    }
+
+    public function post(string $endpoint, array $data, ?int $timeout = null): array
+    {
+        $this->logCall('POST', $endpoint, $data);
+
+        return match (true) {
+            $endpoint === ConfigurationEnum::AUTHORIZATION_PATH->value => $this->ok(['token' => 'mock-token-' . Str::uuid()->toString()]),
+            $endpoint === ConfigurationEnum::CARD_PATH->value => $this->ok($this->cardPayload($data)),
+            $endpoint === ConfigurationEnum::SETUP_PAYER_PATH->value => $this->ok($this->setupPayerPayload($data)),
+            $endpoint === ConfigurationEnum::CHECK_PAYER_ENROLLMENT_PATH->value => $this->ok($this->checkEnrollmentPayload($data)),
+            $endpoint === ConfigurationEnum::VALIDATE_PAYER_AUTH_RESULT_PATH->value => $this->ok($this->validateAuthResultPayload($data)),
+            $endpoint === ConfigurationEnum::PAY_SERVICE_PATH->value => $this->ok($this->authorizePayload($data)),
+            $endpoint === ConfigurationEnum::AUTHORIZE_PAYMENT_PATH->value => $this->ok($this->authorizePayload($data)),
+            $endpoint === ConfigurationEnum::CAPTURE_PAYMENT_PATH->value => $this->ok($this->capturePayload($data)),
+            $endpoint === ConfigurationEnum::REVERSAL_PAYMENT_PATH->value => $this->ok($this->reversePayload($data)),
+            default => $this->ok([]),
+        };
+    }
+
+    public function patch(string $endpoint, array $data): array
+    {
+        $this->logCall('PATCH', $endpoint, $data);
+
+        if (str_starts_with($endpoint, ConfigurationEnum::CARD_PATH->value)) {
+            return $this->ok($this->cardUpdatePayload($data));
+        }
+
+        return $this->ok([]);
+    }
+
+    public function delete(string $endpoint, array $data = []): array
+    {
+        $this->logCall('DELETE', $endpoint, $data);
+
+        return [
+            'message' => 'Card deleted (mock).',
+            'statusCode' => 200,
+        ];
+    }
+
+    protected function ok(array $data): array
+    {
+        return [
+            'data' => $data,
+            '_mock' => true,
+        ];
+    }
+
+    protected function stripQuery(string $endpoint): string
+    {
+        $pos = strpos($endpoint, '?');
+
+        return $pos === false ? $endpoint : substr($endpoint, 0, $pos);
+    }
+
+    protected function logCall(string $method, string $endpoint, array $data = []): void
+    {
+        Log::info('EchoPay MockClient call', [
+            'method' => $method,
+            'endpoint' => $endpoint,
+            'app' => $this->app->getId(),
+            'company' => $this->company->getId(),
+            'payload' => $data,
+        ]);
+    }
+
+    protected function consultServicePayload(): array
+    {
+        return [
+            'serviceCode' => 'MOCK-SVC',
+            'contractNumber' => 'MOCK-CONTRACT',
+            'invoiceNumber' => 'MOCK-INV-001',
+            'invoiceDate' => now()->toDateString(),
+            'clientName' => 'Mock Client',
+            'currency' => 'DOP',
+            'amount' => 100.00,
+            'maxAmount' => 100.00,
+            'minAmount' => 100.00,
+            'chargeId' => 'mock-charge-' . Str::uuid()->toString(),
+            'validatorId' => 'mock-validator',
+        ];
+    }
+
+    protected function cardPayload(array $data): array
+    {
+        $number = $data['card']['number'] ?? '4111111111111111';
+
+        return [
+            'cardNumber' => substr((string) $number, -4),
+            'expirationDate' => '2030-12',
+            'instrumentIdentifierId' => 'mock-iid-' . Str::uuid()->toString(),
+            'paymentInstrumentId' => 'mock-pid-' . Str::uuid()->toString(),
+        ];
+    }
+
+    protected function cardUpdatePayload(array $data): array
+    {
+        return [
+            'card' => [
+                'expirationYear' => $data['card']['expirationYear'] ?? '2030',
+                'expirationMonth' => $data['card']['expirationMonth'] ?? '12',
+            ],
+            'instrumentIdentifierId' => 'mock-iid-' . Str::uuid()->toString(),
+            'paymentInstrumentId' => 'mock-pid-' . Str::uuid()->toString(),
+        ];
+    }
+
+    protected function setupPayerPayload(array $data): array
+    {
+        return [
+            'clientReferenceInformation' => [
+                'code' => $data['payment']['clientReferenceInformation']['code'] ?? 'mock-ref',
+            ],
+            'consumerAuthenticationInformation' => [
+                'accessToken' => 'mock-access-token',
+                'deviceDataCollectionUrl' => 'https://mock.echopay.local/3ds/collect',
+                'referenceId' => 'mock-ref-' . Str::uuid()->toString(),
+                'token' => 'mock-token-' . Str::uuid()->toString(),
+            ],
+            'id' => 'mock-setup-' . Str::uuid()->toString(),
+            'status' => 'COMPLETED',
+            'submitTimeUtc' => now()->toIso8601String(),
+        ];
+    }
+
+    protected function checkEnrollmentPayload(array $data): array
+    {
+        return [
+            'clientReferenceInformation' => [
+                'code' => $data['payment']['clientReferenceInformation']['code'] ?? 'mock-ref',
+            ],
+            'consumerAuthenticationInformation' => $this->authenticatedConsumerInfo(),
+            'id' => 'mock-enroll-' . Str::uuid()->toString(),
+            'paymentInformation' => [
+                'card' => [
+                    'bin' => '411111',
+                    'type' => 'VISA',
+                ],
+            ],
+            'status' => PaymentStatusEnum::AUTHENTICATION_SUCCESSFUL->value,
+            'submitTimeUtc' => now()->toIso8601String(),
+        ];
+    }
+
+    protected function validateAuthResultPayload(array $data): array
+    {
+        return [
+            'clientReferenceInformation' => [
+                'code' => $data['payment']['clientReferenceInformation']['code'] ?? 'mock-ref',
+            ],
+            'consumerAuthenticationInformation' => $this->authenticatedConsumerInfo(),
+            'id' => 'mock-validate-' . Str::uuid()->toString(),
+            'status' => PaymentStatusEnum::AUTHENTICATION_SUCCESSFUL->value,
+        ];
+    }
+
+    protected function authorizePayload(array $data): array
+    {
+        return [
+            'id' => 'mock-intent-' . Str::uuid()->toString(),
+            'status' => 'AUTHORIZED',
+            'processorInformation' => [
+                'transactionId' => 'mock-tx-' . Str::uuid()->toString(),
+                'approvalCode' => '888888',
+                'responseCode' => '00',
+            ],
+            'clientReferenceInformation' => [
+                'code' => $data['payment']['clientReferenceInformation']['code'] ?? 'mock-ref',
+            ],
+            'submitTimeUtc' => now()->toIso8601String(),
+        ];
+    }
+
+    protected function capturePayload(array $data): array
+    {
+        return [
+            'id' => 'mock-capture-' . Str::uuid()->toString(),
+            'status' => 'PENDING',
+            'transactionId' => $data['transactionId'] ?? null,
+            'processorInformation' => [
+                'transactionId' => $data['transactionId'] ?? ('mock-tx-' . Str::uuid()->toString()),
+                'approvalCode' => '888888',
+            ],
+            'submitTimeUtc' => now()->toIso8601String(),
+        ];
+    }
+
+    protected function reversePayload(array $data): array
+    {
+        return [
+            'id' => 'mock-reverse-' . Str::uuid()->toString(),
+            'status' => 'REVERSED',
+            'transactionId' => $data['transactionId'] ?? null,
+            'submitTimeUtc' => now()->toIso8601String(),
+        ];
+    }
+
+    protected function authenticatedConsumerInfo(): array
+    {
+        return [
+            'ecommerceIndicator' => 'vbv',
+            'authenticationTransactionId' => 'mock-auth-tx-' . Str::uuid()->toString(),
+            'eciRaw' => '05',
+            'eci' => '05',
+            'authenticationResult' => '0',
+            'strongAuthentication' => 'YES',
+            'authenticationStatusMsg' => 'Success',
+            'accessToken' => 'mock-access-token',
+            'token' => 'mock-token',
+            'cavv' => 'AAABBBBBCCCCCDDDDD',
+            'paresStatus' => 'Y',
+            'xid' => 'mock-xid',
+            'directoryServerTransactionId' => 'mock-ds-tx',
+            'threeDSServerTransactionId' => 'mock-3ds-tx',
+            'specificationVersion' => '2.2.0',
+            'acsTransactionId' => 'mock-acs-tx',
+            'ucafCollectionIndicator' => '',
+            'ucafAuthenticationData' => '',
+            'challengeRequired' => 'N',
+            'acsUrl' => '',
+            'acsReferenceNumber' => '',
+            'stepUpUrl' => '',
+            'pareq' => '',
+            'veresEnrolled' => 'Y',
+            'acsOperatorID' => '',
+        ];
+    }
+}

--- a/src/Domains/Connectors/EchoPay/Services/EchoPayService.php
+++ b/src/Domains/Connectors/EchoPay/Services/EchoPayService.php
@@ -10,6 +10,7 @@ use Baka\Users\Contracts\UserInterface;
 use Exception;
 use Illuminate\Support\Facades\Log;
 use Kanvas\Connectors\EchoPay\Client;
+use Kanvas\Connectors\EchoPay\Contracts\ClientInterface;
 use Kanvas\Connectors\EchoPay\DataTransferObject\CardTokenization;
 use Kanvas\Connectors\EchoPay\DataTransferObject\ConsultServiceQuery;
 use Kanvas\Connectors\EchoPay\DataTransferObject\ConsumerAuthentication;
@@ -18,13 +19,14 @@ use Kanvas\Connectors\EchoPay\DataTransferObject\PaymentCaptureInput;
 use Kanvas\Connectors\EchoPay\DataTransferObject\PaymentDetail;
 use Kanvas\Connectors\EchoPay\DataTransferObject\PaymentResponse;
 use Kanvas\Connectors\EchoPay\Enums\ConfigurationEnum;
+use Kanvas\Connectors\EchoPay\MockClient;
 use Kanvas\Payments\DataTransferObjet\PaymentMethod;
 use Kanvas\Souk\Payments\Contracts\TokenizationProcessorInterface;
 use Kanvas\Souk\Payments\DataTransferObject\TokenizeResult;
 
 class EchoPayService implements TokenizationProcessorInterface
 {
-    protected Client $client;
+    protected ClientInterface $client;
     protected MerchantDetail $merchant;
 
     public function __construct(
@@ -32,12 +34,29 @@ class EchoPayService implements TokenizationProcessorInterface
         protected CompanyInterface $company,
         protected array $config = []
     ) {
-        $this->client = (new Client($app, $company, $config));
+        $this->client = self::shouldUseMock($app)
+            ? new MockClient($app, $company, $config)
+            : new Client($app, $company, $config);
         $this->merchant = MerchantDetail::from([
             'id' => $app->get(ConfigurationEnum::MERCHANT_ID->value),
             'key' => $app->get(ConfigurationEnum::MERCHANT_KEY->value),
             'secretKey' => $app->get(ConfigurationEnum::MERCHANT_SECRET->value),
         ]);
+    }
+
+    public static function shouldUseMock(AppInterface $app): bool
+    {
+        $raw = $app->get(ConfigurationEnum::USE_MOCK->value);
+        $enabled = filter_var($raw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) === true;
+
+        if ($enabled) {
+            Log::warning('EchoPay MockClient is enabled', [
+                'app' => $app->getId(),
+                'raw_flag_value' => $raw,
+            ]);
+        }
+
+        return $enabled;
     }
 
     public function consultService(ConsultServiceQuery $data): array


### PR DESCRIPTION
Adds ClientInterface + MockClient to EchoPay so the upcoming new PortalProcessor (in src/Domains/Souk/Payments/Infrastructure/Processors/Portal/) can be tested without hitting EchoPay's API. The mock is gated on ECHO_PAY_USE_MOCK so it has no production impact; legacy code paths keep using the real Client.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
