### PR TITLE
feat(social): add is_unread on Message

### DIFF
--- a/graphql/schemas/Social/message.graphql
+++ b/graphql/schemas/Social/message.graphql
@@ -26,6 +26,7 @@ type Message {
     messageType: MessageType! @cacheRedis
     appModuleMessage: AppModuleMessage @cacheRedis
     myInteraction: myInteraction @method(name: "getMyInteraction")
+    is_unread: Boolean! @method(name: "getIsUnread")
     comments: [MessageComments!]! @hasMany(type: PAGINATOR)
     additional_field: Mixed
     created_at: DateTime!

--- a/src/Domains/Social/Messages/Models/Message.php
+++ b/src/Domains/Social/Messages/Models/Message.php
@@ -252,6 +252,29 @@ class Message extends BaseModel
         ];
     }
 
+    /**
+     * Unread = chat message from an external party (not me, not AI) that is currently
+     * the latest message in any of its channels. The flags from_me / from_ia must be
+     * present in the JSON payload — feed posts that lack them never count as unread.
+     */
+    public function getIsUnread(): bool
+    {
+        $payload = $this->message;
+
+        if (! is_array($payload)
+            || ! array_key_exists('from_me', $payload)
+            || ! array_key_exists('from_ia', $payload)
+        ) {
+            return false;
+        }
+
+        if ((bool) $payload['from_me'] || (bool) $payload['from_ia']) {
+            return false;
+        }
+
+        return Channel::where('last_message_id', $this->id)->exists();
+    }
+
     public function searchableAs(): string
     {
         //$message = ! $this->searchableDeleteRecord() ? $this : $this->withTrashed()->find($this->id);

--- a/tests/GraphQL/Social/MessageTest.php
+++ b/tests/GraphQL/Social/MessageTest.php
@@ -1892,4 +1892,144 @@ class MessageTest extends TestCase
         $app->set('filesystem-message-max-filesize', null);
         $app->set('filesystem-message-constrain-verbs', null);
     }
+
+    private function makeChatMessageWithChannel(array $messagePayload): Message
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        $messageType = MessageType::factory()->create();
+
+        $message = Message::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->withMessageType($messageType)
+            ->create(['message' => $messagePayload]);
+
+        Channel::firstOrCreate(
+            [
+                'apps_id' => $app->getId(),
+                'companies_id' => $company->getId(),
+                'slug' => 'is-unread-test-' . $message->getId(),
+            ],
+            [
+                'name' => 'Unread test channel',
+                'description' => 'Channel for is_unread coverage',
+                'users_id' => $user->getId(),
+                'last_message_id' => $message->getId(),
+            ],
+        );
+
+        return $message->fresh();
+    }
+
+    public function testIsUnreadTrueWhenIncomingAndLastInChannel(): void
+    {
+        $message = $this->makeChatMessageWithChannel([
+            'content' => 'hola, info por favor',
+            'from_me' => false,
+            'from_ia' => false,
+        ]);
+
+        $this->assertTrue($message->getIsUnread());
+    }
+
+    public function testIsUnreadFalseWhenFromMe(): void
+    {
+        $message = $this->makeChatMessageWithChannel([
+            'content' => 'reply from agent',
+            'from_me' => true,
+            'from_ia' => false,
+        ]);
+
+        $this->assertFalse($message->getIsUnread());
+    }
+
+    public function testIsUnreadFalseWhenFromIa(): void
+    {
+        $message = $this->makeChatMessageWithChannel([
+            'content' => 'AI generated reply',
+            'from_me' => false,
+            'from_ia' => true,
+        ]);
+
+        $this->assertFalse($message->getIsUnread());
+    }
+
+    public function testIsUnreadFalseWhenFlagsMissing(): void
+    {
+        // Feed-style post without chat flags should never be considered unread.
+        $message = $this->makeChatMessageWithChannel([
+            'message' => 'plain feed post',
+            'params' => [],
+        ]);
+
+        $this->assertFalse($message->getIsUnread());
+    }
+
+    public function testIsUnreadFalseWhenNotChannelsLastMessage(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        $messageType = MessageType::factory()->create();
+
+        $olderMessage = Message::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->withMessageType($messageType)
+            ->create(['message' => ['content' => 'old incoming', 'from_me' => false, 'from_ia' => false]]);
+
+        $newerMessage = Message::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->withMessageType($messageType)
+            ->create(['message' => ['content' => 'newer incoming', 'from_me' => false, 'from_ia' => false]]);
+
+        Channel::firstOrCreate(
+            [
+                'apps_id' => $app->getId(),
+                'companies_id' => $company->getId(),
+                'slug' => 'is-unread-test-not-last-' . $olderMessage->getId(),
+            ],
+            [
+                'name' => 'Unread test channel — older not last',
+                'description' => 'Channel where older incoming is no longer the last message',
+                'users_id' => $user->getId(),
+                'last_message_id' => $newerMessage->getId(),
+            ],
+        );
+
+        $this->assertFalse($olderMessage->fresh()->getIsUnread());
+        $this->assertTrue($newerMessage->fresh()->getIsUnread());
+    }
+
+    public function testIsUnreadExposedThroughGraphQL(): void
+    {
+        $message = $this->makeChatMessageWithChannel([
+            'content' => 'graphql is_unread check',
+            'from_me' => false,
+            'from_ia' => false,
+        ]);
+
+        $this->graphQL('
+            query($id: Mixed!) {
+                messages(where: { column: ID, operator: EQ, value: $id }, first: 1) {
+                    data { id is_unread }
+                }
+            }
+        ', ['id' => $message->getId()])
+            ->assertSuccessful()
+            ->assertJson([
+                'data' => [
+                    'messages' => [
+                        'data' => [
+                            ['id' => (string) $message->getId(), 'is_unread' => true],
+                        ],
+                    ],
+                ],
+            ]);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `Message.is_unread: Boolean!` to the social GraphQL schema (`graphql/schemas/Social/message.graphql`).
- Backed by `Message::getIsUnread()` which returns true when the JSON payload carries `from_me=false` AND `from_ia=false` AND this message is the current `last_message_id` of any of its channels. Feed-style posts that lack the chat flags never count as unread.
- Adds coverage in `tests/GraphQL/Social/MessageTest.php` (incoming-last, from_me, from_ia, flags missing, older-not-last, GraphQL exposure).

## Why
Chat clients need a way to render the "unread incoming" indicator without round-tripping every channel. The flag mirrors what the connector workflows already check (`from_me` / `from_ia` are written by every chat connector: Twilio, WaSender, RespondIO, Mailgun, Microsoft, etc).

## Companion PR
- Same change against `1.x`: #9795

## Notes
- One extra `SELECT EXISTS` against `channels.last_message_id` per resolved field. Acceptable for now; can be eager-loaded later if needed.
- Tests have not been run locally in this branch — the `phpkanvas-ecosystem` docker container was not available in the dev env where the change was authored. Please run the `Social` suite before merge.

## Test plan
- [ ] `docker exec -it phpkanvas-ecosystem bash -c "cd /var/www/html && php vendor/bin/paratest --testsuite=Social"`
- [ ] Smoke: query `messages { data { id is_unread } }` against a channel where the last message is incoming (`from_me=false`, `from_ia=false`) — expect `is_unread: true`.
- [ ] Smoke: reply to that channel from agent (`from_me=true`) — query again, expect `is_unread: false` on the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)