### PR TITLE
feat: route lead messages through Respond.io when enabled

### DIFF
--- a/src/Domains/Connectors/RespondIO/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/RespondIO/Enums/ConfigurationEnum.php
@@ -8,4 +8,5 @@ enum ConfigurationEnum: string
 {
     case NAME = 'RespondIO';
     case BEARER_TOKEN = 'RESPONDIO_BEAR_TOKEN_AUTH';
+    case ENABLED = 'respondio_enabled';
 }

--- a/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
@@ -353,9 +353,9 @@ class SendMessageToLeadAction
 
     protected function sendSmsMessage(string $from, string $message, ?string $to = null): array
     {
-        if ($this->isRespondIoEnabled()) {
-            return $this->sendRespondIoMessage($message, $to);
-        }
+        // if ($this->isRespondIoEnabled()) {
+        //     return $this->sendRespondIoMessage($message, $to);
+        // }
 
         $client = Client::getInstanceByCompany($this->lead->company);
 

--- a/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
@@ -13,6 +13,8 @@ use InvalidArgumentException;
 use Kanvas\ActionEngine\Engagements\Actions\CreateEngagementAction;
 use Kanvas\ActionEngine\Engagements\DataTransferObject\Engagement as EngagementData;
 use Kanvas\ActionEngine\Enums\ActionStatusEnum;
+use Kanvas\Companies\Enums\ConfigurationEnum as CompanyConfigurationEnum;
+use Kanvas\Connectors\RespondIO\Client as RespondIOClient;
 use Kanvas\Connectors\Twilio\Client;
 use Kanvas\Connectors\Twilio\Enums\ConfigurationEnum as TwilioConfigurationEnum;
 use Kanvas\Connectors\VoiceBridge\Actions\InitVoiceSessionAction;
@@ -215,6 +217,10 @@ class SendMessageToLeadAction
 
     protected function sendWhatsAppMessage(string $message, ?string $to = null): array
     {
+        if ($this->isRespondIoEnabled()) {
+            return $this->sendRespondIoMessage($message, $to);
+        }
+
         $isFromWhatsapp = (bool) $this->lead->get(ConfigurationEnum::IS_FROM_WHATSAPP->value);
         $hasOutboundConfigured = ! empty($this->lead->app->get(WaSenderConfigurationEnum::BASE_URL_OUTBOUND->value));
 
@@ -274,8 +280,83 @@ class SendMessageToLeadAction
         }
     }
 
+    protected function isRespondIoEnabled(): bool
+    {
+        return (bool) $this->lead->company->get(CompanyConfigurationEnum::RESPONDIO_ENABLED->value);
+    }
+
+    protected function getRespondIoClient(): RespondIOClient
+    {
+        return new RespondIOClient($this->lead->app, $this->lead->company);
+    }
+
+    protected function sendRespondIoMessage(string $message, ?string $to = null): array
+    {
+        $client = $this->getRespondIoClient();
+
+        $cellphone = ($to !== null && $to !== '')
+            ? $to
+            : $this->lead->people->getCellPhones()->first()?->value;
+
+        if ($cellphone === null || $cellphone === '') {
+            throw new InvalidArgumentException('Lead does not have a cellphone number');
+        }
+
+        $cellphone = $this->hijackPhoneNumber((string) $cellphone, '@s.whatsapp.net');
+        $cellphone = Str::toE164($cellphone);
+
+        $responses = [];
+
+        foreach ($this->videoEngagements as $videoEngagement) {
+            if (! empty($videoEngagement['url'])) {
+                $responses[] = $client->sendMessage($cellphone, $videoEngagement['url']);
+            }
+        }
+
+        foreach ($this->processedFiles as $file) {
+            if (isset($file['is_processed_video']) && $file['is_processed_video']) {
+                continue;
+            }
+
+            $type = $file['type'] ?? null;
+            if (! $type instanceof MediaTypeEnum) {
+                continue;
+            }
+
+            $attachmentType = match ($type) {
+                MediaTypeEnum::IMAGE => 'image',
+                MediaTypeEnum::VIDEO => 'video',
+                MediaTypeEnum::AUDIO => 'audio',
+                MediaTypeEnum::DOCUMENT => 'file',
+                default => null,
+            };
+
+            if ($attachmentType === null) {
+                continue;
+            }
+
+            $responses[] = $client->sendAttachment($cellphone, $attachmentType, $file['url']);
+        }
+
+        if ($message !== '') {
+            $responses[] = $client->sendMessage($cellphone, $message);
+        }
+
+        return [
+            'channel' => 'respondio',
+            'to' => $cellphone,
+            'lead_id' => $this->lead->getId(),
+            'lead_uuid' => $this->lead->uuid,
+            'messages' => $responses,
+        ];
+    }
+
     protected function sendSmsMessage(string $from, string $message, ?string $to = null): array
     {
+        if ($this->isRespondIoEnabled()) {
+            return $this->sendRespondIoMessage($message, $to);
+        }
+
         $client = Client::getInstanceByCompany($this->lead->company);
 
         $cellphone = ($to !== null && $to !== '')

--- a/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
@@ -13,8 +13,8 @@ use InvalidArgumentException;
 use Kanvas\ActionEngine\Engagements\Actions\CreateEngagementAction;
 use Kanvas\ActionEngine\Engagements\DataTransferObject\Engagement as EngagementData;
 use Kanvas\ActionEngine\Enums\ActionStatusEnum;
-use Kanvas\Companies\Enums\ConfigurationEnum as CompanyConfigurationEnum;
 use Kanvas\Connectors\RespondIO\Client as RespondIOClient;
+use Kanvas\Connectors\RespondIO\Enums\ConfigurationEnum as RespondIOConfigurationEnum;
 use Kanvas\Connectors\Twilio\Client;
 use Kanvas\Connectors\Twilio\Enums\ConfigurationEnum as TwilioConfigurationEnum;
 use Kanvas\Connectors\VoiceBridge\Actions\InitVoiceSessionAction;
@@ -282,7 +282,7 @@ class SendMessageToLeadAction
 
     protected function isRespondIoEnabled(): bool
     {
-        return (bool) $this->lead->company->get(CompanyConfigurationEnum::RESPONDIO_ENABLED->value);
+        return (bool) $this->lead->company->get(RespondIOConfigurationEnum::ENABLED->value);
     }
 
     protected function getRespondIoClient(): RespondIOClient

--- a/src/Kanvas/Companies/Enums/ConfigurationEnum.php
+++ b/src/Kanvas/Companies/Enums/ConfigurationEnum.php
@@ -24,5 +24,4 @@ enum ConfigurationEnum: string
     case CHANNEL_ORDER = 'guild_channel_order';
     case FOLLOW_UP_ON_IS_CONTACTED = 'follow_up_on_is_contacted';
     case DEFAULT_SELECTED_CHANNEL = 'guild_default_selected_channel';
-    case RESPONDIO_ENABLED = 'respondio_enabled';
 }

