### PR TITLE
feat: sync NetSuite MAP PRICE to variant cost field

### DIFF
--- a/src/Domains/Connectors/NetSuite/Actions/PullNetSuiteProductPriceAction.php
+++ b/src/Domains/Connectors/NetSuite/Actions/PullNetSuiteProductPriceAction.php
@@ -94,6 +94,10 @@ class PullNetSuiteProductPriceAction
         $variantWarehouse->config = $config;
         $variantWarehouse->saveOrFail();
 
+        // Link NetSuite MAP PRICE (custitem40) to the variant's UMAP Price (cost) field
+        $variant->cost = (float) $product['map_price'];
+        $variant->saveOrFail();
+
         $variant->addAttributes($this->user, [
             [
                 'name' => 'color_code',

--- a/src/Domains/Connectors/NetSuite/Actions/SyncNetSuiteProductsAction.php
+++ b/src/Domains/Connectors/NetSuite/Actions/SyncNetSuiteProductsAction.php
@@ -102,6 +102,10 @@ class SyncNetSuiteProductsAction
                 $variantWarehouse->config = $config;
                 $variantWarehouse->saveOrFail();
 
+                // Link NetSuite MAP PRICE (custitem40) to the variant's UMAP Price (cost) field
+                $variant->cost = (float) $product['map_price'];
+                $variant->saveOrFail();
+
                 $variant->addAttributes($this->mainAppCompany->user, [
                     [
                         'name' => 'color_code',


### PR DESCRIPTION
Link the NetSuite MAP PRICE custom field (custitem40) to the variant's UMAP Price (cost) column during product sync. Previously the value was only stored in the variant warehouse config JSON and never written to the variant.cost column, leaving it at its default 0.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
