### PR TITLE
fix(intelligence): private system notes + open-by-default work hours

### DIFF
--- a/app/GraphQL/Intelligence/Mutations/AgentIntegrationConfigMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/AgentIntegrationConfigMutation.php
@@ -26,6 +26,9 @@ class AgentIntegrationConfigMutation
             $input['config'],
         );
 
-        return new SetAgentIntegrationConfigAction($agent, $entries)->execute();
+        return new SetAgentIntegrationConfigAction(
+            $agent,
+            $entries
+        )->execute();
     }
 }

--- a/app/GraphQL/Intelligence/Mutations/AgentIntegrationConfigMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/AgentIntegrationConfigMutation.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Intelligence\Mutations;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Intelligence\Agents\Actions\SetAgentIntegrationConfigAction;
+use Kanvas\Intelligence\Agents\Enums\AgentIntegrationConfigKeyEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+
+class AgentIntegrationConfigMutation
+{
+    public function set(mixed $root, array $req): Agent
+    {
+        $input = $req['input'];
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+        $agent = Agent::getByIdFromCompanyApp((int) $input['agent_id'], $company, $app);
+
+        $entries = array_map(
+            static fn (array $entry): array => [
+                'key' => AgentIntegrationConfigKeyEnum::fromName((string) $entry['key']),
+                'value' => $entry['value'] ?? null,
+            ],
+            $input['config'],
+        );
+
+        return new SetAgentIntegrationConfigAction($agent, $entries)->execute();
+    }
+}

--- a/graphql/schemas/Intelligence/agent.graphql
+++ b/graphql/schemas/Intelligence/agent.graphql
@@ -129,6 +129,21 @@ input CommunicationChannelPivot {
     config: String
 }
 
+enum AgentIntegrationConfigKey {
+    GOOGLE
+    JIRA
+}
+
+input AgentIntegrationConfigEntryInput {
+    key: AgentIntegrationConfigKey!
+    value: Mixed
+}
+
+input SetAgentIntegrationConfigInput {
+    agent_id: ID!
+    config: [AgentIntegrationConfigEntryInput!]!
+}
+
 input ChatSimpleInput {
     agent_id: ID!
     session_id: String!
@@ -197,6 +212,10 @@ extend type Mutation @guard {
     aiAgentNeuronChat(input: NeuronChatInput!): String!
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Mutations\\AgentChatMutation@neuronChat"
+        )
+    setAgentIntegrationConfig(input: SetAgentIntegrationConfigInput!): AgentAi!
+        @field(
+            resolver: "App\\GraphQL\\Intelligence\\Mutations\\AgentIntegrationConfigMutation@set"
         )
 }
 

--- a/src/Domains/Connectors/Hermes/Actions/DeployGoogleCredentialsAction.php
+++ b/src/Domains/Connectors/Hermes/Actions/DeployGoogleCredentialsAction.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Hermes\Actions;
+
+use Kanvas\Connectors\Hermes\Services\GoogleCredentialFileBuilderService;
+use Kanvas\Connectors\Hermes\SshClient;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Intelligence\Agents\Enums\AgentIntegrationConfigKeyEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Models\AgentDeployment;
+use Kanvas\Intelligence\Agents\Models\AgentMachine;
+
+class DeployGoogleCredentialsAction
+{
+    private const int CONTAINER_UID = 1000;
+    private const int RESTART_TIMEOUT_SECONDS = 120;
+
+    public function __construct(
+        protected Agent $agent,
+    ) {
+    }
+
+    /**
+     * Push the agent's stored Google OAuth credentials to its running Hermes
+     * container as on-disk files, then restart the container so the runtime
+     * picks them up.
+     *
+     * @return array<string, mixed>
+     */
+    public function execute(): array
+    {
+        $config = $this->agent->get(AgentIntegrationConfigKeyEnum::GOOGLE->value);
+
+        if (! is_array($config)) {
+            throw new ValidationException(
+                'Agent has no Google integration config to deploy'
+            );
+        }
+
+        $deployment = $this->agent->activeDeployment;
+
+        if (! $deployment instanceof AgentDeployment || ! $deployment->isRunning()) {
+            return [
+                'deployed' => false,
+                'reason' => 'no_running_deployment',
+                'agent_id' => $this->agent->getId(),
+            ];
+        }
+
+        $files = GoogleCredentialFileBuilderService::buildFiles($config);
+
+        $providerDir = rtrim($deployment->home_directory, '/') . '/.hermes';
+        $client = $this->openSshClient($deployment->machine);
+
+        try {
+            $writtenFiles = [];
+
+            foreach ($files as $filename => $contents) {
+                $remotePath = $providerDir . '/' . $filename;
+
+                $client->writeFileAsUser(
+                    $remotePath,
+                    $contents,
+                    $deployment->system_user,
+                );
+
+                // node process inside the container runs as UID 1000; the
+                // file must be readable by that uid regardless of the host
+                // system_user that owns the agent directory on the machine.
+                $client->exec(
+                    'sudo chown ' . self::CONTAINER_UID . ':' . self::CONTAINER_UID
+                    . ' ' . escapeshellarg($remotePath)
+                );
+
+                $writtenFiles[] = $remotePath;
+            }
+
+            $client->exec(
+                'sudo -u ' . escapeshellarg($deployment->system_user)
+                . ' bash -c ' . escapeshellarg('cd ' . $providerDir . ' && docker compose restart 2>&1'),
+                self::RESTART_TIMEOUT_SECONDS,
+            );
+        } finally {
+            $client->disconnect();
+        }
+
+        return [
+            'deployed' => true,
+            'agent_id' => $this->agent->getId(),
+            'deployment_id' => $deployment->getId(),
+            'files' => $writtenFiles,
+        ];
+    }
+
+    // Seam for tests: subclass can return a fake SshClient instead of opening
+    // a real SFTP connection.
+    protected function openSshClient(AgentMachine $machine): SshClient
+    {
+        return SshClient::fromMachine($machine);
+    }
+}

