### PR TITLE
fix(intelligence): private system notes + open-by-default work hours

### DIFF
--- a/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
+++ b/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
@@ -157,7 +157,7 @@ class ApplyLeadAiModeAction
         try {
             return $this->lead->company->isWithinWorkingHours(now());
         } catch (InvalidArgumentException $e) {
-            return false;
+            return true;
         }
     }
 
@@ -230,6 +230,7 @@ class ApplyLeadAiModeAction
                     'content' => $noteContent,
                     'from_me' => true,
                 ],
+                is_public: 0,
             )
         );
         $createMessageAction->runWorkflow = true;


### PR DESCRIPTION
## Summary

Two small fixes to `ApplyLeadAiModeAction` that together unblock the `TriggerIntelligenceActivityTest` suite (was 4/24 passing → now 24/24).

- **`logSystemNote()` now creates the AI-control message with `is_public: 0`.** System notes ("Sally Mode set to X", "Follow-up enabled/disabled") are internal lifecycle records — they should not appear in public message feeds nor be picked up by Scout/Typesense indexing. The previous default (`is_public: 1` from `MessageInput`) caused every mode change to attempt a Typesense index write, which surfaced as 20 Scout errors in the suite.
- **`isCompanyWithinWorkingHours()` now returns `true` when the company has no `work_hours` configured.** This matches the existing default in [`BaseAgentResponderAction`](src/Domains/Intelligence/Agents/Actions/BaseAgentResponderAction.php#L53-L55). A company that hasn't set a schedule should be treated as open, not silently routed to the `_closed_default` config branch. The previous `false` default caused `applyNewLead` to read `{prefix}_ai_mode_closed_default` from the LeadType config, miss it, and fall back to the company-level `ai_mode` — which is what masked the 3 `testNewLead*UsesLeadTypeAiModeDefault` assertions until the Scout errors were cleared.

## Test plan

- [x] `phpunit tests/Intelligence/Commands/TriggerIntelligenceActivityTest.php` → 24 tests, 51 assertions, OK
- [ ] Confirm no public-feed regressions — system notes still land in the lead's `systemNotes` channel (just not in the global searchable index)
- [ ] Verify open-by-default behavior is desired for companies that intentionally have no `work_hours` set (i.e. they shouldn't unintentionally trip the `_closed_default` branch)