### PR TITLE
feat(intelligence): enable image support + unify Neuron chat history

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/ProcessAgentChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/ProcessAgentChatAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Actions;
 
+use Baka\Support\Str;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Exceptions\ValidationException;
@@ -99,6 +100,8 @@ class ProcessAgentChatAction
         }
 
         $handler->setConfiguration($this->agent, $this->session?->entity(), null, $this->user);
+        $threadId = $this->session?->uuid ?? Str::uuid();
+        $handler->setThreadId($threadId);
 
         return new RunNeuronChatAction(
             agent: $this->agent,

--- a/src/Domains/Intelligence/Agents/Neuron/CRM/IntelligenceCRM.php
+++ b/src/Domains/Intelligence/Agents/Neuron/CRM/IntelligenceCRM.php
@@ -6,7 +6,7 @@ namespace Kanvas\Intelligence\Agents\Neuron\CRM;
 
 use Illuminate\Support\Facades\Blade;
 use Kanvas\Intelligence\Agents\Neuron\BaseKanvasAgent;
-use Kanvas\Intelligence\Agents\Neuron\KanvasMessageHistory;
+use Kanvas\Intelligence\Agents\Neuron\SalesAssistKanvasMessageHistory;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\ArtifactsTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\CommunicationChannelTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\CompanyInformationTool;
@@ -44,7 +44,7 @@ class IntelligenceCRM extends BaseKanvasAgent
             return new InMemoryChatHistory();
         }
 
