### PR TITLE
fix(hermes): fix migration reliability — SOUL.md, logging, failed() hook

### DIFF
--- a/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
+++ b/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
@@ -14,6 +14,7 @@ use Kanvas\Connectors\Hermes\SshClient;
 use Kanvas\Connectors\OpenClaw\SshClient as OpenClawSshClient;
 use Kanvas\Exceptions\ValidationException;
 use Kanvas\Intelligence\AgentRuntime\Enums\DeploymentStatusEnum;
+use Kanvas\Intelligence\AgentRuntime\Services\WorkspaceFileBuilder;
 use Kanvas\Intelligence\AgentRuntime\SshClient as BaseClient;
 use Kanvas\Intelligence\Agents\Models\AgentDeployment;
 use Kanvas\Intelligence\Agents\Models\AgentMachine;
@@ -462,6 +463,20 @@ class MigrateFromOpenClawAction
 
         $runtimeConfig = $builder->buildRuntimeConfig($agent, (string) $gatewayToken, $this->app);
         $client->writeFileAsUser($hermesDir . '/config.yaml', $runtimeConfig, $deployment->system_user);
+
+        // Write workspace files (SOUL.md) from the agent model so the migrated container
+        // uses the agent's actual persona rather than Hermes's blank default template.
+        // `claw migrate` does not copy these from OpenClaw — it only migrates secrets and
+        // platform tokens — so we must write them explicitly here, same as LaunchAgentJob.
+        $files = WorkspaceFileBuilder::buildAll($agent);
+        foreach ($files as $filename => $content) {
+            $target = $builder->getWorkspaceFileTargetPath($hermesDir, $filename);
+            if ($target === null) {
+                continue;
+            }
+            $client->exec('sudo mkdir -p ' . escapeshellarg(dirname($target)));
+            $client->writeFileAsUser($target, $content, $deployment->system_user);
+        }
 
         // Run down + port cleanup + up as a single exec to avoid phpseclib channel reuse errors.
         $downCmd = 'cd ' . escapeshellarg($hermesDir) . ' && docker compose down 2>&1 || true';


### PR DESCRIPTION
## Summary

- **SOUL.md not written after migration**: \`claw migrate\` only transfers secrets and platform tokens — it never writes SOUL.md, leaving the container with Hermes's blank default persona. Added \`WorkspaceFileBuilder::buildAll()\` loop in \`startContainers()\`, identical to the normal launch flow in \`BaseLaunchAgentOnMachineAction\`.
- **Migration logging**: Added \`Log::info\` on success and \`Log::error\` on failure in \`runMigrateCommand\`, capturing agent slug, deployment ID, dirs, image, and full container output — makes misconfigured models/API keys/permissions traceable without SSH access.
- **\`failed()\` hook missing \`report(\$e)\`**: Permanent job failures were silently swallowed (no Sentry). Added \`report(\$e)\` to \`MigrateFromOpenClawJob::failed()\`.
- **Containers not stopped on agent deletion**: \`CascadeSoftDeletes\` only flipped \`is_deleted\` on deployments — it never SSH'd into the machine to stop containers. Added a \`deleting()\` hook in \`AgentObserver\` that dispatches termination for every active deployment before the cascade fires.

## Test plan

- [ ] Run a migration from OpenClaw → Hermes and verify \`/opt/data/SOUL.md\` contains the agent's actual persona (not the default template)
- [ ] Check Laravel logs for \`hermes claw migrate succeeded\` entry with context after a successful migration
- [ ] Verify a failed migration job appears in Sentry
- [ ] Delete an agent and verify its containers are stopped on the machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)