### PR TITLE
feat(guild): track first_message_at / last_message_at on people

### DIFF
--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvi
 use Kanvas\Companies\Groups\Observers\CompaniesGroupsObserver;
 use Kanvas\Companies\Models\CompaniesGroups;
 use Kanvas\Connectors\ScrapperApi\Listeners\CartListener;
+use Kanvas\Guild\Customers\Listeners\UpdatePeopleMessageTimestamps;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Customers\Models\PeopleEmploymentHistory;
 use Kanvas\Guild\Customers\Observers\PeopleEmploymentHistoryObserver;
@@ -34,6 +35,7 @@ use Kanvas\NervousSystem\Plan\Events\PlanBroadcast;
 use Kanvas\NervousSystem\Plan\Listeners\WakeAgentOnPlanChange;
 use Kanvas\Notifications\Events\PushNotificationsEvent;
 use Kanvas\Notifications\Listeners\NotificationsListener;
+use Kanvas\Social\Messages\Events\AppModuleMessageCreatedEvent;
 use Kanvas\Social\Messages\Models\UserMessageActivity;
 use Kanvas\Social\Messages\Observers\UserMessageActivityObserver;
 use Kanvas\Social\UsersLists\Models\UserList;
@@ -69,6 +71,9 @@ class EventServiceProvider extends ServiceProvider
         ],
         WebhookHandled::class => [
             CompanySubscriptionWebhookListener::class,
+        ],
+        AppModuleMessageCreatedEvent::class => [
+            UpdatePeopleMessageTimestamps::class,
         ],
     ];
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvi
 use Kanvas\Companies\Groups\Observers\CompaniesGroupsObserver;
 use Kanvas\Companies\Models\CompaniesGroups;
 use Kanvas\Connectors\ScrapperApi\Listeners\CartListener;
-use Kanvas\Guild\Customers\Listeners\UpdatePeopleMessageTimestamps;
+use Kanvas\Guild\Customers\Listeners\UpdatePeopleMessageTimestampsListener;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Customers\Models\PeopleEmploymentHistory;
 use Kanvas\Guild\Customers\Observers\PeopleEmploymentHistoryObserver;
@@ -73,7 +73,7 @@ class EventServiceProvider extends ServiceProvider
             CompanySubscriptionWebhookListener::class,
         ],
         AppModuleMessageCreatedEvent::class => [
-            UpdatePeopleMessageTimestamps::class,
+            UpdatePeopleMessageTimestampsListener::class,
         ],
     ];
 

--- a/database/migrations/Guild/2026_05_29_000000_add_message_timestamps_to_peoples_table.php
+++ b/database/migrations/Guild/2026_05_29_000000_add_message_timestamps_to_peoples_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::connection('crm')->table('peoples', function (Blueprint $table) {
+            $table->timestamp('first_message_at')->nullable()->after('updated_at');
+            $table->timestamp('last_message_at')->nullable()->after('first_message_at');
+            $table->index('last_message_at', 'peoples_last_message_at_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection('crm')->table('peoples', function (Blueprint $table) {
+            $table->dropIndex('peoples_last_message_at_idx');
+            $table->dropColumn(['first_message_at', 'last_message_at']);
+        });
+    }
+};

