### PR TITLE
feat(elevenlabs): user phone lookup webhook + working_hours dynamic variable

### DIFF
--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsConversationInitiationWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsConversationInitiationWebhookJob.php
@@ -8,6 +8,7 @@ use Baka\Support\Str;
 use Kanvas\Companies\Enums\ConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Repositories\LeadsRepository;
+use Kanvas\Intelligence\Tools\CompanyWorkHoursTool;
 use Override;
 
 class ProcessElevenLabsConversationInitiationWebhookJob extends ProcessElevenLabsWebhookJob
@@ -23,6 +24,7 @@ class ProcessElevenLabsConversationInitiationWebhookJob extends ProcessElevenLab
         $company = $this->receiver->company;
         $timezone = $company->get('timezone') ?? $company->timezone ?? 'UTC';
         $currentDate = now($timezone)->toDateTimeString();
+        $workHoursStatus = new CompanyWorkHoursTool($this->receiver)->execute()['status'] ?? 'after_hours';
 
         $dynamicVariables = [
             'phone' => $normalizedPhone,
@@ -39,6 +41,7 @@ class ProcessElevenLabsConversationInitiationWebhookJob extends ProcessElevenLab
             'customer_name' => '',
             'firstname' => '',
             'lastname' => '',
+            'working_hours' => $workHoursStatus,
             'email' => '',
             'lead_id' => '',
             'lead_uuid' => '',
@@ -115,6 +118,8 @@ class ProcessElevenLabsConversationInitiationWebhookJob extends ProcessElevenLab
             'lead_pipeline' => (string) ($lead->pipeline?->name ?? ''),
             'opportunity_type' => $this->resolveOpportunityType($lead),
             'owner_name' => $lead->owner ? trim((string) $lead->owner->firstname . ' ' . (string) $lead->owner->lastname) : '',
+            'onwer_phone' => $lead->owner?->phone_number,
+            'owner_cellphone' => $lead->owner?->cell_phone_number,
             'ai_mode' => (string) ($lead->get(ConfigurationEnum::AI_MODE->value) ?? ''),
             'vehicle_year' => (string) ($lead->get('vehicleYear') ?? $lead->get('year') ?? ''),
             'vehicle_make' => (string) ($lead->get('vehicleMake') ?? $lead->get('vehicleBrand') ?? ''),

--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsLookupUserPhoneByNameWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsLookupUserPhoneByNameWebhookJob.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\ElevenLabs\Webhooks;
+
+use Illuminate\Database\Eloquent\Builder;
+use Kanvas\Enums\StateEnums;
+use Kanvas\Users\Models\Users;
+use Override;
+
+class ProcessElevenLabsLookupUserPhoneByNameWebhookJob extends ProcessElevenLabsWebhookJob
+{
+    #[Override]
+    public function execute(): array
+    {
+        $payload = (array) $this->webhookRequest->payload;
+        $name = isset($payload['name']) ? trim((string) $payload['name']) : '';
+
+        if ($name === '') {
+            $this->failedReturnHttpCode = 422;
+
+            return ['status' => 422, 'message' => 'Name is required'];
+        }
+
+        $app = $this->receiver->app;
+        $company = $this->receiver->company;
+
+        $users = Users::select('users.*')
+            ->join('users_associated_apps', 'users_associated_apps.users_id', 'users.id')
+            ->where('users_associated_apps.apps_id', $app->getId())
+            ->where('users_associated_apps.companies_id', $company->getId())
+            ->where('users_associated_apps.is_deleted', StateEnums::NO->getValue())
+            ->where(function (Builder $query) use ($name): void {
+                $like = '%' . $name . '%';
+                $query->where('users.firstname', 'like', $like)
+                    ->orWhere('users.lastname', 'like', $like)
+                    ->orWhere('users.displayname', 'like', $like)
+                    ->orWhereRaw("CONCAT_WS(' ', users.firstname, users.lastname) like ?", [$like]);
+            })
+            ->groupBy('users.id')
+            ->limit(10)
+            ->get();
+
+        if ($users->isEmpty()) {
+            return [
+                'message' => 'No users found',
+                'name' => $name,
+                'matches' => [],
+            ];
+        }
+
+        return [
+            'message' => 'Users found',
+            'name' => $name,
+            'matches' => $users->map(fn (Users $user): array => $this->formatUser($user))->all(),
+        ];
+    }
+
+    protected function formatUser(Users $user): array
+    {
+        return [
+            'id' => $user->getId(),
+            'firstname' => (string) $user->firstname,
+            'lastname' => (string) $user->lastname,
+            'displayname' => (string) $user->displayname,
+            'phone_number' => (string) ($user->phone_number ?? ''),
+            'cell_phone_number' => (string) ($user->cell_phone_number ?? ''),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- New webhook `ProcessElevenLabsLookupUserPhoneByNameWebhookJob` searches users by name (firstname / lastname / displayname / concatenated full name) within the receiver's app + company and returns matching `phone_number` / `cell_phone_number`. Returns `422` if no `name` is supplied; returns up to 10 matches.
- `ProcessElevenLabsConversationInitiationWebhookJob` now adds a `working_hours` dynamic variable (`work_hours` / `after_hours`) using `CompanyWorkHoursTool`, so the ElevenLabs agent can adjust greeting/routing based on whether the company is open.

## Test plan
- [ ] POST to the new webhook with `{ "name": "Juan" }` and confirm matches are scoped to the receiver's app + company.
- [ ] POST with empty `name` and confirm `422` response.
- [ ] Trigger the conversation initiation webhook and confirm `dynamic_variables.working_hours` is `work_hours` during business hours and `after_hours` outside.
- [ ] Run the ElevenLabs connector test suite.