### PR TITLE
feat: limit Respond.io routing to WhatsApp; SMS keeps Twilio

### DIFF
--- a/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
@@ -353,9 +353,9 @@ class SendMessageToLeadAction
 
     protected function sendSmsMessage(string $from, string $message, ?string $to = null): array
     {
-        if ($this->isRespondIoEnabled()) {
-            return $this->sendRespondIoMessage($message, $to);
-        }
+        // if ($this->isRespondIoEnabled()) {
+        //     return $this->sendRespondIoMessage($message, $to);
+        // }
 
         $client = Client::getInstanceByCompany($this->lead->company);
 


### PR DESCRIPTION
## Summary
- Follow-up to #9756. Only WhatsApp is rerouted through Respond.io when `respondio_enabled` is on; SMS keeps using Twilio.
- The SMS branch in `SendMessageToLeadAction::sendSmsMessage()` is left as commented scaffolding in case the project decides to enable it later.

## Test plan
- [x] `docker exec -i php bash -c "cd /var/www/html && php vendor/bin/phpunit tests/Guild/Unit/SendMessageToLeadActionTest.php"` — 8 tests pass.
- [ ] Manual smoke (WhatsApp): set `respondio_enabled=true`, send a WhatsApp message to a lead → lands in Respond.io.
- [ ] Manual smoke (SMS): with `respondio_enabled=true`, send an SMS → still goes through Twilio.