### PR TITLE
feat(intelligence): work-hours-aware AI mode + close/sold follow-up triggers (1.x)

### DIFF
--- a/src/Domains/Intelligence/Services/LeadConfigurationService.php
+++ b/src/Domains/Intelligence/Services/LeadConfigurationService.php
@@ -95,4 +95,50 @@ class LeadConfigurationService
 
         return "{$prefix}_con_fu_active_default";
     }
+
+    public function getFollowUpActiveDefaultKey(Lead $lead): string
+    {
+        $prefix = $this->getTypePrefix($lead->type()->first());
+
+        return "{$prefix}_con_fu_active_default";
+    }
+
+    public function getFollowUpClosedNotSoldDefaultKey(Lead $lead): string
+    {
+        $prefix = $this->getTypePrefix($lead->type()->first());
+
+        return "{$prefix}_con_fu_cns_default";
+    }
+
+    public function getFollowUpClosedSoldDefaultKey(Lead $lead): string
+    {
+        $prefix = $this->getTypePrefix($lead->type()->first());
+
+        return "{$prefix}_con_fu_closed-sold_default";
+    }
+
+    public function getAllDefaultKeys(Lead $lead, bool $isOpen = true): array
+    {
+        $leadType = $lead->type()->first();
+        $leadTypeConfig = $leadType?->config ?? [];
+
+        $aiModeKey = $this->getAiModeDefaultKey($lead, $isOpen);
+        $followUpKey = $this->getFollowUpActiveDefaultKey($lead);
+        $firstMessageKey = $this->getFirstMessageDefaultKey($lead);
+
+        return [
+            'ai_mode' => [
+                'key' => $aiModeKey,
+                'value' => $leadTypeConfig[$aiModeKey] ?? null,
+            ],
+            'follow_up' => [
+                'key' => $followUpKey,
+                'value' => $leadTypeConfig[$followUpKey] ?? null,
+            ],
+            'first_message' => [
+                'key' => $firstMessageKey,
+                'value' => $leadTypeConfig[$firstMessageKey] ?? null,
+            ],
+        ];
+    }
 }

--- a/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
+++ b/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Triggers\Actions;
 
 use Exception;
+use InvalidArgumentException;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
@@ -82,7 +83,8 @@ class ApplyLeadAiModeAction
             TriggersEnum::MANUAL_FON->value => $this->applyManualFullOn(),
             TriggersEnum::FOLLOW_UP_ON->value => $this->setFollowUp(FollowUpValueEnum::ON()),
             TriggersEnum::FOLLOW_UP_OFF->value => $this->setFollowUp(FollowUpValueEnum::OFF()),
-
+            TriggersEnum::CLOSE_LEAD->value => $this->closeLead(),
+            TriggersEnum::SOLD_LEAD->value => $this->soldLead(),
             default => null,
         };
     }
@@ -93,6 +95,38 @@ class ApplyLeadAiModeAction
         $this->setMode($aiMode);
     }
 
