### PR TITLE
feat(elevenlabs): user phone lookup webhook + working_hours dynamic variable

### DIFF
--- a/app/Console/Commands/Workflows/KanvasWorkflowSynActionCommand.php
+++ b/app/Console/Commands/Workflows/KanvasWorkflowSynActionCommand.php
@@ -40,6 +40,7 @@ use Kanvas\Connectors\Elead\Workflow\ScheduleActivityFromEventActivity;
 use Kanvas\Connectors\ElevenLabs\Webhooks\ProcessElevenLabsAgentDateWebhookJob;
 use Kanvas\Connectors\ElevenLabs\Webhooks\ProcessElevenLabsAgentWebhookJob;
 use Kanvas\Connectors\ElevenLabs\Webhooks\ProcessElevenLabsCalendarEventWebhookJob;
+use Kanvas\Connectors\ElevenLabs\Webhooks\ProcessElevenLabsCallUsersByRoleWebhookJob;
 use Kanvas\Connectors\ElevenLabs\Webhooks\ProcessElevenLabsConversationInitiationWebhookJob;
 use Kanvas\Connectors\ElevenLabs\Webhooks\ProcessElevenLabsHandOffWebhookJob;
 use Kanvas\Connectors\ElevenLabs\Webhooks\ProcessElevenLabsProductShareWebhookJob;
@@ -448,6 +449,7 @@ class KanvasWorkflowSynActionCommand extends Command
             ProcessElevenLabsProductShareWebhookJob::class,
             ProcessElevenLabsHandOffWebhookJob::class,
             ProcessElevenLabsSendMessageWebhookJob::class,
+            ProcessElevenLabsCallUsersByRoleWebhookJob::class,
         ];
 
         $createdActions = [];

