### PR TITLE
fix: throw on empty message creation in agent responder

### DIFF
--- a/graphql/schemas/Ecosystem/notification.graphql
+++ b/graphql/schemas/Ecosystem/notification.graphql
@@ -8,7 +8,7 @@ type Notification {
     interaction_id: Int
     types(filter: NotificationTypeFilterInput): NotificationType! @belongsTo
     entity_id: String!
-    entity(fields: JSON): Mixed @method(name: "getEntityData")
+    entity(fields: Mixed): Mixed @method(name: "getEntityData")
     entity_children(fields: JSON): Mixed @method(name: "getEntityChildrenData")
     content: String
     read: Int!

--- a/src/Domains/ActionEngine/Engagements/Events/EngagementStatusChangedEvent.php
+++ b/src/Domains/ActionEngine/Engagements/Events/EngagementStatusChangedEvent.php
@@ -38,7 +38,10 @@ class EngagementStatusChangedEvent implements ShouldBroadcast
             $overwriteMessage = $this->message;
         }
 
-        $this->notificationTextAction = new MessageNotificationTextAction($this->engagement, $overwriteMessage);
+        $this->notificationTextAction = new MessageNotificationTextAction(
+            $this->engagement,
+            $overwriteMessage
+        );
         $this->handleStatus();
     }
 
@@ -46,7 +49,9 @@ class EngagementStatusChangedEvent implements ShouldBroadcast
     public function broadcastOn(): Channel
     {
         //return new Channel('engagement-lead-' . $this->engagement->lead->getId());
-        return new Channel('engagement-lead-status-' . $this->engagement->apps_id . '-' . $this->engagement->lead->leads_owner_id . '-' . $this->engagement->company->getId());
+        return new Channel(
+            'engagement-lead-status-' . $this->engagement->apps_id . '-' . $this->engagement->lead->leads_owner_id . '-' . $this->engagement->company->getId()
+        );
     }
 
     public function broadcastAs(): string
@@ -105,14 +110,19 @@ class EngagementStatusChangedEvent implements ShouldBroadcast
             return;
         }
 
-        $notification = new EngagementStatusChangedNotification($this->engagement, [
+        $notification = new EngagementStatusChangedNotification(
+            $this->engagement,
+            [
             'messageText' => $messageText,
             'action' => $this->action,
             'subject' => 'Opened - ' . ucfirst($this->action),
-        ]);
+        ]
+        );
 
-        new NotifyLeadStakeholdersService($this->lead, $notification)->all();
-        //(new Notify($this->lead, $notification))->all();
+        new NotifyLeadStakeholdersService(
+            $this->lead,
+            $notification
+        )->all();
     }
 
     protected function handleSubmitted(): void
@@ -123,26 +133,36 @@ class EngagementStatusChangedEvent implements ShouldBroadcast
             return;
         }
 
-        $notification = new EngagementStatusChangedNotification($this->engagement, [
-         'messageText' => $messageText,
-         'action' => $this->action,
-         'subject' => 'Submitted - ' . ucfirst($this->action),
-        ]);
+        $notification = new EngagementStatusChangedNotification(
+            $this->engagement,
+            [
+                'messageText' => $messageText,
+                'action' => $this->action,
+                'subject' => 'Submitted - ' . ucfirst($this->action),
+            ]
+        );
 
         new NotifyLeadStakeholdersService($this->lead, $notification)->all();
         $notificationImport = $this->lead->app->get('notification-import-types') ?? [];
+
         if (is_array($this->message->message) && ! empty($this->message->message)) {
             $messageArray = $this->message->message;
             if (in_array($messageArray['verb'] ?? '', $notificationImport, true)) {
                 $importText = $this->lead->getFullName() . ' ' . ($messageArray['text'] ?? '') . ' is ready to be imported into eLead.';
 
-                $notification = new EngagementStatusChangedNotification($this->engagement, [
-                    'messageText' => $importText,
-                    'action' => $this->action,
-                    'subject' => 'Reader to Import - ' . ucfirst($this->action),
-                ]);
+                $notification = new EngagementStatusChangedNotification(
+                    $this->engagement,
+                    [
+                        'messageText' => $importText,
+                        'action' => $this->action,
+                        'subject' => 'Reader to Import - ' . ucfirst($this->action),
+                    ]
+                );
 
-                new NotifyLeadStakeholdersService($this->lead, $notification)->all();
+                new NotifyLeadStakeholdersService(
+                    $this->lead,
+                    $notification
+                )->all();
             }
         }
     }