+    public function closeLead(): void
+    {
+        $leadType = $this->lead->type()->first();
+        $configService = new LeadConfigurationService();
+        $aiFollowUpKey = $configService->getFollowUpModeKey($this->lead);
+
+        $leadTypeConfig = $leadType?->config ?? [];
+        $followUpDefaultKey = $configService->getFollowUpClosedNotSoldDefaultKey($this->lead);
+
+        $followUpRawValue = $leadTypeConfig[$followUpDefaultKey] ?? $this->lead->company->get($aiFollowUpKey);
+
+        if ($followUpRawValue !== null) {
+            $this->setFollowUp(FollowUpValueEnum::from($followUpRawValue));
+        }
+    }
+
+    public function soldLead(): void
+    {
+        $leadType = $this->lead->type()->first();
+        $configService = new LeadConfigurationService();
+        $aiFollowUpKey = $configService->getFollowUpModeKey($this->lead);
+
+        $leadTypeConfig = $leadType?->config ?? [];
+        $followUpDefaultKey = $configService->getFollowUpClosedSoldDefaultKey($this->lead);
+
+        $followUpRawValue = $leadTypeConfig[$followUpDefaultKey] ?? $this->lead->company->get($aiFollowUpKey);
+
+        if ($followUpRawValue !== null) {
+            $this->setFollowUp(FollowUpValueEnum::from($followUpRawValue));
+        }
+    }
+
     protected function applyNewLead(): void
     {
         $leadType = $this->lead->type()->first();
@@ -100,9 +134,11 @@ class ApplyLeadAiModeAction
         $aiModeKey = $configService->getAiModeKey($this->lead);
         $aiFollowUpKey = $configService->getFollowUpModeKey($this->lead);
 
+        $isOpen = $this->isCompanyWithinWorkingHours();
+
         $leadTypeConfig = $leadType?->config ?? [];
-        $aiModeDefaultKey = $configService->getAiModeDefaultKey($this->lead);
-        $followUpDefaultKey = $configService->getFollowUpDefaultKey($this->lead);
+        $aiModeDefaultKey = $configService->getAiModeDefaultKey($this->lead, $isOpen);
+        $followUpDefaultKey = $configService->getFollowUpActiveDefaultKey($this->lead);
 
         $aiModeValue = $leadTypeConfig[$aiModeDefaultKey] ?? $this->lead->company->get($aiModeKey);
         $followUpRawValue = $leadTypeConfig[$followUpDefaultKey] ?? $this->lead->company->get($aiFollowUpKey);
@@ -112,6 +148,17 @@ class ApplyLeadAiModeAction
         }
 
         $this->setMode($aiModeValue);
+
+        $this->lead->set('first_followup', $configService->getAllDefaultKeys($this->lead, $isOpen));
+    }
+
+    protected function isCompanyWithinWorkingHours(): bool
+    {
+        try {
+            return $this->lead->company->isWithinWorkingHours(now());
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
     }
 
     protected function applyManualFullOn(): void

--- a/tests/Intelligence/Services/LeadConfigurationServiceV2Test.php
+++ b/tests/Intelligence/Services/LeadConfigurationServiceV2Test.php
@@ -165,4 +165,107 @@ class LeadConfigurationServiceV2Test extends TestCase
             );
         }
     }
