### PR TITLE
feat: agent integration config mutation

### DIFF
--- a/app/GraphQL/Intelligence/Mutations/AgentIntegrationConfigMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/AgentIntegrationConfigMutation.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Intelligence\Mutations;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Intelligence\Agents\Actions\SetAgentIntegrationConfigAction;
+use Kanvas\Intelligence\Agents\Enums\AgentIntegrationConfigKeyEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+
+class AgentIntegrationConfigMutation
+{
+    public function set(mixed $root, array $req): Agent
+    {
+        $input = $req['input'];
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+        $agent = Agent::getByIdFromCompanyApp((int) $input['agent_id'], $company, $app);
+
+        $entries = array_map(
+            static fn (array $entry): array => [
+                'key' => AgentIntegrationConfigKeyEnum::fromName((string) $entry['key']),
+                'value' => $entry['value'] ?? null,
+            ],
+            $input['config'],
+        );
+
+        return new SetAgentIntegrationConfigAction($agent, $entries)->execute();
+    }
+}

--- a/graphql/schemas/Intelligence/agent.graphql
+++ b/graphql/schemas/Intelligence/agent.graphql
@@ -129,6 +129,21 @@ input CommunicationChannelPivot {
     config: String
 }
 
+enum AgentIntegrationConfigKey {
+    GOOGLE
+    JIRA
+}
+
+input AgentIntegrationConfigEntryInput {
+    key: AgentIntegrationConfigKey!
+    value: Mixed
+}
+
+input SetAgentIntegrationConfigInput {
+    agent_id: ID!
+    config: [AgentIntegrationConfigEntryInput!]!
+}
+
 input ChatSimpleInput {
     agent_id: ID!
     session_id: String!
@@ -197,6 +212,10 @@ extend type Mutation @guard {
     aiAgentNeuronChat(input: NeuronChatInput!): String!
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Mutations\\AgentChatMutation@neuronChat"
+        )
+    setAgentIntegrationConfig(input: SetAgentIntegrationConfigInput!): AgentAi!
+        @field(
+            resolver: "App\\GraphQL\\Intelligence\\Mutations\\AgentIntegrationConfigMutation@set"
         )
 }
 

--- a/src/Domains/Intelligence/Agents/Actions/SetAgentIntegrationConfigAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/SetAgentIntegrationConfigAction.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Actions;
+
+use Kanvas\Intelligence\Agents\Enums\AgentIntegrationConfigKeyEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Workflow\Enums\WorkflowEnum;
+
+class SetAgentIntegrationConfigAction
+{
+    /**
+     * @param array<int, array{key: AgentIntegrationConfigKeyEnum, value: mixed}> $entries
+     */
+    public function __construct(
+        protected Agent $agent,
+        protected array $entries,
+    ) {
+    }
+
+    public function execute(): Agent
+    {
+        $changedKeys = [];
+
+        foreach ($this->entries as $entry) {
+            $key = $entry['key']->value;
+            $this->agent->set($key, $entry['value'] ?? null);
+            $changedKeys[] = $key;
+        }
+
+        $this->agent->fireWorkflow(
+            WorkflowEnum::AFTER_CONFIGURATION->value,
+            true,
+            [
+                'app' => $this->agent->app,
+                'company' => $this->agent->company,
+                'integration_config_changed' => true,
+                'changed_keys' => $changedKeys,
+            ],
+        );
+
+        return $this->agent;
+    }
+}

--- a/src/Domains/Intelligence/Agents/Enums/AgentIntegrationConfigKeyEnum.php
+++ b/src/Domains/Intelligence/Agents/Enums/AgentIntegrationConfigKeyEnum.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Enums;
+
+enum AgentIntegrationConfigKeyEnum: string
+{
+    case GOOGLE = 'integration_google';
+    case JIRA = 'integration_jira';
+
+    public static function fromName(string $name): self
+    {
+        foreach (self::cases() as $case) {
+            if ($case->name === $name) {
+                return $case;
+            }
+        }
+
+        throw new \ValueError(sprintf('Unknown integration key: %s', $name));
+    }
+}

--- a/src/Domains/Intelligence/Agents/Models/Agent.php
+++ b/src/Domains/Intelligence/Agents/Models/Agent.php
@@ -29,6 +29,7 @@ use Kanvas\Intelligence\Agents\Types\OpenClawAgentHandler;
 use Kanvas\Intelligence\Models\BaseModel;
 use Kanvas\NervousSystem\Capability\Models\Tool;
 use Kanvas\Users\Models\Users;
+use Kanvas\Workflow\Traits\CanUseWorkflow;
 use Nevadskiy\Tree\AsTree;
 use Override;
 
