### PR TITLE
feat(wallet): drive useOrderTotal from app setting

### DIFF
--- a/app/GraphQL/Inventory/Builders/Products/ProductBuilder.php
+++ b/app/GraphQL/Inventory/Builders/Products/ProductBuilder.php
@@ -48,6 +48,15 @@ class ProductBuilder
             $query->filterByVariantAttributeValue($args['variantAttributeValue']);
         }
 
+        if (! empty($args['withAttributeSlug'])) {
+            $slug = $args['withAttributeSlug'];
+            $query->whereHas(
+                'attributeValues',
+                fn (Builder $q) => $q->where('is_deleted', 0)
+                    ->whereHas('attribute', fn (Builder $a) => $a->where('slug', $slug))
+            );
+        }
+
         if (! empty($args['variantAttributeOrderBy'])) {
             $order = $args['variantAttributeOrderBy'];
             $query->orderByVariantAttribute(

--- a/graphql/schemas/Inventory/product.graphql
+++ b/graphql/schemas/Inventory/product.graphql
@@ -228,6 +228,7 @@ extend type Query @guard {
     products(
         search: String @search
         variantAttributeValue: String
+        withAttributeSlug: String
         variantAttributeOrderBy: ProductAttributeOrderBy
         attributeOrderBy: ProductAttributeOrderBy
         nearByLocation: NearByLocationInput

--- a/src/Domains/Souk/Wallet/Activities/AddFundsToUserWalletActivity.php
+++ b/src/Domains/Souk/Wallet/Activities/AddFundsToUserWalletActivity.php
@@ -59,6 +59,7 @@ class AddFundsToUserWalletActivity extends KanvasActivity
 
                 $transaction = new AddFundsToUserWalletAction(
                     order: $order,
+                    useOrderTotal: (bool) $app->get(ConfigurationEnum::WALLET_USE_ORDER_TOTAL->value),
                     source: TransactionSourceEnum::RECHARGE_MANUAL,
                 )->execute($params['processTransactionsByWalletType'] ?? false);
 

--- a/src/Domains/Souk/Wallet/Activities/AddFundsToWalletActivity.php
+++ b/src/Domains/Souk/Wallet/Activities/AddFundsToWalletActivity.php
@@ -61,6 +61,7 @@ class AddFundsToWalletActivity extends KanvasActivity
 
                 $transaction = new AddFundsToCompanyWalletAction(
                     order: $order,
+                    useOrderTotal: (bool) $app->get(ConfigurationEnum::WALLET_USE_ORDER_TOTAL->value),
                     source: TransactionSourceEnum::RECHARGE_MANUAL,
                     resolveCompanyFromMetadata: (bool) $app->get(ConfigurationEnum::WALLET_RESOLVE_COMPANY_FROM_METADATA->value),
                 )->execute();

--- a/src/Domains/Souk/Wallet/Enums/ConfigurationEnum.php
+++ b/src/Domains/Souk/Wallet/Enums/ConfigurationEnum.php
@@ -27,4 +27,5 @@ enum ConfigurationEnum: string
     case VARIANT_WALLET_CREDIT_AMOUNT = 'credit';
 
     case WALLET_RESOLVE_COMPANY_FROM_METADATA = 'wallet_resolve_company_from_metadata';
+    case WALLET_USE_ORDER_TOTAL = 'wallet_use_order_total';
 }

--- a/tests/GraphQL/Inventory/ProductsTest.php
+++ b/tests/GraphQL/Inventory/ProductsTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\GraphQL\Inventory;
 
+use Kanvas\Apps\Models\Apps;
 use Kanvas\Inventory\Products\Models\Products;
 use Kanvas\Inventory\Warehouses\Models\Warehouses;
 use Kanvas\Languages\Models\Languages;
+use Kanvas\Users\Models\Users;
 use Tests\GraphQL\Inventory\Traits\InventoryCases;
 use Tests\TestCase;
 
@@ -524,5 +526,46 @@ class ProductsTest extends TestCase
 
         $matchingIds = collect($response->json('data.products.data'))->pluck('id')->toArray();
         $this->assertContains($productId, $matchingIds);
+    }
+
+    public function testFilterByWithAttributeSlug(): void
+    {
+        /** @var Users $user */
+        $user = auth()->user();
+        $app = app(Apps::class);
+        $company = $user->getCurrentCompany();
+
+        $taggedProduct = Products::factory()->state([
+            'apps_id' => $app->getId(),
+            'companies_id' => $company->getId(),
+            'users_id' => $user->getId(),
+        ])->create();
+        $taggedProduct->addAttributes(
+            $user,
+            [['name' => 'tag_number', 'value' => (string) random_int(100000000000, 999999999999)]]
+        );
+
+        $untaggedProduct = Products::factory()->state([
+            'apps_id' => $app->getId(),
+            'companies_id' => $company->getId(),
+            'users_id' => $user->getId(),
+        ])->create();
+        $untaggedProduct->addAttributes(
+            $user,
+            [['name' => 'color', 'value' => 'red']]
+        );
+
+        $response = $this->graphQL('
+            query($slug: String!) {
+                products(withAttributeSlug: $slug, first: 200) {
+                    paginatorInfo { total }
+                    data { id }
+                }
+            }
+        ', ['slug' => 'tag-number'])->assertSuccessful();
+
+        $ids = collect($response->json('data.products.data'))->pluck('id')->map(fn ($id) => (int) $id)->all();
+        $this->assertContains($taggedProduct->getId(), $ids);
+        $this->assertNotContains($untaggedProduct->getId(), $ids);
     }
 }


### PR DESCRIPTION
Reads ConfigurationEnum::WALLET_USE_ORDER_TOTAL on the company and user AddFunds activities so tenants can opt into depositing the order's gross total instead of summing coin-variant attributes. Defaults to false.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