--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsCallUsersByRoleWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsCallUsersByRoleWebhookJob.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\ElevenLabs\Webhooks;
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Str;
+use Kanvas\Connectors\Twilio\Client as TwilioClient;
+use Kanvas\Connectors\Twilio\Enums\ConfigurationEnum as TwilioConfigurationEnum;
+use Kanvas\Users\Models\Users;
+use Kanvas\Users\Repositories\UsersRepository;
+use Override;
+use Throwable;
+use Twilio\TwiML\VoiceResponse;
+
+class ProcessElevenLabsCallUsersByRoleWebhookJob extends ProcessElevenLabsWebhookJob
+{
+    #[Override]
+    public function execute(): array
+    {
+        $payload = (array) $this->webhookRequest->payload;
+        $role = isset($payload['role']) ? trim((string) $payload['role']) : '';
+
+        if ($role === '') {
+            $this->failedReturnHttpCode = 422;
+
+            return ['status' => 422, 'message' => 'Role is required'];
+        }
+
+        $app = $this->receiver->app;
+        $company = $this->receiver->company;
+
+        try {
+            $users = UsersRepository::getCompanyAppUserByRole($company, $app, $role)
+                ->groupBy('users.id')
+                ->limit(50)
+                ->get();
+        } catch (ModelNotFoundException) {
+            $this->failedReturnHttpCode = 404;
+
+            return ['status' => 404, 'message' => "Role '{$role}' not found"];
+        }
+
+        $agents = $users->map(function (Users $user): array {
+            $phone = trim((string) ($user->cell_phone_number ?? $user->phone_number ?? ''));
+
+            return [
+                'id' => (string) $user->uuid,
+                'firstname' => (string) $user->firstname,
+                'lastname' => (string) $user->lastname,
+                'phone' => $phone,
+            ];
+        })->filter(fn (array $a): bool => $a['phone'] !== '')->values();
+
+        if ($agents->isEmpty()) {
+            return [
+                'message' => 'No users with phone numbers found for role',
+                'role' => $role,
+                'matches' => [],
+            ];
+        }
+
+        $leadId = isset($payload['lead_id']) ? (string) $payload['lead_id'] : '';
+        $callId = Str::uuid()->toString();
+
+        $twiml = $this->buildTwiml($agents->all(), $callId, $leadId, $payload);
+        $twimlXml = (string) $twiml;
+
+        $twilioCallSid = null;
+        $callError = null;
+        $to = isset($payload['to']) && (string) $payload['to'] !== '' ? (string) $payload['to'] : null;
+
+        if ($to !== null) {
+            try {
+                $fromPhone = $company->get(TwilioConfigurationEnum::TWILIO_FROM_PHONE_NUMBER->value)
+                    ?? $company->get(TwilioConfigurationEnum::TWILIO_PHONE_NUMBER->value);
+
+                if ($fromPhone === null || (string) $fromPhone === '') {
+                    $callError = 'Twilio from phone number is not configured for company';
+                } else {
+                    $call = TwilioClient::getInstanceByCompany($company)->calls->create(
+                        $to,
+                        (string) $fromPhone,
+                        ['twiml' => $twimlXml],
+                    );
+                    $twilioCallSid = $call->sid;
+                }
+            } catch (Throwable $e) {
+                $callError = $e->getMessage();
+            }
+        }
+
+        return [
+            'message' => 'Call dispatched to users by role',
+            'role' => $role,
+            'call_id' => $callId,
+            'lead_id' => $leadId !== '' ? $leadId : null,
+            'twiml' => $twimlXml,
+            'twilio_call_sid' => $twilioCallSid,
+            'twilio_call_error' => $callError,
+            'matches' => $agents->all(),
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, string>> $agents
+     */
+    protected function buildTwiml(array $agents, string $callId, string $leadId, array $payload): VoiceResponse
+    {
+        $baseUrl = rtrim((string) config('app.url'), '/');
+        $actionUrl = $this->resolveCallbackUrl(
+            $payload['action_url'] ?? null,
+            "{$baseUrl}/webhooks/twilio/dial-complete",
+            ['lead_id' => $leadId, 'call_id' => $callId],
+        );
+        $statusBaseUrl = $this->resolveCallbackUrl(
+            $payload['status_callback_url'] ?? null,
+            "{$baseUrl}/webhooks/twilio/agent-status",
+            ['lead_id' => $leadId, 'call_id' => $callId],
+        );
+
+        $voiceResponse = new VoiceResponse();
+        $dial = $voiceResponse->dial(
+            null,
+            [
+                'action' => $actionUrl,
+                'method' => 'POST',
+            ],
+        );
+
+        foreach ($agents as $agent) {
+            $dial->number(
+                $agent['phone'],
+                [
+                    'statusCallback' => $this->appendQuery($statusBaseUrl, ['agent_id' => $agent['id']]),
+                    'statusCallbackEvent' => 'initiated ringing answered completed',
+                    'statusCallbackMethod' => 'POST',
+                ],
+            );
+        }
+
+        return $voiceResponse;
+    }
+
+    /**
+     * @param array<string, string> $query
+     */
+    protected function resolveCallbackUrl(mixed $override, string $default, array $query): string
+    {
+        $url = is_string($override) && $override !== '' ? $override : $default;
+
+        return $this->appendQuery($url, $query);
+    }
+
+    /**
+     * @param array<string, string> $query
+     */
+    protected function appendQuery(string $url, array $query): string
+    {
+        $query = array_filter($query, fn (string $v): bool => $v !== '');
+
+        if ($query === []) {
+            return $url;
+        }
+
+        $separator = str_contains($url, '?') ? '&' : '?';
+
+        return $url . $separator . http_build_query($query);
+    }
+}

--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsConversationInitiationWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsConversationInitiationWebhookJob.php
@@ -8,6 +8,7 @@ use Baka\Support\Str;
 use Kanvas\Companies\Enums\ConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Repositories\LeadsRepository;
+use Kanvas\Intelligence\Tools\CompanyWorkHoursTool;
 use Override;
 
 class ProcessElevenLabsConversationInitiationWebhookJob extends ProcessElevenLabsWebhookJob
@@ -23,6 +24,7 @@ class ProcessElevenLabsConversationInitiationWebhookJob extends ProcessElevenLab
         $company = $this->receiver->company;
         $timezone = $company->get('timezone') ?? $company->timezone ?? 'UTC';
         $currentDate = now($timezone)->toDateTimeString();
+        $workHoursStatus = new CompanyWorkHoursTool($this->receiver)->execute()['status'] ?? 'after_hours';
 
         $dynamicVariables = [
             'phone' => $normalizedPhone,
@@ -39,6 +41,7 @@ class ProcessElevenLabsConversationInitiationWebhookJob extends ProcessElevenLab
             'customer_name' => '',
             'firstname' => '',
             'lastname' => '',
+            'working_hours' => $workHoursStatus,
             'email' => '',
             'lead_id' => '',
             'lead_uuid' => '',
@@ -115,6 +118,8 @@ class ProcessElevenLabsConversationInitiationWebhookJob extends ProcessElevenLab
             'lead_pipeline' => (string) ($lead->pipeline?->name ?? ''),
             'opportunity_type' => $this->resolveOpportunityType($lead),
             'owner_name' => $lead->owner ? trim((string) $lead->owner->firstname . ' ' . (string) $lead->owner->lastname) : '',
+            'onwer_phone' => $lead->owner?->phone_number,
+            'owner_cellphone' => $lead->owner?->cell_phone_number,
             'ai_mode' => (string) ($lead->get(ConfigurationEnum::AI_MODE->value) ?? ''),
             'vehicle_year' => (string) ($lead->get('vehicleYear') ?? $lead->get('year') ?? ''),
             'vehicle_make' => (string) ($lead->get('vehicleMake') ?? $lead->get('vehicleBrand') ?? ''),

--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsLookupUserPhoneByNameWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsLookupUserPhoneByNameWebhookJob.php
@@ -23,6 +23,8 @@ class ProcessElevenLabsLookupUserPhoneByNameWebhookJob extends ProcessElevenLabs
             return ['status' => 422, 'message' => 'Name is required'];
         }
 
+        [$firstname, $lastname] = $this->splitName($name);
+
         $app = $this->receiver->app;
         $company = $this->receiver->company;
 
@@ -31,12 +33,12 @@ class ProcessElevenLabsLookupUserPhoneByNameWebhookJob extends ProcessElevenLabs
             ->where('users_associated_apps.apps_id', $app->getId())
             ->where('users_associated_apps.companies_id', $company->getId())
             ->where('users_associated_apps.is_deleted', StateEnums::NO->getValue())
-            ->where(function (Builder $query) use ($name): void {
-                $like = '%' . $name . '%';
-                $query->where('users.firstname', 'like', $like)
-                    ->orWhere('users.lastname', 'like', $like)
-                    ->orWhere('users.displayname', 'like', $like)
-                    ->orWhereRaw("CONCAT_WS(' ', users.firstname, users.lastname) like ?", [$like]);
+            ->where(function (Builder $query) use ($firstname, $lastname): void {
+                $query->where('users.firstname', 'like', '%' . $firstname . '%');
+
+                if ($lastname !== '') {
+                    $query->where('users.lastname', 'like', '%' . $lastname . '%');
+                }
             })
             ->groupBy('users.id')
             ->limit(10)
@@ -46,6 +48,8 @@ class ProcessElevenLabsLookupUserPhoneByNameWebhookJob extends ProcessElevenLabs
             return [
                 'message' => 'No users found',
                 'name' => $name,
+                'firstname' => $firstname,
+                'lastname' => $lastname,
                 'matches' => [],
             ];
         }
@@ -53,8 +57,22 @@ class ProcessElevenLabsLookupUserPhoneByNameWebhookJob extends ProcessElevenLabs
         return [
             'message' => 'Users found',
             'name' => $name,
+            'firstname' => $firstname,
+            'lastname' => $lastname,
             'matches' => $users->map(fn (Users $user): array => $this->formatUser($user))->all(),
         ];
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    protected function splitName(string $name): array
+    {
+        $parts = preg_split('/\s+/', $name, 2) ?: [$name];
+        $firstname = trim($parts[0] ?? '');
+        $lastname = trim($parts[1] ?? '');
+
+        return [$firstname, $lastname];
     }
 
     protected function formatUser(Users $user): array

--- a/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsLookupUserPhoneByNameWebhookJob.php
+++ b/src/Domains/Connectors/ElevenLabs/Webhooks/ProcessElevenLabsLookupUserPhoneByNameWebhookJob.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\ElevenLabs\Webhooks;
+
+use Illuminate\Database\Eloquent\Builder;
+use Kanvas\Enums\StateEnums;
+use Kanvas\Users\Models\Users;
+use Override;
+
+class ProcessElevenLabsLookupUserPhoneByNameWebhookJob extends ProcessElevenLabsWebhookJob
+{
+    #[Override]
+    public function execute(): array
+    {
+        $payload = (array) $this->webhookRequest->payload;
+        $name = isset($payload['name']) ? trim((string) $payload['name']) : '';
+
+        if ($name === '') {
+            $this->failedReturnHttpCode = 422;
+
+            return ['status' => 422, 'message' => 'Name is required'];
+        }
+
+        $app = $this->receiver->app;
+        $company = $this->receiver->company;
+
+        $users = Users::select('users.*')
+            ->join('users_associated_apps', 'users_associated_apps.users_id', 'users.id')
+            ->where('users_associated_apps.apps_id', $app->getId())
+            ->where('users_associated_apps.companies_id', $company->getId())
+            ->where('users_associated_apps.is_deleted', StateEnums::NO->getValue())
+            ->where(function (Builder $query) use ($name): void {
+                $like = '%' . $name . '%';
+                $query->where('users.firstname', 'like', $like)
+                    ->orWhere('users.lastname', 'like', $like)
+                    ->orWhere('users.displayname', 'like', $like)
+                    ->orWhereRaw("CONCAT_WS(' ', users.firstname, users.lastname) like ?", [$like]);
+            })
+            ->groupBy('users.id')
+            ->limit(10)
+            ->get();
+
+        if ($users->isEmpty()) {
+            return [
+                'message' => 'No users found',
+                'name' => $name,
+                'matches' => [],
+            ];
+        }
+
+        return [
+            'message' => 'Users found',
+            'name' => $name,
+            'matches' => $users->map(fn (Users $user): array => $this->formatUser($user))->all(),
+        ];
+    }
+
+    protected function formatUser(Users $user): array
+    {
+        return [
+            'id' => $user->getId(),
+            'firstname' => (string) $user->firstname,
+            'lastname' => (string) $user->lastname,
+            'displayname' => (string) $user->displayname,
+            'phone_number' => (string) ($user->phone_number ?? ''),
+            'cell_phone_number' => (string) ($user->cell_phone_number ?? ''),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- New webhook `ProcessElevenLabsLookupUserPhoneByNameWebhookJob` searches users by name (firstname / lastname / displayname / concatenated full name) within the receiver's app + company and returns matching `phone_number` / `cell_phone_number`. Returns `422` if no `name` is supplied; returns up to 10 matches.
- `ProcessElevenLabsConversationInitiationWebhookJob` now adds a `working_hours` dynamic variable (`work_hours` / `after_hours`) using `CompanyWorkHoursTool`, so the ElevenLabs agent can adjust greeting/routing based on whether the company is open.

## Test plan
- [ ] POST to the new webhook with `{ "name": "Juan" }` and confirm matches are scoped to the receiver's app + company.
- [ ] POST with empty `name` and confirm `422` response.
- [ ] Trigger the conversation initiation webhook and confirm `dynamic_variables.working_hours` is `work_hours` during business hours and `after_hours` outside.
- [ ] Run the ElevenLabs connector test suite.