### PR TITLE
fix(paso-rapido): correct bulk recharge payload to pass .NET validation

### DIFF
--- a/src/Domains/Connectors/Movipass/Actions/BulkRechargeOrderTagsAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/BulkRechargeOrderTagsAction.php
@@ -23,6 +23,7 @@ class BulkRechargeOrderTagsAction
     public function __construct(
         protected readonly Order $order,
         protected readonly AppInterface $app,
+        protected readonly ?PasoRapidoService $injectedService = null,
     ) {
     }
 
@@ -49,14 +50,16 @@ class BulkRechargeOrderTagsAction
         $bankTransaction = $this->resolveBankTransaction();
         $fiscalCredit = (bool) ($this->order->metadata['data']['fiscal_credit'] ?? false);
 
-        $service = null;
+        $service = $this->injectedService;
         $serviceError = null;
 
-        try {
-            $service = new PasoRapidoService($this->app, $company);
-        } catch (Throwable $e) {
-            report($e);
-            $serviceError = $e->getMessage();
+        if ($service === null) {
+            try {
+                $service = new PasoRapidoService($this->app, $company);
+            } catch (Throwable $e) {
+                report($e);
+                $serviceError = $e->getMessage();
+            }
         }
 
         $results = [];
@@ -248,6 +251,8 @@ class BulkRechargeOrderTagsAction
             return explode(':', (string) $intentId)[1] ?? (string) $intentId;
         }
 
-        return 'wallet_bulk_' . $this->order->uuid;
+        // PasoRapido transaccionBanco max length = 50. Per-item suffix `-{id}` adds ~10 more,
+        // so cap the order prefix at 22 chars (BR + 20 hex from uuid, no separators).
+        return 'BR' . substr(str_replace('-', '', (string) $this->order->uuid), 0, 20);
     }
 }

--- a/src/Domains/Connectors/PasoRapido/Services/PasoRapidoService.php
+++ b/src/Domains/Connectors/PasoRapido/Services/PasoRapidoService.php
@@ -204,7 +204,9 @@ class PasoRapidoService
         $response = $this->client->post(ConfigurationEnum::CONFIRM_PAYMENT_PATH->value, [
             'referencia' => $data->reference,
             'transaccionBanco' => $data->bankTransaction,
-            'valorPagado' => $data->amount,
+            // PasoRapido validates valorPagado as .NET Int32. round() avoids losing
+            // a peso on 500.99 → 500; spec works in whole DOP, no cents.
+            'valorPagado' => (int) round($data->amount),
             'creditoFiscal' => $data->fiscalCredit,
             'rnc_Cedula' => $data->dni,
         ]);

--- a/tests/Connectors/Integration/Movipass/BulkRechargeTagsActivityTest.php
+++ b/tests/Connectors/Integration/Movipass/BulkRechargeTagsActivityTest.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Tests\Connectors\Integration\Movipass;
 
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Movipass\Actions\BulkRechargeOrderTagsAction;
 use Kanvas\Connectors\Movipass\Enums\OrderTypeEnum;
 use Kanvas\Connectors\Movipass\Handlers\MovipassHandler;
 use Kanvas\Connectors\Movipass\Workflows\Activities\BulkRechargeTagsActivity;
+use Kanvas\Connectors\PasoRapido\DataTransferObject\InvoiceDetails;
+use Kanvas\Connectors\PasoRapido\DataTransferObject\PaymentConfirmData;
+use Kanvas\Connectors\PasoRapido\DataTransferObject\PaymentConfirmResponse;
+use Kanvas\Connectors\PasoRapido\Services\PasoRapidoService;
 use Kanvas\Currencies\Models\Currencies;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Inventory\Products\Models\Products;
@@ -17,6 +22,7 @@ use Kanvas\Souk\Orders\Models\Order;
 use Kanvas\Users\Models\Users;
 use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Kanvas\Workflow\Models\StoredWorkflow;
+use Mockery;
 use Tests\Connectors\Traits\HasIntegrationCompany;
 use Tests\TestCase;
 
@@ -258,5 +264,58 @@ final class BulkRechargeTagsActivityTest extends TestCase
         $this->assertNotNull($entry);
         $this->assertSame('failed', $entry['status']);
         $this->assertTrue($entry['reversed'] ?? false);
