### PR TITLE
fix(netsuite): write MAP PRICE to warehouse cost column, not variant

### DIFF
--- a/src/Domains/Connectors/NetSuite/Actions/PullNetSuiteProductPriceAction.php
+++ b/src/Domains/Connectors/NetSuite/Actions/PullNetSuiteProductPriceAction.php
@@ -91,12 +91,10 @@ class PullNetSuiteProductPriceAction
         $variantWarehouse->quantity = $product['quantity_available'] ?? 0;
         $variantWarehouse->price = $warehouseOptions['price'] ?? 0;
 
+        // Link NetSuite MAP PRICE (custitem40) to the warehouse's UMAP Price (cost) column
+        $variantWarehouse->cost = (float) $product['map_price'];
         $variantWarehouse->config = $config;
         $variantWarehouse->saveOrFail();
-
-        // Link NetSuite MAP PRICE (custitem40) to the variant's UMAP Price (cost) field
-        $variant->cost = (float) $product['map_price'];
-        $variant->saveOrFail();
 
         $variant->addAttributes($this->user, [
             [

--- a/src/Domains/Connectors/NetSuite/Actions/SyncNetSuiteProductsAction.php
+++ b/src/Domains/Connectors/NetSuite/Actions/SyncNetSuiteProductsAction.php
@@ -99,12 +99,10 @@ class SyncNetSuiteProductsAction
                 $variantWarehouse->quantity = $product["quantity_available"];
                 $variantWarehouse->price = $warehouseOptions['price'] ?? 0;
 
+                // Link NetSuite MAP PRICE (custitem40) to the warehouse's UMAP Price (cost) column
+                $variantWarehouse->cost = (float) $product['map_price'];
                 $variantWarehouse->config = $config;
                 $variantWarehouse->saveOrFail();
-
-                // Link NetSuite MAP PRICE (custitem40) to the variant's UMAP Price (cost) field
-                $variant->cost = (float) $product['map_price'];
-                $variant->saveOrFail();
 
                 $variant->addAttributes($this->mainAppCompany->user, [
                     [


### PR DESCRIPTION
The previous code set $variant->cost, but products_variants has no cost column (only base_cost) — saveOrFail() threw "Unknown column 'cost'", breaking the product sync webhook and batch. Write map_price to products_variants_warehouses.cost instead, in the same save as the config.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
