### PR TITLE
fix: throw on empty message creation in agent responder

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
@@ -77,6 +77,9 @@ class BaseAgentResponderAction
         Channel $channel,
         ?string $from = null
     ): Message {
+        if (! $text) {
+            throw new Exception('Empty message was created');
+        }
         $user = $this->channel->company->getAiAgentUser() ?? $message->user;
         $type = $this->getMessageType($message->app);
         $messageInput = new MessageInput(

--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
@@ -77,7 +77,7 @@ class BaseAgentResponderAction
         Channel $channel,
         ?string $from = null
     ): Message {
-        if (! $text) {
+        if (empty($text)) {
             throw new Exception('Empty message was created');
         }
         $user = $this->channel->company->getAiAgentUser() ?? $message->user;


### PR DESCRIPTION
## Summary
- Throw when `BaseAgentResponderAction::createMessage` receives an empty text body, instead of silently persisting an empty message.

## Test plan
- [ ] Manual: trigger the responder path with an empty AI completion and confirm the exception surfaces (no empty `Message` row created).
- [ ] Verify existing happy-path agent responses still create messages normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)