--- a/src/Kanvas/Companies/Enums/ConfigurationEnum.php
+++ b/src/Kanvas/Companies/Enums/ConfigurationEnum.php
@@ -24,4 +24,5 @@ enum ConfigurationEnum: string
     case CHANNEL_ORDER = 'guild_channel_order';
     case FOLLOW_UP_ON_IS_CONTACTED = 'follow_up_on_is_contacted';
     case DEFAULT_SELECTED_CHANNEL = 'guild_default_selected_channel';
+    case RESPONDIO_ENABLED = 'respondio_enabled';
 }

--- a/tests/Guild/Unit/SendMessageToLeadActionTest.php
+++ b/tests/Guild/Unit/SendMessageToLeadActionTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Guild\Unit;
 
+use InvalidArgumentException;
+use Kanvas\Companies\Enums\ConfigurationEnum as CompanyConfigurationEnum;
+use Kanvas\Connectors\RespondIO\Client as RespondIOClient;
 use Kanvas\Connectors\Twilio\Enums\ConfigurationEnum as TwilioConfigurationEnum;
 use Kanvas\Filesystem\Enums\MediaTypeEnum;
 use Kanvas\Guild\Leads\Actions\SendMessageToLeadAction;
@@ -65,5 +68,216 @@ final class SendMessageToLeadActionTest extends TestCaseUnit
             'https://cdn.example.com/voice.mp3',
             'https://cdn.example.com/contract.pdf',
         ], $action->getMediaUrlsForTwilioForTest());