+
+    public function testGetFollowUpActiveDefaultKeyUsesCorrectPrefix(): void
+    {
+        $cases = [
+            'Internet' => 'internet_con_fu_active_default',
+            'Showroom' => 'showroom_con_fu_active_default',
+            'Phone' => 'phone_con_fu_active_default',
+        ];
+
+        $service = new LeadConfigurationService(true);
+
+        foreach ($cases as $typeName => $expectedKey) {
+            $lead = $this->createLead($typeName);
+
+            $this->assertEquals(
+                $expectedKey,
+                $service->getFollowUpActiveDefaultKey($lead),
+                "{$typeName} lead should always use active key {$expectedKey}"
+            );
+        }
+    }
+
+    public function testGetFollowUpClosedNotSoldDefaultKeyUsesCorrectPrefix(): void
+    {
+        $cases = [
+            'Internet' => 'internet_con_fu_cns_default',
+            'Showroom' => 'showroom_con_fu_cns_default',
+            'Phone' => 'phone_con_fu_cns_default',
+        ];
+
+        $service = new LeadConfigurationService(true);
+
+        foreach ($cases as $typeName => $expectedKey) {
+            $lead = $this->createLead($typeName);
+
+            $this->assertEquals(
+                $expectedKey,
+                $service->getFollowUpClosedNotSoldDefaultKey($lead),
+                "{$typeName} lead should use closed-not-sold key {$expectedKey}"
+            );
+        }
+    }
+
+    public function testGetFollowUpClosedSoldDefaultKeyUsesCorrectPrefix(): void
+    {
+        $cases = [
+            'Internet' => 'internet_con_fu_closed-sold_default',
+            'Showroom' => 'showroom_con_fu_closed-sold_default',
+            'Phone' => 'phone_con_fu_closed-sold_default',
+        ];
+
+        $service = new LeadConfigurationService(true);
+
+        foreach ($cases as $typeName => $expectedKey) {
+            $lead = $this->createLead($typeName);
+
+            $this->assertEquals(
+                $expectedKey,
+                $service->getFollowUpClosedSoldDefaultKey($lead),
+                "{$typeName} lead should use closed-sold key {$expectedKey}"
+            );
+        }
+    }
+
+    public function testGetAllDefaultKeysReturnsKeysAndResolvedValues(): void
+    {
+        $lead = $this->createLead('Internet');
+        $leadType = $lead->type()->first();
+        $leadType->config = [
+            'internet_ai_mode_open_default' => 'full_on',
+            'internet_con_fu_active_default' => 'on',
+            'internet_first_fu_active_default' => true,
+        ];
+        $leadType->saveOrFail();
+        $lead->refresh();
+
+        $result = new LeadConfigurationService(true)->getAllDefaultKeys($lead, true);
+
+        $this->assertEquals('internet_ai_mode_open_default', $result['ai_mode']['key']);
+        $this->assertEquals('full_on', $result['ai_mode']['value']);
+        $this->assertEquals('internet_con_fu_active_default', $result['follow_up']['key']);
+        $this->assertEquals('on', $result['follow_up']['value']);
+        $this->assertEquals('internet_first_fu_active_default', $result['first_message']['key']);
+        $this->assertTrue($result['first_message']['value']);
+    }
+
+    public function testGetAllDefaultKeysUsesClosedAiModeWhenIsOpenIsFalse(): void
+    {
+        $lead = $this->createLead('Internet');
+
+        $result = new LeadConfigurationService(true)->getAllDefaultKeys($lead, false);
+
+        $this->assertEquals('internet_ai_mode_closed_default', $result['ai_mode']['key']);
+    }
+
+    public function testGetAllDefaultKeysForcesActiveFollowUpRegardlessOfStatus(): void
+    {
+        $lead = $this->createLead('Internet');
+
+        $result = new LeadConfigurationService(true)->getAllDefaultKeys($lead);
+
+        $this->assertEquals('internet_con_fu_active_default', $result['follow_up']['key']);
+    }
 }


### PR DESCRIPTION
## Summary

Backport of #9834 to `1.x`.

- `ApplyLeadAiModeAction::applyNewLead` now checks `company->isWithinWorkingHours()` before picking the AI mode default key — outside working hours we pass `isOpen = false` so the closed AI-mode default applies.
- The resolved default keys + values are persisted on the lead as `first_followup` (via `$lead->set`), giving a snapshot of what config was used at creation time.
- `closeLead` and `soldLead` triggers are now implemented: they read `*_con_fu_cns_default` / `*_con_fu_closed-sold_default` from the lead type config and apply the follow-up via `setFollowUp()`.
- `LeadConfigurationService` gains: `getFollowUpActiveDefaultKey`, `getFollowUpClosedNotSoldDefaultKey`, `getFollowUpClosedSoldDefaultKey`, `getAllDefaultKeys`.

## Test plan

- [x] `phpunit tests/Intelligence/Services/LeadConfigurationServiceV2Test.php` — 15 tests, 36 assertions, all green
- [ ] Manual: create a lead outside working hours and verify the closed AI-mode default key is applied
- [ ] Manual: fire `CLOSE_LEAD` trigger and confirm `_con_fu_cns_default` is used
- [ ] Manual: fire `SOLD_LEAD` trigger and confirm `_con_fu_closed-sold_default` is used
- [ ] Manual: confirm `$lead->get('first_followup')` returns the snapshot after a new lead is created