+    }
+
+    public function testBankTransactionStaysWithinPasoRapidoFiftyCharLimit(): void
+    {
+        // PasoRapido rejects transaccionBanco > 50 chars. The wallet-paid bulk path
+        // is the only producer of this id (no EchoPay intent to crib from), so we
+        // need to keep its format short on every TAG.
+        [$tag1, $tag2, $tag3] = $this->createTagVariants(3);
+        $order = $this->createBulkRechargeOrder([
+            ['variant' => $tag1, 'tag_number' => '941001', 'amount' => 500.00],
+            ['variant' => $tag2, 'tag_number' => '941002', 'amount' => 1000.00],
+            ['variant' => $tag3, 'tag_number' => '941003', 'amount' => 250.00],
+        ]);
+
+        $captured = [];
+        $mockService = Mockery::mock(PasoRapidoService::class);
+        $mockService->shouldReceive('confirmPayment')
+            ->andReturnUsing(function (PaymentConfirmData $data) use (&$captured) {
+                $captured[] = $data;
+
+                return PaymentConfirmResponse::from([
+                    'message' => 'ok',
+                    'amount' => (int) round($data->amount),
+                    'order' => 'ord-' . $data->reference,
+                    'tag' => $data->reference,
+                    'account' => '1234',
+                    'creditDate' => '2026-06-01',
+                    'invoiceDetails' => InvoiceDetails::from([
+                        'commercialName' => '',
+                        'document' => '',
+                        'fiscalCredit' => false,
+                        'invoice' => '',
+                        'pdf' => '',
+                        'reference' => '',
+                    ]),
+                ]);
+            });
+
+        new BulkRechargeOrderTagsAction($order, $this->kanvasApp, $mockService)->execute();
+
+        $this->assertNotEmpty($captured, 'PasoRapidoService::confirmPayment was never called');
+
+        foreach ($captured as $data) {
+            $this->assertLessThanOrEqual(
+                50,
+                strlen($data->bankTransaction),
+                sprintf(
+                    'bankTransaction "%s" (length %d) exceeds PasoRapido limit of 50 chars',
+                    $data->bankTransaction,
+                    strlen($data->bankTransaction),
+                ),
+            );
+        }
     }
 }

--- a/tests/Connectors/Integration/PasoRapido/PasoRapidoTest.php
+++ b/tests/Connectors/Integration/PasoRapido/PasoRapidoTest.php
@@ -141,6 +141,49 @@ final class PasoRapidoTest extends TestCase
         $this->assertInstanceOf(PaymentConfirmResponse::class, $confirmedPayment);
     }
 
+    public function testConfirmPaymentSendsValorPagadoAsIntegerOnTheWire(): void
+    {
+        // PasoRapido validates valorPagado as .NET Int32 — sending a float (e.g. 500.5)
+        // makes the API reject with "The JSON value could not be converted to System.Int32".
+        $captured = [];
+
+        $mockClient = Mockery::mock(Client::class);
+        $mockClient->shouldReceive('post')
+            ->once()
+            ->withArgs(function (string $endpoint, array $body) use (&$captured) {
+                $captured = $body;
+
+                return true;
+            })
+            ->andReturn([
+                'descripcionMensaje' => 'ok',
+                'montoAcreditado' => 500,
+                'orden' => 'ord-1',
+                'tag' => '941001',
+                'cuenta' => '1234',
+                'fechaCredito' => '2026-06-01',
+                'detallesFactura' => [],
+            ]);
+
+        $pasoRapidoService = new PasoRapidoService(
+            app: app(Apps::class),
+            company: Companies::first(),
+            config: $this->getPasoRapidoConfig(),
+            client: $mockClient,
+        );
+
+        $pasoRapidoService->confirmPayment(PaymentConfirmData::from([
+            'reference' => '941001',
+            'amount' => 500.99, // fractional on purpose — must arrive as int 501
+            'fiscalCredit' => false,
+            'bankTransaction' => 'BR0123456789AB',
+            'dni' => '13112345',
+        ]));
+
+        $this->assertIsInt($captured['valorPagado'] ?? null);
+        $this->assertSame(501, $captured['valorPagado']);
+    }
+
     public function testTokenIsCachedAndReused()
     {
         $app = app(Apps::class);


### PR DESCRIPTION
PasoRapido validates confirmarPago payload server-side and rejects two fields that the bulk recharge flow was sending wrong:

- valorPagado must be Int32; we sent float, so fractional amounts (e.g. 500.99 from tax math) became "500.99" on the wire and the API returned "The JSON value could not be converted to System.Int32". Cast to (int) round(...) at the service boundary — PasoRapido works in whole DOP and rounding avoids losing a peso on edge cases.

- transaccionBanco max length is 50; the wallet-paid bulk path was building "wallet_bulk_<uuid>-<itemId>" = 53+ chars. Shortened to "BR<20-hex>" so per-item ids fit comfortably under the cap.

Individual paso_rapido orders never tripped either rule (EchoPay intent ids are short alphanumeric and amounts came rounded from the FE), so the validation only surfaced once corporate bulk recharge hit stage.

Regression tests:
- PasoRapidoTest::testConfirmPaymentSendsValorPagadoAsIntegerOnTheWire mocks the HTTP Client and asserts the wire body has an int.
- BulkRechargeTagsActivityTest::testBankTransactionStaysWithinPasoRapido\ FiftyCharLimit captures PaymentConfirmData and asserts strlen <= 50 per TAG. Required adding an optional ?PasoRapidoService injection parameter to BulkRechargeOrderTagsAction (backward compatible).

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