+    }
+
+    public function testIsRespondIoEnabledReturnsFalseWhenSettingMissing(): void
+    {
+        $company = Mockery::mock();
+        $company->shouldReceive('get')
+            ->with(CompanyConfigurationEnum::RESPONDIO_ENABLED->value)
+            ->andReturn(null);
+
+        $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
+
+        $action = $this->makeAction($lead);
+
+        $this->assertFalse($action->isRespondIoEnabledForTest());
+    }
+
+    public function testIsRespondIoEnabledReturnsTrueWhenSettingIsTrue(): void
+    {
+        $company = Mockery::mock();
+        $company->shouldReceive('get')
+            ->with(CompanyConfigurationEnum::RESPONDIO_ENABLED->value)
+            ->andReturn(true);
+
+        $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
+
+        $action = $this->makeAction($lead);
+
+        $this->assertTrue($action->isRespondIoEnabledForTest());
+    }
+
+    public function testSendRespondIoMessageThrowsWhenLeadHasNoPhone(): void
+    {
+        $cellphones = Mockery::mock();
+        $cellphones->shouldReceive('first')->andReturn(null);
+
+        $people = Mockery::mock();
+        $people->shouldReceive('getCellPhones')->andReturn($cellphones);
+
+        $company = Mockery::mock();
+        $company->shouldReceive('get')->with('allow_session_hijack', false)->andReturn(false);
+
+        $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('getAttribute')->with('people')->andReturn($people);
+        $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
+
+        $client = Mockery::mock(RespondIOClient::class);
+        $action = $this->makeAction($lead, $client);
+
+        $this->expectException(InvalidArgumentException::class);
+        $action->sendRespondIoMessageForTest('hello');
+    }
+
+    public function testSendRespondIoMessageSendsTextBody(): void
+    {
+        $client = Mockery::mock(RespondIOClient::class);
+        $client->shouldReceive('sendMessage')
+            ->once()
+            ->with('+15551234567', 'hello world')
+            ->andReturn(['ok' => true]);
+
+        $action = $this->makeAction($this->makeLead(), $client);
+
+        $result = $action->sendRespondIoMessageForTest('hello world', '+15551234567');
+
+        $this->assertSame('respondio', $result['channel']);
+        $this->assertSame('+15551234567', $result['to']);
+        $this->assertCount(1, $result['messages']);
+    }
+
+    public function testSendRespondIoMessageSendsVideoEngagementsAttachmentsAndTextInOrder(): void
+    {
+        $client = Mockery::mock(RespondIOClient::class);
+
+        $client->shouldReceive('sendMessage')
+            ->once()
+            ->with('+15551234567', 'https://cdn.example.com/engagement-1')
+            ->ordered()
+            ->andReturn(['id' => 'engagement-1']);
+
+        $client->shouldReceive('sendAttachment')
+            ->once()
+            ->with('+15551234567', 'image', 'https://cdn.example.com/image.jpg')
+            ->ordered()
+            ->andReturn(['id' => 'image']);
+
+        $client->shouldReceive('sendAttachment')
+            ->once()
+            ->with('+15551234567', 'audio', 'https://cdn.example.com/voice.mp3')
+            ->ordered()
+            ->andReturn(['id' => 'audio']);
+
+        $client->shouldReceive('sendAttachment')
+            ->once()
+            ->with('+15551234567', 'file', 'https://cdn.example.com/contract.pdf')
+            ->ordered()
+            ->andReturn(['id' => 'file']);
+
+        $client->shouldReceive('sendMessage')
+            ->once()
+            ->with('+15551234567', 'final body')
+            ->ordered()
+            ->andReturn(['id' => 'body']);
+
+        $action = $this->makeAction($this->makeLead(), $client);
+
+        $action->setVideoEngagementsForTest([
+            ['url' => 'https://cdn.example.com/engagement-1'],
+            ['url' => ''],
+        ]);
+
+        $action->setProcessedFilesForTest([
+            ['is_processed_video' => true, 'video' => [], 'gif' => []],
+            ['url' => 'https://cdn.example.com/image.jpg', 'type' => MediaTypeEnum::IMAGE],
+            ['url' => 'https://cdn.example.com/voice.mp3', 'type' => MediaTypeEnum::AUDIO],
+            ['url' => 'https://cdn.example.com/contract.pdf', 'type' => MediaTypeEnum::DOCUMENT],
+        ]);
+
+        $result = $action->sendRespondIoMessageForTest('final body', '+15551234567');
+
+        $this->assertCount(5, $result['messages']);
+    }
+
+    public function testSendRespondIoMessageSkipsTextWhenBodyIsEmpty(): void
+    {
+        $client = Mockery::mock(RespondIOClient::class);
+        $client->shouldNotReceive('sendMessage');
+        $client->shouldReceive('sendAttachment')
+            ->once()
+            ->with('+15551234567', 'image', 'https://cdn.example.com/image.jpg')
+            ->andReturn(['id' => 'image']);
+
+        $action = $this->makeAction($this->makeLead(), $client);
+        $action->setProcessedFilesForTest([
+            ['url' => 'https://cdn.example.com/image.jpg', 'type' => MediaTypeEnum::IMAGE],
+        ]);
+
+        $result = $action->sendRespondIoMessageForTest('', '+15551234567');
+
+        $this->assertCount(1, $result['messages']);
+    }
+
+    public function testSendRespondIoMessageMapsVideoFileToAttachment(): void
+    {
+        $client = Mockery::mock(RespondIOClient::class);
+        $client->shouldReceive('sendAttachment')
+            ->once()
+            ->with('+15551234567', 'video', 'https://cdn.example.com/clip.mp4')
+            ->andReturn(['id' => 'video']);
+        $client->shouldReceive('sendMessage')
+            ->once()
+            ->with('+15551234567', 'caption')
+            ->andReturn(['id' => 'body']);
+
+        $action = $this->makeAction($this->makeLead(), $client);
+        $action->setProcessedFilesForTest([
+            ['url' => 'https://cdn.example.com/clip.mp4', 'type' => MediaTypeEnum::VIDEO],
+        ]);
+
+        $result = $action->sendRespondIoMessageForTest('caption', '+15551234567');
+
+        $this->assertCount(2, $result['messages']);
+    }
+
+    private function makeLead(): Lead
+    {
+        $company = Mockery::mock();
+        $company->shouldReceive('get')->with('allow_session_hijack', false)->andReturn(false);
+
+        $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
+        $lead->shouldReceive('getAttribute')->with('uuid')->andReturn('lead-uuid');
+        $lead->shouldReceive('getId')->andReturn(42);
+
+        return $lead;
+    }
+
+    private function makeAction(Lead $lead, ?RespondIOClient $client = null): SendMessageToLeadAction
+    {
+        return new class ($lead, $client) extends SendMessageToLeadAction {
+            public function __construct(Lead $lead, private readonly ?RespondIOClient $injectedClient = null)
+            {
+                parent::__construct($lead);
+            }
+
+            protected function getRespondIoClient(): RespondIOClient
+            {
+                return $this->injectedClient ?? parent::getRespondIoClient();
+            }
+
+            public function isRespondIoEnabledForTest(): bool
+            {
+                return $this->isRespondIoEnabled();
+            }
+
+            public function sendRespondIoMessageForTest(string $message, ?string $to = null): array
+            {
+                return $this->sendRespondIoMessage($message, $to);
+            }
+
+            public function setProcessedFilesForTest(array $processedFiles): void
+            {
+                $this->processedFiles = $processedFiles;
+            }
+
+            public function setVideoEngagementsForTest(array $videoEngagements): void
+            {
+                $this->videoEngagements = $videoEngagements;
+            }
+        };
     }
 }

