### PR TITLE
Fix notes_channel_slug in CreateContentSessionAction

### DIFF
--- a/src/Domains/Intelligence/Sessions/Actions/CreateContentSessionAction.php
+++ b/src/Domains/Intelligence/Sessions/Actions/CreateContentSessionAction.php
@@ -114,7 +114,7 @@ class CreateContentSessionAction
                 'allow_call_appointments' => $lead->company->get(EnumsConfigurationEnum::ALLOW_CALL_APPOINTMENTS->value) ?? true,
                 'work_hours' => $lead->company->get('work_hours'),
                 'working_holiday_days' => $lead->company->get('working_holiday_days'),
-                'notes_channel_uuid' => $lead->notes?->uuid,
+                'notes_channel_slug' => $lead->notes?->slug,
             ],
             $this->mapPeople($lead->people, $lead),
             $lead->get(ConfigurationEnum::LEAD_CONTEXT_INFO->value) ?? []


### PR DESCRIPTION
Renamed notes_channel_uuid to notes_channel_slug and used $lead->notes?->slug instead of uuid.