### PR TITLE
fix(hermes): overwrite config.yaml on migration and fix default model name

### DIFF
--- a/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
+++ b/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
@@ -401,8 +401,15 @@ class MigrateFromOpenClawAction
     }
 
     /**
-     * Rewrite docker-compose.yml with the destination ports, stop any existing
-     * containers, then start fresh. Assumes the shared image is already present.
+     * Rewrite docker-compose.yml and config.yaml with the destination ports and app model
+     * settings, stop any existing containers, then start fresh.
+     * Assumes the shared image is already present.
+     *
+     * Writing config.yaml here is important for migrations: `hermes claw migrate` copies the
+     * model name from the OpenClaw workspace into config.yaml, which may be a non-existent or
+     * stale model name (e.g. Hermes's own migration default is Claude). Overwriting it here
+     * ensures the agent always starts with the model configured for this app (or gemini-2.0-flash
+     * as the valid default).
      */
     private function startContainers(SshClient $client, AgentDeployment $deployment): void
     {
@@ -414,6 +421,9 @@ class MigrateFromOpenClawAction
         $gatewayToken = $this->company->get(ConfigurationEnum::GATEWAY_TOKEN->value) ?? bin2hex(random_bytes(32));
         $composeContent = $builder->buildDockerCompose($deployment, (string) $gatewayToken, $this->app, $agent);
         $client->writeFileAsUser($hermesDir . '/docker-compose.yml', $composeContent, $deployment->system_user);
+
+        $runtimeConfig = $builder->buildRuntimeConfig($agent, (string) $gatewayToken, $this->app);
+        $client->writeFileAsUser($hermesDir . '/config.yaml', $runtimeConfig, $deployment->system_user);
 
         // Run down + port cleanup + up as a single exec to avoid phpseclib channel reuse errors.
         $downCmd = 'cd ' . escapeshellarg($hermesDir) . ' && docker compose down 2>&1 || true';

--- a/src/Domains/Connectors/Hermes/Services/DockerComposeBuilder.php
+++ b/src/Domains/Connectors/Hermes/Services/DockerComposeBuilder.php
@@ -141,7 +141,7 @@ class DockerComposeBuilder extends BaseDockerComposeBuilder
         AppInterface $app,
         array $channelConfig = [],
     ): string {
-        $rawModel = (string) ($app->get($this->getDefaultModelConfigKey()) ?? 'gemini-3.1-pro-preview');
+        $rawModel = (string) ($app->get($this->getDefaultModelConfigKey()) ?? 'gemini-2.0-flash');
         $provider = $this->detectProvider($rawModel);
         $model = $this->normalizeModelName($rawModel, $provider);
         $baseUrl = $this->providerBaseUrl($provider);

--- a/src/Domains/Connectors/Hermes/Templates/docker-compose.yml
+++ b/src/Domains/Connectors/Hermes/Templates/docker-compose.yml
@@ -16,6 +16,9 @@ services:
     ports:
       - "{{GATEWAY_PORT}}:18789"
       - "{{PROXY_PORT}}:18790"
+    env_file:
+      - path: {{HERMES_DIR}}/.env
+        required: false
     environment:
 {{ENV_LINES}}
   socat-proxy:


### PR DESCRIPTION
## Summary

- After \`hermes claw migrate\`, Hermes writes \`config.yaml\` defaulting to Claude — even when the original OpenClaw agent was using Gemini. \`startContainers()\` now overwrites it with \`buildRuntimeConfig()\` so the agent uses the app-configured model instead of the migration default.
- The previous fallback model \`gemini-3.1-pro-preview\` is not a valid Gemini API model name — it caused HTTP 404 on every inference call. Changed to \`gemini-2.0-flash\`.

## Test plan

- [ ] Run migration from OpenClaw → Hermes
- [ ] Confirm \`~/.hermes/config.yaml\` contains \`gemini-2.0-flash\` (or app-configured model), not Claude
- [ ] Confirm agent starts without HTTP 404 inference errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)