-        return new KanvasMessageHistory(
+        return new SalesAssistKanvasMessageHistory(
             app: $this->app,
             company: $this->company,
             user: $this->user,

--- a/src/Domains/Intelligence/Agents/Neuron/KanvasGenericNeuronAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/KanvasGenericNeuronAgent.php
@@ -6,11 +6,29 @@ namespace Kanvas\Intelligence\Agents\Neuron;
 
 use Kanvas\NervousSystem\Capability\Models\Tool;
 use Kanvas\NervousSystem\Capability\Services\CapabilityProvider;
+use NeuronAI\Chat\History\AbstractChatHistory;
+use NeuronAI\Chat\History\InMemoryChatHistory;
 use Override;
 use ReflectionClass;
 
 class KanvasGenericNeuronAgent extends BaseKanvasAgent
 {
+    #[Override]
+    protected function chatHistory(): AbstractChatHistory
+    {
+        if ($this->user === null || $this->app === null || $this->company === null) {
+            return new InMemoryChatHistory();
+        }
+
+        return new KanvasMessageHistory(
+            app: $this->app,
+            company: $this->company,
+            user: $this->user,
+            agentClass: static::class,
+            conversationId: $this->threadId,
+        );
+    }
+
     #[Override]
     protected function tools(): array
     {

--- a/src/Domains/Intelligence/Agents/Neuron/KanvasMessageHistory.php
+++ b/src/Domains/Intelligence/Agents/Neuron/KanvasMessageHistory.php
@@ -4,17 +4,13 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Neuron;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
-use Kanvas\Social\Messages\Actions\CreateMessageAction;
-use Kanvas\Social\Messages\DataTransferObject\MessageInput;
-use Kanvas\Social\Messages\Models\AppModuleMessage;
-use Kanvas\Social\MessagesTypes\Services\MessageTypeService;
 use Kanvas\Users\Models\Users;
 use NeuronAI\Chat\Enums\MessageRole;
 use NeuronAI\Chat\History\AbstractChatHistory;
-use NeuronAI\Chat\History\ChatHistoryInterface;
 use NeuronAI\Chat\Messages\AssistantMessage;
 use NeuronAI\Chat\Messages\Message;
 use NeuronAI\Chat\Messages\UserMessage;
@@ -22,131 +18,69 @@ use Override;
 
 class KanvasMessageHistory extends AbstractChatHistory
 {
-    private const string AGENT_VERB = 'agent';
-    private const string USER_VERB = 'user';
-
-    // Verbos que nunca deben exponerse al lead
-    private const array INTERNAL_VERBS = ['notes', 'ai_assist', 'internal'];
+    private const string CONNECTION = 'intelligence';
+    private const string TABLE_CONVERSATIONS = 'agent_conversations';
+    private const string TABLE_MESSAGES = 'agent_conversation_messages';
 
     public function __construct(
         private readonly Apps $app,
         private readonly Companies $company,
         private readonly Users $user,
-        private readonly Model $entity,
-        private readonly ?string $threadId = null,
-        private readonly bool $includeInternal = false,
+        private readonly string $agentClass,
+        private ?string $conversationId = null,
         int $contextWindow = 50000,
     ) {
         parent::__construct($contextWindow);
-        $this->load();
+
+        $this->conversationId ??= $this->findLatestConversation();
+
+        if ($this->conversationId !== null) {
+            $this->load();
+        }
+    }
+
+    public function getConversationId(): ?string
+    {
+        return $this->conversationId;
+    }
+
+    private function findLatestConversation(): ?string
+    {
+        return DB::connection(self::CONNECTION)
+            ->table(self::TABLE_CONVERSATIONS)
+            ->where('user_id', $this->user->getId())
+            ->where('apps_id', $this->app->getId())
+            ->where('companies_id', $this->company->getId())
+            ->orderBy('updated_at', 'desc')
+            ->first()?->id;
     }
 
     private function load(): void
     {
-        $messages = AppModuleMessage::query()
-            ->where('system_modules', get_class($this->entity))
-            ->where('entity_id', $this->entity->getKey())
-            ->where('apps_id', $this->app->getId())
-            ->whereHas('message', fn ($q) => $q->where('is_deleted', 0))
-            ->with(['message.messageType'])
+        $messages = DB::connection(self::CONNECTION)
+            ->table(self::TABLE_MESSAGES)
+            ->where('conversation_id', $this->conversationId)
+            ->orderBy('created_at', 'asc')
             ->orderBy('id', 'asc')
             ->get()
-            ->map(function (AppModuleMessage $appModuleMessage): ?Message {
-                $socialMessage = $appModuleMessage->message;
+            ->map(function ($row): ?Message {
+                $content = (string) ($row->content ?? '');
 
-                if (! $socialMessage) {
+                if ($content === '') {
                     return null;
                 }
 
-                $stored = $socialMessage->getMessage();
-
-                if ($this->threadId !== null && ($stored['thread_id'] ?? null) !== $this->threadId) {
-                    return null;
-                }
-
-                $verb = $socialMessage->messageType?->verb ?? self::USER_VERB;
-
-                if (! $this->includeInternal && in_array($verb, self::INTERNAL_VERBS, true)) {
-                    return null;
-                }
-
-                $text = (string) ($stored['content'] ?? $stored['text'] ?? '');
-
-                if ($text === '') {
-                    return null;
-                }
-
-                $fromIa = (bool) ($stored['from_ia'] ?? false);
-                $fromHuman = (bool) ($stored['from_human'] ?? false);
-
-                $channel = $socialMessage->channels()->first();
-                $isInternal = $channel?->isNoteChannel() || $channel?->isAiAssistChannel();
-
-                if ($isInternal) {
-                    $prefixed = "[INTERNAL - {$channel->name}] {$text}";
-                } elseif ($fromIa) {
-                    $prefixed = "[Assistant] {$text}";
-                } elseif ($fromHuman) {
-                    $owner = $socialMessage->user?->displayname ?: 'Owner';
-                    $prefixed = "[Owner - {$owner}] {$text}";
-                } else {
-                    $prefixed = '[' . $this->entityIdentityLabel() . "] {$text}";
-                }
-
-                return $fromIa
-                    ? new AssistantMessage($prefixed)
-                    : new UserMessage($prefixed);
+                return $row->role === MessageRole::ASSISTANT->value
+                    ? new AssistantMessage($content)
+                    : new UserMessage($content);
             })
             ->filter()
             ->values()
-            ->toArray();
+            ->all();
 
-        $coalesced = [];
-        foreach ($messages as $m) {
-            $last = end($coalesced) ?: null;
-            if ($last !== null && $last->getRole() === $m->getRole()) {
-                $last->setContents($last->getContent() . "\n\n" . $m->getContent());
-
-                continue;
-            }
-            $coalesced[] = $m;
+        if (! empty($messages)) {
+            $this->history = $messages;
         }
-
-        while (! empty($coalesced) && $coalesced[0]->getRole() !== MessageRole::USER->value) {
-            array_shift($coalesced);
-        }
-
-        if (! empty($coalesced)) {
-            $this->history = array_values($coalesced);
-        }
-    }
-
-    #[Override]
-    public function addMessage(Message $message): ChatHistoryInterface
-    {
-        $last = end($this->history) ?: null;
-        if ($last !== null && $last->getRole() === $message->getRole()) {
-            $last->setContents($last->getContent() . "\n\n" . $message->getContent());
-            $this->trimHistory();
-            $this->onNewMessage($message);
-            $this->setMessages($this->history);
-
-            return $this;
-        }
-
-        return parent::addMessage($message);
-    }
-
-    private function entityIdentityLabel(): string
-    {
-        if (method_exists($this->entity, 'people') && $this->entity->people) {
-            $name = (string) $this->entity->people->getName();
-            if ($name !== '') {
-                return "Lead - {$name}";
-            }
-        }
-
-        return class_basename($this->entity) . ':' . $this->entity->getKey();
     }
 
     #[Override]
@@ -164,33 +98,46 @@ class KanvasMessageHistory extends AbstractChatHistory
             return;
         }
 
-        $isAssistant = $role === MessageRole::ASSISTANT->value;
-        $verb = $isAssistant ? self::AGENT_VERB : self::USER_VERB;
-        $messageType = MessageTypeService::getOrCreate($this->app, $verb);
-
-        $messageData = [
-            'content' => $content,
-            'from_me' => $isAssistant,
-            'from_ia' => $isAssistant,
-            'from_human' => ! $isAssistant,
-        ];
-
-        if ($this->threadId !== null) {
-            $messageData['thread_id'] = $this->threadId;
+        if ($this->conversationId === null) {
+            $this->conversationId = $this->createConversation($content);
+        } else {
+            DB::connection(self::CONNECTION)
+                ->table(self::TABLE_CONVERSATIONS)
+                ->where('id', $this->conversationId)
+                ->update(['updated_at' => now()]);
         }
 
-        $createMessageAction = new CreateMessageAction(
-            new MessageInput(
-                app: $this->app,
-                company: $this->company,
-                user: $this->user,
-                type: $messageType,
-                message: $messageData,
-                is_public: 0,
-            )
-        );
-        $createMessageAction->runWorkflow = false;
-        $socialMessage = $createMessageAction->execute();
-        $socialMessage->addEntity($this->entity);
+        DB::connection(self::CONNECTION)->table(self::TABLE_MESSAGES)->insert([
+            'id' => (string) Str::uuid7(),
+            'conversation_id' => $this->conversationId,
+            'user_id' => $this->user->getId(),
+            'agent' => $this->agentClass,
+            'role' => $role,
+            'content' => $content,
+            'attachments' => '[]',
+            'tool_calls' => '[]',
+            'tool_results' => '[]',
+            'usage' => '[]',
+            'meta' => '[]',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createConversation(string $firstMessage): string
+    {
+        $conversationId = (string) Str::uuid7();
+
+        DB::connection(self::CONNECTION)->table(self::TABLE_CONVERSATIONS)->insert([
+            'id' => $conversationId,
+            'user_id' => $this->user->getId(),
+            'apps_id' => $this->app->getId(),
+            'companies_id' => $this->company->getId(),
+            'title' => Str::limit($firstMessage, 100, ''),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $conversationId;
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/SalesAssistKanvasMessageHistory.php
+++ b/src/Domains/Intelligence/Agents/Neuron/SalesAssistKanvasMessageHistory.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron;
+
+use Illuminate\Database\Eloquent\Model;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Social\Messages\Actions\CreateMessageAction;
+use Kanvas\Social\Messages\DataTransferObject\MessageInput;
+use Kanvas\Social\Messages\Models\AppModuleMessage;
+use Kanvas\Social\MessagesTypes\Services\MessageTypeService;
+use Kanvas\Users\Models\Users;
+use NeuronAI\Chat\Enums\MessageRole;
+use NeuronAI\Chat\History\AbstractChatHistory;
+use NeuronAI\Chat\History\ChatHistoryInterface;
+use NeuronAI\Chat\Messages\AssistantMessage;
+use NeuronAI\Chat\Messages\Message;
+use NeuronAI\Chat\Messages\UserMessage;
+use Override;
+
+class SalesAssistKanvasMessageHistory extends AbstractChatHistory
+{
+    private const string AGENT_VERB = 'agent';
+    private const string USER_VERB = 'user';
+
+    // Verbos que nunca deben exponerse al lead
+    private const array INTERNAL_VERBS = ['notes', 'ai_assist', 'internal'];
+
+    public function __construct(
+        private readonly Apps $app,
+        private readonly Companies $company,
+        private readonly Users $user,
+        private readonly Model $entity,
+        private readonly ?string $threadId = null,
+        private readonly bool $includeInternal = false,
+        int $contextWindow = 50000,
+    ) {
+        parent::__construct($contextWindow);
+        $this->load();
+    }
+
+    private function load(): void
+    {
+        $messages = AppModuleMessage::query()
+            ->where('system_modules', get_class($this->entity))
+            ->where('entity_id', $this->entity->getKey())
+            ->where('apps_id', $this->app->getId())
+            ->whereHas('message', fn ($q) => $q->where('is_deleted', 0))
+            ->with(['message.messageType'])
+            ->orderBy('id', 'asc')
+            ->get()
+            ->map(function (AppModuleMessage $appModuleMessage): ?Message {
+                $socialMessage = $appModuleMessage->message;
+
+                if (! $socialMessage) {
+                    return null;
+                }
+
+                $stored = $socialMessage->getMessage();
+
+                if ($this->threadId !== null && ($stored['thread_id'] ?? null) !== $this->threadId) {
+                    return null;
+                }
+
+                $verb = $socialMessage->messageType?->verb ?? self::USER_VERB;
+
+                if (! $this->includeInternal && in_array($verb, self::INTERNAL_VERBS, true)) {
+                    return null;
+                }
+
+                $text = (string) ($stored['content'] ?? $stored['text'] ?? '');
+
+                if ($text === '') {
+                    return null;
+                }
+
+                $fromIa = (bool) ($stored['from_ia'] ?? false);
+                $fromHuman = (bool) ($stored['from_human'] ?? false);
+
+                $channel = $socialMessage->channels()->first();
+                $isInternal = $channel?->isNoteChannel() || $channel?->isAiAssistChannel();
+
+                if ($isInternal) {
+                    $prefixed = "[INTERNAL - {$channel->name}] {$text}";
+                } elseif ($fromIa) {
+                    $prefixed = "[Assistant] {$text}";
+                } elseif ($fromHuman) {
+                    $owner = $socialMessage->user?->displayname ?: 'Owner';
+                    $prefixed = "[Owner - {$owner}] {$text}";
+                } else {
+                    $prefixed = '[' . $this->entityIdentityLabel() . "] {$text}";
+                }
+
+                return $fromIa
+                    ? new AssistantMessage($prefixed)
+                    : new UserMessage($prefixed);
+            })
+            ->filter()
+            ->values()
+            ->toArray();
+
+        $coalesced = [];
+        foreach ($messages as $m) {
+            $last = end($coalesced) ?: null;
+            if ($last !== null && $last->getRole() === $m->getRole()) {
+                $last->setContents($last->getContent() . "\n\n" . $m->getContent());
+
+                continue;
+            }
+            $coalesced[] = $m;
+        }
+
+        while (! empty($coalesced) && $coalesced[0]->getRole() !== MessageRole::USER->value) {
+            array_shift($coalesced);
+        }
+
+        if (! empty($coalesced)) {
+            $this->history = array_values($coalesced);
+        }
+    }
+
+    #[Override]
+    public function addMessage(Message $message): ChatHistoryInterface
+    {
+        $last = end($this->history) ?: null;
+        if ($last !== null && $last->getRole() === $message->getRole()) {
+            $last->setContents($last->getContent() . "\n\n" . $message->getContent());
+            $this->trimHistory();
+            $this->onNewMessage($message);
+            $this->setMessages($this->history);
+
+            return $this;
+        }
+
+        return parent::addMessage($message);
+    }
+
+    private function entityIdentityLabel(): string
+    {
+        if (method_exists($this->entity, 'people') && $this->entity->people) {
+            $name = (string) $this->entity->people->getName();
+            if ($name !== '') {
+                return "Lead - {$name}";
+            }
+        }
+
+        return class_basename($this->entity) . ':' . $this->entity->getKey();
+    }
+
+    #[Override]
+    protected function onNewMessage(Message $message): void
+    {
+        $role = $message->getRole();
+
+        if (! in_array($role, [MessageRole::USER->value, MessageRole::ASSISTANT->value], true)) {
+            return;
+        }
+
+        $content = (string) $message->getContent();
+
+        if ($content === '') {
+            return;
+        }
+
+        $isAssistant = $role === MessageRole::ASSISTANT->value;
+        $verb = $isAssistant ? self::AGENT_VERB : self::USER_VERB;
+        $messageType = MessageTypeService::getOrCreate($this->app, $verb);
+
+        $messageData = [
+            'content' => $content,
+            'from_me' => $isAssistant,
+            'from_ia' => $isAssistant,
+            'from_human' => ! $isAssistant,
+        ];
+
+        if ($this->threadId !== null) {
+            $messageData['thread_id'] = $this->threadId;
+        }
+
+        $createMessageAction = new CreateMessageAction(
+            new MessageInput(
+                app: $this->app,
+                company: $this->company,
+                user: $this->user,
+                type: $messageType,
+                message: $messageData,
+                is_public: 0,
+            )
+        );
+        $createMessageAction->runWorkflow = false;
+        $socialMessage = $createMessageAction->execute();
+        $socialMessage->addEntity($this->entity);
+    }
+}


### PR DESCRIPTION
## Summary
- Enable image attachments through the Neuron chat pipeline (`ProcessAgentChatAction` → `RunNeuronChatAction` now forwards images).
- Add `MessageFileConstrainerService` and adjust `ImageOptimizerService` to validate and optimize message attachments before send.
- Unify Neuron agent chat history with Laravel-AI tables:
  - Rename lead-scoped `KanvasMessageHistory` → `SalesAssistKanvasMessageHistory` (no behavior change; `IntelligenceCRM` import updated).
  - New generic `KanvasMessageHistory` persists in `intelligence.agent_conversation_messages` (shared with Laravel-AI agents via `KanvasConversationStore`).
  - Wire it into `KanvasGenericNeuronAgent::chatHistory()` using `threadId` as `conversation_id`.
- `ProcessAgentChatAction` seeds Neuron handler `threadId` from the session UUID so the new history can scope by conversation.

## Test plan
- [ ] Send an image attachment through `agentChat` and verify it reaches the model.
- [ ] Verify image optimization respects file-size/dimension constraints.
- [ ] `KanvasGenericNeuronAgent` follow-up: send two prompts in the same session, second prompt sees the first turn loaded from `agent_conversation_messages`.
- [ ] `IntelligenceCRM` (sales-assist) still routes through social messages — no regression in lead chat.
- [ ] Cross-agent verification: Laravel-AI agent and a Neuron generic agent in the same session both produce rows in `agent_conversation_messages` (same `conversation_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)