### PR TITLE
feat(movipass): add --force to re-generate existing order voucher

### DIFF
--- a/app/Console/Commands/Connectors/Movipass/GenerateOrderVoucherCommand.php
+++ b/app/Console/Commands/Connectors/Movipass/GenerateOrderVoucherCommand.php
@@ -22,15 +22,14 @@ class GenerateOrderVoucherCommand extends Command
     protected $signature = 'kanvas:movipass-generate-order-voucher
                             {app_id : The application ID}
                             {plate : Vehicle plate number to generate voucher for}
-
-                        ';
+                            {--force : Re-generate the voucher even if one already exists}';
 
     /**
      * The console command description.
      *
      * @var string|null
      */
-    protected $description = 'Fix order items for Movipass orders within a date range';
+    protected $description = 'Generate (or re-generate with --force) the release voucher PDF for a Movipass order by vehicle plate';
 
     public function handle(): void
     {
@@ -57,9 +56,14 @@ class GenerateOrderVoucherCommand extends Command
 
         $voucherUrl = $order->get("voucher_url") ?? '';
 
-        if ($voucherUrl) {
+        if ($voucherUrl && ! $this->option('force')) {
             $this->info("Voucher already exists for order({$order->id}) {$order->order_number} : {$voucherUrl}");
+            $this->info('Use --force to re-generate it.');
             return;
+        }
+
+        if ($voucherUrl) {
+            $this->warn("Re-generating voucher for order({$order->id}) {$order->order_number} (previous: {$voucherUrl})");
         }
 
         $vehiclePlate = $order->metadata['data']['vehiclePlate'] ?? '';


### PR DESCRIPTION
The kanvas:movipass-generate-order-voucher command previously skipped any order that already had a voucher_url. Add a --force flag that re-generates the PDF (GeneratePdfVoucherJob overwrites voucher_url), and fix the copy-paste command description.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
