### PR TITLE
feat: add active_channel key to lead session content

### DIFF
--- a/graphql/schemas/Social/message.graphql
+++ b/graphql/schemas/Social/message.graphql
@@ -22,7 +22,22 @@ type Message {
     total_purchase: Int
     parent: Message @cacheRedis
     user: User!
-    children: [Message!] @hasMany(type: PAGINATOR)
+    children(
+        orderBy: _
+            @orderBy(
+                columns: [
+                    "created_at"
+                    "updated_at"
+                    "id"
+                    "total_view"
+                    "total_liked"
+                    "total_shared"
+                    "total_saved"
+                    "total_children"
+                    "total_disliked"
+                ]
+            )
+    ): [Message!] @hasMany(relation: "children", type: PAGINATOR)
     messageType: MessageType! @cacheRedis
     appModuleMessage: AppModuleMessage @cacheRedis
     myInteraction: myInteraction @method(name: "getMyInteraction")

--- a/src/Domains/Connectors/Lendflow/Activities/SubmitApplicationActivity.php
+++ b/src/Domains/Connectors/Lendflow/Activities/SubmitApplicationActivity.php
@@ -6,6 +6,7 @@ namespace Kanvas\Connectors\Lendflow\Activities;
 
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\Lendflow\Actions\SubmitApplicationAction;
+use Kanvas\Connectors\Lendflow\Enums\CustomFieldEnum;
 use Kanvas\Guild\Deals\Models\Deal;
 use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Kanvas\Workflow\KanvasActivity;
@@ -24,6 +25,15 @@ class SubmitApplicationActivity extends KanvasActivity
             integration: IntegrationsEnum::LENDFLOW,
             additionalParams: $params,
             integrationOperation: function (Deal $deal) {
+                $exit = $deal->get(CustomFieldEnum::LENDFLOW_APPLICATION_ID->value);
+                if ($exit) {
+                    return $this->failWorkflow([
+                        'message' => 'Deal already has a Lendflow application ID: ' . $exit,
+                        'application_id' => $exit,
+                        'deal_id' => $deal->getId(),
+                    ]);
+                }
+
                 $result = new SubmitApplicationAction($deal)->execute();
 
                 return [

--- a/src/Domains/Intelligence/Sessions/Actions/CreateContentSessionAction.php
+++ b/src/Domains/Intelligence/Sessions/Actions/CreateContentSessionAction.php
@@ -28,6 +28,7 @@ use Kanvas\Intelligence\Tools\CompanyWorkHoursTool;
 use Kanvas\Intelligence\Tools\LeadIntentTool;
 use Kanvas\Inventory\Channels\Models\Channels;
 use Kanvas\Inventory\Variants\Models\Variants;
+use Kanvas\Social\Enums\ChannelCategoryEnum;
 use Kanvas\Users\Models\Users;
 use RuntimeException;
 use Throwable;
@@ -138,6 +139,14 @@ class CreateContentSessionAction
         $timezone = $lead->company->get('timezone') ?? 'UTC';
         $lastMessageTime = $lastMessage !== null ? Carbon::parse($lastMessage->created_at, $timezone)->toDateTimeString() : null;
 
+        $activeChannel = $lead->socialChannels()
+            ->pluck('slug')
+            ->map(fn (string $slug): string => ChannelCategoryEnum::getLeadChannelName($slug))
+            ->reject(fn (string $name): bool => $name === 'notes')
+            ->unique()
+            ->values()
+            ->all();
+
         return array_merge(
             [
                 'lead_id' => $lead->id,
@@ -161,6 +170,7 @@ class CreateContentSessionAction
                 'work_hours' => $lead->company->get('work_hours'),
                 'working_holiday_days' => $lead->company->get('working_holiday_days'),
                 'notes_channel_slug' => $lead->notes?->slug,
+                'active_channel' => $activeChannel,
             ],
             $this->mapPeople($lead->people, $lead),
             $lead->get(ConfigurationEnum::LEAD_CONTEXT_INFO->value) ?? []


### PR DESCRIPTION
## Summary
- Adds an `active_channel` key to the lead context returned by `CreateContentSessionAction::mapLead()`.
- The value is the unique list of communication channels the lead has (e.g. `sms`, `email`, `whatsapp`, `mailgun-email`), derived from `socialChannels` slugs via `ChannelCategoryEnum::getLeadChannelName()`. The `notes` channel is excluded since it isn't a customer-facing channel.

## Test plan
- [ ] Trigger a session creation for a Lead with multiple `socialChannels` (sms + whatsapp + email).
- [ ] Confirm the resulting array contains `active_channel` with the expected slugs and no duplicates.
- [ ] Confirm leads with only a `notes` channel return an empty `active_channel` array.