### PR TITLE
refact: flatten ai_mode / ai_follow_up keys on Lead in V2

### DIFF
--- a/app/Console/Commands/Intelligence/BackfillLeadAiModeKeysCommand.php
+++ b/app/Console/Commands/Intelligence/BackfillLeadAiModeKeysCommand.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Intelligence;
+
+use Baka\Traits\KanvasJobsTrait;
+use Illuminate\Console\Command;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
+
+class BackfillLeadAiModeKeysCommand extends Command
+{
+    use KanvasJobsTrait;
+
+    protected $signature = 'kanvas:intelligence:backfill-lead-ai-mode-keys
+                            {company_id : The company ID (required)}
+                            {app_id : The app ID (required)}
+                            {--dry-run : Report planned changes without writing}';
+
+    protected $description = 'Copy legacy V2 prefixed lead settings (internet_/phone_/showroom_ ai_mode and follow-up variants) into the generic ai_mode and ai_follow_up keys';
+
+    private const PREFIXES = ['internet', 'phone', 'showroom'];
+
+    public function handle(): int
+    {
+        $companyId = (int) $this->argument('company_id');
+        $appId = (int) $this->argument('app_id');
+        $isDryRun = (bool) $this->option('dry-run');
+
+        $company = Companies::findOrFail($companyId);
+        $app = Apps::findOrFail($appId);
+        $this->overwriteAppService($app);
+
+        $this->info("Company: {$company->name} (ID: {$company->getId()})");
+        $this->info("App: {$app->name} (ID: {$app->getId()})");
+
+        if ($isDryRun) {
+            $this->warn('DRY-RUN: no changes will be written.');
+        }
+
+        $processed = 0;
+        $aiModeCopied = 0;
+        $followUpCopied = 0;
+        $aiModeSkipped = 0;
+        $followUpSkipped = 0;
+
+        $leads = Lead::query()
+            ->where('companies_id', $company->getId())
+            ->where('apps_id', $app->getId())
+            ->where('is_deleted', 0)
+            ->with(['type', 'status'])
+            ->cursor();
+
+        foreach ($leads as $lead) {
+            $processed++;
+
+            $aiModeValue = $this->pickFirstNonEmpty($lead, $this->legacyAiModeKeys());
+            if ($aiModeValue !== null) {
+                $currentGeneric = $lead->get('ai_mode');
+                if ($currentGeneric === null || $currentGeneric === '') {
+                    if (! $isDryRun) {
+                        $lead->set('ai_mode', $aiModeValue);
+                    }
+                    $aiModeCopied++;
+                    $this->line("  Lead {$lead->getId()}: ai_mode <- {$aiModeValue}");
+                } else {
+                    $aiModeSkipped++;
+                }
+            }
+
+            $followUpValue = $this->pickFirstNonEmpty($lead, $this->legacyFollowUpKeys());
+            if ($followUpValue !== null) {
+                $currentGeneric = $lead->get(IntelligenceModeEnum::AI_FOLLOW_UP->value);
+                if ($currentGeneric === null || $currentGeneric === '') {
+                    if (! $isDryRun) {
+                        $lead->set(IntelligenceModeEnum::AI_FOLLOW_UP->value, $followUpValue);
+                    }
+                    $followUpCopied++;
+                    $this->line("  Lead {$lead->getId()}: ai_follow_up <- {$followUpValue}");
+                } else {
+                    $followUpSkipped++;
+                }
+            }
+        }
+
+        $this->info("Processed: {$processed}");
+        $this->info("ai_mode copied: {$aiModeCopied} (skipped because generic already set: {$aiModeSkipped})");
+        $this->info("ai_follow_up copied: {$followUpCopied} (skipped because generic already set: {$followUpSkipped})");
+
+        return Command::SUCCESS;
+    }
+
+    private function pickFirstNonEmpty(Lead $lead, array $keys): mixed
+    {
+        foreach ($keys as $key) {
+            $value = $lead->get($key);
+            if ($value !== null && $value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    private function legacyAiModeKeys(): array
+    {
+        return array_map(fn (string $prefix) => "{$prefix}_ai_mode", self::PREFIXES);
+    }
+
+    private function legacyFollowUpKeys(): array
+    {
+        $keys = [];
+        foreach (self::PREFIXES as $prefix) {
+            $keys[] = "{$prefix}_follow_up_mode";
+            $keys[] = "{$prefix}_followup_closed-sold";
+            $keys[] = "{$prefix}_followup_closed-not-sold";
+        }
+
+        return $keys;
+    }
+}

--- a/src/Domains/Intelligence/Services/LeadConfigurationService.php
+++ b/src/Domains/Intelligence/Services/LeadConfigurationService.php
@@ -57,37 +57,12 @@ class LeadConfigurationService
 
     public function getAiModeKey(Lead $lead): string
     {
-        if (! $this->isV2Enabled($lead->company)) {
-            return 'ai_mode';
-        }
-
-        $prefix = $this->getTypePrefix($lead->type()->first());
-
-        return match ($prefix) {
-            'showroom' => 'showroom_ai_mode',
-            'phone' => 'phone_ai_mode',
-            default => 'ai_mode',
-        };
+        return 'ai_mode';
     }
 
     public function getFollowUpModeKey(Lead $lead): string
     {
-        if (! $this->isV2Enabled($lead->company)) {
-            return IntelligenceModeEnum::AI_FOLLOW_UP->value;
-        }
-
-        $prefix = $this->getTypePrefix($lead->type()->first());
-        $statusSuffix = $this->getStatusSuffix($lead);
-
-        if ($statusSuffix !== '') {
-            return "{$prefix}_followup_{$statusSuffix}";
-        }
-
-        return match ($prefix) {
-            'showroom' => 'showroom_follow_up_mode',
-            'phone' => 'phone_follow_up_mode',
-            default => 'internet_follow_up_mode',
-        };
+        return IntelligenceModeEnum::AI_FOLLOW_UP->value;
     }
 
     public function getFirstMessageDefaultKey(Lead $lead): string

--- a/tests/Intelligence/Services/LeadConfigurationServiceV2Test.php
+++ b/tests/Intelligence/Services/LeadConfigurationServiceV2Test.php
@@ -52,46 +52,34 @@ class LeadConfigurationServiceV2Test extends TestCase
         $this->assertTrue(new LeadConfigurationService(true)->isV2Enabled(auth()->user()->getCurrentCompany()));
     }
 
-    public function testGetAiModeKeyReturnsShowroomKeyForShowroomLeadType(): void
+    public function testGetAiModeKeyReturnsGenericAiModeForEveryLeadType(): void
     {
-        $lead = $this->createLead('Showroom');
+        $service = new LeadConfigurationService(true);
 
-        $this->assertEquals('showroom_ai_mode', new LeadConfigurationService(true)->getAiModeKey($lead));
+        foreach (['Internet', 'Showroom', 'Phone'] as $typeName) {
+            $lead = $this->createLead($typeName);
+
+            $this->assertEquals(
+                'ai_mode',
+                $service->getAiModeKey($lead),
+                "Lead key must be the generic 'ai_mode' regardless of lead type ({$typeName})"
+            );
+        }
     }
 
-    public function testGetAiModeKeyReturnsPhoneKeyForPhoneLeadType(): void
+    public function testGetFollowUpModeKeyReturnsGenericAiFollowUpForEveryLeadType(): void
     {
-        $lead = $this->createLead('Phone');
+        $service = new LeadConfigurationService(true);
 
-        $this->assertEquals('phone_ai_mode', new LeadConfigurationService(true)->getAiModeKey($lead));
-    }
+        foreach (['Internet', 'Showroom', 'Phone'] as $typeName) {
+            $lead = $this->createLead($typeName);
 
-    public function testGetAiModeKeyReturnsGenericKeyForInternetLeadType(): void
-    {
-        $lead = $this->createLead('Internet');
-
-        $this->assertEquals('ai_mode', new LeadConfigurationService(true)->getAiModeKey($lead));
-    }
-
-    public function testGetFollowUpModeKeyReturnsInternetFollowUpKeyForInternetType(): void
-    {
-        $lead = $this->createLead('Internet');
-
-        $this->assertEquals('internet_follow_up_mode', new LeadConfigurationService(true)->getFollowUpModeKey($lead));
-    }
-
-    public function testGetFollowUpModeKeyReturnsShowroomFollowUpKeyForShowroomType(): void
-    {
-        $lead = $this->createLead('Showroom');
-
-        $this->assertEquals('showroom_follow_up_mode', new LeadConfigurationService(true)->getFollowUpModeKey($lead));
-    }
-
-    public function testGetFollowUpModeKeyReturnsPhoneFollowUpKeyForPhoneType(): void
-    {
-        $lead = $this->createLead('Phone');
-
-        $this->assertEquals('phone_follow_up_mode', new LeadConfigurationService(true)->getFollowUpModeKey($lead));
+            $this->assertEquals(
+                'ai_follow_up',
+                $service->getFollowUpModeKey($lead),
+                "Lead key must be the generic 'ai_follow_up' regardless of lead type ({$typeName})"
+            );
+        }
     }
 
     public function testGetAiModeDefaultKeyReturnsOpenKeyWhenOpen(): void


### PR DESCRIPTION
## Summary

Lead settings in V2 used per-type prefixed keys (`internet_ai_mode`, `phone_ai_mode`, `showroom_ai_mode`, `internet_follow_up_mode`, `phone_followup_closed-sold`, etc.). Since a lead only has one type at a time, the prefix is redundant — the runtime keys are now flattened to the generic `ai_mode` and `ai_follow_up`.

- `LeadConfigurationService::getAiModeKey()` always returns `ai_mode`.
- `LeadConfigurationService::getFollowUpModeKey()` always returns `ai_follow_up`.
- `LeadType.config` defaults keep their `internet_*` / `phone_*` / `showroom_*` prefixes (one row per type, defaults are stored alongside each other).
- V1 path (`ApplyLeadAiModeV1Action`, `isV2Enabled` switch in `TriggerIntelligenceActivity`) is untouched.
- New artisan command `kanvas:intelligence:backfill-lead-ai-mode-keys {company_id} {app_id} [--dry-run]` copies legacy prefixed values on existing leads into the generic keys (does not overwrite, does not delete).

## Test plan

- [x] `LeadConfigurationServiceV1Test` + `LeadConfigurationServiceV2Test` (12/12) pass
- [x] `ApplyLeadAiModeV1ActionTest`, `FollowUpEngagementActionV1Test`, `FollowUpEngagementActionV2Test`, `TriggerIntelligenceActivityTest` pass (51/51 across the touched call sites)
- [ ] Run the backfill on a single company/app with `--dry-run` before applying for real