--- a/database/migrations/Guild/2026_05_29_000000_add_message_timestamps_to_peoples_table.php
+++ b/database/migrations/Guild/2026_05_29_000000_add_message_timestamps_to_peoples_table.php
@@ -10,16 +10,14 @@ return new class () extends Migration {
     public function up(): void
     {
         Schema::connection('crm')->table('peoples', function (Blueprint $table) {
-            $table->timestamp('first_message_at')->nullable()->after('updated_at');
-            $table->timestamp('last_message_at')->nullable()->after('first_message_at');
-            $table->index('last_message_at', 'peoples_last_message_at_idx');
+            $table->timestamp('first_message_at')->nullable()->after('updated_at')->index();
+            $table->timestamp('last_message_at')->nullable()->after('first_message_at')->index();
         });
     }
 
     public function down(): void
     {
         Schema::connection('crm')->table('peoples', function (Blueprint $table) {
-            $table->dropIndex('peoples_last_message_at_idx');
             $table->dropColumn(['first_message_at', 'last_message_at']);
         });
     }

--- a/graphql/schemas/Guild/people.graphql
+++ b/graphql/schemas/Guild/people.graphql
@@ -17,6 +17,8 @@ type People {
     address: [Address!]! @hasMany
     created_at: DateTime!
     updated_at: DateTime
+    first_message_at: DateTime
+    last_message_at: DateTime
     photo: Filesystem @method(name: "getPhoto")
     employment_history: [PeopleEmploymentHistory!]
         @hasMany(relation: "employmentHistory")
@@ -199,7 +201,17 @@ extend type Query @guard {
                 columns: ["name", "value"]
             )
         orderBy: _
-            @orderBy(columns: ["id", "created_at", "updated_at", "name", "dob"])
+            @orderBy(
+                columns: [
+                    "id"
+                    "created_at"
+                    "updated_at"
+                    "name"
+                    "dob"
+                    "first_message_at"
+                    "last_message_at"
+                ]
+            )
     ): [People!]!
         @paginate(
             model: "Kanvas\\Guild\\Customers\\Models\\People"

--- a/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestamps.php
+++ b/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestamps.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Customers\Listeners;
+
+use Illuminate\Support\Facades\DB;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Social\Messages\Events\AppModuleMessageCreatedEvent;
+
+class UpdatePeopleMessageTimestamps
+{
+    public function handle(AppModuleMessageCreatedEvent $event): void
+    {
+        $appModuleMessage = $event->appModuleMessage;
+
+        if ($appModuleMessage->system_modules !== Lead::class) {
+            return;
+        }
+
+        $messageAt = (string) $appModuleMessage->created_at;
+
+        DB::connection('crm')->update(
+            <<<'SQL'
+            UPDATE peoples p
+            INNER JOIN leads l ON l.people_id = p.id
+            SET
+                p.first_message_at = COALESCE(p.first_message_at, ?),
+                p.last_message_at  = GREATEST(COALESCE(p.last_message_at, ?), ?)
+            WHERE l.id = ?
+              AND l.is_deleted = 0
+              AND p.is_deleted = 0
+            SQL,
+            [$messageAt, $messageAt, $messageAt, $appModuleMessage->entity_id],
+        );
+    }
+}

--- a/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
+++ b/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
@@ -35,6 +35,6 @@ class UpdatePeopleMessageTimestampsListener
         );
 
         $lead = $appModuleMessage->entity;
-        $lead?->people?->set('last_unread_reply_at', 1);
+        $lead?->people?->set('unread_message', 1);
     }
 }

--- a/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
+++ b/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
@@ -33,5 +33,8 @@ class UpdatePeopleMessageTimestampsListener
             SQL,
             [$messageAt, $messageAt, $messageAt, $appModuleMessage->entity_id],
         );
+
+        $lead = Lead::find($appModuleMessage->entity_id);
+        $lead?->people?->set('last_unread_reply_at', 1);
     }
 }

--- a/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
+++ b/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
@@ -34,7 +34,7 @@ class UpdatePeopleMessageTimestampsListener
             [$messageAt, $messageAt, $messageAt, $appModuleMessage->entity_id],
         );
 
-        $lead = Lead::find($appModuleMessage->entity_id);
+        $lead = $appModuleMessage->entity;
         $lead?->people?->set('last_unread_reply_at', 1);
     }
 }

--- a/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
+++ b/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Social\Messages\Events\AppModuleMessageCreatedEvent;
 
