### PR TITLE
feat: allow sorting message children via orderBy

### DIFF
--- a/graphql/schemas/Social/message.graphql
+++ b/graphql/schemas/Social/message.graphql
@@ -22,7 +22,22 @@ type Message {
     total_purchase: Int
     parent: Message @cacheRedis
     user: User!
-    children: [Message!] @hasMany(type: PAGINATOR)
+    children(
+        orderBy: _
+            @orderBy(
+                columns: [
+                    "created_at"
+                    "updated_at"
+                    "id"
+                    "total_view"
+                    "total_liked"
+                    "total_shared"
+                    "total_saved"
+                    "total_children"
+                    "total_disliked"
+                ]
+            )
+    ): [Message!] @hasMany(relation: "children", type: PAGINATOR)
     messageType: MessageType! @cacheRedis
     appModuleMessage: AppModuleMessage @cacheRedis
     myInteraction: myInteraction @method(name: "getMyInteraction")


### PR DESCRIPTION
## Summary
- Add `orderBy` argument to `Message.children` so clients can sort child messages (ascending or descending) by `created_at`, `updated_at`, `id`, and the engagement counters.
- Make the relation method explicit (`@hasMany(relation: "children", type: PAGINATOR)`) per the schema convention.

## Test plan
- [ ] Query `messages { data { id children(orderBy: [{ column: CREATED_AT, order: ASC }]) { data { id created_at } } } }` and verify the children come back in ascending order.
- [ ] Verify the same with `order: DESC` and with other allowed columns (e.g. `TOTAL_LIKED`).