### PR TITLE
fix(hermes): fix hermesDir permissions and correct in-container UID to 10000

### DIFF
--- a/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
+++ b/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
@@ -111,12 +111,10 @@ class MigrateFromOpenClawAction
             $client->exec(
                 'sudo cp -r ' . escapeshellarg($sourceDir) . '/. ' . escapeshellarg($stagingDir) . '/'
             );
-            // The hermes container runs as UID 1000. Chown the staging tree to 1000 and
-            // open group/other read+traverse so the in-container user can actually read
-            // workspace/ — without this the migrate command finds nothing and exits 0,
-            // which looked exactly like "fresh agent" in the wild.
-            $client->exec('sudo chown -R 1000:1000 ' . escapeshellarg($stagingDir));
-            $client->exec('sudo chmod -R u+rwX,go+rX ' . escapeshellarg($stagingDir));
+            // The hermes container runs as UID 10000 (confirmed: docker run image id → uid=10000(hermes)).
+            // Chown the staging tree to 10000 so the in-container user can actually read workspace/.
+            $client->exec('sudo chown -R 10000:10000 ' . escapeshellarg($stagingDir));
+            $client->exec('sudo chmod -R 755 ' . escapeshellarg($stagingDir));
 
             $this->runMigrateCommand($client, $stagingDir, $destDeployment);
 
@@ -303,10 +301,10 @@ class MigrateFromOpenClawAction
         // Remove the archive now that the files are extracted.
         $client->exec('rm -f ' . escapeshellarg($remoteArchive));
 
-        // Chown to UID 1000 (in-container hermes user) so `claw migrate` can read the
-        // workspace through the bind mount. Same fix as the same-machine path.
-        $client->exec('sudo chown -R 1000:1000 ' . escapeshellarg($openclawExtractDir));
-        $client->exec('sudo chmod -R u+rwX,go+rX ' . escapeshellarg($openclawExtractDir));
+        // Chown to UID 10000 (confirmed in-container hermes user) so `claw migrate` can read
+        // the workspace through the bind mount. Same fix as the same-machine path.
+        $client->exec('sudo chown -R 10000:10000 ' . escapeshellarg($openclawExtractDir));
+        $client->exec('sudo chmod -R 755 ' . escapeshellarg($openclawExtractDir));
 
         $this->runMigrateCommand($client, $openclawExtractDir, $deployment);
     }

--- a/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
+++ b/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
@@ -6,6 +6,7 @@ namespace Kanvas\Connectors\Hermes\Actions;
 
 use Baka\Contracts\AppInterface;
 use Baka\Contracts\CompanyInterface;
+use Illuminate\Support\Facades\Log;
 use Kanvas\Connectors\Hermes\Enums\ConfigurationEnum;
 use Kanvas\Connectors\Hermes\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Hermes\Services\DockerComposeBuilder;
@@ -365,9 +366,22 @@ class MigrateFromOpenClawAction
             300
         );
 
+        $context = [
+            'agent' => $deployment->agent->slug,
+            'deployment_id' => $deployment->getId(),
+            'staging_dir' => $stagingDir,
+            'hermes_dir' => $hermesDir,
+            'image' => $imageName,
+            'output' => $result,
+        ];
+
         if (! str_contains($result, 'EXIT_CODE:0')) {
+            Log::error('hermes claw migrate failed', $context);
+
             throw new ValidationException('hermes claw migrate failed: ' . $result);
         }
+
+        Log::info('hermes claw migrate succeeded', $context);
 
         // Fix ownership so the host system user (agent-<slug>) can read the migrated files,
         // while preserving UID 10000 as the owner so the container can also write them.

--- a/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
+++ b/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
@@ -332,8 +332,12 @@ class MigrateFromOpenClawAction
         $hermesDir = $homeDir . '/.hermes';
 
         $client->exec('sudo mkdir -p ' . escapeshellarg($hermesDir));
+        // UID 10000 = hermes user inside the container. The target dir must be writable by it
+        // before the run — sudo mkdir creates it root:root 755, which allows traversal but not
+        // writes, so every file claw migrate tries to create silently fails or exits non-zero.
+        $client->exec('sudo chown 10000:10000 ' . escapeshellarg($hermesDir));
 
-        // UID 10000 = hermes user inside the container. The staging dir must be readable by it.
+        // The staging dir must also be readable by UID 10000.
         $client->exec('sudo chown -R 10000:10000 ' . escapeshellarg($stagingDir));
         $client->exec('sudo chmod -R 755 ' . escapeshellarg($stagingDir));
 

--- a/src/Domains/Connectors/Hermes/Jobs/MigrateFromOpenClawJob.php
+++ b/src/Domains/Connectors/Hermes/Jobs/MigrateFromOpenClawJob.php
@@ -64,6 +64,8 @@ class MigrateFromOpenClawJob implements ShouldQueue
 
     public function failed(Throwable $e): void
     {
+        report($e);
+
         $sourceDeployment = AgentDeployment::find($this->sourceDeployment->id);
 
         if (! $sourceDeployment) {


### PR DESCRIPTION
## Summary

Follow-up to the merged #9617. Two remaining bugs prevented workspace files (SOUL.md, memories/, skills/) from being written during migration:

**Bug: `~/.hermes` target dir not writable by the container**
`sudo mkdir -p ~/.hermes` creates the dir as `root:root 755`. UID 10000 inside the container can traverse it but cannot create any files — so `claw migrate` either silently drops all writes or exits non-zero, leaving the workspace empty. Fixed: `chown 10000:10000 ~/.hermes` immediately after `mkdir`, before the `docker run`.

**Bug: staging dirs chowned to UID 1000 instead of 10000**
A prior commit on this branch used `1000:1000` based on an incorrect UID assumption. Verified the actual UID by running `docker run nousresearch/hermes-agent:latest id`:
```
uid=10000(hermes) gid=10000(hermes) groups=10000(hermes)
```
Updated all three chown calls (`executeOnSameMachine`, `extractAndMigrate`, `runMigrateCommand`) to use UID 10000.

## Test plan

- [ ] SSH into agent machine and run the dry-run docker command manually (see PR description for steps)
- [ ] Confirm `SOUL.md`, `memories/`, `skills/` appear in the target dir after the run
- [ ] Trigger full migration via GraphQL and confirm migrated agent has workspace context

🤖 Generated with [Claude Code](https://claude.com/claude-code)