### PR TITLE
fix(agents): container cleanup on termination/deletion + live workspace sync

### DIFF
--- a/src/Domains/Connectors/Hermes/Actions/TerminateAgentOnMachineAction.php
+++ b/src/Domains/Connectors/Hermes/Actions/TerminateAgentOnMachineAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\Hermes\Actions;
 
+use Kanvas\Connectors\Hermes\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Hermes\SshClient;
 use Kanvas\Intelligence\AgentRuntime\Actions\BaseTerminateAgentOnMachineAction;
 use Kanvas\Intelligence\AgentRuntime\Contracts\ProviderConfig;
@@ -26,5 +27,11 @@ class TerminateAgentOnMachineAction extends BaseTerminateAgentOnMachineAction
     protected function createSshClient(): BaseSshClient
     {
         return SshClient::fromMachine($this->deployment->machine);
+    }
+
+    #[Override]
+    protected function afterTerminate(BaseSshClient $client): void
+    {
+        $this->deployment->agent->del(CustomFieldEnum::HERMES_DEPLOYMENT_ID->value);
     }
 }

--- a/src/Domains/Connectors/Hermes/Actions/UpdateWorkspaceFilesAction.php
+++ b/src/Domains/Connectors/Hermes/Actions/UpdateWorkspaceFilesAction.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Hermes\Actions;
+
+use Kanvas\Connectors\Hermes\Services\DockerComposeBuilder;
+use Kanvas\Connectors\Hermes\SshClient;
+use Kanvas\Intelligence\AgentRuntime\Actions\BaseUpdateWorkspaceFilesAction;
+use Kanvas\Intelligence\AgentRuntime\Contracts\ProviderConfig;
+use Kanvas\Intelligence\AgentRuntime\SshClient as BaseSshClient;
+use Override;
+
+class UpdateWorkspaceFilesAction extends BaseUpdateWorkspaceFilesAction
+{
+    #[Override]
+    protected function getProviderConfig(): ProviderConfig
+    {
+        return SshClient::makeProviderConfig();
+    }
+
+    #[Override]
+    protected function createSshClient(): BaseSshClient
+    {
+        return SshClient::fromMachine($this->deployment->machine);
+    }
+
+    #[Override]
+    protected function getDockerComposeBuilder(): DockerComposeBuilder
+    {
+        return new DockerComposeBuilder();
+    }
+}

--- a/src/Domains/Connectors/Hermes/Jobs/UpdateWorkspaceFilesJob.php
+++ b/src/Domains/Connectors/Hermes/Jobs/UpdateWorkspaceFilesJob.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Hermes\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Kanvas\Connectors\Hermes\Actions\UpdateWorkspaceFilesAction;
+use Kanvas\Intelligence\Agents\Models\AgentDeployment;
+use Throwable;
+
+class UpdateWorkspaceFilesJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public function __construct(
+        protected AgentDeployment $deployment,
+    ) {
+        $this->onQueue('agent-runtime');
+    }
+
+    public function handle(): void
+    {
+        try {
+            new UpdateWorkspaceFilesAction($this->deployment)->execute();
+        } catch (Throwable $e) {
+            report($e);
+
+            throw $e;
+        }
+    }
+}

--- a/src/Domains/Connectors/Hermes/Providers/HermesProvider.php
+++ b/src/Domains/Connectors/Hermes/Providers/HermesProvider.php
@@ -19,6 +19,7 @@ use Kanvas\Connectors\Hermes\Jobs\MigrateFromOpenClawJob;
 use Kanvas\Connectors\Hermes\Jobs\RestartAgentContainerJob;
 use Kanvas\Connectors\Hermes\Jobs\TerminateAgentJob;
 use Kanvas\Connectors\Hermes\Jobs\UpdateHermesOnMachineJob;
+use Kanvas\Connectors\Hermes\Jobs\UpdateWorkspaceFilesJob;
 use Kanvas\Connectors\Hermes\SshClient;
 use Kanvas\Intelligence\AgentRuntime\Providers\AbstractAgentRuntimeProvider;
 use Kanvas\Intelligence\Agents\Enums\AgentProviderEnum;
