### PR TITLE
feat(intelligence): enable image support + unify Neuron chat history

### DIFF
--- a/app/Console/Commands/Connectors/Movipass/GenerateOrderVoucherCommand.php
+++ b/app/Console/Commands/Connectors/Movipass/GenerateOrderVoucherCommand.php
@@ -22,15 +22,14 @@ class GenerateOrderVoucherCommand extends Command
     protected $signature = 'kanvas:movipass-generate-order-voucher
                             {app_id : The application ID}
                             {plate : Vehicle plate number to generate voucher for}
-
-                        ';
+                            {--force : Re-generate the voucher even if one already exists}';
 
     /**
      * The console command description.
      *
      * @var string|null
      */
-    protected $description = 'Fix order items for Movipass orders within a date range';
+    protected $description = 'Generate (or re-generate with --force) the release voucher PDF for a Movipass order by vehicle plate';
 
     public function handle(): void
     {
@@ -57,9 +56,14 @@ class GenerateOrderVoucherCommand extends Command
 
         $voucherUrl = $order->get("voucher_url") ?? '';
 
-        if ($voucherUrl) {
+        if ($voucherUrl && ! $this->option('force')) {
             $this->info("Voucher already exists for order({$order->id}) {$order->order_number} : {$voucherUrl}");
+            $this->info('Use --force to re-generate it.');
             return;
+        }
+
+        if ($voucherUrl) {
+            $this->warn("Re-generating voucher for order({$order->id}) {$order->order_number} (previous: {$voucherUrl})");
         }
 
         $vehiclePlate = $order->metadata['data']['vehiclePlate'] ?? '';

--- a/app/Console/Commands/NervousSystem/ProvisionDefaultConsumerModulesCommand.php
+++ b/app/Console/Commands/NervousSystem/ProvisionDefaultConsumerModulesCommand.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\NervousSystem;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection as SupportCollection;
+use Illuminate\Support\Facades\DB;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Exceptions\ModelNotFoundException;
+use Kanvas\KanvasModules\Enums\CompanyKanvasModuleStatusEnum;
+use Kanvas\KanvasModules\Models\CompanyKanvasModule;
+use Kanvas\KanvasModules\Models\KanvasModule;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\warning;
+
+class ProvisionDefaultConsumerModulesCommand extends Command
+{
+    protected $signature = 'kanvas:nervous-system:provision-default-consumer-modules
+        {app_id : The app id whose companies should be backfilled}
+        {--reactivate-deleted : Also flip is_deleted=false / is_active=true on existing soft-deleted rows (status is preserved)}
+        {--dry-run : Report what would change without writing}';
+
+    protected $description = 'Backfill companies_kanvas_modules for every company of an app with the default consumer modules (is_default=1, is_internal=0). Existing rows are left untouched unless --reactivate-deleted is passed.';
+
+    public function handle(): int
+    {
+        $appId = (int) $this->argument('app_id');
+        $reactivate = (bool) $this->option('reactivate-deleted');
+        $dryRun = (bool) $this->option('dry-run');
+
+        try {
+            $app = Apps::getById($appId);
+        } catch (ModelNotFoundException) {
+            warning("App id={$appId} not found.");
+
+            return self::FAILURE;
+        }
+
+        info("App: {$app->name} (id={$app->getId()})");
+
+        $eligibleModuleIds = DB::table('abilities_modules')
+            ->where('apps_id', $app->getId())
+            ->distinct()
+            ->pluck('module_id')
+            ->filter()
+            ->map(fn (mixed $id): int => (int) $id)
+            ->all();
+
+        if ($eligibleModuleIds === []) {
+            warning('No abilities_modules rows for this app, nothing to provision.');
+
+            return self::SUCCESS;
+        }
+
+        $moduleIds = KanvasModule::whereIn('id', $eligibleModuleIds)
+            ->where('is_default', 1)
+            ->where('is_internal', 0)
+            ->where('is_deleted', 0)
+            ->pluck('id')
+            ->map(fn (mixed $id): int => (int) $id)
+            ->all();
+
+        if ($moduleIds === []) {
+            warning('No default consumer modules registered for this app, nothing to provision.');
+
+            return self::SUCCESS;
+        }
+
+        $this->line('  default consumer modules: ' . implode(',', $moduleIds));
+
+        $totals = ['inserted' => 0, 'reactivated' => 0, 'skipped' => 0, 'companies' => 0];
+
+        $appCompanyIds = DB::table('user_company_apps')
+            ->select('companies_id')
+            ->where('apps_id', $app->getId())
+            ->distinct();
+
+        Companies::query()
+            ->whereIn('id', $appCompanyIds)
+            ->orderBy('id')
+            ->chunkById(
+                200,
+                function (SupportCollection $chunk) use ($app, $moduleIds, $reactivate, $dryRun, &$totals): void {
+                    foreach ($chunk as $company) {
+                        $totals['companies']++;
+
+                        /** @var EloquentCollection<int, CompanyKanvasModule> $existingByModule */
+                        $existingByModule = CompanyKanvasModule::where('apps_id', $app->getId())
+                            ->where('companies_id', $company->getId())
+                            ->whereIn('kanvas_modules_id', $moduleIds)
+                            ->get()
+                            ->keyBy('kanvas_modules_id');
+
+                        foreach ($moduleIds as $moduleId) {
+                            $existing = $existingByModule->get($moduleId);
+
+                            if ($existing === null) {
+                                if (! $dryRun) {
+                                    CompanyKanvasModule::create([
+                                        'apps_id' => $app->getId(),
+                                        'companies_id' => $company->getId(),
+                                        'kanvas_modules_id' => $moduleId,
+                                        'is_active' => true,
+                                        'is_deleted' => false,
+                                        'status' => CompanyKanvasModuleStatusEnum::CONNECTED->value,
+                                    ]);
+                                }
+                                $totals['inserted']++;
+
+                                continue;
+                            }
+
+                            if ($reactivate && ($existing->is_deleted || ! $existing->is_active)) {
+                                if (! $dryRun) {
+                                    $existing->is_active = true;
+                                    $existing->is_deleted = false;
+                                    $existing->save();
+                                }
+                                $totals['reactivated']++;
+
+                                continue;
+                            }
+
+                            $totals['skipped']++;
+                        }
+                    }
+                },
+            );
+
+        $this->newLine();
+        info(sprintf(
+            'Summary: companies=%d inserted=%d reactivated=%d skipped=%d%s',
+            $totals['companies'],
+            $totals['inserted'],
+            $totals['reactivated'],
+            $totals['skipped'],
+            $dryRun ? '  [DRY RUN]' : '',
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/NervousSystem/ProvisionDefaultConsumerModulesCommand.php
+++ b/app/Console/Commands/NervousSystem/ProvisionDefaultConsumerModulesCommand.php
@@ -43,21 +43,7 @@ class ProvisionDefaultConsumerModulesCommand extends Command
 
         info("App: {$app->name} (id={$app->getId()})");
 
-        $eligibleModuleIds = DB::table('abilities_modules')
-            ->where('apps_id', $app->getId())
-            ->distinct()
-            ->pluck('module_id')
-            ->filter()
-            ->map(fn (mixed $id): int => (int) $id)
-            ->all();
-
-        if ($eligibleModuleIds === []) {
-            warning('No abilities_modules rows for this app, nothing to provision.');
-
-            return self::SUCCESS;
-        }
-
-        $moduleIds = KanvasModule::whereIn('id', $eligibleModuleIds)
+        $moduleIds = KanvasModule::query()
             ->where('is_default', 1)
             ->where('is_internal', 0)
             ->where('is_deleted', 0)
@@ -66,7 +52,7 @@ class ProvisionDefaultConsumerModulesCommand extends Command
             ->all();
 
         if ($moduleIds === []) {
-            warning('No default consumer modules registered for this app, nothing to provision.');
+            warning('No default consumer modules found.');
 
             return self::SUCCESS;
         }
@@ -107,7 +93,7 @@ class ProvisionDefaultConsumerModulesCommand extends Command
                                         'kanvas_modules_id' => $moduleId,
                                         'is_active' => true,
                                         'is_deleted' => false,
-                                        'status' => CompanyKanvasModuleStatusEnum::CONNECTED->value,
+                                        'status' => CompanyKanvasModuleStatusEnum::NOT_CONNECTED->value,
                                     ]);
                                 }
                                 $totals['inserted']++;

--- a/app/GraphQL/Social/Mutations/Messages/MessageManagementMutation.php
+++ b/app/GraphQL/Social/Mutations/Messages/MessageManagementMutation.php
@@ -21,6 +21,7 @@ use Kanvas\Social\Messages\Actions\UpdateMessageAction;
 use Kanvas\Social\Messages\DataTransferObject\MessageInput;
 use Kanvas\Social\Messages\Enums\DistributionTypeEnum;
 use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Social\Messages\Services\MessageFileConstrainerService;
 use Kanvas\Social\MessagesTypes\Actions\CreateMessageTypeAction;
 use Kanvas\Social\MessagesTypes\DataTransferObject\MessageTypeInput;
 use Kanvas\Social\MessagesTypes\Repositories\MessagesTypesRepository;
@@ -227,6 +228,19 @@ class MessageManagementMutation
 
         if (($message->user->getId() !== auth()->user()->getId()) && ! auth()->user()->isAdmin()) {
             throw new Exception('The message does not belong to the authenticated user');
+        }
+
+        $files = isset($request['file']) ? [$request['file']] : ($request['files'] ?? []);
+        $files = MessageFileConstrainerService::constrain(
+            $app,
+            (string) $message->messageType->verb,
+            $files,
+        );
+
+        if (isset($request['file'])) {
+            $request['file'] = $files[0];
+        } else {
+            $request['files'] = $files;
         }
 
         return $this->uploadFileToEntity(

--- a/src/Domains/Connectors/Twilio/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/Twilio/Enums/ConfigurationEnum.php
@@ -18,4 +18,5 @@ enum ConfigurationEnum: string
     case TWILIO_FROM_PHONE_NUMBER = 'twilio_from_phone_number';
     case TWILIO_PHONE_NUMBER = 'twilio_phone_number';
     case TWILIO_MMS_BATCH_SIZE = 'twilio-mms-batch-size';
+    case TWILIO_MMS_MAX_TOTAL_MEDIA = 'twilio-mms-max-total-media';
 }

--- a/src/Domains/Connectors/Twilio/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/Twilio/Enums/ConfigurationEnum.php
@@ -17,4 +17,5 @@ enum ConfigurationEnum: string
     case TWILIO_2FA_SEND_COOLDOWN_SECONDS = 'TWILIO_2FA_SEND_COOLDOWN_SECONDS';
     case TWILIO_FROM_PHONE_NUMBER = 'twilio_from_phone_number';
     case TWILIO_PHONE_NUMBER = 'twilio_phone_number';
+    case TWILIO_MMS_BATCH_SIZE = 'twilio-mms-batch-size';
 }

--- a/src/Domains/Connectors/Twilio/Workflows/HumanAgentChannelResponseActivity.php
+++ b/src/Domains/Connectors/Twilio/Workflows/HumanAgentChannelResponseActivity.php
@@ -32,10 +32,22 @@ class HumanAgentChannelResponseActivity extends KanvasActivity
         $this->overwriteAppService($app);
         $message = $params['message'] ?? null;
 
+        $channelContext = [
+            'channel_id' => $channel->getId(),
+            'channel_uuid' => $channel->uuid ?? null,
+            'channel_slug' => $channel->slug ?? null,
+            'channel_entity_type' => $channel->entity_namespace ?? null,
+            'channel_entity_id' => $channel->entity_id ?? null,
+            'app_id' => $app->getId(),
+            'company_id' => $channel->companies_id ?? null,
+            'from' => $params['from'] ?? null,
+        ];
+
         if (! $message instanceof Message) {
             return $this->failWorkflow([
                 'message' => 'Message not found',
                 'entity' => null,
+                'context' => $channelContext,
             ]);
         }
 
@@ -46,17 +58,29 @@ class HumanAgentChannelResponseActivity extends KanvasActivity
 
         $fromPhone = $params['from'] ?? null;
 
+        $messageContext = $channelContext + [
+            'message_id' => $message->getId(),
+            'message_uuid' => $message->uuid ?? null,
+            'message_type' => $message->messageType?->verb,
+            'message_from_human' => (bool) $fromHumanAgent,
+            'message_has_content' => ! empty($content),
+        ];
+
         return $this->executeIntegration(
             entity: $channel,
             app: $app,
             integration: IntegrationsEnum::INTERNAL,
-            integrationOperation: function ($channel, $app, $integrationCompany, $additionalParams) use ($message, $content, $fromPhone, $fromHumanAgent, $params) {
+            integrationOperation: function ($channel, $app, $integrationCompany, $additionalParams) use ($message, $content, $fromPhone, $fromHumanAgent, $params, $messageContext) {
                 $files = $message->getFiles();
+
+                $messageContext['message_has_files'] = $files->isNotEmpty();
+                $messageContext['message_files_count'] = $files->count();
 
                 if (empty($content) && $files->isEmpty()) {
                     return $this->failWorkflow([
-                        'message' => 'Message or user not found',
+                        'message' => 'Message content and files are both empty',
                         'entity' => null,
+                        'context' => $messageContext,
                     ]);
                 }
 
@@ -64,6 +88,7 @@ class HumanAgentChannelResponseActivity extends KanvasActivity
                     return $this->failWorkflow([
                         'message' => 'Message is not from human agent',
                         'entity' => null,
+                        'context' => $messageContext,
                     ]);
                 }
 
@@ -71,20 +96,28 @@ class HumanAgentChannelResponseActivity extends KanvasActivity
                     return $this->failWorkflow([
                         'message' => 'From phone number is required',
                         'entity' => null,
+                        'context' => $messageContext,
                     ]);
                 }
 
                 $channelEntity = $channel->entityData();
                 $messageEntity = $message->entity();
 
+                $messageContext['channel_entity_class'] = $channelEntity ? $channelEntity::class : null;
+                $messageContext['message_entity_class'] = $messageEntity ? $messageEntity::class : null;
+
                 if (! $messageEntity instanceof Lead && $channelEntity instanceof Lead) {
                     return $this->failWorkflow([
                         'message' => 'Channel entity is not a Lead',
                         'entity' => null,
+                        'context' => $messageContext,
                     ]);
                 }
 
                 $lead = $messageEntity instanceof Lead ? $messageEntity : $channelEntity;
+
+                $messageContext['lead_id'] = $lead?->getId();
+                $messageContext['lead_uuid'] = $lead?->uuid ?? null;
 
                 $lastMessage = $channel->getLastMessage();
                 if ($lastMessage && $lastMessage->isLocked() && strtolower((string) $lastMessage->messageType?->verb) !== 'note') {
@@ -114,6 +147,8 @@ class HumanAgentChannelResponseActivity extends KanvasActivity
                     default => LeadCommunicationChannelEnum::SMS->value,
                 };
 
+                $messageContext['channel_type'] = $channelType;
+
                 //we have a loop when you create a msg , its sent back via webhook, so we hide the msg that initiate everything
                 if ($message->messageType->verb === ChannelCategoryEnum::WHATSAPP->value) {
                     $message->is_public = 0;
@@ -134,9 +169,14 @@ class HumanAgentChannelResponseActivity extends KanvasActivity
                 new MarkLeadMessagesAsRespondedAction($lead, $message)->execute();
                 new NotifyLeadStakeholdersService($lead)->onAgentReply($message, isHuman: true);
 
-                return $result;
+                return [
+                    'message' => 'Message sent to lead via ' . $channelType,
+                    'result' => $result,
+                    'context' => $messageContext,
+                ];
             },
             company: $channel->company,
+            additionalParams: $params,
         );
     }
 }