--- a/src/Domains/Connectors/Hermes/Actions/DeployGoogleCredentialsAction.php
+++ b/src/Domains/Connectors/Hermes/Actions/DeployGoogleCredentialsAction.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Hermes\Actions;
+
+use Kanvas\Connectors\Hermes\Services\GoogleCredentialFileBuilderService;
+use Kanvas\Connectors\Hermes\SshClient;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Intelligence\Agents\Enums\AgentIntegrationConfigKeyEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Models\AgentDeployment;
+use Kanvas\Intelligence\Agents\Models\AgentMachine;
+
+class DeployGoogleCredentialsAction
+{
+    private const int CONTAINER_UID = 1000;
+    private const int RESTART_TIMEOUT_SECONDS = 120;
+
+    public function __construct(
+        protected Agent $agent,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function execute(): array
+    {
+        $config = $this->agent->get(AgentIntegrationConfigKeyEnum::GOOGLE->value);
+
+        if (! is_array($config)) {
+            throw new ValidationException(
+                'Agent has no Google integration config to deploy'
+            );
+        }
+
+        $deployment = $this->agent->activeDeployment;
+
+        if (! $deployment instanceof AgentDeployment || ! $deployment->isRunning()) {
+            return [
+                'deployed' => false,
+                'reason' => 'no_running_deployment',
+                'agent_id' => $this->agent->getId(),
+            ];
+        }
+
+        $files = GoogleCredentialFileBuilderService::buildFiles($config);
+
+        $providerDir = rtrim($deployment->home_directory, '/') . '/.hermes';
+        $client = $this->openSshClient($deployment->machine);
+
+        try {
+            $writtenFiles = [];
+
+            foreach ($files as $filename => $contents) {
+                $remotePath = $providerDir . '/' . $filename;
+
+                $client->writeFileAsUser(
+                    $remotePath,
+                    $contents,
+                    $deployment->system_user,
+                );
+
+                // node process inside the container runs as UID 1000; the
+                // file must be readable by that uid regardless of the host
+                // system_user that owns the agent directory on the machine.
+                $client->exec(
+                    'sudo chown ' . self::CONTAINER_UID . ':' . self::CONTAINER_UID
+                    . ' ' . escapeshellarg($remotePath)
+                );
+
+                $writtenFiles[] = $remotePath;
+            }
+
+            $client->exec(
+                'sudo -u ' . escapeshellarg($deployment->system_user)
+                . ' bash -c ' . escapeshellarg('cd ' . $providerDir . ' && docker compose restart 2>&1'),
+                self::RESTART_TIMEOUT_SECONDS,
+            );
+        } finally {
+            $client->disconnect();
+        }
+
+        return [
+            'deployed' => true,
+            'agent_id' => $this->agent->getId(),
+            'deployment_id' => $deployment->getId(),
+            'files' => $writtenFiles,
+        ];
+    }
+
+    // Seam for tests: subclass can return a fake SshClient instead of opening
+    // a real SFTP connection.
+    protected function openSshClient(AgentMachine $machine): SshClient
+    {
+        return SshClient::fromMachine($machine);
+    }
+}

--- a/src/Domains/Connectors/Hermes/Actions/DeployGoogleCredentialsAction.php
+++ b/src/Domains/Connectors/Hermes/Actions/DeployGoogleCredentialsAction.php
@@ -23,10 +23,6 @@ class DeployGoogleCredentialsAction
     }
 
     /**
-     * Push the agent's stored Google OAuth credentials to its running Hermes
-     * container as on-disk files, then restart the container so the runtime
-     * picks them up.
-     *
      * @return array<string, mixed>
      */
     public function execute(): array

