### PR TITLE
refact: move intelligence_lead_type_mode_v2 from app to company setting

### DIFF
--- a/app/Console/Commands/Intelligence/FollowUpEngagementCommand.php
+++ b/app/Console/Commands/Intelligence/FollowUpEngagementCommand.php
@@ -211,7 +211,7 @@ class FollowUpEngagementCommand extends Command
                 //how do we avoid sending notifications for leads that haven'b been contacted
                 try {
                     $this->info('Executing FollowUpEngagementAction for lead ID ' . $lead->id . ' - ' . $lead->people->name);
-                    $followUpClass = (new LeadConfigurationService())->isV2Enabled($lead->app)
+                    $followUpClass = (new LeadConfigurationService())->isV2Enabled($lead->company)
                         ? FollowUpEngagementAction::class
                         : FollowUpEngagementV1Action::class;
                     $result = new $followUpClass($lead, $log)->execute();

--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
@@ -46,7 +46,7 @@ class BaseAgentResponderAction
             ? $configService->getAiModeKey($lead)
             : 'ai_mode';
 
-        if ($lead instanceof Lead && ! $lead->get(LeadConfigurationEnum::AI_MODE_IS_MANUAL->value) && $configService->isV2Enabled($lead->app)) {
+        if ($lead instanceof Lead && ! $lead->get(LeadConfigurationEnum::AI_MODE_IS_MANUAL->value) && $configService->isV2Enabled($lead->company)) {
             try {
                 $isOpen = $lead->company->isWithinWorkingHours(now());
             } catch (InvalidArgumentException) {

--- a/src/Domains/Intelligence/Agents/Traits/HandlesSupportModeDelayedResponseTrait.php
+++ b/src/Domains/Intelligence/Agents/Traits/HandlesSupportModeDelayedResponseTrait.php
@@ -49,7 +49,7 @@ trait HandlesSupportModeDelayedResponseTrait
             return null;
         }
 
-        if (! $configService->isV2Enabled($app)) {
+        if (! $configService->isV2Enabled($lead->company)) {
             if (UnrespondedLeadAgentMessageCache::exists($lead, $channel)) {
                 return [
                     'message' => 'There is already an unresponded message pending in this channel',
@@ -62,7 +62,7 @@ trait HandlesSupportModeDelayedResponseTrait
             CompanyConfigurationEnum::UN_RESPONDED_SALESPERSON_MESSAGES->value
         ) ?? 60;
 
-        if (! $configService->isV2Enabled($app)) {
+        if (! $configService->isV2Enabled($lead->company)) {
             UnrespondedLeadAgentMessageCache::set($lead, $channel, $message, $delayMinutes + 5);
         }
 
@@ -72,7 +72,7 @@ trait HandlesSupportModeDelayedResponseTrait
         }
 
         if ($agentIdForDispatch === null) {
-            if (! $configService->isV2Enabled($app)) {
+            if (! $configService->isV2Enabled($lead->company)) {
                 UnrespondedLeadAgentMessageCache::clear($lead, $channel);
             }
 
@@ -84,7 +84,7 @@ trait HandlesSupportModeDelayedResponseTrait
 
         $agentModel = Agent::getById($agentIdForDispatch, $app);
 
-        if ($configService->isV2Enabled($app)) {
+        if ($configService->isV2Enabled($lead->company)) {
             SendUnrespondedAgentMessageJob::dispatch(
                 $channel,
                 $message,

--- a/src/Domains/Intelligence/Services/LeadConfigurationService.php
+++ b/src/Domains/Intelligence/Services/LeadConfigurationService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Services;
 
-use Kanvas\Apps\Models\Apps;
+use Baka\Contracts\CompanyInterface;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Models\LeadType;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
@@ -16,9 +16,9 @@ class LeadConfigurationService
     ) {
     }
 
-    public function isV2Enabled(Apps $app): bool
+    public function isV2Enabled(CompanyInterface $company): bool
     {
-        if ((bool) $app->get('intelligence_lead_type_mode_v2')) {
+        if ((bool) $company->get('intelligence_lead_type_mode_v2')) {
             return true;
         }
 
@@ -57,7 +57,7 @@ class LeadConfigurationService
 
     public function getAiModeKey(Lead $lead): string
     {
-        if (! $this->isV2Enabled($lead->app)) {
+        if (! $this->isV2Enabled($lead->company)) {
             return 'ai_mode';
         }
 
@@ -72,7 +72,7 @@ class LeadConfigurationService
 
     public function getFollowUpModeKey(Lead $lead): string
     {
-        if (! $this->isV2Enabled($lead->app)) {
+        if (! $this->isV2Enabled($lead->company)) {
             return IntelligenceModeEnum::AI_FOLLOW_UP->value;
         }
 

--- a/src/Domains/Intelligence/Triggers/Workflows/MessageHumanTakeoverTriggerActivity.php
+++ b/src/Domains/Intelligence/Triggers/Workflows/MessageHumanTakeoverTriggerActivity.php
@@ -57,7 +57,7 @@ class MessageHumanTakeoverTriggerActivity extends KanvasActivity
                     ];
                 }
 
-                if (! (new LeadConfigurationService())->isV2Enabled($app)) {
+                if (! (new LeadConfigurationService())->isV2Enabled($lead->company)) {
                     $channel = $message->channels()->first();
                     if ($channel && ! $channel->isNoteChannel()) {
                         UnrespondedLeadAgentMessageCache::clear($lead, $channel);

--- a/src/Domains/Intelligence/Triggers/Workflows/TriggerIntelligenceActivity.php
+++ b/src/Domains/Intelligence/Triggers/Workflows/TriggerIntelligenceActivity.php
@@ -32,7 +32,7 @@ class TriggerIntelligenceActivity extends KanvasActivity
                 }
 
                 $configService = new LeadConfigurationService();
-                $actionClass = $configService->isV2Enabled($app)
+                $actionClass = $configService->isV2Enabled($lead->company)
                     ? ApplyLeadAiModeAction::class
                     : ApplyLeadAiModeV1Action::class;
                 $result = new $actionClass($lead, $triggerType)->execute();

--- a/tests/Intelligence/Commands/TriggerIntelligenceActivityTest.php
+++ b/tests/Intelligence/Commands/TriggerIntelligenceActivityTest.php
@@ -27,7 +27,7 @@ class TriggerIntelligenceActivityTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        app(Apps::class)->set('intelligence_lead_type_mode_v2', 0);
+        auth()->user()->getCurrentCompany()->set('intelligence_lead_type_mode_v2', 0);
     }
 
     private function createLead(string $leadTypeName = ''): Lead

--- a/tests/Intelligence/PipelineStages/FollowUpEngagementActionV1Test.php
+++ b/tests/Intelligence/PipelineStages/FollowUpEngagementActionV1Test.php
@@ -41,9 +41,7 @@ class FollowUpEngagementActionV1Test extends TestCase
     {
         parent::setUp();
 
-        $app = app(Apps::class);
-
-        $app->set('intelligence_lead_type_mode_v2', false);
+        auth()->user()->getCurrentCompany()->set('intelligence_lead_type_mode_v2', false);
     }
 
     public function testNotificationEngagementAction(): void

--- a/tests/Intelligence/Services/LeadConfigurationServiceV1Test.php
+++ b/tests/Intelligence/Services/LeadConfigurationServiceV1Test.php
@@ -18,7 +18,7 @@ class LeadConfigurationServiceV1Test extends TestCase
         parent::setUp();
         $app = app(Apps::class);
         $app->set('search_engine', 'database');
-        $app->set('intelligence_lead_type_mode_v2', false);
+        auth()->user()->getCurrentCompany()->set('intelligence_lead_type_mode_v2', false);
     }
 
     private function createLead(string $leadTypeName = ''): Lead
@@ -51,7 +51,7 @@ class LeadConfigurationServiceV1Test extends TestCase
 
     public function testIsV2EnabledReturnsFalseByDefault(): void
     {
-        $this->assertFalse(new LeadConfigurationService(false)->isV2Enabled(app(Apps::class)));
+        $this->assertFalse(new LeadConfigurationService(false)->isV2Enabled(auth()->user()->getCurrentCompany()));
     }
 
     public function testGetAiModeKeyReturnsGenericKeyWhenV1(): void

--- a/tests/Intelligence/Services/LeadConfigurationServiceV2Test.php
+++ b/tests/Intelligence/Services/LeadConfigurationServiceV2Test.php
@@ -49,7 +49,7 @@ class LeadConfigurationServiceV2Test extends TestCase
 
     public function testIsV2EnabledReturnsTrueWhenFlagSet(): void
     {
-        $this->assertTrue(new LeadConfigurationService(true)->isV2Enabled(app(Apps::class)));
+        $this->assertTrue(new LeadConfigurationService(true)->isV2Enabled(auth()->user()->getCurrentCompany()));
     }
 
     public function testGetAiModeKeyReturnsShowroomKeyForShowroomLeadType(): void


### PR DESCRIPTION
## Summary
- `LeadConfigurationService::isV2Enabled` now takes a `CompanyInterface` and reads the flag from the company instead of the app.
- All callers updated to pass the lead's company (`FollowUpEngagementCommand`, `TriggerIntelligenceActivity`, `MessageHumanTakeoverTriggerActivity`, `HandlesSupportModeDelayedResponseTrait`, `BaseAgentResponderAction`).
- Tests' `setUp` writes the flag on the authenticated user's current company.

## How to activate V2 now
```php
$company->set('intelligence_lead_type_mode_v2', true);
```

## Test plan
- [ ] Set `intelligence_lead_type_mode_v2=true` on a company → verify V2 follow-up path (`FollowUpEngagementAction`) runs for that company's leads
- [ ] Set the flag on the app but not on the company → V1 path should run (no app fallback anymore)
- [ ] Lead on a company without the flag → V1 path