--- a/src/Domains/Connectors/Zoho/ZohoService.php
+++ b/src/Domains/Connectors/Zoho/ZohoService.php
@@ -74,6 +74,8 @@ class ZohoService
             $data['Lead_Routing'] = $zohoOwnerAgent ? $zohoOwnerAgent->Lead_Routing : (string) $this->company->get('default_lead_routing');
 
             $this->lastCreateAgentRequest = $data;
+            $this->lastCreateAgentRequest['zohoOwnerAgent'] = $zohoOwnerAgent;
+            
             $zohoAgent = $this->zohoCrm->agents->create($data);
         } else {
             $data['Vendor_Name'] = $agentInfo->name;

--- a/src/Domains/Connectors/Zoho/ZohoService.php
+++ b/src/Domains/Connectors/Zoho/ZohoService.php
@@ -71,7 +71,11 @@ class ZohoService
         $data = $this->applySponsorData($agentInfo, $data);
 
         if ($zohoAgentModule == self::DEFAULT_AGENT_MODULE) {
-            $data['Lead_Routing'] = $zohoOwnerAgent ? $zohoOwnerAgent->Lead_Routing : (string) $this->company->get('default_lead_routing');
+            if ($zohoOwnerAgent instanceof Agent && $zohoOwnerAgent->users_linked_source_id) {
+                $zohoOwnerAgent = $this->zohoCrm->agents->get($zohoOwnerAgent->users_linked_source_id);
+            }
+
+            $data['Lead_Routing'] = $zohoOwnerAgent !== null ? $zohoOwnerAgent->Lead_Routing : (string) $this->company->get('default_lead_routing');
 
             $this->lastCreateAgentRequest = $data;
             $this->lastCreateAgentRequest['zohoOwnerAgent'] = $zohoOwnerAgent;

--- a/src/Domains/Connectors/Zoho/ZohoService.php
+++ b/src/Domains/Connectors/Zoho/ZohoService.php
@@ -75,7 +75,7 @@ class ZohoService
 
             $this->lastCreateAgentRequest = $data;
             $this->lastCreateAgentRequest['zohoOwnerAgent'] = $zohoOwnerAgent;
-            
+
             $zohoAgent = $this->zohoCrm->agents->create($data);
         } else {
             $data['Vendor_Name'] = $agentInfo->name;

--- a/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
@@ -41,6 +41,13 @@ class SendMessageToLeadAction
     private const int DEFAULT_MMS_BATCH_SIZE = 8;
     private const int MAX_MMS_BATCH_SIZE = 10;
 
+    /**
+     * Hard upper bound on total media attached to one outbound SMS, regardless of batching.
+     * Guards against runaway "entire camera roll" sends. Override per-app via
+     * `twilio-mms-max-total-media`.
+     */
+    private const int DEFAULT_MMS_MAX_TOTAL_MEDIA = 30;
+
     protected array $processedFiles = [];
     protected array $videoEngagements = [];
 
@@ -370,7 +377,8 @@ class SendMessageToLeadAction
         }
 
         $mediaUrls = [];
-        $maxUrls = 10;
+        $maxUrls = (int) ($this->lead->app->get(TwilioConfigurationEnum::TWILIO_MMS_MAX_TOTAL_MEDIA->value) ?: self::DEFAULT_MMS_MAX_TOTAL_MEDIA);
+        $maxUrls = max(1, $maxUrls);
 
         foreach ($this->videoEngagements as $videoEngagement) {
             if (count($mediaUrls) >= $maxUrls) {

--- a/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
@@ -14,6 +14,7 @@ use Kanvas\ActionEngine\Engagements\Actions\CreateEngagementAction;
 use Kanvas\ActionEngine\Engagements\DataTransferObject\Engagement as EngagementData;
 use Kanvas\ActionEngine\Enums\ActionStatusEnum;
 use Kanvas\Connectors\Twilio\Client;
+use Kanvas\Connectors\Twilio\Enums\ConfigurationEnum as TwilioConfigurationEnum;
 use Kanvas\Connectors\VoiceBridge\Actions\InitVoiceSessionAction;
 use Kanvas\Connectors\VoiceBridge\Actions\TriggerVoiceCallAction;
 use Kanvas\Connectors\WaSender\Enums\ConfigurationEnum as WaSenderConfigurationEnum;
@@ -31,6 +32,15 @@ use Ramsey\Uuid\Uuid;
 
 class SendMessageToLeadAction
 {
+    /**
+     * Default media items per Twilio MMS API call. Override per-app via
+     * `twilio-mms-batch-size` setting. Twilio's documented hard cap is 10 but
+     * 21623 fires on some account/carrier combos before that; 8 is the safe
+     * default measured against the active production account.
+     */
+    private const int DEFAULT_MMS_BATCH_SIZE = 8;
+    private const int MAX_MMS_BATCH_SIZE = 10;
+
     protected array $processedFiles = [];
     protected array $videoEngagements = [];
 
@@ -278,23 +288,60 @@ class SendMessageToLeadAction
             $fullMessage .= "\n\n" . implode("\n", $engagementUrls);
         }
 
-        $messageData = [
-            'from' => $from,
-        ];
-
-        if ($fullMessage) {
-            $messageData['body'] = $fullMessage;
-        }
-
         $mediaUrls = $this->getMediaUrlsForTwilio();
-        if (! empty($mediaUrls)) {
-            $messageData['mediaUrl'] = $mediaUrls;
+
+        if (empty($mediaUrls)) {
+            $payload = ['from' => $from];
+            if ($fullMessage !== '') {
+                $payload['body'] = $fullMessage;
+            }
+
+            $twilioMessage = $client->messages->create($cellphone, $payload);
+
+            return [
+                'channel' => 'sms',
+                'batches' => 1,
+                'batch_size' => 0,
+                'media_per_batch' => [0],
+                'lead_id' => $this->lead->getId(),
+                'lead_uuid' => $this->lead->uuid,
+                'messages' => [$this->describeTwilioMessage($twilioMessage)],
+            ];
         }
 
-        $twilioMessage = $client->messages->create($cellphone, $messageData);
+        $batchSize = (int) ($this->lead->app->get(TwilioConfigurationEnum::TWILIO_MMS_BATCH_SIZE->value) ?: self::DEFAULT_MMS_BATCH_SIZE);
+        $batchSize = max(1, min(self::MAX_MMS_BATCH_SIZE, $batchSize));
+
+        $batches = array_chunk($mediaUrls, $batchSize);
+        $twilioMessages = [];
+
+        foreach ($batches as $index => $batch) {
+            $payload = [
+                'from' => $from,
+                'mediaUrl' => $batch,
+            ];
+
+            if ($index === 0 && $fullMessage !== '') {
+                $payload['body'] = $fullMessage;
+            }
+
+            $twilioMessages[] = $client->messages->create($cellphone, $payload);
+        }
 
         return [
             'channel' => 'sms',
+            'batches' => count($batches),
+            'batch_size' => $batchSize,
+            'media_per_batch' => array_map('count', $batches),
+            'lead_id' => $this->lead->getId(),
+            'lead_uuid' => $this->lead->uuid,
+            'messages' => array_map(fn ($m) => $this->describeTwilioMessage($m), $twilioMessages),
+        ];
+    }
+
+    private function describeTwilioMessage(object $twilioMessage): array
+    {
+        return [
             'sid' => $twilioMessage->sid,
             'account_sid' => $twilioMessage->accountSid,
             'messaging_service_sid' => $twilioMessage->messagingServiceSid,
@@ -305,7 +352,6 @@ class SendMessageToLeadAction
             'body' => $twilioMessage->body,
             'num_segments' => $twilioMessage->numSegments,
             'num_media' => $twilioMessage->numMedia,
-            'media_urls' => $mediaUrls,
             'error_code' => $twilioMessage->errorCode,
             'error_message' => $twilioMessage->errorMessage,
             'price' => $twilioMessage->price,
@@ -314,8 +360,6 @@ class SendMessageToLeadAction
             'date_sent' => $twilioMessage->dateSent?->format(DateTimeInterface::ATOM),
             'date_updated' => $twilioMessage->dateUpdated?->format(DateTimeInterface::ATOM),
             'uri' => $twilioMessage->uri,
-            'lead_id' => $this->lead->getId(),
-            'lead_uuid' => $this->lead->uuid,
         ];
     }
 

--- a/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Guild\Leads\Actions;
 
 use Baka\Support\Str;
+use DateTimeInterface;
 use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Notification;
@@ -292,7 +293,30 @@ class SendMessageToLeadAction
 
         $twilioMessage = $client->messages->create($cellphone, $messageData);
 
-        return [$twilioMessage->body];
+        return [
+            'channel' => 'sms',
+            'sid' => $twilioMessage->sid,
+            'account_sid' => $twilioMessage->accountSid,
+            'messaging_service_sid' => $twilioMessage->messagingServiceSid,
+            'status' => $twilioMessage->status,
+            'direction' => $twilioMessage->direction,
+            'from' => $twilioMessage->from,
+            'to' => $twilioMessage->to,
+            'body' => $twilioMessage->body,
+            'num_segments' => $twilioMessage->numSegments,
+            'num_media' => $twilioMessage->numMedia,
+            'media_urls' => $mediaUrls,
+            'error_code' => $twilioMessage->errorCode,
+            'error_message' => $twilioMessage->errorMessage,
+            'price' => $twilioMessage->price,
+            'price_unit' => $twilioMessage->priceUnit,
+            'date_created' => $twilioMessage->dateCreated?->format(DateTimeInterface::ATOM),
+            'date_sent' => $twilioMessage->dateSent?->format(DateTimeInterface::ATOM),
+            'date_updated' => $twilioMessage->dateUpdated?->format(DateTimeInterface::ATOM),
+            'uri' => $twilioMessage->uri,
+            'lead_id' => $this->lead->getId(),
+            'lead_uuid' => $this->lead->uuid,
+        ];
     }
 
     protected function getMediaUrlsForTwilio(): array
@@ -377,7 +401,18 @@ class SendMessageToLeadAction
         }
         Notification::route('mail', $leadEmail)->notify($notification);
 
-        return [];
+        return [
+          'channel' => 'email',
+          'to' => $leadEmail,
+          'template' => 'first-time-agent-engagement',
+          'body_length' => strlen($message),
+          'signature' => $signature,
+          'engagement_urls' => array_values($engagementUrls),
+          'attachments' => $attachments,
+          'attachments_count' => count($attachments),
+          'lead_id' => $this->lead->getId(),
+          'lead_uuid' => $this->lead->uuid,
+        ];
     }
 
     protected function sendVoiceMessage(string $instructions = ''): array