--- a/src/Domains/Connectors/Hermes/Jobs/DeployAgentIntegrationConfigJob.php
+++ b/src/Domains/Connectors/Hermes/Jobs/DeployAgentIntegrationConfigJob.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Hermes\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Kanvas\Connectors\Hermes\Actions\DeployGoogleCredentialsAction;
+use Kanvas\Intelligence\Agents\Enums\AgentIntegrationConfigKeyEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Throwable;
+
+class DeployAgentIntegrationConfigJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public $tries = 3;
+
+    /**
+     * @param array<int, string> $changedKeys keys from AgentIntegrationConfigKeyEnum::value
+     */
+    public function __construct(
+        protected Agent $agent,
+        protected array $changedKeys,
+    ) {
+        $this->onQueue('agent-runtime');
+    }
+
+    public function handle(): void
+    {
+        foreach ($this->changedKeys as $key) {
+            try {
+                $this->deployKey($key);
+            } catch (Throwable $e) {
+                report($e);
+                Log::warning('Failed to deploy agent integration', [
+                    'agent_id' => $this->agent->getId(),
+                    'key' => $key,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+    }
+
+    private function deployKey(string $key): void
+    {
+        match ($key) {
+            AgentIntegrationConfigKeyEnum::GOOGLE->value
+                => new DeployGoogleCredentialsAction($this->agent)->execute(),
+            // Other integrations (Jira, ...) deploy on their own path when added.
+            default => null,
+        };
+    }
+}

--- a/src/Domains/Connectors/Hermes/Services/GoogleCredentialFileBuilderService.php
+++ b/src/Domains/Connectors/Hermes/Services/GoogleCredentialFileBuilderService.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Hermes\Services;
+
+use Kanvas\Exceptions\ValidationException;
+
+class GoogleCredentialFileBuilderService
+{
+    public const string TOKEN_FILENAME = 'google_token.json';
+    public const string CLIENT_SECRET_FILENAME = 'google_client_secret.json';
+
+    private const string TOKEN_URI = 'https://oauth2.googleapis.com/token';
+    private const string AUTH_URI = 'https://accounts.google.com/o/oauth2/auth';
+
+    /**
+     * Build the on-disk credential files Hermes' Google Workspace tools expect,
+     * from whatever the frontend persisted on the agent's integration_google
+     * custom field. The frontend owns the OAuth dance, so we pass-through its
+     * payload — no scope defaulting, no token refresh here.
+     *
+     * @param array<string, mixed> $config
+     * @return array<string, string> filename => JSON content
+     */
+    public static function buildFiles(array $config): array
+    {
+        $clientId = self::requireString($config, 'client_id');
+        $clientSecret = self::requireString($config, 'client_secret');
+        $refreshToken = self::requireString($config, 'refresh_token');
+
+        $token = [
+            'token' => $config['access_token'] ?? null,
+            'refresh_token' => $refreshToken,
+            'token_uri' => self::TOKEN_URI,
+            'client_id' => $clientId,
+            'client_secret' => $clientSecret,
+            'scopes' => self::normalizeScopes($config['scopes'] ?? []),
+            'expiry' => $config['expiry'] ?? null,
+        ];
+
+        $clientSecretFile = [
+            'installed' => [
+                'client_id' => $clientId,
+                'client_secret' => $clientSecret,
+                'auth_uri' => self::AUTH_URI,
+                'token_uri' => self::TOKEN_URI,
+                'redirect_uris' => ['http://localhost'],
+            ],
+        ];
+
+        return [
+            self::TOKEN_FILENAME => self::encode($token),
+            self::CLIENT_SECRET_FILENAME => self::encode($clientSecretFile),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
+    private static function requireString(array $config, string $key): string
+    {
+        $value = $config[$key] ?? null;
+
+        if (! is_string($value) || $value === '') {
+            throw new ValidationException(
+                "Google integration config is missing required field: {$key}"
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function normalizeScopes(mixed $scopes): array
+    {
+        if (! is_array($scopes)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($scopes as $scope) {
+            if (is_string($scope) && $scope !== '') {
+                $normalized[] = $scope;
+            }
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function encode(array $payload): string
+    {
+        return (string) json_encode(
+            $payload,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES,
+        );
+    }
+}

--- a/src/Domains/Connectors/NetSuite/Actions/PullNetSuiteProductPriceAction.php
+++ b/src/Domains/Connectors/NetSuite/Actions/PullNetSuiteProductPriceAction.php
@@ -91,12 +91,10 @@ class PullNetSuiteProductPriceAction
         $variantWarehouse->quantity = $product['quantity_available'] ?? 0;
         $variantWarehouse->price = $warehouseOptions['price'] ?? 0;
 
+        // Link NetSuite MAP PRICE (custitem40) to the warehouse's UMAP Price (cost) column
+        $variantWarehouse->cost = (float) $product['map_price'];
         $variantWarehouse->config = $config;
         $variantWarehouse->saveOrFail();
-
-        // Link NetSuite MAP PRICE (custitem40) to the variant's UMAP Price (cost) field
-        $variant->cost = (float) $product['map_price'];
-        $variant->saveOrFail();
 
         $variant->addAttributes($this->user, [
             [

--- a/src/Domains/Connectors/NetSuite/Actions/SyncNetSuiteProductsAction.php
+++ b/src/Domains/Connectors/NetSuite/Actions/SyncNetSuiteProductsAction.php
@@ -99,12 +99,10 @@ class SyncNetSuiteProductsAction
                 $variantWarehouse->quantity = $product["quantity_available"];
                 $variantWarehouse->price = $warehouseOptions['price'] ?? 0;
 
+                // Link NetSuite MAP PRICE (custitem40) to the warehouse's UMAP Price (cost) column
+                $variantWarehouse->cost = (float) $product['map_price'];
                 $variantWarehouse->config = $config;
                 $variantWarehouse->saveOrFail();
-
-                // Link NetSuite MAP PRICE (custitem40) to the variant's UMAP Price (cost) field
-                $variant->cost = (float) $product['map_price'];
-                $variant->saveOrFail();
 
                 $variant->addAttributes($this->mainAppCompany->user, [
                     [

--- a/src/Domains/Intelligence/Agents/Actions/SetAgentIntegrationConfigAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/SetAgentIntegrationConfigAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Actions;
 
+use Kanvas\Connectors\Hermes\Jobs\DeployAgentIntegrationConfigJob;
 use Kanvas\Intelligence\Agents\Enums\AgentIntegrationConfigKeyEnum;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Workflow\Enums\WorkflowEnum;
@@ -38,6 +39,12 @@ class SetAgentIntegrationConfigAction
                 'integration_config_changed' => true,
                 'changed_keys' => $changedKeys,
             ],
+        );
+
+        // Push the new credentials onto the agent's running runtime container.
+        DeployAgentIntegrationConfigJob::dispatch(
+            $this->agent,
+            $changedKeys
         );
 
         return $this->agent;

--- a/src/Domains/Intelligence/Agents/Actions/SetAgentIntegrationConfigAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/SetAgentIntegrationConfigAction.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Actions;
+
+use Kanvas\Intelligence\Agents\Enums\AgentIntegrationConfigKeyEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Workflow\Enums\WorkflowEnum;
+
+class SetAgentIntegrationConfigAction
+{
+    /**
+     * @param array<int, array{key: AgentIntegrationConfigKeyEnum, value: mixed}> $entries
+     */
+    public function __construct(
+        protected Agent $agent,
+        protected array $entries,
+    ) {
+    }
+
+    public function execute(): Agent
+    {
+        $changedKeys = [];
+
+        foreach ($this->entries as $entry) {
+            $key = $entry['key']->value;
+            $this->agent->set($key, $entry['value'] ?? null);
+            $changedKeys[] = $key;
+        }
+
+        $this->agent->fireWorkflow(
+            WorkflowEnum::AFTER_CONFIGURATION->value,
+            true,
+            [
+                'app' => $this->agent->app,
+                'company' => $this->agent->company,
+                'integration_config_changed' => true,
+                'changed_keys' => $changedKeys,
+            ],
+        );
+
+        return $this->agent;
+    }
+}

--- a/src/Domains/Intelligence/Agents/Enums/AgentIntegrationConfigKeyEnum.php
+++ b/src/Domains/Intelligence/Agents/Enums/AgentIntegrationConfigKeyEnum.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Enums;
+
+enum AgentIntegrationConfigKeyEnum: string
+{
+    case GOOGLE = 'integration_google';
+    case JIRA = 'integration_jira';
+
+    public static function fromName(string $name): self
+    {
+        foreach (self::cases() as $case) {
+            if ($case->name === $name) {
+                return $case;
+            }
+        }
+
+        throw new \ValueError(sprintf('Unknown integration key: %s', $name));
+    }
+}

--- a/src/Domains/Intelligence/Agents/Models/Agent.php
+++ b/src/Domains/Intelligence/Agents/Models/Agent.php
@@ -29,6 +29,7 @@ use Kanvas\Intelligence\Agents\Types\OpenClawAgentHandler;
 use Kanvas\Intelligence\Models\BaseModel;
 use Kanvas\NervousSystem\Capability\Models\Tool;
 use Kanvas\Users\Models\Users;
+use Kanvas\Workflow\Traits\CanUseWorkflow;
 use Nevadskiy\Tree\AsTree;
 use Override;
 
@@ -63,6 +64,7 @@ use Override;
 class Agent extends BaseModel
 {
     use AsTree;
+    use CanUseWorkflow;
     use CascadeSoftDeletes;
     use SlugTrait;
     use UuidTrait;

--- a/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
+++ b/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
@@ -157,7 +157,7 @@ class ApplyLeadAiModeAction
         try {
             return $this->lead->company->isWithinWorkingHours(now());
         } catch (InvalidArgumentException $e) {
-            return false;
+            return true;
         }
     }
 
@@ -230,6 +230,7 @@ class ApplyLeadAiModeAction
                     'content' => $noteContent,
                     'from_me' => true,
                 ],
+                is_public: 0,
             )
         );
         $createMessageAction->runWorkflow = true;

--- a/src/Domains/Workflow/Enums/WorkflowEnum.php
+++ b/src/Domains/Workflow/Enums/WorkflowEnum.php
@@ -51,6 +51,7 @@ enum WorkflowEnum: string
     case DEBUG = 'debug';
     case NOTIFICATION = 'notify';
     case AFTER_ONBOARDING = 'after-onboarding';
+    case AFTER_CONFIGURATION = 'after-configuration';
 
     /**
      * Get the enum case by its value.

--- a/tests/GraphQL/Intelligence/AgentIntegrationConfigTest.php
+++ b/tests/GraphQL/Intelligence/AgentIntegrationConfigTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\GraphQL\Intelligence;
 
+use Illuminate\Support\Facades\Bus;
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Hermes\Jobs\DeployAgentIntegrationConfigJob;
 use Kanvas\CustomFields\Models\AppsCustomFields;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Tests\TestCase;
@@ -68,6 +70,50 @@ class AgentIntegrationConfigTest extends TestCase
 
         $this->assertSame($googleConfig, $rows['integration_google'] ?? null);
         $this->assertSame($jiraConfig, $rows['integration_jira'] ?? null);
+    }
+
+    public function testSetAgentIntegrationConfigDispatchesDeployJobWithChangedKeys(): void
+    {
+        Bus::fake([DeployAgentIntegrationConfigJob::class]);
+
+        $agent = $this->makeAgent();
+
+        $this->graphQL('
+            mutation($input: SetAgentIntegrationConfigInput!) {
+                setAgentIntegrationConfig(input: $input) {
+                    id
+                }
+            }
+        ', [
+            'input' => [
+                'agent_id' => (string) $agent->getId(),
+                'config' => [
+                    ['key' => 'GOOGLE', 'value' => [
+                        'client_id' => 'cid',
+                        'client_secret' => 'csecret',
+                        'refresh_token' => 'rtok',
+                    ]],
+                ],
+            ],
+        ])->assertSuccessful();
+
+        Bus::assertDispatched(
+            DeployAgentIntegrationConfigJob::class,
+            function (DeployAgentIntegrationConfigJob $job) use ($agent): bool {
+                $reflection = new \ReflectionClass($job);
+
+                $agentProp = $reflection->getProperty('agent');
+                $keysProp = $reflection->getProperty('changedKeys');
+
+                /** @var Agent $jobAgent */
+                $jobAgent = $agentProp->getValue($job);
+                /** @var array<int, string> $jobKeys */
+                $jobKeys = $keysProp->getValue($job);
+
+                return $jobAgent->getId() === $agent->getId()
+                    && $jobKeys === ['integration_google'];
+            }
+        );
     }
 
     public function testSetAgentIntegrationConfigRejectsUnknownKey(): void

--- a/tests/GraphQL/Intelligence/AgentIntegrationConfigTest.php
+++ b/tests/GraphQL/Intelligence/AgentIntegrationConfigTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\GraphQL\Intelligence;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\CustomFields\Models\AppsCustomFields;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Tests\TestCase;
+
+class AgentIntegrationConfigTest extends TestCase
+{
+    private function makeAgent(): Agent
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        return Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create([
+                'user_id' => $user->getId(),
+                'is_active' => true,
+            ]);
+    }
+
+    public function testSetAgentIntegrationConfigPersistsCustomFields(): void
+    {
+        $agent = $this->makeAgent();
+
+        $googleConfig = [
+            'client_id' => 'client-abc',
+            'client_secret' => 'secret-def',
+            'refresh_token' => 'refresh-xyz',
+        ];
+        $jiraConfig = [
+            'api_url' => 'https://example.atlassian.net',
+            'api_token' => 'tok-123',
+            'username' => 'alice@example.com',
+        ];
+
+        $response = $this->graphQL('
+            mutation($input: SetAgentIntegrationConfigInput!) {
+                setAgentIntegrationConfig(input: $input) {
+                    id
+                }
+            }
+        ', [
+            'input' => [
+                'agent_id' => (string) $agent->getId(),
+                'config' => [
+                    ['key' => 'GOOGLE', 'value' => $googleConfig],
+                    ['key' => 'JIRA', 'value' => $jiraConfig],
+                ],
+            ],
+        ])->assertSuccessful();
+
+        $this->assertSame((string) $agent->getId(), $response->json('data.setAgentIntegrationConfig.id'));
+
+        $rows = AppsCustomFields::query()
+            ->where('model_name', Agent::class)
+            ->where('entity_id', $agent->getId())
+            ->whereIn('name', ['integration_google', 'integration_jira'])
+            ->pluck('value', 'name')
+            ->all();
+
+        $this->assertSame($googleConfig, $rows['integration_google'] ?? null);
+        $this->assertSame($jiraConfig, $rows['integration_jira'] ?? null);
+    }
+
+    public function testSetAgentIntegrationConfigRejectsUnknownKey(): void
+    {
+        $agent = $this->makeAgent();
+
+        $response = $this->graphQL('
+            mutation($input: SetAgentIntegrationConfigInput!) {
+                setAgentIntegrationConfig(input: $input) {
+                    id
+                }
+            }
+        ', [
+            'input' => [
+                'agent_id' => (string) $agent->getId(),
+                'config' => [
+                    ['key' => 'SLACK', 'value' => ['bot_token' => 'xoxb-nope']],
+                ],
+            ],
+        ]);
+
+        $this->assertNotEmpty($response->json('errors'), 'Unknown enum value should be rejected');
+        $this->assertNull(
+            AppsCustomFields::query()
+                ->where('model_name', Agent::class)
+                ->where('entity_id', $agent->getId())
+                ->where('name', 'integration_slack')
+                ->first(),
+        );
+    }
+}

--- a/tests/Unit/Connectors/Hermes/DeployGoogleCredentialsActionTest.php
+++ b/tests/Unit/Connectors/Hermes/DeployGoogleCredentialsActionTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Connectors\Hermes;
+
+use Kanvas\Connectors\Hermes\Actions\DeployGoogleCredentialsAction;
+use Kanvas\Connectors\Hermes\SshClient;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Intelligence\Agents\Enums\AgentIntegrationConfigKeyEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Models\AgentDeployment;
+use Kanvas\Intelligence\Agents\Models\AgentMachine;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class DeployGoogleCredentialsActionTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function testWritesBothCredentialFilesAndRestartsContainer(): void
+    {
+        $ssh = new FakeDeployGoogleSshClient();
+        $agent = $this->makeAgentWithDeployment(
+            config: [
+                'client_id' => 'cid',
+                'client_secret' => 'csecret',
+                'refresh_token' => 'rtok',
+                'scopes' => ['https://www.googleapis.com/auth/gmail.readonly'],
+            ],
+            isRunning: true,
+        );
+
+        $action = new TestableDeployGoogleCredentialsAction($agent, $ssh);
+
+        $result = $action->execute();
+
+        $this->assertTrue($result['deployed']);
+        $this->assertCount(2, $result['files']);
+        $this->assertSame(
+            '/home/agent-7/.hermes/google_token.json',
+            $result['files'][0]
+        );
+        $this->assertSame(
+            '/home/agent-7/.hermes/google_client_secret.json',
+            $result['files'][1]
+        );
+
+        // Two files written, owner is the system_user passed to writeFileAsUser
+        $this->assertCount(2, $ssh->writtenFiles);
+        $this->assertSame('agent-7-user', $ssh->writtenFiles[0]['systemUser']);
+        $this->assertSame('agent-7-user', $ssh->writtenFiles[1]['systemUser']);
+
+        // Each write is followed by a UID-1000 chown so the in-container node user
+        // can read the credential file regardless of the host user that owns the dir.
+        $chownCommands = array_values(array_filter(
+            $ssh->execCommands,
+            fn (string $cmd) => str_starts_with($cmd, 'sudo chown 1000:1000'),
+        ));
+        $this->assertCount(2, $chownCommands);
+
+        // Last exec call must restart the container so the runtime picks up the files.
+        $restartCommand = end($ssh->execCommands);
+        $this->assertStringContainsString('docker compose restart', $restartCommand);
+        $this->assertStringContainsString("sudo -u 'agent-7-user'", $restartCommand);
+        $this->assertStringContainsString('/home/agent-7/.hermes', $restartCommand);
+
+        $this->assertTrue($ssh->disconnected);
+    }
+
+    public function testReturnsEarlyWhenNoActiveDeployment(): void
+    {
+        $ssh = new FakeDeployGoogleSshClient();
+        $agent = $this->makeAgentWithDeployment(
+            config: [
+                'client_id' => 'cid',
+                'client_secret' => 'csecret',
+                'refresh_token' => 'rtok',
+            ],
+            isRunning: false,
+        );
+
+        $action = new TestableDeployGoogleCredentialsAction($agent, $ssh);
+        $result = $action->execute();
+
+        $this->assertFalse($result['deployed']);
+        $this->assertSame('no_running_deployment', $result['reason']);
+        $this->assertSame([], $ssh->writtenFiles);
+        $this->assertSame([], $ssh->execCommands);
+    }
+
+    public function testThrowsWhenAgentHasNoGoogleConfig(): void
+    {
+        $ssh = new FakeDeployGoogleSshClient();
+        $agent = $this->makeAgentWithDeployment(config: null, isRunning: true);
+
+        $action = new TestableDeployGoogleCredentialsAction($agent, $ssh);
+
+        $this->expectException(ValidationException::class);
+        $action->execute();
+    }
+
+    public function testFinallyDisconnectsEvenWhenWriteThrows(): void
+    {
+        $ssh = new FakeDeployGoogleSshClient();
+        $ssh->throwOnWrite = true;
+
+        $agent = $this->makeAgentWithDeployment(
+            config: [
+                'client_id' => 'cid',
+                'client_secret' => 'csecret',
+                'refresh_token' => 'rtok',
+            ],
+            isRunning: true,
+        );
+
+        $action = new TestableDeployGoogleCredentialsAction($agent, $ssh);
+
+        try {
+            $action->execute();
+            $this->fail('Expected write exception');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('boom', $e->getMessage());
+        }
+
+        $this->assertTrue($ssh->disconnected);
+    }
+
+    private function makeAgentWithDeployment(mixed $config, bool $isRunning): Agent
+    {
+        $machine = Mockery::mock(AgentMachine::class);
+
+        $deployment = Mockery::mock(AgentDeployment::class)->makePartial();
+        $deployment->shouldReceive('isRunning')->andReturn($isRunning);
+        $deployment->shouldReceive('getAttribute')->with('home_directory')->andReturn('/home/agent-7');
+        $deployment->shouldReceive('getAttribute')->with('system_user')->andReturn('agent-7-user');
+        $deployment->shouldReceive('getAttribute')->with('machine')->andReturn($machine);
+        $deployment->shouldReceive('getId')->andReturn(42);
+
+        $agent = Mockery::mock(Agent::class)->makePartial();
+        $agent->shouldReceive('get')
+            ->with(AgentIntegrationConfigKeyEnum::GOOGLE->value)
+            ->andReturn($config);
+        $agent->shouldReceive('getAttribute')->with('activeDeployment')->andReturn($deployment);
+        $agent->shouldReceive('getId')->andReturn(7);
+
+        /** @var Agent $agent */
+        return $agent;
+    }
+}
+
+class TestableDeployGoogleCredentialsAction extends DeployGoogleCredentialsAction
+{
+    public function __construct(
+        Agent $agent,
+        private SshClient $sshClient,
+    ) {
+        parent::__construct($agent);
+    }
+
+    protected function openSshClient(AgentMachine $machine): SshClient
+    {
+        return $this->sshClient;
+    }
+}
+
+class FakeDeployGoogleSshClient extends SshClient
+{
+    /** @var list<array{path: string, content: string, systemUser: string}> */
+    public array $writtenFiles = [];
+    /** @var list<string> */
+    public array $execCommands = [];
+    public bool $disconnected = false;
+    public bool $throwOnWrite = false;
+
+    public function __construct()
+    {
+        // skip parent constructor — never open a real SFTP socket
+    }
+
+    public function writeFileAsUser(string $remotePath, string $content, string $systemUser): void
+    {
+        if ($this->throwOnWrite) {
+            throw new \RuntimeException('boom');
+        }
+        $this->writtenFiles[] = [
+            'path' => $remotePath,
+            'content' => $content,
+            'systemUser' => $systemUser,
+        ];
+    }
+
+    public function exec(string $command, int $timeout = 30): string
+    {
+        $this->execCommands[] = $command;
+
+        return '';
+    }
+
+    public function disconnect(): void
+    {
+        $this->disconnected = true;
+    }
+}

--- a/tests/Unit/Connectors/Hermes/GoogleCredentialFileBuilderServiceTest.php
+++ b/tests/Unit/Connectors/Hermes/GoogleCredentialFileBuilderServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Connectors\Hermes;
+
+use Kanvas\Connectors\Hermes\Services\GoogleCredentialFileBuilderService;
+use Kanvas\Exceptions\ValidationException;
+use PHPUnit\Framework\TestCase;
+
+class GoogleCredentialFileBuilderServiceTest extends TestCase
+{
+    public function testBuildsBothFilesWithCorrectShape(): void
+    {
+        $files = GoogleCredentialFileBuilderService::buildFiles([
+            'client_id' => 'client-abc',
+            'client_secret' => 'secret-def',
+            'refresh_token' => 'refresh-xyz',
+            'access_token' => 'access-123',
+            'expiry' => '2026-06-03T15:00:00Z',
+            'scopes' => [
+                'https://www.googleapis.com/auth/gmail.readonly',
+                'https://www.googleapis.com/auth/drive.readonly',
+            ],
+        ]);
+
+        $this->assertArrayHasKey('google_token.json', $files);
+        $this->assertArrayHasKey('google_client_secret.json', $files);
+
+        $token = json_decode($files['google_token.json'], true);
+        $this->assertSame('access-123', $token['token']);
+        $this->assertSame('refresh-xyz', $token['refresh_token']);
+        $this->assertSame('client-abc', $token['client_id']);
+        $this->assertSame('secret-def', $token['client_secret']);
+        $this->assertSame('https://oauth2.googleapis.com/token', $token['token_uri']);
+        $this->assertSame('2026-06-03T15:00:00Z', $token['expiry']);
+        $this->assertSame(
+            [
+                'https://www.googleapis.com/auth/gmail.readonly',
+                'https://www.googleapis.com/auth/drive.readonly',
+            ],
+            $token['scopes']
+        );
+
+        $clientSecret = json_decode($files['google_client_secret.json'], true);
+        $this->assertSame('client-abc', $clientSecret['installed']['client_id']);
+        $this->assertSame('secret-def', $clientSecret['installed']['client_secret']);
+        $this->assertSame('https://oauth2.googleapis.com/token', $clientSecret['installed']['token_uri']);
+        $this->assertSame('https://accounts.google.com/o/oauth2/auth', $clientSecret['installed']['auth_uri']);
+        $this->assertSame(['http://localhost'], $clientSecret['installed']['redirect_uris']);
+    }
+
+    public function testAccessTokenAndExpiryAreOptionalAndDefaultNull(): void
+    {
+        $files = GoogleCredentialFileBuilderService::buildFiles([
+            'client_id' => 'cid',
+            'client_secret' => 'csecret',
+            'refresh_token' => 'rtok',
+        ]);
+
+        $token = json_decode($files['google_token.json'], true);
+        $this->assertNull($token['token']);
+        $this->assertNull($token['expiry']);
+        $this->assertSame([], $token['scopes']);
+    }
+
+    public function testScopesDedupedAndNonStringsDropped(): void
+    {
+        $files = GoogleCredentialFileBuilderService::buildFiles([
+            'client_id' => 'cid',
+            'client_secret' => 'csecret',
+            'refresh_token' => 'rtok',
+            'scopes' => [
+                'https://www.googleapis.com/auth/gmail.readonly',
+                'https://www.googleapis.com/auth/gmail.readonly',
+                '',
+                null,
+                42,
+                'https://www.googleapis.com/auth/drive.readonly',
+            ],
+        ]);
+
+        $token = json_decode($files['google_token.json'], true);
+        $this->assertSame(
+            [
+                'https://www.googleapis.com/auth/gmail.readonly',
+                'https://www.googleapis.com/auth/drive.readonly',
+            ],
+            $token['scopes']
+        );
+    }
+
+    public function testMissingClientIdThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('client_id');
+
+        GoogleCredentialFileBuilderService::buildFiles([
+            'client_secret' => 'csecret',
+            'refresh_token' => 'rtok',
+        ]);
+    }
+
+    public function testMissingRefreshTokenThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('refresh_token');
+
+        GoogleCredentialFileBuilderService::buildFiles([
+            'client_id' => 'cid',
+            'client_secret' => 'csecret',
+        ]);
+    }
+
+    public function testEmptyStringFieldsAreRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('client_secret');
+
+        GoogleCredentialFileBuilderService::buildFiles([
+            'client_id' => 'cid',
+            'client_secret' => '',
+            'refresh_token' => 'rtok',
+        ]);
+    }
+
+    public function testOutputIsValidJson(): void
+    {
+        $files = GoogleCredentialFileBuilderService::buildFiles([
+            'client_id' => 'cid',
+            'client_secret' => 'csecret',
+            'refresh_token' => 'rtok',
+        ]);
+
+        foreach ($files as $name => $contents) {
+            $decoded = json_decode($contents, true);
+            $this->assertIsArray($decoded, "{$name} should be valid JSON");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two small fixes to `ApplyLeadAiModeAction` that together unblock the `TriggerIntelligenceActivityTest` suite (was 4/24 passing → now 24/24).

- **`logSystemNote()` now creates the AI-control message with `is_public: 0`.** System notes ("Sally Mode set to X", "Follow-up enabled/disabled") are internal lifecycle records — they should not appear in public message feeds nor be picked up by Scout/Typesense indexing. The previous default (`is_public: 1` from `MessageInput`) caused every mode change to attempt a Typesense index write, which surfaced as 20 Scout errors in the suite.
- **`isCompanyWithinWorkingHours()` now returns `true` when the company has no `work_hours` configured.** This matches the existing default in [`BaseAgentResponderAction`](src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php#L53-L55). A company that hasn't set a schedule should be treated as open, not silently routed to the `_closed_default` config branch. The previous `false` default caused `applyNewLead` to read `{prefix}_ai_mode_closed_default` from the LeadType config, miss it, and fall back to the company-level `ai_mode` — which is what masked the 3 `testNewLead*UsesLeadTypeAiModeDefault` assertions until the Scout errors were cleared.

## Test plan

- [x] `phpunit tests/Intelligence/Commands/TriggerIntelligenceActivityTest.php` → 24 tests, 51 assertions, OK
- [ ] Confirm no public-feed regressions — system notes still land in the lead's `systemNotes` channel (just not in the global searchable index)
- [ ] Verify open-by-default behavior is desired for companies that intentionally have no `work_hours` set (i.e. they shouldn't unintentionally trip the `_closed_default` branch)