@@ -63,6 +64,7 @@ use Override;
 class Agent extends BaseModel
 {
     use AsTree;
+    use CanUseWorkflow;
     use CascadeSoftDeletes;
     use SlugTrait;
     use UuidTrait;

--- a/src/Domains/Workflow/Enums/WorkflowEnum.php
+++ b/src/Domains/Workflow/Enums/WorkflowEnum.php
@@ -51,6 +51,7 @@ enum WorkflowEnum: string
     case DEBUG = 'debug';
     case NOTIFICATION = 'notify';
     case AFTER_ONBOARDING = 'after-onboarding';
+    case AFTER_CONFIGURATION = 'after-configuration';
 
     /**
      * Get the enum case by its value.

--- a/tests/GraphQL/Intelligence/AgentIntegrationConfigTest.php
+++ b/tests/GraphQL/Intelligence/AgentIntegrationConfigTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\GraphQL\Intelligence;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\CustomFields\Models\AppsCustomFields;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Tests\TestCase;
+
+class AgentIntegrationConfigTest extends TestCase
+{
+    private function makeAgent(): Agent
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        return Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create([
+                'user_id' => $user->getId(),
+                'is_active' => true,
+            ]);
+    }
+
+    public function testSetAgentIntegrationConfigPersistsCustomFields(): void
+    {
+        $agent = $this->makeAgent();
+
+        $googleConfig = [
+            'client_id' => 'client-abc',
+            'client_secret' => 'secret-def',
+            'refresh_token' => 'refresh-xyz',
+        ];
+        $jiraConfig = [
+            'api_url' => 'https://example.atlassian.net',
+            'api_token' => 'tok-123',
+            'username' => 'alice@example.com',
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: SetAgentIntegrationConfigInput!) {
+                setAgentIntegrationConfig(input: $input) {
+                    id
+                }
+            }
+        ', [
+            'input' => [
+                'agent_id' => (string) $agent->getId(),
+                'config' => [
+                    ['key' => 'GOOGLE', 'value' => $googleConfig],
+                    ['key' => 'JIRA', 'value' => $jiraConfig],
+                ],
+            ],
+        ])->assertSuccessful();
+
+        $this->assertSame((string) $agent->getId(), $response->json('data.setAgentIntegrationConfig.id'));
+
+        $rows = AppsCustomFields::query()
+            ->where('model_name', Agent::class)
+            ->where('entity_id', $agent->getId())
+            ->whereIn('name', ['integration_google', 'integration_jira'])
+            ->pluck('value', 'name')
+            ->all();
+
+        $this->assertSame($googleConfig, $rows['integration_google'] ?? null);
+        $this->assertSame($jiraConfig, $rows['integration_jira'] ?? null);
+    }
+
+    public function testSetAgentIntegrationConfigRejectsUnknownKey(): void
+    {
+        $agent = $this->makeAgent();
+
+        $response = $this->graphQL('
+            mutation($input: SetAgentIntegrationConfigInput!) {
+                setAgentIntegrationConfig(input: $input) {
+                    id
+                }
+            }
+        ', [
+            'input' => [
+                'agent_id' => (string) $agent->getId(),
+                'config' => [
+                    ['key' => 'SLACK', 'value' => ['bot_token' => 'xoxb-nope']],
+                ],
+            ],
+        ]);
+
+        $this->assertNotEmpty($response->json('errors'), 'Unknown enum value should be rejected');
+        $this->assertNull(
+            AppsCustomFields::query()
+                ->where('model_name', Agent::class)
+                ->where('entity_id', $agent->getId())
+                ->where('name', 'integration_slack')
+                ->first(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- New `setAgentIntegrationConfig` mutation lets the frontend persist per-integration config (Google, Jira, …) as agent custom fields.
- Frontend sends `{ key: AgentIntegrationConfigKey, value: Mixed }` entries; `value` is the full integration JSON, stored under one custom field per integration (`integration_google`, `integration_jira`).
- After persisting, the action fires `WorkflowEnum::AFTER_CONFIGURATION` on the agent so a workflow rule can push the new config to the runtime container.
- Adds `CanUseWorkflow` trait to `Agent` (parity with Lead/People/Apps) and a new `AFTER_CONFIGURATION` workflow enum value.

## Test plan
- [x] `tests/GraphQL/Intelligence/AgentIntegrationConfigTest.php` — happy path (persists `integration_google` + `integration_jira` blobs) and unknown-key rejection (`SLACK` → GraphQL enum error)
- [x] Full Agent suite still green (98 tests / 251 assertions)
- [ ] Verify in staging: call the mutation, confirm a workflow rule on `(Agent, after-configuration)` fires and reaches the runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)