@@ -141,6 +142,12 @@ class HermesProvider extends AbstractAgentRuntimeProvider
     public function dispatchUpdateMachineContainers(AgentMachine $machine): void
     {
         UpdateHermesOnMachineJob::dispatch($machine);
+    }
+
+    #[Override]
+    public function dispatchWorkspaceUpdate(AgentDeployment $deployment): void
+    {
+        UpdateWorkspaceFilesJob::dispatch($deployment);
     }
 
     /**

--- a/src/Domains/Intelligence/AgentRuntime/Actions/BaseTerminateAgentOnMachineAction.php
+++ b/src/Domains/Intelligence/AgentRuntime/Actions/BaseTerminateAgentOnMachineAction.php
@@ -42,6 +42,9 @@ abstract class BaseTerminateAgentOnMachineAction
         $config = $this->getProviderConfig();
         $providerDir = $this->deployment->home_directory . '/.' . $config->dotDir;
         $systemUser = $this->deployment->system_user;
+        $homeDir = $this->deployment->home_directory;
+        $gatewayPort = $this->deployment->gateway_port;
+        $proxyPort = $this->deployment->proxy_port;
         $client = $this->createSshClient();
 
         try {
@@ -51,7 +54,7 @@ abstract class BaseTerminateAgentOnMachineAction
 
             if (str_contains($dirCheck, 'EXISTS')) {
                 $result = $client->exec(
-                    'sudo bash -c ' . escapeshellarg('cd ' . $providerDir . ' && docker compose down --rmi local 2>&1')
+                    'sudo bash -c ' . escapeshellarg('cd ' . $providerDir . ' && docker compose down --rmi local --remove-orphans 2>&1')
                     . '; echo "EXIT_CODE:$?"',
                     900,
                 );
@@ -63,20 +66,46 @@ abstract class BaseTerminateAgentOnMachineAction
                 }
             }
             // If the dir is missing the containers can't be running off it — fall through to
-            // userdel + status update. The deployment row gets marked terminated regardless,
-            // so this stays the canonical "make this go away" entry point.
+            // port cleanup + userdel + status update. The deployment row gets marked terminated
+            // regardless, so this stays the canonical "make this go away" entry point.
+
+            // Force-remove any containers still bound to the deployment ports — catches stray
+            // containers that survived compose down or were started outside compose.
+            $client->exec(
+                'docker ps -q --filter publish=' . $gatewayPort . ' | xargs -r docker rm -f 2>/dev/null || true'
+                . ' ; docker ps -q --filter publish=' . $proxyPort . ' | xargs -r docker rm -f 2>/dev/null || true',
+                30
+            );
+
+            // Prune dangling images left by --rmi local (intermediate build layers, etc.).
+            // Safe: only removes untagged images not referenced by any container.
+            $client->exec('docker image prune -f 2>/dev/null || true', 60);
 
             $client->exec('sudo userdel -r ' . escapeshellarg($systemUser) . ' 2>/dev/null || true', 60);
+
+            // userdel -r silently fails to remove files owned by root (e.g. written by docker
+            // containers that ran as root inside the bind-mounted volume). Remove explicitly.
+            $client->exec('sudo rm -rf ' . escapeshellarg($homeDir) . ' 2>/dev/null || true', 60);
 
             $this->deployment->status = DeploymentStatusEnum::TERMINATED->value;
             $this->deployment->terminated_at = new Carbon();
             $this->deployment->saveOrFail();
 
             $this->deployment->agent->update(['deployment_status' => 'pending']);
+
+            $this->afterTerminate($client);
         } finally {
             $client->disconnect();
         }
 
         return true;
+    }
+
+    /**
+     * Hook for provider-specific cleanup after containers and user are removed.
+     * Called after status is persisted — safe for DB writes and non-critical work.
+     */
+    protected function afterTerminate(SshClient $client): void
+    {
     }
 }

--- a/src/Domains/Intelligence/AgentRuntime/Actions/BaseUpdateWorkspaceFilesAction.php
+++ b/src/Domains/Intelligence/AgentRuntime/Actions/BaseUpdateWorkspaceFilesAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\AgentRuntime\Actions;
+
+use Kanvas\Intelligence\AgentRuntime\Contracts\ProviderConfig;
+use Kanvas\Intelligence\AgentRuntime\Services\WorkspaceFileBuilder;
+use Kanvas\Intelligence\AgentRuntime\SshClient;
+use Kanvas\Intelligence\Agents\Models\AgentDeployment;
+
+abstract class BaseUpdateWorkspaceFilesAction
+{
+    public function __construct(
+        protected AgentDeployment $deployment,
+    ) {
+    }
+
+    abstract protected function getProviderConfig(): ProviderConfig;
+
+    abstract protected function createSshClient(): SshClient;
+
+    abstract protected function getDockerComposeBuilder(): mixed;
+
+    public function execute(): void
+    {
+        $config = $this->getProviderConfig();
+        $providerDir = $this->deployment->home_directory . '/.' . $config->dotDir;
+        $systemUser = $this->deployment->system_user;
+        $agent = $this->deployment->agent;
+        $builder = $this->getDockerComposeBuilder();
+        $client = $this->createSshClient();
+
+        try {
+            $files = WorkspaceFileBuilder::buildAll($agent);
+
+            foreach ($files as $filename => $content) {
+                $target = $builder->getWorkspaceFileTargetPath($providerDir, $filename);
+
+                if ($target === null) {
+                    continue;
+                }
+
+                $client->exec('sudo mkdir -p ' . escapeshellarg(dirname($target)));
+                $client->writeFileAsUser($target, $content, $systemUser);
+            }
+        } finally {
+            $client->disconnect();
+        }
+    }
+}

--- a/src/Domains/Intelligence/AgentRuntime/Contracts/AgentRuntimeProvider.php
+++ b/src/Domains/Intelligence/AgentRuntime/Contracts/AgentRuntimeProvider.php
@@ -80,4 +80,6 @@ interface AgentRuntimeProvider
     ): void;
 
     public function dispatchUpdateMachineContainers(AgentMachine $machine): void;