-class UpdatePeopleMessageTimestamps
+class UpdatePeopleMessageTimestampsListener
 {
     public function handle(AppModuleMessageCreatedEvent $event): void
     {

--- a/src/Domains/Guild/Customers/Models/People.php
+++ b/src/Domains/Guild/Customers/Models/People.php
@@ -86,6 +86,8 @@ class People extends BaseModel
         'dob' => 'datetime:Y-m-d',
         'license_expiration_date' => 'datetime:Y-m-d',
         'is_deleted' => 'boolean',
+        'first_message_at' => 'datetime',
+        'last_message_at' => 'datetime',
     ];
 
     public function trashed()

--- a/tests/Guild/Integration/PeopleMessageTimestampsTest.php
+++ b/tests/Guild/Integration/PeopleMessageTimestampsTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Guild\Integration;
+
+use Carbon\Carbon;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Customers\Factories\PeopleFactory;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Social\Messages\Models\Message;
+use Tests\TestCase;
+
+final class PeopleMessageTimestampsTest extends TestCase
+{
+    public function testFirstMessageStampsBothColumns(): void
+    {
+        [$people, $lead] = $this->createPeopleAndLead();
+
+        $this->assertNull($people->first_message_at);
+        $this->assertNull($people->last_message_at);
+
+        $message = $this->createMessageForLead($lead);
+
+        $people->refresh();
+
+        $this->assertNotNull(
+            $people->first_message_at,
+            'first_message_at must be set when the first message is attached to a lead',
+        );
+        $this->assertNotNull(
+            $people->last_message_at,
+            'last_message_at must be set when the first message is attached to a lead',
+        );
+        $this->assertEquals(
+            $message->appModuleMessage->created_at->format('Y-m-d H:i:s'),
+            $people->first_message_at->format('Y-m-d H:i:s'),
+        );
+    }
+
+    public function testSecondMessageOnlyAdvancesLastMessageAt(): void
+    {
+        [$people, $lead] = $this->createPeopleAndLead();
+
+        $this->createMessageForLead($lead);
+        $people->refresh();
+        $firstStamp = $people->first_message_at;
+        $this->assertNotNull($firstStamp);
+
+        // Make sure clock moves forward at least 1 second so MariaDB can distinguish timestamps.
+        sleep(1);
+
+        $this->createMessageForLead($lead);
+        $people->refresh();
+
+        $this->assertEquals(
+            $firstStamp->format('Y-m-d H:i:s'),
+            $people->first_message_at->format('Y-m-d H:i:s'),
+            'first_message_at must not move when subsequent messages arrive',
+        );
+        $this->assertTrue(
+            $people->last_message_at->gt($firstStamp),
+            'last_message_at must advance when a newer message arrives',
+        );
+    }
+
+    public function testNonLeadEntityDoesNotTouchPeople(): void
+    {
+        [$people, $lead] = $this->createPeopleAndLead();
+
+        // Attach a message to People itself (not to the Lead) — the listener must ignore it.
+        $message = Message::factory()->create();
+        $message->addEntity($people);
+
+        $people->refresh();
+
+        $this->assertNull(
+            $people->first_message_at,
+            'Messages attached to entities other than Lead must not stamp people',
+        );
+        $this->assertNull(
+            $people->last_message_at,
+            'Messages attached to entities other than Lead must not stamp people',
+        );
+    }
+
+    public function testPeoplesQueryCanOrderByLastMessageAt(): void
+    {
+        [$older, ] = $this->createPeopleAndLead();
+        [$newer, ] = $this->createPeopleAndLead();
+
+        $marker = 'ts-' . uniqid('', true);
+        $older->forceFill([
+            'firstname' => $marker . '-A',
+            'first_message_at' => Carbon::now()->subDays(10),
+            'last_message_at' => Carbon::now()->subDays(10),
+        ])->saveQuietly();
+        $newer->forceFill([
+            'firstname' => $marker . '-B',
+            'first_message_at' => Carbon::now()->subDays(1),
+            'last_message_at' => Carbon::now()->subDays(1),
+        ])->saveQuietly();
+
+        $raw = $this->graphQL(
+            'query($firstname: Mixed) {
+                peoples(
+                    where: { column: FIRSTNAME, operator: LIKE, value: $firstname }
+                    orderBy: [{ column: LAST_MESSAGE_AT, order: DESC }]
+                ) {
+                    data { id last_message_at }
+                }
+            }',
+            ['firstname' => $marker . '%'],
+        )->assertOk()->json();
+        $response = $raw['data']['peoples']['data'] ?? null;
+        $this->assertIsArray(
+            $response,
+            'peoples query must return data, got: ' . json_encode($raw),
+        );
+        $ids = array_map(fn ($row) => (int) $row['id'], $response);
+
+        $this->assertSame(
+            [$newer->getId(), $older->getId()],
+            $ids,
+            'peoples must order by last_message_at DESC',
+        );
+    }
+
+    /**
+     * @return array{0: People, 1: Lead}
+     */
+    private function createPeopleAndLead(): array
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        /** @var People $people */
+        $people = PeopleFactory::new()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->withUserId($user->getId())
+            ->withContacts()
+            ->create();
+
+        /** @var Lead $lead */
+        $lead = Lead::factory()
+            ->withAppAndCompany($app->getId(), $company->getId())
+            ->withUserId($user->getId())
+            ->withPeopleId($people->getId())
+            ->create();
+
+        return [$people->fresh(), $lead];
+    }
+
+    private function createMessageForLead(Lead $lead): Message
+    {
+        $message = Message::factory()->create([
+            'apps_id' => $lead->apps_id,
+            'companies_id' => $lead->companies_id,
+        ]);
+        $message->addEntity($lead);
+
+        return $message->fresh('appModuleMessage');
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `first_message_at` and `last_message_at` columns to `peoples` (crm) so the `peoples` GraphQL query can be ordered by message activity without crossing the crm/social connection boundary.
- New listener `UpdatePeopleMessageTimestamps` reacts to `AppModuleMessageCreatedEvent`: when the entity is a `Lead`, runs a single crm-side `UPDATE peoples JOIN leads` — `first_message_at = COALESCE(...)`, `last_message_at = GREATEST(...)`. Non-Lead entities are ignored.
- Both columns are exposed on the `People` GraphQL type and added to the `orderBy` whitelist (`FIRST_MESSAGE_AT`, `LAST_MESSAGE_AT`).

Usage:
\`\`\`graphql
peoples(orderBy: [{ column: LAST_MESSAGE_AT, order: DESC }]) {
  data { id name last_message_at }
}
\`\`\`

Known caveat: deleted messages don't recompute the stamps (no `deleted` hook). Out of scope; can be added later if needed.

## Test plan

- [x] Migration runs cleanly on crm
- [x] `tests/Guild/Integration/PeopleMessageTimestampsTest.php` — 4 tests, 13 assertions, all green
  - First message stamps both columns
  - Subsequent messages only advance `last_message_at`
  - Messages on non-Lead entities are ignored
  - `peoples` GraphQL query orders correctly by `LAST_MESSAGE_AT DESC`
- [ ] Smoke-test in staging: inbound WhatsApp / Twilio message reflects on the related People