### PR TITLE
feat(acl): add Event module to ACL with CRUD abilities (1.x)

### DIFF
--- a/src/Kanvas/AccessControlList/Templates/ModulesRepositories.php
+++ b/src/Kanvas/AccessControlList/Templates/ModulesRepositories.php
@@ -12,6 +12,9 @@ use Kanvas\ActionEngine\Tasks\Models\TaskListItem;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Enums\ModuleEnum;
+use Kanvas\Event\Events\Models\Event;
+use Kanvas\Event\Events\Models\EventType;
+use Kanvas\Event\Events\Models\EventVersion;
 use Kanvas\Guild\Agents\Models\Agent;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Leads\Models\Lead;
@@ -54,6 +57,7 @@ class ModulesRepositories
             ModuleEnum::ACTION_ENGINE,
             ModuleEnum::AI,
             ModuleEnum::COMMERCE,
+            ModuleEnum::EVENT,
         ];
 
         $permissions = [];
@@ -122,6 +126,11 @@ class ModulesRepositories
             ],
             ModuleEnum::COMMERCE->value => [
                 Order::class => $crud,
+            ],
+            ModuleEnum::EVENT->value => [
+                Event::class => $crud,
+                EventVersion::class => $crud,
+                EventType::class => $crud,
             ],
         ];
 

--- a/src/Kanvas/Enums/ModuleEnum.php
+++ b/src/Kanvas/Enums/ModuleEnum.php
@@ -17,4 +17,5 @@ enum ModuleEnum: int
     case SETTING = 9;
     case AI = 10;
     case COMMERCE = 11;
+    case EVENT = 12;
 }


### PR DESCRIPTION
## Summary
Mirror of #9663 against the `1.x` branch.

- Adds a new `EVENT` case (`= 12`) to `ModuleEnum`.
- Wires the Event module into `ModulesRepositories::getAbilitiesByModule()` with `Event`, `EventVersion`, and `EventType` models, each granted the standard CRUD ability set (view / create / edit / delete).
- Registers `ModuleEnum::EVENT` in `getModulePermissions()` so `view-module-event` / `manage-module-event` are generated alongside the other modules.

## Test plan
- [ ] `getAllAbilities()` includes Event, EventVersion, EventType keys
- [ ] `getModuleIdByModelName(Event::class)` returns `12`
- [ ] `getAllModulePermissionNames()` includes `view-module-event` and `manage-module-event`
- [ ] Existing seeders/role builders that consume `getAbilitiesByModule()` pick up the new abilities without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)