+
+    public function dispatchWorkspaceUpdate(AgentDeployment $deployment): void;
 }

--- a/src/Domains/Intelligence/AgentRuntime/Providers/AbstractAgentRuntimeProvider.php
+++ b/src/Domains/Intelligence/AgentRuntime/Providers/AbstractAgentRuntimeProvider.php
@@ -133,6 +133,12 @@ abstract class AbstractAgentRuntimeProvider implements AgentRuntimeProvider
         throw $this->unsupported('machine container updates');
     }
 
+    #[Override]
+    public function dispatchWorkspaceUpdate(AgentDeployment $deployment): void
+    {
+        throw $this->unsupported('workspace file update');
+    }
+
     protected function unsupported(string $operation): LogicException
     {
         return new LogicException(

--- a/src/Domains/Intelligence/Agents/Observers/AgentObserver.php
+++ b/src/Domains/Intelligence/Agents/Observers/AgentObserver.php
@@ -4,12 +4,30 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Observers;
 
+use Kanvas\Intelligence\AgentRuntime\Providers\AgentRuntimeProviderFactory;
 use Kanvas\Intelligence\Agents\Actions\ReconcileAgentKanvasModulesAction;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Throwable;
 
 class AgentObserver
 {
+    public function deleting(Agent $agent): void
+    {
+        // Dispatch container termination for every active deployment before CascadeSoftDeletes
+        // flips is_deleted — otherwise the containers keep running on the machine indefinitely.
+        foreach ($agent->deployments()->where('is_deleted', 0)->get() as $deployment) {
+            if ($deployment->status === 'terminated') {
+                continue;
+            }
+
+            try {
+                AgentRuntimeProviderFactory::forDeployment($deployment)->dispatchTermination($deployment);
+            } catch (Throwable $e) {
+                report($e);
+            }
+        }
+    }
+
     public function saved(Agent $agent): void
     {
         $agent->clearLightHouseCache(withKanvasConfiguration: false);

--- a/src/Domains/Intelligence/Agents/Observers/AgentObserver.php
+++ b/src/Domains/Intelligence/Agents/Observers/AgentObserver.php
@@ -7,6 +7,7 @@ namespace Kanvas\Intelligence\Agents\Observers;
 use Kanvas\Intelligence\AgentRuntime\Providers\AgentRuntimeProviderFactory;
 use Kanvas\Intelligence\Agents\Actions\ReconcileAgentKanvasModulesAction;
 use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Models\AgentDeployment;
 use Throwable;
 
 class AgentObserver
@@ -26,6 +27,30 @@ class AgentObserver
                 report($e);
             }
         }
+    }
+
+    public function updated(Agent $agent): void
+    {
+        $workspaceFields = [
+            'soul', 'instructions', 'identity', 'user_context',
+            'tools_config', 'output_format', 'role', 'name',
+        ];
+
+        if (! $agent->wasChanged($workspaceFields)) {
+            return;
+        }
+
+        $agent->deployments()
+            ->where('status', 'running')
+            ->where('is_deleted', 0)
+            ->get()
+            ->each(function (AgentDeployment $deployment) {
+                try {
+                    AgentRuntimeProviderFactory::forDeployment($deployment)->dispatchWorkspaceUpdate($deployment);
+                } catch (Throwable $e) {
+                    report($e);
+                }
+            });
     }
 
     public function saved(Agent $agent): void


### PR DESCRIPTION
## Summary

**Container cleanup on termination and deletion:**
- `CascadeSoftDeletes` only flipped `is_deleted` — containers kept running on deletion. Added `deleting()` hook in `AgentObserver` to dispatch termination for every active deployment before the cascade fires.
- Added port-based `docker rm -f` to force-kill stray containers that survived `compose down` or were started outside compose.
- Added `sudo rm -rf \$homeDir` fallback after `userdel -r` (which silently skips root-owned files written by docker inside the volume mount).
- Added `docker image prune -f` and `--remove-orphans` to `compose down`.
- Added `afterTerminate()` hook; Hermes overrides it to clear the `HERMES_DEPLOYMENT_ID` custom field from the agent.

**Live workspace file sync:**
- When `soul`, `instructions`, `identity`, `user_context`, `tools_config`, `output_format`, `role`, or `name` change via Kanvas, the running container was never notified.
- `AgentObserver::updated()` now checks `wasChanged()` for those fields and dispatches `UpdateWorkspaceFilesJob` for each running deployment.
- The job SSHs in and rewrites SOUL.md, AGENTS.md, IDENTITY.md, USER.md, TOOLS.md via the existing `WorkspaceFileBuilder` path. Hermes reads SOUL.md fresh on every message — no container restart needed.

## Test plan

- [ ] Delete an agent and verify its containers are stopped on the machine
- [ ] Terminate a deployment and verify home directory is fully removed
- [ ] Verify `HERMES_DEPLOYMENT_ID` custom field is cleared on the agent after termination
- [ ] Update an agent's soul/instructions and verify the change is reflected in the container's SOUL.md without a restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)