### PR TITLE
feat(users): add updateBannerUrl mutation

### DIFF
--- a/app/GraphQL/Ecosystem/Mutations/Users/UserManagementMutation.php
+++ b/app/GraphQL/Ecosystem/Mutations/Users/UserManagementMutation.php
@@ -377,11 +377,9 @@ class UserManagementMutation
     {
         $loggedUser = auth()->user();
         $app = app(Apps::class);
-        $userId = (int) $request['user_id'];
-
-        if ($userId !== $loggedUser->getId() && ! $loggedUser->isAdmin()) {
-            throw new Exception('You are not allowed to update this user banner');
-        }
+        $userId = $loggedUser->isAdmin() && (int) $request['user_id'] > 0
+            ? (int) $request['user_id']
+            : $loggedUser->getId();
 
         $user = UsersRepository::getUserOfAppById($userId, $app);
         $user->set('banner_url', $request['url'], true);

--- a/app/GraphQL/Ecosystem/Mutations/Users/UserManagementMutation.php
+++ b/app/GraphQL/Ecosystem/Mutations/Users/UserManagementMutation.php
@@ -372,4 +372,20 @@ class UserManagementMutation
 
         return true;
     }
+
+    public function updateBannerUrl(mixed $rootValue, array $request): Users
+    {
+        $loggedUser = auth()->user();
+        $app = app(Apps::class);
+        $userId = (int) $request['user_id'];
+
+        if ($userId !== $loggedUser->getId() && ! $loggedUser->isAdmin()) {
+            throw new Exception('You are not allowed to update this user banner');
+        }
+
+        $user = UsersRepository::getUserOfAppById($userId, $app);
+        $user->set('banner_url', $request['url'], true);
+
+        return $user;
+    }
 }

--- a/graphql/schemas/Ecosystem/user.graphql
+++ b/graphql/schemas/Ecosystem/user.graphql
@@ -325,6 +325,11 @@ extend type Mutation {
         @field(
             resolver: "App\\GraphQL\\Ecosystem\\Mutations\\Users\\UserManagementMutation@saveUserAppPreferences"
         )
+    updateBannerUrl(user_id: ID!, url: String!): User!
+        @guard
+        @field(
+            resolver: "App\\GraphQL\\Ecosystem\\Mutations\\Users\\UserManagementMutation@updateBannerUrl"
+        )
 }
 
 type Query @guard {


### PR DESCRIPTION
## Summary
- Adds `updateBannerUrl(user_id: ID!, url: String!): User!` GraphQL mutation
- Stores the banner URL as a public custom field (`banner_url`) via the existing `HashTableTrait::set()` mechanism
- Only the user themselves or an admin can update the banner

## Test plan
- [ ] Call `updateBannerUrl` as the owner user — confirm `banner_url` appears in `custom_fields`
- [ ] Call `updateBannerUrl` as a different non-admin user — confirm 403/exception
- [ ] Call `updateBannerUrl` as an admin for another user — confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)