### PR TITLE
feat: add active_channel key to lead session content

### DIFF
--- a/src/Domains/Intelligence/Sessions/Actions/CreateContentSessionAction.php
+++ b/src/Domains/Intelligence/Sessions/Actions/CreateContentSessionAction.php
@@ -28,6 +28,7 @@ use Kanvas\Intelligence\Tools\CompanyWorkHoursTool;
 use Kanvas\Intelligence\Tools\LeadIntentTool;
 use Kanvas\Inventory\Channels\Models\Channels;
 use Kanvas\Inventory\Variants\Models\Variants;
+use Kanvas\Social\Enums\ChannelCategoryEnum;
 use Kanvas\Users\Models\Users;
 use RuntimeException;
 use Throwable;
@@ -138,6 +139,14 @@ class CreateContentSessionAction
         $timezone = $lead->company->get('timezone') ?? 'UTC';
         $lastMessageTime = $lastMessage !== null ? Carbon::parse($lastMessage->created_at, $timezone)->toDateTimeString() : null;
 
+        $activeChannel = $lead->socialChannels()
+            ->pluck('slug')
+            ->map(fn (string $slug): string => ChannelCategoryEnum::getLeadChannelName($slug))
+            ->reject(fn (string $name): bool => $name === 'notes')
+            ->unique()
+            ->values()
+            ->all();
+
         return array_merge(
             [
                 'lead_id' => $lead->id,
@@ -161,6 +170,7 @@ class CreateContentSessionAction
                 'work_hours' => $lead->company->get('work_hours'),
                 'working_holiday_days' => $lead->company->get('working_holiday_days'),
                 'notes_channel_slug' => $lead->notes?->slug,
+                'active_channel' => $activeChannel,
             ],
             $this->mapPeople($lead->people, $lead),
             $lead->get(ConfigurationEnum::LEAD_CONTEXT_INFO->value) ?? []


### PR DESCRIPTION
## Summary
- Adds an `active_channel` key to the lead context returned by `CreateContentSessionAction::mapLead()`.
- The value is the unique list of communication channels the lead has (e.g. `sms`, `email`, `whatsapp`, `mailgun-email`), derived from `socialChannels` slugs via `ChannelCategoryEnum::getLeadChannelName()`. The `notes` channel is excluded since it isn't a customer-facing channel.

## Test plan
- [ ] Trigger a session creation for a Lead with multiple `socialChannels` (sms + whatsapp + email).
- [ ] Confirm the resulting array contains `active_channel` with the expected slugs and no duplicates.
- [ ] Confirm leads with only a `notes` channel return an empty `active_channel` array.