--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
@@ -77,6 +77,9 @@ class BaseAgentResponderAction
         Channel $channel,
         ?string $from = null
     ): Message {
+        if (! $text) {
+            throw new Exception('Empty message was created');
+        }
         $user = $this->channel->company->getAiAgentUser() ?? $message->user;
         $type = $this->getMessageType($message->app);
         $messageInput = new MessageInput(

--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php
@@ -77,7 +77,7 @@ class BaseAgentResponderAction
         Channel $channel,
         ?string $from = null
     ): Message {
-        if (! $text) {
+        if (empty($text)) {
             throw new Exception('Empty message was created');
         }
         $user = $this->channel->company->getAiAgentUser() ?? $message->user;

--- a/src/Kanvas/Notifications/Models/Notifications.php
+++ b/src/Kanvas/Notifications/Models/Notifications.php
@@ -9,6 +9,7 @@ use Baka\Enums\StateEnums;
 use Baka\Support\Str;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\RelationNotFoundException;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
@@ -147,7 +148,7 @@ class Notifications extends BaseModel
     /**
      * Get the entity related to the notification.
      */
-    public function getEntityData(): mixed
+    public function getEntityData(?array $fields = null): mixed
     {
         if ($this->entity_content !== null && Str::isJson($this->entity_content)) {
             return $this->entity_content;
@@ -160,7 +161,19 @@ class Notifications extends BaseModel
             /**
              * @todo cache
              */
-            return $modelName::getById($this->entity_id);
+            $entity = $modelName::getById($this->entity_id);
+
+            if ($entity !== null && is_array($fields) && ! empty($fields['relations'])) {
+                foreach ((array) $fields['relations'] as $relation) {
+                    try {
+                        $entity->loadMissing($relation);
+                    } catch (RelationNotFoundException) {
+                        // entity type doesn't define this relation — skip it, keep the rest
+                    }
+                }
+            }
+
+            return $entity;
         } catch (Throwable $e) {
         }
 

--- a/tests/GraphQL/Ecosystem/Notifications/NotificationTest.php
+++ b/tests/GraphQL/Ecosystem/Notifications/NotificationTest.php
@@ -8,13 +8,17 @@ use Illuminate\Support\Facades\Notification;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Enums\AppEnums;
+use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Notifications\Actions\CreateNotificationTypeAction;
 use Kanvas\Notifications\DataTransferObject\NotificationType;
 use Kanvas\Notifications\Enums\NotificationChannelEnum;
 use Kanvas\Notifications\Models\NotificationChannel;
 use Kanvas\Notifications\Models\Notifications;
+use Kanvas\Notifications\Models\NotificationTypes;
+use Kanvas\SystemModules\Actions\CreateInCurrentAppAction;
 use Kanvas\Templates\Actions\CreateTemplateAction;
 use Kanvas\Templates\DataTransferObject\TemplateInput;
+use Kanvas\Users\Models\Users;
 use Tests\TestCase;
 
 class NotificationTest extends TestCase
@@ -372,5 +376,205 @@ class NotificationTest extends TestCase
         foreach ($notifications as $notification) {
             $this->assertEquals((string) $companyA->getId(), $notification['companies']['id']);
         }
+    }
+
+    /**
+     * getEntityData eager-loads the relations passed in `fields.relations`. For a
+     * notification whose entity is a Lead, requesting `people` loads the related
+     * person so its firstname/lastname are available. A relation the entity does
+     * not define is skipped silently — no RelationNotFoundException bubbles up.
+     */
+    public function testGetEntityDataLoadsLeadPeopleRelationAndSkipsMissingOnes(): void
+    {
+        $user = auth()->user();
+        $app = app(Apps::class);
+        $company = $user->getCurrentCompany();
+
+        $lead = Lead::factory()
+            ->withAppAndCompany($app->getId(), $company->getId())
+            ->create();
+
+        $lead->people->firstname = 'Ada';
+        $lead->people->lastname = 'Lovelace';
+        $lead->people->saveOrFail();
+        $lead->unsetRelation('people');
+
+        $systemModule = new CreateInCurrentAppAction($app)->execute(Lead::class);
+        $notificationType = $this->createNotificationType($app, $user, 'test-notification-lead-people');
+
+        $notification = $this->createNotificationForEntity(
+            $user,
+            $app,
+            $company->getId(),
+            $systemModule->getId(),
+            $notificationType->getId(),
+            $lead->getId()
+        );
+
+        // people relation is loaded with the real firstname/lastname.
+        $withPeople = $notification->getEntityData(['relations' => ['people']]);
+        $this->assertInstanceOf(Lead::class, $withPeople);
+        $this->assertTrue($withPeople->relationLoaded('people'));
+        $this->assertSame('Ada', $withPeople->people->firstname);
+        $this->assertSame('Lovelace', $withPeople->people->lastname);
+
+        // Relation the entity does not define — must NOT throw, entity still returned.
+        $withMissing = $notification->getEntityData(['relations' => ['thisRelationDoesNotExist']]);
+        $this->assertInstanceOf(Lead::class, $withMissing);
+        $this->assertFalse($withMissing->relationLoaded('thisRelationDoesNotExist'));
+
+        // No `fields` at all still returns the entity unchanged.
+        $this->assertInstanceOf(Lead::class, $notification->getEntityData());
+    }
+
+    /**
+     * Same behavior end-to-end through the `notifications` GraphQL query: asking
+     * for the Lead's `people` relation embeds firstname/lastname in the `entity`
+     * JSON, while a relation the Lead does not define leaves the query successful
+     * and simply omits that key.
+     */
+    public function testNotificationLeadPeopleEntityThroughGraphQL(): void
+    {
+        $user = auth()->user();
+        $app = app(Apps::class);
+        $company = $user->getCurrentCompany();
+
+        $lead = Lead::factory()
+            ->withAppAndCompany($app->getId(), $company->getId())
+            ->create();
+
+        $lead->people->firstname = 'Grace';
+        $lead->people->lastname = 'Hopper';
+        $lead->people->saveOrFail();
+
+        $systemModule = new CreateInCurrentAppAction($app)->execute(Lead::class);
+        $notificationType = $this->createNotificationType($app, $user, 'test-notification-lead-people-graphql');
+
+        $notification = $this->createNotificationForEntity(
+            $user,
+            $app,
+            $company->getId(),
+            $systemModule->getId(),
+            $notificationType->getId(),
+            $lead->getId()
+        );
+
+        $query = /** @lang GraphQL */ '
+            query notificationEntity($id: Mixed, $fields: Mixed) {
+                notifications(first: 1, where: { column: ID, operator: EQ, value: $id }) {
+                    data {
+                        id
+                        entity(fields: $fields)
+                    }
+                }
+            }
+        ';
+
+        // people relation embedded in the entity JSON with firstname/lastname.
+        $response = $this->graphQL($query, [
+            'id' => $notification->getId(),
+            'fields' => ['relations' => ['people']],
+        ]);
+        $response->assertSuccessful();
+
+        $this->assertEquals(
+            (string) $notification->getId(),
+            $response->json('data.notifications.data.0.id')
+        );
+
+        $entity = $response->json('data.notifications.data.0.entity');
+        $this->assertIsArray($entity);
+        $this->assertArrayHasKey('people', $entity);
+        $this->assertEquals('Grace', $entity['people']['firstname']);
+        $this->assertEquals('Hopper', $entity['people']['lastname']);
+    }
+
+    /**
+     * Requesting a relation the entity does not define must not break the query:
+     * no GraphQL error is returned, the entity itself still comes back intact,
+     * and the unknown relation key is simply absent from the JSON.
+     */
+    public function testNotificationEntityIgnoresUnknownRelationThroughGraphQL(): void
+    {
+        $user = auth()->user();
+        $app = app(Apps::class);
+        $company = $user->getCurrentCompany();
+
+        $lead = Lead::factory()
+            ->withAppAndCompany($app->getId(), $company->getId())
+            ->create();
+
+        $systemModule = new CreateInCurrentAppAction($app)->execute(Lead::class);
+        $notificationType = $this->createNotificationType($app, $user, 'test-notification-unknown-relation');
+
+        $notification = $this->createNotificationForEntity(
+            $user,
+            $app,
+            $company->getId(),
+            $systemModule->getId(),
+            $notificationType->getId(),
+            $lead->getId()
+        );
+
+        $response = $this->graphQL(/** @lang GraphQL */ '
+            query notificationEntity($id: Mixed, $fields: Mixed) {
+                notifications(first: 1, where: { column: ID, operator: EQ, value: $id }) {
+                    data {
+                        id
+                        entity(fields: $fields)
+                    }
+                }
+            }
+        ', [
+            'id' => $notification->getId(),
+            'fields' => ['relations' => ['thisRelationDoesNotExist']],
+        ]);
+
+        $response->assertSuccessful();
+        // No RelationNotFoundException surfaced to the client as a GraphQL error.
+        $this->assertNull($response->json('errors'));
+
+        $entity = $response->json('data.notifications.data.0.entity');
+        $this->assertIsArray($entity);
+        // The entity itself is still returned intact ...
+        $this->assertEquals($lead->getId(), $entity['id']);
+        // ... only the unknown relation is missing.
+        $this->assertArrayNotHasKey('thisRelationDoesNotExist', $entity);
+    }
+
+    private function createNotificationType(Apps $app, Users $user, string $slug): NotificationTypes
+    {
+        $template = new CreateTemplateAction(
+            TemplateInput::from([
+                'app' => $app,
+                'name' => $slug,
+                'template' => '<html><body>' . $slug . '</body></html>',
+            ])
+        )->execute();
+
+        return new CreateNotificationTypeAction(
+            new NotificationType($app, $user, $slug, $slug, $template)
+        )->execute();
+    }
+
+    private function createNotificationForEntity(
+        Users $user,
+        Apps $app,
+        int $companyId,
+        int $systemModuleId,
+        int $notificationTypeId,
+        int $entityId
+    ): Notifications {
+        return Notifications::create([
+            'users_id' => $user->getId(),
+            'from_users_id' => $user->getId(),
+            'companies_id' => $companyId,
+            'apps_id' => $app->getId(),
+            'system_modules_id' => $systemModuleId,
+            'notification_type_id' => $notificationTypeId,
+            'entity_id' => $entityId,
+            'content' => 'entity relations test',
+            'read' => 0,
+        ]);
     }
 }


### PR DESCRIPTION
Why: empty messages were being persisted silently, polluting channels and downstream consumers. Failing loud lets the caller catch and handle (or surface) the bad state.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