--- a/tests/Guild/Unit/SendMessageToLeadActionTest.php
+++ b/tests/Guild/Unit/SendMessageToLeadActionTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\Guild\Unit;
 
 use InvalidArgumentException;
-use Kanvas\Companies\Enums\ConfigurationEnum as CompanyConfigurationEnum;
 use Kanvas\Connectors\RespondIO\Client as RespondIOClient;
+use Kanvas\Connectors\RespondIO\Enums\ConfigurationEnum as RespondIOConfigurationEnum;
 use Kanvas\Connectors\Twilio\Enums\ConfigurationEnum as TwilioConfigurationEnum;
 use Kanvas\Filesystem\Enums\MediaTypeEnum;
 use Kanvas\Guild\Leads\Actions\SendMessageToLeadAction;
@@ -74,7 +74,7 @@ final class SendMessageToLeadActionTest extends TestCaseUnit
     {
         $company = Mockery::mock();
         $company->shouldReceive('get')
-            ->with(CompanyConfigurationEnum::RESPONDIO_ENABLED->value)
+            ->with(RespondIOConfigurationEnum::ENABLED->value)
             ->andReturn(null);
 
         $lead = Mockery::mock(Lead::class);
@@ -89,7 +89,7 @@ final class SendMessageToLeadActionTest extends TestCaseUnit
     {
         $company = Mockery::mock();
         $company->shouldReceive('get')
-            ->with(CompanyConfigurationEnum::RESPONDIO_ENABLED->value)
+            ->with(RespondIOConfigurationEnum::ENABLED->value)
             ->andReturn(true);
 
         $lead = Mockery::mock(Lead::class);


### PR DESCRIPTION
## Summary
- New `respondio_enabled` company setting (`Kanvas\Companies\Enums\ConfigurationEnum::RESPONDIO_ENABLED`).
- When the flag is on, `SendMessageToLeadAction::sendWhatsAppMessage()` and `sendSmsMessage()` early-return through a new `sendRespondIoMessage()` that uses `Kanvas\Connectors\RespondIO\Client`. Email and voice channels are unchanged.
- Video engagements are sent first as text URLs, then non-video processed files via `sendAttachment` (`image` / `video` / `audio` / `file`), then the body. Phone is hijack-normalized and forced to E.164 like the SMS path.
- `getRespondIoClient()` is a small seam to let tests inject a mock client.

## Test plan
- [x] `docker exec -i php bash -c "cd /var/www/html && php vendor/bin/phpunit tests/Guild/Unit/SendMessageToLeadActionTest.php"` — 8 tests pass.
- [ ] Manual smoke: set `respondio_enabled=true` on a tenant company, send a lead message through WhatsApp and SMS channels, confirm it lands in Respond.io and not via WaSender/Twilio.
- [ ] Confirm email + voice channels remain untouched when the flag is on.