--- a/src/Domains/Intelligence/Agents/Actions/ProcessAgentChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/ProcessAgentChatAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Actions;
 
+use Baka\Support\Str;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Exceptions\ValidationException;
@@ -99,6 +100,8 @@ class ProcessAgentChatAction
         }
 
         $handler->setConfiguration($this->agent, $this->session?->entity(), null, $this->user);
+        $threadId = $this->session?->uuid ?? Str::uuid();
+        $handler->setThreadId($threadId);
 
         return new RunNeuronChatAction(
             agent: $this->agent,

--- a/src/Domains/Intelligence/Agents/Neuron/CRM/IntelligenceCRM.php
+++ b/src/Domains/Intelligence/Agents/Neuron/CRM/IntelligenceCRM.php
@@ -6,7 +6,7 @@ namespace Kanvas\Intelligence\Agents\Neuron\CRM;
 
 use Illuminate\Support\Facades\Blade;
 use Kanvas\Intelligence\Agents\Neuron\BaseKanvasAgent;
-use Kanvas\Intelligence\Agents\Neuron\KanvasMessageHistory;
+use Kanvas\Intelligence\Agents\Neuron\SalesAssistKanvasMessageHistory;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\ArtifactsTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\CommunicationChannelTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\CompanyInformationTool;
@@ -44,7 +44,7 @@ class IntelligenceCRM extends BaseKanvasAgent
             return new InMemoryChatHistory();
         }
 
-        return new KanvasMessageHistory(
+        return new SalesAssistKanvasMessageHistory(
             app: $this->app,
             company: $this->company,
             user: $this->user,

--- a/src/Domains/Intelligence/Agents/Neuron/KanvasGenericNeuronAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/KanvasGenericNeuronAgent.php
@@ -6,11 +6,29 @@ namespace Kanvas\Intelligence\Agents\Neuron;
 
 use Kanvas\NervousSystem\Capability\Models\Tool;
 use Kanvas\NervousSystem\Capability\Services\CapabilityProvider;
+use NeuronAI\Chat\History\AbstractChatHistory;
+use NeuronAI\Chat\History\InMemoryChatHistory;
 use Override;
 use ReflectionClass;
 
 class KanvasGenericNeuronAgent extends BaseKanvasAgent
 {
+    #[Override]
+    protected function chatHistory(): AbstractChatHistory
+    {
+        if ($this->user === null || $this->app === null || $this->company === null) {
+            return new InMemoryChatHistory();
+        }
+
+        return new KanvasMessageHistory(
+            app: $this->app,
+            company: $this->company,
+            user: $this->user,
+            agentClass: static::class,
+            conversationId: $this->threadId,
+        );
+    }
+
     #[Override]
     protected function tools(): array
     {

--- a/src/Domains/Intelligence/Agents/Neuron/KanvasMessageHistory.php
+++ b/src/Domains/Intelligence/Agents/Neuron/KanvasMessageHistory.php
@@ -4,17 +4,13 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Neuron;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
-use Kanvas\Social\Messages\Actions\CreateMessageAction;
-use Kanvas\Social\Messages\DataTransferObject\MessageInput;
-use Kanvas\Social\Messages\Models\AppModuleMessage;
-use Kanvas\Social\MessagesTypes\Services\MessageTypeService;
 use Kanvas\Users\Models\Users;
 use NeuronAI\Chat\Enums\MessageRole;
 use NeuronAI\Chat\History\AbstractChatHistory;
-use NeuronAI\Chat\History\ChatHistoryInterface;
 use NeuronAI\Chat\Messages\AssistantMessage;
 use NeuronAI\Chat\Messages\Message;
 use NeuronAI\Chat\Messages\UserMessage;
@@ -22,131 +18,69 @@ use Override;
 
 class KanvasMessageHistory extends AbstractChatHistory
 {
-    private const string AGENT_VERB = 'agent';
-    private const string USER_VERB = 'user';
-
-    // Verbos que nunca deben exponerse al lead
-    private const array INTERNAL_VERBS = ['notes', 'ai_assist', 'internal'];
+    private const string CONNECTION = 'intelligence';
+    private const string TABLE_CONVERSATIONS = 'agent_conversations';
+    private const string TABLE_MESSAGES = 'agent_conversation_messages';
 
     public function __construct(
         private readonly Apps $app,
         private readonly Companies $company,
         private readonly Users $user,
-        private readonly Model $entity,
-        private readonly ?string $threadId = null,
-        private readonly bool $includeInternal = false,
+        private readonly string $agentClass,
+        private ?string $conversationId = null,
         int $contextWindow = 50000,
     ) {
         parent::__construct($contextWindow);
-        $this->load();
+
+        $this->conversationId ??= $this->findLatestConversation();
+
+        if ($this->conversationId !== null) {
+            $this->load();
+        }
+    }
+
+    public function getConversationId(): ?string
+    {
+        return $this->conversationId;
+    }
+
+    private function findLatestConversation(): ?string
+    {
+        return DB::connection(self::CONNECTION)
+            ->table(self::TABLE_CONVERSATIONS)
+            ->where('user_id', $this->user->getId())
+            ->where('apps_id', $this->app->getId())
+            ->where('companies_id', $this->company->getId())
+            ->orderBy('updated_at', 'desc')
+            ->first()?->id;
     }
 
     private function load(): void
     {
-        $messages = AppModuleMessage::query()
-            ->where('system_modules', get_class($this->entity))
-            ->where('entity_id', $this->entity->getKey())
-            ->where('apps_id', $this->app->getId())
-            ->whereHas('message', fn ($q) => $q->where('is_deleted', 0))
-            ->with(['message.messageType'])
+        $messages = DB::connection(self::CONNECTION)
+            ->table(self::TABLE_MESSAGES)
+            ->where('conversation_id', $this->conversationId)
+            ->orderBy('created_at', 'asc')
             ->orderBy('id', 'asc')
             ->get()
-            ->map(function (AppModuleMessage $appModuleMessage): ?Message {
-                $socialMessage = $appModuleMessage->message;
+            ->map(function ($row): ?Message {
+                $content = (string) ($row->content ?? '');
 
-                if (! $socialMessage) {
+                if ($content === '') {
                     return null;
                 }
 
-                $stored = $socialMessage->getMessage();
-
-                if ($this->threadId !== null && ($stored['thread_id'] ?? null) !== $this->threadId) {
-                    return null;
-                }
-
-                $verb = $socialMessage->messageType?->verb ?? self::USER_VERB;
-
-                if (! $this->includeInternal && in_array($verb, self::INTERNAL_VERBS, true)) {
-                    return null;
-                }
-
-                $text = (string) ($stored['content'] ?? $stored['text'] ?? '');
-
-                if ($text === '') {
-                    return null;
-                }
-
-                $fromIa = (bool) ($stored['from_ia'] ?? false);
-                $fromHuman = (bool) ($stored['from_human'] ?? false);
-
-                $channel = $socialMessage->channels()->first();
-                $isInternal = $channel?->isNoteChannel() || $channel?->isAiAssistChannel();
-
-                if ($isInternal) {
-                    $prefixed = "[INTERNAL - {$channel->name}] {$text}";
-                } elseif ($fromIa) {
-                    $prefixed = "[Assistant] {$text}";
-                } elseif ($fromHuman) {
-                    $owner = $socialMessage->user?->displayname ?: 'Owner';
-                    $prefixed = "[Owner - {$owner}] {$text}";
-                } else {
-                    $prefixed = '[' . $this->entityIdentityLabel() . "] {$text}";
-                }
-
-                return $fromIa
-                    ? new AssistantMessage($prefixed)
-                    : new UserMessage($prefixed);
+                return $row->role === MessageRole::ASSISTANT->value
+                    ? new AssistantMessage($content)
+                    : new UserMessage($content);
             })
             ->filter()
             ->values()
-            ->toArray();
+            ->all();
 
-        $coalesced = [];
-        foreach ($messages as $m) {
-            $last = end($coalesced) ?: null;
-            if ($last !== null && $last->getRole() === $m->getRole()) {
-                $last->setContents($last->getContent() . "\n\n" . $m->getContent());
-
-                continue;
-            }
-            $coalesced[] = $m;
+        if (! empty($messages)) {
+            $this->history = $messages;
         }
-
-        while (! empty($coalesced) && $coalesced[0]->getRole() !== MessageRole::USER->value) {
-            array_shift($coalesced);
-        }
-
-        if (! empty($coalesced)) {
-            $this->history = array_values($coalesced);
-        }
-    }
-
-    #[Override]
-    public function addMessage(Message $message): ChatHistoryInterface
-    {
-        $last = end($this->history) ?: null;
-        if ($last !== null && $last->getRole() === $message->getRole()) {
-            $last->setContents($last->getContent() . "\n\n" . $message->getContent());
-            $this->trimHistory();
-            $this->onNewMessage($message);
-            $this->setMessages($this->history);
-
-            return $this;
-        }
-
-        return parent::addMessage($message);
-    }
-
-    private function entityIdentityLabel(): string
-    {
-        if (method_exists($this->entity, 'people') && $this->entity->people) {
-            $name = (string) $this->entity->people->getName();
-            if ($name !== '') {
-                return "Lead - {$name}";
-            }
-        }
-
-        return class_basename($this->entity) . ':' . $this->entity->getKey();
     }
 
     #[Override]
@@ -164,33 +98,46 @@ class KanvasMessageHistory extends AbstractChatHistory
             return;
         }
 
-        $isAssistant = $role === MessageRole::ASSISTANT->value;
-        $verb = $isAssistant ? self::AGENT_VERB : self::USER_VERB;
-        $messageType = MessageTypeService::getOrCreate($this->app, $verb);
-
-        $messageData = [
-            'content' => $content,
-            'from_me' => $isAssistant,
-            'from_ia' => $isAssistant,
-            'from_human' => ! $isAssistant,
-        ];
-
-        if ($this->threadId !== null) {
-            $messageData['thread_id'] = $this->threadId;
+        if ($this->conversationId === null) {
+            $this->conversationId = $this->createConversation($content);
+        } else {
+            DB::connection(self::CONNECTION)
+                ->table(self::TABLE_CONVERSATIONS)
+                ->where('id', $this->conversationId)
+                ->update(['updated_at' => now()]);
         }
 
-        $createMessageAction = new CreateMessageAction(
-            new MessageInput(
-                app: $this->app,
-                company: $this->company,
-                user: $this->user,
-                type: $messageType,
-                message: $messageData,
-                is_public: 0,
-            )
-        );
-        $createMessageAction->runWorkflow = false;
-        $socialMessage = $createMessageAction->execute();
-        $socialMessage->addEntity($this->entity);
+        DB::connection(self::CONNECTION)->table(self::TABLE_MESSAGES)->insert([
+            'id' => (string) Str::uuid7(),
+            'conversation_id' => $this->conversationId,
+            'user_id' => $this->user->getId(),
+            'agent' => $this->agentClass,
+            'role' => $role,
+            'content' => $content,
+            'attachments' => '[]',
+            'tool_calls' => '[]',
+            'tool_results' => '[]',
+            'usage' => '[]',
+            'meta' => '[]',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createConversation(string $firstMessage): string
+    {
+        $conversationId = (string) Str::uuid7();
+
+        DB::connection(self::CONNECTION)->table(self::TABLE_CONVERSATIONS)->insert([
+            'id' => $conversationId,
+            'user_id' => $this->user->getId(),
+            'apps_id' => $this->app->getId(),
+            'companies_id' => $this->company->getId(),
+            'title' => Str::limit($firstMessage, 100, ''),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $conversationId;
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/SalesAssistKanvasMessageHistory.php
+++ b/src/Domains/Intelligence/Agents/Neuron/SalesAssistKanvasMessageHistory.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron;
+
+use Illuminate\Database\Eloquent\Model;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Social\Messages\Actions\CreateMessageAction;
+use Kanvas\Social\Messages\DataTransferObject\MessageInput;
+use Kanvas\Social\Messages\Models\AppModuleMessage;
+use Kanvas\Social\MessagesTypes\Services\MessageTypeService;
+use Kanvas\Users\Models\Users;
+use NeuronAI\Chat\Enums\MessageRole;
+use NeuronAI\Chat\History\AbstractChatHistory;
+use NeuronAI\Chat\History\ChatHistoryInterface;
+use NeuronAI\Chat\Messages\AssistantMessage;
+use NeuronAI\Chat\Messages\Message;
+use NeuronAI\Chat\Messages\UserMessage;
+use Override;
+
+class SalesAssistKanvasMessageHistory extends AbstractChatHistory
+{
+    private const string AGENT_VERB = 'agent';
+    private const string USER_VERB = 'user';
+
+    // Verbos que nunca deben exponerse al lead
+    private const array INTERNAL_VERBS = ['notes', 'ai_assist', 'internal'];
+
+    public function __construct(
+        private readonly Apps $app,
+        private readonly Companies $company,
+        private readonly Users $user,
+        private readonly Model $entity,
+        private readonly ?string $threadId = null,
+        private readonly bool $includeInternal = false,
+        int $contextWindow = 50000,
+    ) {
+        parent::__construct($contextWindow);
+        $this->load();
+    }
+
+    private function load(): void
+    {
+        $messages = AppModuleMessage::query()
+            ->where('system_modules', get_class($this->entity))
+            ->where('entity_id', $this->entity->getKey())
+            ->where('apps_id', $this->app->getId())
+            ->whereHas('message', fn ($q) => $q->where('is_deleted', 0))
+            ->with(['message.messageType'])
+            ->orderBy('id', 'asc')
+            ->get()
+            ->map(function (AppModuleMessage $appModuleMessage): ?Message {
+                $socialMessage = $appModuleMessage->message;
+
+                if (! $socialMessage) {
+                    return null;
+                }
+
+                $stored = $socialMessage->getMessage();
+
+                if ($this->threadId !== null && ($stored['thread_id'] ?? null) !== $this->threadId) {
+                    return null;
+                }
+
+                $verb = $socialMessage->messageType?->verb ?? self::USER_VERB;
+
+                if (! $this->includeInternal && in_array($verb, self::INTERNAL_VERBS, true)) {
+                    return null;
+                }
+
+                $text = (string) ($stored['content'] ?? $stored['text'] ?? '');
+
+                if ($text === '') {
+                    return null;
+                }
+
+                $fromIa = (bool) ($stored['from_ia'] ?? false);
+                $fromHuman = (bool) ($stored['from_human'] ?? false);
+
+                $channel = $socialMessage->channels()->first();
+                $isInternal = $channel?->isNoteChannel() || $channel?->isAiAssistChannel();
+
+                if ($isInternal) {
+                    $prefixed = "[INTERNAL - {$channel->name}] {$text}";
+                } elseif ($fromIa) {
+                    $prefixed = "[Assistant] {$text}";
+                } elseif ($fromHuman) {
+                    $owner = $socialMessage->user?->displayname ?: 'Owner';
+                    $prefixed = "[Owner - {$owner}] {$text}";
+                } else {
+                    $prefixed = '[' . $this->entityIdentityLabel() . "] {$text}";
+                }
+
+                return $fromIa
+                    ? new AssistantMessage($prefixed)
+                    : new UserMessage($prefixed);
+            })
+            ->filter()
+            ->values()
+            ->toArray();
+
+        $coalesced = [];
+        foreach ($messages as $m) {
+            $last = end($coalesced) ?: null;
+            if ($last !== null && $last->getRole() === $m->getRole()) {
+                $last->setContents($last->getContent() . "\n\n" . $m->getContent());
+
+                continue;
+            }
+            $coalesced[] = $m;
+        }
+
+        while (! empty($coalesced) && $coalesced[0]->getRole() !== MessageRole::USER->value) {
+            array_shift($coalesced);
+        }
+
+        if (! empty($coalesced)) {
+            $this->history = array_values($coalesced);
+        }
+    }
+
+    #[Override]
+    public function addMessage(Message $message): ChatHistoryInterface
+    {
+        $last = end($this->history) ?: null;
+        if ($last !== null && $last->getRole() === $message->getRole()) {
+            $last->setContents($last->getContent() . "\n\n" . $message->getContent());
+            $this->trimHistory();
+            $this->onNewMessage($message);
+            $this->setMessages($this->history);
+
+            return $this;
+        }
+
+        return parent::addMessage($message);
+    }
+
+    private function entityIdentityLabel(): string
+    {
+        if (method_exists($this->entity, 'people') && $this->entity->people) {
+            $name = (string) $this->entity->people->getName();
+            if ($name !== '') {
+                return "Lead - {$name}";
+            }
+        }
+
+        return class_basename($this->entity) . ':' . $this->entity->getKey();
+    }
+
+    #[Override]
+    protected function onNewMessage(Message $message): void
+    {
+        $role = $message->getRole();
+
+        if (! in_array($role, [MessageRole::USER->value, MessageRole::ASSISTANT->value], true)) {
+            return;
+        }
+
+        $content = (string) $message->getContent();
+
+        if ($content === '') {
+            return;
+        }
+
+        $isAssistant = $role === MessageRole::ASSISTANT->value;
+        $verb = $isAssistant ? self::AGENT_VERB : self::USER_VERB;
+        $messageType = MessageTypeService::getOrCreate($this->app, $verb);
+
+        $messageData = [
+            'content' => $content,
+            'from_me' => $isAssistant,
+            'from_ia' => $isAssistant,
+            'from_human' => ! $isAssistant,
+        ];
+
+        if ($this->threadId !== null) {
+            $messageData['thread_id'] = $this->threadId;
+        }
+
+        $createMessageAction = new CreateMessageAction(
+            new MessageInput(
+                app: $this->app,
+                company: $this->company,
+                user: $this->user,
+                type: $messageType,
+                message: $messageData,
+                is_public: 0,
+            )
+        );
+        $createMessageAction->runWorkflow = false;
+        $socialMessage = $createMessageAction->execute();
+        $socialMessage->addEntity($this->entity);
+    }
+}

--- a/src/Domains/Social/Messages/Actions/CreateMessageAction.php
+++ b/src/Domains/Social/Messages/Actions/CreateMessageAction.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace Kanvas\Social\Messages\Actions;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 use Kanvas\Exceptions\ValidationException;
-use Kanvas\Filesystem\Services\ImageOptimizerService;
 use Kanvas\Filesystem\Traits\HasMutationUploadFiles;
 use Kanvas\Social\Channels\Actions\CreateChannelAction;
 use Kanvas\Social\Channels\DataTransferObject\Channel;
@@ -17,6 +15,7 @@ use Kanvas\Social\Channels\Models\Channel as ModelsChannel;
 use Kanvas\Social\Enums\AppEnum;
 use Kanvas\Social\Messages\DataTransferObject\MessageInput;
 use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Social\Messages\Services\MessageFileConstrainerService;
 use Kanvas\Social\Messages\Validations\ValidParentMessage;
 use Kanvas\SystemModules\Models\SystemModules;
 use Kanvas\Workflow\Enums\WorkflowEnum;
@@ -146,48 +145,12 @@ class CreateMessageAction
         });
     }
 
-    /**
-     * Constrain image file sizes for message types that have size limits (e.g., SMS/MMS).
-     */
     private function constrainMessageFiles(): void
     {
-        $app = $this->messageInput->app;
-        $maxFileSize = (int) ($app->get('filesystem-message-max-filesize') ?: 0);
-
-        if ($maxFileSize <= 0) {
-            return;
-        }
-
-        $allowedVerbs = (array) $app->get('filesystem-message-constrain-verbs');
-        if (empty($allowedVerbs)) {
-            return;
-        }
-
-        if (! in_array($this->messageInput->type->verb, $allowedVerbs, true)) {
-            return;
-        }
-
-        foreach ($this->messageInput->files as $key => $file) {
-            if (! $file instanceof UploadedFile) {
-                continue;
-            }
-
-            $convertedPath = ImageOptimizerService::constrainFileSize(
-                $file->getRealPath(),
-                $maxFileSize,
-            );
-
-            // constrainFileSize may convert HEIC to JPEG at a new path,
-            // so we need to update the file reference
-            if ($convertedPath !== $file->getRealPath()) {
-                $this->messageInput->files[$key] = new UploadedFile(
-                    $convertedPath,
-                    pathinfo($convertedPath, PATHINFO_BASENAME),
-                    (string) mime_content_type($convertedPath),
-                    $file->getError(),
-                    true
-                );
-            }
-        }
+        $this->messageInput->files = MessageFileConstrainerService::constrain(
+            $this->messageInput->app,
+            $this->messageInput->type->verb,
+            $this->messageInput->files,
+        );
     }
 }

--- a/src/Domains/Social/Messages/Services/MessageFileConstrainerService.php
+++ b/src/Domains/Social/Messages/Services/MessageFileConstrainerService.php
@@ -26,7 +26,8 @@ class MessageFileConstrainerService
             return $files;
         }
 
-        $allowedVerbs = (array) $app->get('filesystem-message-constrain-verbs');
+        $rawVerbs = $app->get('filesystem-message-constrain-verbs');
+        $allowedVerbs = is_string($rawVerbs) ? (json_decode($rawVerbs, true) ?: []) : (array) $rawVerbs;
         if (empty($allowedVerbs) || ! in_array($verb, $allowedVerbs, true)) {
             return $files;
         }
@@ -42,8 +43,6 @@ class MessageFileConstrainerService
                 $maxFileSize,
             );
 
-            // constrainFileSize may convert HEIC to JPEG at a new path,
-            // so we need to update the file reference
             if ($convertedPath !== $originalPath) {
                 $files[$key] = new UploadedFile(
                     $convertedPath,

--- a/src/Domains/Social/Messages/Services/MessageFileConstrainerService.php
+++ b/src/Domains/Social/Messages/Services/MessageFileConstrainerService.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Social\Messages\Services;
+
+use Baka\Contracts\AppInterface;
+use Illuminate\Http\UploadedFile;
+use Kanvas\Filesystem\Services\ImageOptimizerService;
+
+class MessageFileConstrainerService
+{
+    /**
+     * Constrain image file sizes for message types whose verb is in the app's
+     * `filesystem-message-constrain-verbs` allowlist, using `filesystem-message-max-filesize`
+     * as the per-file byte budget.
+     *
+     * Returns the (possibly mutated) files array — UploadedFile instances are constrained
+     * in-place; HEIC inputs are converted to JPEG and re-wrapped in a new UploadedFile.
+     * Non-UploadedFile entries are passed through unchanged.
+     */
+    public static function constrain(AppInterface $app, string $verb, array $files): array
+    {
+        $maxFileSize = (int) ($app->get('filesystem-message-max-filesize') ?: 0);
+        if ($maxFileSize <= 0) {
+            return $files;
+        }
+
+        $allowedVerbs = (array) $app->get('filesystem-message-constrain-verbs');
+        if (empty($allowedVerbs) || ! in_array($verb, $allowedVerbs, true)) {
+            return $files;
+        }
+
+        foreach ($files as $key => $file) {
+            if (! $file instanceof UploadedFile) {
+                continue;
+            }
+
+            $originalPath = $file->getRealPath();
+            $convertedPath = ImageOptimizerService::constrainFileSize(
+                $originalPath,
+                $maxFileSize,
+            );
+
+            // constrainFileSize may convert HEIC to JPEG at a new path,
+            // so we need to update the file reference
+            if ($convertedPath !== $originalPath) {
+                $files[$key] = new UploadedFile(
+                    $convertedPath,
+                    pathinfo($convertedPath, PATHINFO_BASENAME),
+                    (string) mime_content_type($convertedPath),
+                    $file->getError(),
+                    true
+                );
+            }
+        }
+
+        return $files;
+    }
+}

--- a/src/Domains/Social/Messages/Services/MessageFileConstrainerService.php
+++ b/src/Domains/Social/Messages/Services/MessageFileConstrainerService.php
@@ -26,8 +26,7 @@ class MessageFileConstrainerService
             return $files;
         }
 
-        $rawVerbs = $app->get('filesystem-message-constrain-verbs');
-        $allowedVerbs = is_string($rawVerbs) ? (json_decode($rawVerbs, true) ?: []) : (array) $rawVerbs;
+        $allowedVerbs = (array) $app->get('filesystem-message-constrain-verbs');
         if (empty($allowedVerbs) || ! in_array($verb, $allowedVerbs, true)) {
             return $files;
         }

--- a/src/Kanvas/Filesystem/Services/ImageOptimizerService.php
+++ b/src/Kanvas/Filesystem/Services/ImageOptimizerService.php
@@ -333,11 +333,7 @@ class ImageOptimizerService
 
                 $img = $img->scale($newWidth, $newHeight);
 
-                match (true) {
-                    self::isJpeg($extension) => $img->save($filePath, quality: 85),
-                    self::isPng($extension) => $img->save($filePath),
-                    default => null,
-                };
+                self::saveWithFormat($img, $filePath, $extension, 85);
                 clearstatcache(true, $filePath);
             }
 

--- a/tests/GraphQL/Social/MessageTest.php
+++ b/tests/GraphQL/Social/MessageTest.php
@@ -1788,6 +1788,66 @@ class MessageTest extends TestCase
         @unlink($tempPath);
     }
 
+    public function testCreateMessageConstrainsFileWithoutExtension(): void
+    {
+        // Regression: PHP multipart uploads land at /tmp/phpXXXXXX with no extension.
+        // Intervention v4 $img->save($path) infers encoder from filename — fails on no extension.
+        // saveWithFormat() must use the MIME-resolved $extension to encode explicitly.
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        $verb = 'twilio-sms-noext-' . uniqid();
+        $messageType = MessageType::factory()->create(['verb' => $verb]);
+
+        $prevOptimize = $app->get('filesystem-optimize-on-upload');
+        $app->set('filesystem-optimize-on-upload', false);
+
+        // Multipart-style temp path: no extension, like /tmp/phpWtmcv1
+        $tempPath = sys_get_temp_dir() . '/php' . substr(uniqid(), -6);
+        $img = imagecreatetruecolor(3000, 3000);
+        for ($y = 0; $y < 3000; $y += 2) {
+            for ($x = 0; $x < 3000; $x += 2) {
+                $color = imagecolorallocate($img, rand(0, 255), rand(0, 255), rand(0, 255));
+                imagesetpixel($img, $x, $y, $color);
+            }
+        }
+        imagejpeg($img, $tempPath, 100);
+        imagedestroy($img);
+
+        $originalSize = filesize($tempPath);
+        $maxFileSize = (int) ($originalSize * 0.25);
+        $app->set('filesystem-message-max-filesize', $maxFileSize);
+        $app->set('filesystem-message-constrain-verbs', [$verb]);
+
+        $file = new UploadedFile($tempPath, 'no-ext-photo.jpg', 'image/jpeg', null, true);
+
+        $action = new CreateMessageAction(
+            new MessageInput(
+                app: $app,
+                company: $company,
+                user: $user,
+                type: $messageType,
+                message: 'no-extension temp upload',
+                files: [$file],
+            ),
+        );
+        $action->runWorkflow = false;
+        $action->execute();
+
+        clearstatcache(true, $tempPath);
+        $this->assertLessThanOrEqual(
+            $maxFileSize,
+            filesize($tempPath),
+            'Image at extensionless temp path should still be constrained'
+        );
+
+        $app->set('filesystem-message-max-filesize', null);
+        $app->set('filesystem-message-constrain-verbs', null);
+        $app->set('filesystem-optimize-on-upload', $prevOptimize);
+        @unlink($tempPath);
+    }
+
     public function testCreateMessageConstrainsHeicFile(): void
     {
         $app = app(Apps::class);

--- a/tests/GraphQL/Social/MessageTest.php
+++ b/tests/GraphQL/Social/MessageTest.php
@@ -1730,6 +1730,64 @@ class MessageTest extends TestCase
         @unlink($tempPath);
     }
 
+    public function testAttachFileToMessageConstrainsLargeImage(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+
+        $verb = 'twilio-sms-attach-' . uniqid();
+        $messageType = MessageType::factory()->create(['verb' => $verb]);
+
+        $prevOptimize = $app->get('filesystem-optimize-on-upload');
+        $app->set('filesystem-optimize-on-upload', false);
+
+        $tempPath = sys_get_temp_dir() . '/attach-large-' . uniqid() . '.jpg';
+        $img = imagecreatetruecolor(3000, 3000);
+        for ($y = 0; $y < 3000; $y += 2) {
+            for ($x = 0; $x < 3000; $x += 2) {
+                $color = imagecolorallocate($img, rand(0, 255), rand(0, 255), rand(0, 255));
+                imagesetpixel($img, $x, $y, $color);
+            }
+        }
+        imagejpeg($img, $tempPath, 100);
+        imagedestroy($img);
+
+        $originalSize = filesize($tempPath);
+        $maxFileSize = (int) ($originalSize * 0.25);
+        $app->set('filesystem-message-max-filesize', $maxFileSize);
+        $app->set('filesystem-message-constrain-verbs', [$verb]);
+
+        $message = Message::create([
+            'apps_id' => $app->getId(),
+            'companies_id' => $user->getCurrentCompany()->getId(),
+            'users_id' => $user->getId(),
+            'message_types_id' => $messageType->getId(),
+            'message' => ['content' => 'attach test'],
+            'is_public' => 1,
+            'is_locked' => 0,
+        ]);
+
+        $file = new UploadedFile($tempPath, 'large-attach.jpg', 'image/jpeg', null, true);
+
+        $mutation = new \App\GraphQL\Social\Mutations\Messages\MessageManagementMutation();
+        $mutation->attachFileToMessage(null, [
+            'message_id' => $message->getId(),
+            'file' => $file,
+        ]);
+
+        clearstatcache(true, $tempPath);
+        $this->assertLessThanOrEqual(
+            $maxFileSize,
+            filesize($tempPath),
+            'Image attached via attachFileToMessage should be constrained to max file size'
+        );
+
+        $app->set('filesystem-message-max-filesize', null);
+        $app->set('filesystem-message-constrain-verbs', null);
+        $app->set('filesystem-optimize-on-upload', $prevOptimize);
+        @unlink($tempPath);
+    }
+
     public function testCreateMessageConstrainsHeicFile(): void
     {
         $app = app(Apps::class);


### PR DESCRIPTION
## Summary
- Enable image attachments through the Neuron chat pipeline (`ProcessAgentChatAction` → `RunNeuronChatAction` now forwards images).
- Add `MessageFileConstrainerService` and adjust `ImageOptimizerService` to validate and optimize message attachments before send.
- Unify Neuron agent chat history with Laravel-AI tables:
  - Rename lead-scoped `KanvasMessageHistory` → `SalesAssistKanvasMessageHistory` (no behavior change; `IntelligenceCRM` import updated).
  - New generic `KanvasMessageHistory` persists in `intelligence.agent_conversation_messages` (shared with Laravel-AI agents via `KanvasConversationStore`).
  - Wire it into `KanvasGenericNeuronAgent::chatHistory()` using `threadId` as `conversation_id`.
- `ProcessAgentChatAction` seeds Neuron handler `threadId` from the session UUID so the new history can scope by conversation.

## Test plan
- [ ] Send an image attachment through `agentChat` and verify it reaches the model.
- [ ] Verify image optimization respects file-size/dimension constraints.
- [ ] `KanvasGenericNeuronAgent` follow-up: send two prompts in the same session, second prompt sees the first turn loaded from `agent_conversation_messages`.
- [ ] `IntelligenceCRM` (sales-assist) still routes through social messages — no regression in lead chat.
- [ ] Cross-agent verification: Laravel-AI agent and a Neuron generic agent in the same session both produce rows in `agent_conversation_messages` (same `conversation_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)