### PR TITLE
fix(followup): channel resolution belongs to the Lead, not the Session

### DIFF
--- a/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
@@ -75,7 +75,7 @@ class SendMessageToLeadAction
         return match ($channel) {
             LeadCommunicationChannelEnum::WHATSAPP->value => $this->sendWhatsAppMessage($message, $to),
             LeadCommunicationChannelEnum::SMS->value => $this->sendSmsMessage((string) $from, $message, $to),
-            LeadCommunicationChannelEnum::EMAIL->value => $this->sendEmailMessage($message, $title, $signature),
+            LeadCommunicationChannelEnum::EMAIL->value => $this->sendEmailMessage($message, $title, $signature, $to),
             LeadCommunicationChannelEnum::VOICE->value => $this->sendVoiceMessage($message),
             default => throw new InvalidArgumentException('Unsupported communication channel ' . $channel),
         };
@@ -495,7 +495,8 @@ class SendMessageToLeadAction
     protected function sendEmailMessage(
         string $message,
         ?string $title = null,
-        bool $signature = true
+        bool $signature = true,
+        ?string $to = null
     ): array {
         $attachments = [];
 
@@ -528,7 +529,9 @@ class SendMessageToLeadAction
         );
         $notification->setFromUser($this->lead->user);
         $notification->setSubject($title ?? 'Message from ' . $this->lead->company->name);
-        $leadEmail = $this->lead->people->getEmails()->first()?->value;
+        $leadEmail = ($to !== null && $to !== '')
+            ? $to
+            : $this->lead->people->getEmails()->first()?->value;
         if (! $leadEmail) {
             throw new Exception('Lead does not have an email address');
         }

--- a/src/Domains/Intelligence/FollowUp/Actions/FollowUpLeadAction.php
+++ b/src/Domains/Intelligence/FollowUp/Actions/FollowUpLeadAction.php
@@ -88,9 +88,7 @@ final class FollowUpLeadAction
             return $this->skip('ai_mode_manual');
         }
 
-        // Channel resolution lives on the Lead's contacts, NOT the Session. The
-        // session is agent memory (channel-agnostic). What we CAN reach the
-        // person on is decided by their contact rows + stage config + opt-outs.
+        // Channel resolution lives on the Lead's contacts
         $candidates = new LeadOutboundChannelResolver()->resolve($this->lead, $config);
         if ($candidates === []) {
             return $this->skip('no_reachable_channel');
@@ -102,10 +100,12 @@ final class FollowUpLeadAction
         }
 
         $lastInboundAt = $this->getLastInboundAt($session);
-        $picked = $this->selectByStrategy($candidates, $config, $session);
-        $channelType = $picked->channelType;
+        $targets = $this->selectTargets($candidates, $config, $session);
+        // Primary target drives prompt + template + ledger summary. For
+        // FAN_OUT_ALL the same body is dispatched to every target below.
+        $primary = $targets[0];
+        $channelType = $primary->channelType;
         $channelConfig = $config->channelByType($channelType);
-        $outboundContact = $picked->contact;
 
         $silenceMin = $this->lead->followUpSilenceMinutesSince($lastInboundAt);
 
@@ -153,6 +153,7 @@ final class FollowUpLeadAction
         }
 
         $sentBody = null;
+        $channelsForBump = [];
         if ($result->shouldRespond && $result->message !== null) {
             $sentBody = $this->resolveOutboundBody(
                 channelType: $channelType,
@@ -160,20 +161,25 @@ final class FollowUpLeadAction
                 agentMessage: $result->message,
             );
 
-            $this->persistMessage($session, $channelType, $sentBody);
-            $this->dispatchOutbound($channelType, $sentBody, $outboundContact);
-            $this->lead->bumpFollowUp([$channelType], $template?->name);
+            foreach ($targets as $target) {
+                $this->persistMessage($session, $target->channelType, $sentBody);
+                $this->dispatchOutbound($target->channelType, $sentBody, $target->contact);
+                $channelsForBump[] = $target->channelType;
+            }
+
+            // One touch = one bump regardless of N channels dispatched.
+            $this->lead->bumpFollowUp($channelsForBump, $template?->name);
         }
 
         $advanced = $result->advanceStage && $this->advanceLeadStage();
 
         $this->emitSent(
-            $channelType,
+            $channelsForBump !== [] ? $channelsForBump : [$channelType],
             $template?->name,
             $metaTemplate,
             $result->reason,
             $advanced,
-            $picked,
+            $primary,
             $config->channelSelection,
         );
 
@@ -182,14 +188,16 @@ final class FollowUpLeadAction
 
     /**
      * @param ResolvedChannel[] $candidates
+     * @return ResolvedChannel[] single-element for pick-one strategies, all candidates for fan_out_all
      */
-    private function selectByStrategy(array $candidates, FollowUpConfig $config, Session $session): ResolvedChannel
+    private function selectTargets(array $candidates, FollowUpConfig $config, Session $session): array
     {
+        // AGENT_PICKS aliases to sticky_then_priority pending v1.5 (see FollowUp CLAUDE.md).
         return match ($config->channelSelection) {
-            ChannelSelectionEnum::PRIORITY_ONLY => $candidates[0],
-            // v1.5 — agent-aware routing aliases to sticky_then_priority for now.
+            ChannelSelectionEnum::FAN_OUT_ALL => $candidates,
+            ChannelSelectionEnum::PRIORITY_ONLY => [$candidates[0]],
             ChannelSelectionEnum::STICKY_THEN_PRIORITY,
-            ChannelSelectionEnum::AGENT_PICKS => $this->pickStickyOrFallback($candidates, $session),
+            ChannelSelectionEnum::AGENT_PICKS => [$this->pickStickyOrFallback($candidates, $session)],
         };
     }
 
@@ -198,9 +206,6 @@ final class FollowUpLeadAction
      */
     private function pickStickyOrFallback(array $candidates, Session $session): ResolvedChannel
     {
-        // Sticky = the most recent inbound's channel, IF it matches a candidate.
-        // Channel-on-session is OK as a "last seen on" signal (not as the
-        // outbound decision driver — that's the resolver's job).
         $stickyChannel = (string) $session->getChannel();
 
         foreach ($candidates as $candidate) {
@@ -497,18 +502,21 @@ final class FollowUpLeadAction
         return FollowUpOutcome::exhausted($reason);
     }
 
+    /**
+     * @param string[] $channels  one element for pick-one strategies, N for fan_out_all
+     */
     private function emitSent(
-        string $channelType,
+        array $channels,
         ?string $templateName,
         ?string $metaTemplate,
         ?string $reason,
         bool $advanced,
-        ResolvedChannel $picked,
+        ResolvedChannel $primary,
         ChannelSelectionEnum $strategy,
     ): void {
         $this->lead->emitLedgerEvent('lead.follow_up.sent', payload: [
             'stage_id' => $this->lead->pipeline_stage_id,
-            'channels' => [$channelType],
+            'channels' => $channels,
             'template' => $templateName,
             'meta_template' => $metaTemplate,
             'follow_up_count' => $this->lead->getFollowUpStateCount(),
@@ -516,8 +524,8 @@ final class FollowUpLeadAction
             'reason' => $reason,
             'advanced_stage' => $advanced,
             'channel_selection_strategy' => $strategy->value,
-            'channel_selection_reason' => $picked->reason,
-            'contact_id' => $picked->contact->getKey(),
+            'channel_selection_reason' => $primary->reason,
+            'contact_id' => $primary->contact->getKey(),
         ]);
     }
 }

--- a/src/Domains/Intelligence/FollowUp/Actions/FollowUpLeadAction.php
+++ b/src/Domains/Intelligence/FollowUp/Actions/FollowUpLeadAction.php
@@ -10,6 +10,7 @@ use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\Twilio\Enums\ConfigurationEnum as TwilioConfigurationEnum;
 use Kanvas\Connectors\WaSender\Enums\MessageTypeEnum;
+use Kanvas\Guild\Customers\Models\Contact;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Leads\Actions\SendMessageToLeadAction;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
@@ -21,8 +22,11 @@ use Kanvas\Intelligence\FollowUp\DataTransferObject\AgentFollowUpResult;
 use Kanvas\Intelligence\FollowUp\DataTransferObject\ChannelConfig;
 use Kanvas\Intelligence\FollowUp\DataTransferObject\FollowUpConfig;
 use Kanvas\Intelligence\FollowUp\DataTransferObject\FollowUpOutcome;
+use Kanvas\Intelligence\FollowUp\DataTransferObject\ResolvedChannel;
+use Kanvas\Intelligence\FollowUp\Enums\ChannelSelectionEnum;
 use Kanvas\Intelligence\FollowUp\Enums\ExhaustedActionEnum;
 use Kanvas\Intelligence\FollowUp\Enums\FollowUpModeEnum;
+use Kanvas\Intelligence\FollowUp\Services\LeadOutboundChannelResolver;
 use Kanvas\Intelligence\Sessions\DataTransferObject\AiChatMessagePayload;
 use Kanvas\Intelligence\Sessions\Models\Session;
 use Kanvas\Social\Channels\Models\Channel;
@@ -84,18 +88,25 @@ final class FollowUpLeadAction
             return $this->skip('ai_mode_manual');
         }
 
+        // Channel resolution lives on the Lead's contacts, NOT the Session. The
+        // session is agent memory (channel-agnostic). What we CAN reach the
+        // person on is decided by their contact rows + stage config + opt-outs.
+        $candidates = new LeadOutboundChannelResolver()->resolve($this->lead, $config);
+        if ($candidates === []) {
+            return $this->skip('no_reachable_channel');
+        }
+
         $session = $this->resolveSession();
         if (! $session) {
             return $this->skip('no_session');
         }
 
-        $channelType = (string) $session->getChannel();
-        $channelConfig = $config->channelByType($channelType);
-        if (! $channelConfig) {
-            return $this->skip('channel_not_configured');
-        }
-
         $lastInboundAt = $this->getLastInboundAt($session);
+        $picked = $this->selectByStrategy($candidates, $config, $session);
+        $channelType = $picked->channelType;
+        $channelConfig = $config->channelByType($channelType);
+        $outboundContact = $picked->contact;
+
         $silenceMin = $this->lead->followUpSilenceMinutesSince($lastInboundAt);
 
         if (! $this->force && $silenceMin < $config->timeBased->intervalMinutes) {
@@ -150,7 +161,7 @@ final class FollowUpLeadAction
             );
 
             $this->persistMessage($session, $channelType, $sentBody);
-            $this->dispatchOutbound($channelType, $sentBody);
+            $this->dispatchOutbound($channelType, $sentBody, $outboundContact);
             $this->lead->bumpFollowUp([$channelType], $template?->name);
         }
 
@@ -161,10 +172,44 @@ final class FollowUpLeadAction
             $template?->name,
             $metaTemplate,
             $result->reason,
-            $advanced
+            $advanced,
+            $picked,
+            $config->channelSelection,
         );
 
         return FollowUpOutcome::sent($sentBody);
+    }
+
+    /**
+     * @param ResolvedChannel[] $candidates
+     */
+    private function selectByStrategy(array $candidates, FollowUpConfig $config, Session $session): ResolvedChannel
+    {
+        return match ($config->channelSelection) {
+            ChannelSelectionEnum::PRIORITY_ONLY => $candidates[0],
+            // v1.5 — agent-aware routing aliases to sticky_then_priority for now.
+            ChannelSelectionEnum::STICKY_THEN_PRIORITY,
+            ChannelSelectionEnum::AGENT_PICKS => $this->pickStickyOrFallback($candidates, $session),
+        };
+    }
+
+    /**
+     * @param ResolvedChannel[] $candidates
+     */
+    private function pickStickyOrFallback(array $candidates, Session $session): ResolvedChannel
+    {
+        // Sticky = the most recent inbound's channel, IF it matches a candidate.
+        // Channel-on-session is OK as a "last seen on" signal (not as the
+        // outbound decision driver — that's the resolver's job).
+        $stickyChannel = (string) $session->getChannel();
+
+        foreach ($candidates as $candidate) {
+            if ($candidate->channelType === $stickyChannel) {
+                return $candidate;
+            }
+        }
+
+        return $candidates[0];
     }
 
     // Sessions are keyed to People (not Lead) in the new sales-agent infra —
@@ -387,7 +432,7 @@ final class FollowUpLeadAction
         return $message;
     }
 
-    private function dispatchOutbound(string $channelType, string $body): void
+    private function dispatchOutbound(string $channelType, string $body, Contact $outboundContact): void
     {
         $emailTitle = (string) ($this->lead->get('title_email_follow_up') ?? $this->company->name);
         $twilioFrom = (string) $this->company->get(TwilioConfigurationEnum::TWILIO_PHONE_NUMBER->value);
@@ -398,6 +443,7 @@ final class FollowUpLeadAction
                 message: $body,
                 from: $twilioFrom,
                 title: $emailTitle,
+                to: (string) $outboundContact->value,
             );
         } catch (Throwable $e) {
             // Outbound failure does NOT roll back the persisted message — the
@@ -457,6 +503,8 @@ final class FollowUpLeadAction
         ?string $metaTemplate,
         ?string $reason,
         bool $advanced,
+        ResolvedChannel $picked,
+        ChannelSelectionEnum $strategy,
     ): void {
         $this->lead->emitLedgerEvent('lead.follow_up.sent', payload: [
             'stage_id' => $this->lead->pipeline_stage_id,
@@ -467,6 +515,9 @@ final class FollowUpLeadAction
             'by_agent_id' => $this->agent->getId(),
             'reason' => $reason,
             'advanced_stage' => $advanced,
+            'channel_selection_strategy' => $strategy->value,
+            'channel_selection_reason' => $picked->reason,
+            'contact_id' => $picked->contact->getKey(),
         ]);
     }
 }

--- a/src/Domains/Intelligence/FollowUp/CLAUDE.md
+++ b/src/Domains/Intelligence/FollowUp/CLAUDE.md
@@ -159,34 +159,37 @@ If a tenant needs pure calendar-driven walking regardless of message outcome, th
 
 ## Channel resolution lives on the Lead, NOT the Session
 
-**The lead's reachable channels are decided by the person's `Contact` rows + the stage's enabled channels + opt-outs.** Not by which channel happened to have the most recent inbound. `Session::getChannel()` is `@deprecated for outbound channel selection` — it stays valid for "what channel did this conversation happen on?" inspection but does NOT drive outbound decisions.
+Reachable channels come from the person's `Contact` rows + stage-enabled channels + opt-outs — never from `Session::getChannel()` (which stays valid for inspection but is `@deprecated for outbound channel selection`).
 
-The flow lives in [`LeadOutboundChannelResolver`](Services/LeadOutboundChannelResolver.php):
+Resolved in [`LeadOutboundChannelResolver`](Services/LeadOutboundChannelResolver.php) — contact-type priority per channel:
 
-1. Read all non-opted-out `Contact` rows for the lead's person.
-2. For each `stage.config.follow_up.channels[].enabled` channel type, pick the best-matching contact:
-   - **`email`** → `PRIMARY_EMAIL` (9) → `EMAIL` (1) → `SECONDARY_EMAIL` (10), then `weight DESC`, then `id DESC`
-   - **`sms`** → `CELLPHONE` (3) → `PHONE` (2) → `WORK_PHONE` (8), then `weight DESC`, then `id DESC`
-   - **`whatsapp`** → only `CELLPHONE` (3) (need a mobile), then `weight DESC`, then `id DESC`
-3. Return ordered `ResolvedChannel[]` (stage-config order). Empty when nothing matches.
+| Channel | Eligible contact types (best → fallback) |
+|---|---|
+| `email` | `PRIMARY_EMAIL` (9) → `EMAIL` (1) → `SECONDARY_EMAIL` (10) |
+| `sms` | `CELLPHONE` (3) → `PHONE` (2) → `WORK_PHONE` (8) |
+| `whatsapp` | `CELLPHONE` (3) only |
 
-`channel_selection` strategy then picks one from the resolved list:
+Within each type, ordered by `weight DESC`, then `id DESC`. Opt-outs (`is_opt_out = 1`) excluded. Returns `ResolvedChannel[]` in stage-config order.
+
+`channel_selection` strategies:
 
 | Strategy | Behavior |
 |---|---|
-| `priority_only` | Always pick `candidates[0]` — stage config's first enabled-and-reachable channel wins. Past inbound history ignored. |
-| `sticky_then_priority` (default) | If `Session::getChannel()` matches a candidate, prefer that. Else fall back to `candidates[0]`. |
-| `agent_picks` | v1.5 — currently aliases to `sticky_then_priority`. See "Open v1.5 work" below. |
+| `priority_only` | One channel per touch — always `candidates[0]`. |
+| `sticky_then_priority` (default) | One channel per touch — sticky to last inbound channel if it's in candidates; else `candidates[0]`. |
+| `agent_picks` | v1.5 — currently aliases to `sticky_then_priority`. |
+| `fan_out_all` | **All reachable channels per touch.** Same agent message dispatched to every candidate. One touch = one bump (does NOT consume N retry slots for N channels). Same template + same body across channels — if you need per-channel templates, use a pick-one strategy instead. Reserved for high-urgency stages (demo reminder, deal closing). Tenants opt in per stage; default stays pick-one to avoid accidental cross-channel spam / TCPA-class compliance exposure. |
 
-**Skip reasons that depend on channel resolution:**
-- `no_session` — no Session row exists at all for the person. Still the gate for agent memory continuity.
-- `no_reachable_channel` — every stage-enabled channel has zero matching non-opted-out contacts. Replaces the old `channel_not_configured` skip (which was a session-driven false positive and is now dead).
+**Skip reasons:** `no_session` (no Session row for the person), `no_reachable_channel` (no stage-enabled channel has a matching non-opted-out contact). The old `channel_not_configured` skip is dead — was a session-driven false positive.
 
-**Opt-outs are now respected at the resolver level.** A `Contact` with `is_opt_out = 1` is silently filtered out. This is a behavior change from pre-fix: leads who had unsubscribed but were still being nudged on opted-out contacts will now skip with `no_reachable_channel` (assuming no other channel is reachable).
+**Opt-out behavior change:** leads who unsubscribed but were still being nudged on opted-out contacts will now skip with `no_reachable_channel` if no other channel is reachable. Pre-fix the action didn't consult opt-outs at all.
 
-### Open v1.5 work — agent-aware channel routing
+### Open v1.5 work — channel routing intelligence
 
-`ChannelSelectionEnum::AGENT_PICKS` is reserved but currently aliases to `sticky_then_priority`. The v1.5 spec: the resolver should consult per-channel agent decision history (`should_respond: false` outcomes from prior touches in this stage) and de-prioritize channels the agent has already declined. This requires a new "per-channel decision" sub-state in `follow_up_state`. Don't implement piecemeal — design it alongside the v1.5 role-mapping work in [`Agent resolution — current design + planned evolution`](#agent-resolution--current-design--planned-evolution).
+1. **Agent-aware routing.** `ChannelSelectionEnum::AGENT_PICKS` should consult per-channel agent decision history (`should_respond: false` outcomes from prior touches in this stage) and de-prioritize channels the agent already declined. Needs a "per-channel decision" sub-state in `follow_up_state`. Design alongside the v1.5 role-mapping work above.
+2. **Touch-number rotation.** Add `ChannelSelectionEnum::ROTATE_BY_TOUCH` — `$candidates[$lead->getFollowUpStateCount() % count($candidates)]`. Deterministic "email first, sms second, whatsapp third, wrap" pattern. No sticky/priority signal consulted.
+
+Both can ship independently — enum case + branch in `selectTargets` + test. Don't pre-build before a tenant actually needs it.
 
 ## `exhausted_action` is an enum — extend it deliberately
 

--- a/src/Domains/Intelligence/FollowUp/CLAUDE.md
+++ b/src/Domains/Intelligence/FollowUp/CLAUDE.md
@@ -157,6 +157,37 @@ Required config per stage:
 
 If a tenant needs pure calendar-driven walking regardless of message outcome, that's a separate cron/command (~50 lines): iterate drip-enabled leads at midnight, bump `pipeline_stage_id` based on `stage_entered_at + N days`. Not in v1.
 
+## Channel resolution lives on the Lead, NOT the Session
+
+**The lead's reachable channels are decided by the person's `Contact` rows + the stage's enabled channels + opt-outs.** Not by which channel happened to have the most recent inbound. `Session::getChannel()` is `@deprecated for outbound channel selection` — it stays valid for "what channel did this conversation happen on?" inspection but does NOT drive outbound decisions.
+
+The flow lives in [`LeadOutboundChannelResolver`](Services/LeadOutboundChannelResolver.php):
+
+1. Read all non-opted-out `Contact` rows for the lead's person.
+2. For each `stage.config.follow_up.channels[].enabled` channel type, pick the best-matching contact:
+   - **`email`** → `PRIMARY_EMAIL` (9) → `EMAIL` (1) → `SECONDARY_EMAIL` (10), then `weight DESC`, then `id DESC`
+   - **`sms`** → `CELLPHONE` (3) → `PHONE` (2) → `WORK_PHONE` (8), then `weight DESC`, then `id DESC`
+   - **`whatsapp`** → only `CELLPHONE` (3) (need a mobile), then `weight DESC`, then `id DESC`
+3. Return ordered `ResolvedChannel[]` (stage-config order). Empty when nothing matches.
+
+`channel_selection` strategy then picks one from the resolved list:
+
+| Strategy | Behavior |
+|---|---|
+| `priority_only` | Always pick `candidates[0]` — stage config's first enabled-and-reachable channel wins. Past inbound history ignored. |
+| `sticky_then_priority` (default) | If `Session::getChannel()` matches a candidate, prefer that. Else fall back to `candidates[0]`. |
+| `agent_picks` | v1.5 — currently aliases to `sticky_then_priority`. See "Open v1.5 work" below. |
+
+**Skip reasons that depend on channel resolution:**
+- `no_session` — no Session row exists at all for the person. Still the gate for agent memory continuity.
+- `no_reachable_channel` — every stage-enabled channel has zero matching non-opted-out contacts. Replaces the old `channel_not_configured` skip (which was a session-driven false positive and is now dead).
+
+**Opt-outs are now respected at the resolver level.** A `Contact` with `is_opt_out = 1` is silently filtered out. This is a behavior change from pre-fix: leads who had unsubscribed but were still being nudged on opted-out contacts will now skip with `no_reachable_channel` (assuming no other channel is reachable).
+
+### Open v1.5 work — agent-aware channel routing
+
+`ChannelSelectionEnum::AGENT_PICKS` is reserved but currently aliases to `sticky_then_priority`. The v1.5 spec: the resolver should consult per-channel agent decision history (`should_respond: false` outcomes from prior touches in this stage) and de-prioritize channels the agent has already declined. This requires a new "per-channel decision" sub-state in `follow_up_state`. Don't implement piecemeal — design it alongside the v1.5 role-mapping work in [`Agent resolution — current design + planned evolution`](#agent-resolution--current-design--planned-evolution).
+
 ## `exhausted_action` is an enum — extend it deliberately
 
 [`ExhaustedActionEnum`](Enums/ExhaustedActionEnum.php) currently has **two** cases. Always type-hint against the enum (DTOs already do); don't compare against raw strings in new code.

--- a/src/Domains/Intelligence/FollowUp/DataTransferObject/ResolvedChannel.php
+++ b/src/Domains/Intelligence/FollowUp/DataTransferObject/ResolvedChannel.php
@@ -5,18 +5,14 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\FollowUp\DataTransferObject;
 
 use Kanvas\Guild\Customers\Models\Contact;
+use Spatie\LaravelData\Data;
 
-/**
- * One eligible outbound channel for a follow-up — the channel type plus the
- * specific Contact row to dispatch to. `reason` is a short tag for the ledger
- * payload so we can audit why this channel/contact won the resolution.
- */
-final readonly class ResolvedChannel
+class ResolvedChannel extends Data
 {
     public function __construct(
-        public string $channelType,
-        public Contact $contact,
-        public string $reason,
+        public readonly string $channelType,
+        public readonly Contact $contact,
+        public readonly string $reason,
     ) {
     }
 }

--- a/src/Domains/Intelligence/FollowUp/DataTransferObject/ResolvedChannel.php
+++ b/src/Domains/Intelligence/FollowUp/DataTransferObject/ResolvedChannel.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\FollowUp\DataTransferObject;
+
+use Kanvas\Guild\Customers\Models\Contact;
+
+/**
+ * One eligible outbound channel for a follow-up — the channel type plus the
+ * specific Contact row to dispatch to. `reason` is a short tag for the ledger
+ * payload so we can audit why this channel/contact won the resolution.
+ */
+final readonly class ResolvedChannel
+{
+    public function __construct(
+        public string $channelType,
+        public Contact $contact,
+        public string $reason,
+    ) {
+    }
+}

--- a/src/Domains/Intelligence/FollowUp/Enums/ChannelSelectionEnum.php
+++ b/src/Domains/Intelligence/FollowUp/Enums/ChannelSelectionEnum.php
@@ -9,4 +9,5 @@ enum ChannelSelectionEnum: string
     case STICKY_THEN_PRIORITY = 'sticky_then_priority';
     case PRIORITY_ONLY = 'priority_only';
     case AGENT_PICKS = 'agent_picks';
+    case FAN_OUT_ALL = 'fan_out_all';
 }

--- a/src/Domains/Intelligence/FollowUp/Services/LeadOutboundChannelResolver.php
+++ b/src/Domains/Intelligence/FollowUp/Services/LeadOutboundChannelResolver.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\FollowUp\Services;
+
+use Illuminate\Support\Collection;
+use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
+use Kanvas\Guild\Customers\Models\Contact;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\FollowUp\DataTransferObject\FollowUpConfig;
+use Kanvas\Intelligence\FollowUp\DataTransferObject\ResolvedChannel;
+
+/**
+ * Maps a Lead's reachable contacts (email/phone) against a stage's enabled
+ * channels to produce an ORDERED list of outbound options. The first item
+ * is what `priority_only` picks; `sticky_then_priority` may override based
+ * on inbound history.
+ *
+ * Opt-outs are filtered out — never returned in candidates.
+ *
+ * @todo v1.5 — agent-aware routing: take prior `should_respond: false`
+ *       outcomes per channel into account so the resolver can de-prioritize
+ *       channels the agent already declined this stage. Today the resolver
+ *       has no view of agent decision history.
+ */
+final class LeadOutboundChannelResolver
+{
+    private const array EMAIL_CONTACT_TYPES = [
+        ContactTypeEnum::PRIMARY_EMAIL,
+        ContactTypeEnum::EMAIL,
+        ContactTypeEnum::SECONDARY_EMAIL,
+    ];
+
+    private const array SMS_CONTACT_TYPES = [
+        ContactTypeEnum::CELLPHONE,
+        ContactTypeEnum::PHONE,
+        ContactTypeEnum::WORK_PHONE,
+    ];
+
+    /**
+     * @return ResolvedChannel[]  in stage-config order; opt-outs excluded
+     */
+    public function resolve(Lead $lead, FollowUpConfig $config): array
+    {
+        $people = $lead->people;
+        if ($people === null) {
+            return [];
+        }
+
+        $contacts = $people->contacts()
+            ->where('is_opt_out', 0)
+            ->get();
+
+        $resolved = [];
+
+        foreach ($config->channels as $channelConfig) {
+            if (! $channelConfig->enabled) {
+                continue;
+            }
+
+            $contact = $this->pickContactForChannel($channelConfig->type, $contacts);
+            if ($contact === null) {
+                continue;
+            }
+
+            $resolved[] = new ResolvedChannel(
+                channelType: $channelConfig->type,
+                contact: $contact,
+                reason: $this->reasonFor($channelConfig->type, $contact),
+            );
+        }
+
+        return $resolved;
+    }
+
+    private function pickContactForChannel(string $channelType, Collection $contacts): ?Contact
+    {
+        $eligibleTypeIds = match ($channelType) {
+            'email' => array_map(fn (ContactTypeEnum $t) => $t->value, self::EMAIL_CONTACT_TYPES),
+            'sms' => array_map(fn (ContactTypeEnum $t) => $t->value, self::SMS_CONTACT_TYPES),
+            'whatsapp' => [ContactTypeEnum::CELLPHONE->value],
+            default => [],
+        };
+
+        if ($eligibleTypeIds === []) {
+            return null;
+        }
+
+        $filtered = $contacts->filter(
+            fn (Contact $c) => in_array((int) $c->contacts_types_id, $eligibleTypeIds, true)
+        );
+
+        if ($filtered->isEmpty()) {
+            return null;
+        }
+
+        $order = array_flip($eligibleTypeIds);
+
+        return $filtered
+            ->sortBy([
+                fn (Contact $a, Contact $b) => ($order[(int) $a->contacts_types_id] ?? PHP_INT_MAX) <=> ($order[(int) $b->contacts_types_id] ?? PHP_INT_MAX),
+                fn (Contact $a, Contact $b) => (int) $b->weight <=> (int) $a->weight,
+                fn (Contact $a, Contact $b) => (int) $b->getKey() <=> (int) $a->getKey(),
+            ])
+            ->first();
+    }
+
+    private function reasonFor(string $channelType, Contact $contact): string
+    {
+        $typeId = (int) $contact->contacts_types_id;
+
+        return match ($channelType) {
+            'email' => match ($typeId) {
+                ContactTypeEnum::PRIMARY_EMAIL->value => 'primary_email',
+                ContactTypeEnum::SECONDARY_EMAIL->value => 'secondary_email',
+                default => 'email',
+            },
+            'sms' => match ($typeId) {
+                ContactTypeEnum::CELLPHONE->value => 'cellphone_for_sms',
+                ContactTypeEnum::PHONE->value => 'home_phone_for_sms',
+                ContactTypeEnum::WORK_PHONE->value => 'work_phone_for_sms',
+                default => 'sms',
+            },
+            'whatsapp' => 'cellphone_for_whatsapp',
+            default => $channelType,
+        };
+    }
+}

--- a/src/Domains/Intelligence/FollowUp/Services/LeadOutboundChannelResolver.php
+++ b/src/Domains/Intelligence/FollowUp/Services/LeadOutboundChannelResolver.php
@@ -12,17 +12,9 @@ use Kanvas\Intelligence\FollowUp\DataTransferObject\FollowUpConfig;
 use Kanvas\Intelligence\FollowUp\DataTransferObject\ResolvedChannel;
 
 /**
- * Maps a Lead's reachable contacts (email/phone) against a stage's enabled
- * channels to produce an ORDERED list of outbound options. The first item
- * is what `priority_only` picks; `sticky_then_priority` may override based
- * on inbound history.
- *
- * Opt-outs are filtered out — never returned in candidates.
- *
- * @todo v1.5 — agent-aware routing: take prior `should_respond: false`
- *       outcomes per channel into account so the resolver can de-prioritize
- *       channels the agent already declined this stage. Today the resolver
- *       has no view of agent decision history.
+ * Maps a Lead's reachable contacts against a stage's enabled channels.
+ * Opt-outs (`is_opt_out = 1`) are filtered out. See FollowUp CLAUDE.md
+ * "Channel resolution lives on the Lead" + v1.5 TODOs.
  */
 final class LeadOutboundChannelResolver
 {

--- a/src/Domains/Intelligence/Sessions/Models/Session.php
+++ b/src/Domains/Intelligence/Sessions/Models/Session.php
@@ -71,6 +71,17 @@ class Session extends BaseModel
             : null;
     }
 
+    /**
+     * Returns the channel this session's history lives on (derived from the
+     * uuid marker — sessions are created per-channel by the connector layer).
+     *
+     * @deprecated for outbound channel selection — use
+     *             `Kanvas\Intelligence\FollowUp\Services\LeadOutboundChannelResolver`
+     *             which decides outbound channel from the Lead's contacts +
+     *             stage config + opt-outs, not from session history. This
+     *             method remains valid for "what channel did this conversation
+     *             happen on?" inspection.
+     */
     public function getChannel(): string
     {
         if (str_contains($this->uuid, 'email')) {

--- a/tests/Intelligence/FollowUp/Actions/FollowUpLeadActionTest.php
+++ b/tests/Intelligence/FollowUp/Actions/FollowUpLeadActionTest.php
@@ -223,15 +223,19 @@ class FollowUpLeadActionTest extends TestCase
     // ─────────────────────────────────────────────────────────────────────
     // Gate 4: session channel not in stage config → channel_not_configured
     // ─────────────────────────────────────────────────────────────────────
-    public function testSkipsWhenChannelNotConfigured(): void
+    public function testSkipsWhenLeadHasNoReachableContactForEnabledChannels(): void
     {
-        // Stage config only enables 'email' but session is on 'whatsapp'.
+        // Stage enables ONLY whatsapp. Person has only an email contact (no
+        // phones). Resolver returns zero candidates → no_reachable_channel.
         $cfg = $this->defaultStageConfig();
         $cfg['follow_up']['channels'] = [
-            ['type' => 'email', 'enabled' => true, 'template_name' => null],
+            ['type' => 'whatsapp', 'enabled' => true, 'template_name' => null],
         ];
         $lead = $this->seedLeadWithStageConfig($cfg);
         $this->seedSessionAndChannel($lead, 'whatsapp');
+
+        // Strip all phone contacts so the person can only be emailed.
+        $lead->people->contacts()->whereIn('contacts_types_id', [2, 3, 8])->delete();
 
         $outcome = new FollowUpLeadAction(
             app: $this->testApp,
@@ -241,7 +245,7 @@ class FollowUpLeadActionTest extends TestCase
         )->execute();
 
         $this->assertSame(FollowUpOutcomeKindEnum::SKIPPED, $outcome->kind);
-        $this->assertSame('channel_not_configured', $outcome->reason);
+        $this->assertSame('no_reachable_channel', $outcome->reason);
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -592,5 +596,164 @@ class FollowUpLeadActionTest extends TestCase
             'content' => [],
             'is_deleted' => 0,
         ]);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Channel resolution — multi-channel selection via the resolver path.
+    // Regression coverage for the bug where Session::getChannel() drove the
+    // outbound choice and skipped leads whose latest session was on a
+    // non-configured channel even when other channels were reachable.
+    // ─────────────────────────────────────────────────────────────────────
+
+    public function testSessionFromOtherChannelStillProvidesMemoryWhileResolverPicksConfiguredChannel(): void
+    {
+        // Stage enables ONLY email. Session is on whatsapp (memory continuity).
+        // Old code skipped with channel_not_configured; new code resolves
+        // email from the person's contacts and proceeds.
+        $cfg = $this->defaultStageConfig();
+        $cfg['follow_up']['channels'] = [
+            ['type' => 'email', 'enabled' => true, 'template_name' => null],
+        ];
+        $lead = $this->seedLeadWithStageConfig($cfg);
+        $this->seedSessionAndChannel($lead, 'whatsapp');
+
+        FollowUpAgentStub::configure(
+            shouldRespond: true,
+            advanceStage: false,
+            message: 'Hi via email despite whatsapp memory.',
+            reason: 'happy_path_multi_channel',
+        );
+
+        $outcome = new FollowUpLeadAction(
+            app: $this->testApp,
+            company: $this->company,
+            lead: $lead,
+            agent: $this->seedFollowUpAgent(),
+        )->execute();
+
+        $this->assertSame(FollowUpOutcomeKindEnum::SENT, $outcome->kind);
+        $lead->refresh();
+        $this->assertContains('email', $lead->getFollowUpChannelsUsed());
+    }
+
+    public function testStickyThenPriorityPicksStickyChannelWhenMatchingConfig(): void
+    {
+        // Stage enables [email, sms]. Last inbound (session) is on sms.
+        // sticky_then_priority should pick sms even though email is config[0].
+        $cfg = $this->defaultStageConfig();
+        $cfg['follow_up']['channels'] = [
+            ['type' => 'email', 'enabled' => true, 'template_name' => null],
+            ['type' => 'sms', 'enabled' => true, 'template_name' => null],
+        ];
+        $cfg['follow_up']['channel_selection'] = 'sticky_then_priority';
+        $lead = $this->seedLeadWithStageConfig($cfg);
+        $this->seedSessionAndChannel($lead, 'sms');
+
+        FollowUpAgentStub::configure(
+            shouldRespond: true,
+            advanceStage: false,
+            message: 'Sticky sms wins.',
+            reason: 'sticky_match',
+        );
+
+        $outcome = new FollowUpLeadAction(
+            app: $this->testApp,
+            company: $this->company,
+            lead: $lead,
+            agent: $this->seedFollowUpAgent(),
+        )->execute();
+
+        $this->assertSame(FollowUpOutcomeKindEnum::SENT, $outcome->kind);
+        $lead->refresh();
+        $this->assertContains('sms', $lead->getFollowUpChannelsUsed());
+        $this->assertNotContains('email', $lead->getFollowUpChannelsUsed());
+    }
+
+    public function testPriorityOnlyHonorsConfigOrderRegardlessOfStickyChannel(): void
+    {
+        // Stage enables [email, sms]. Last inbound is on sms. priority_only
+        // ignores the sticky signal and picks email (config[0]).
+        $cfg = $this->defaultStageConfig();
+        $cfg['follow_up']['channels'] = [
+            ['type' => 'email', 'enabled' => true, 'template_name' => null],
+            ['type' => 'sms', 'enabled' => true, 'template_name' => null],
+        ];
+        $cfg['follow_up']['channel_selection'] = 'priority_only';
+        $lead = $this->seedLeadWithStageConfig($cfg);
+        $this->seedSessionAndChannel($lead, 'sms');
+
+        FollowUpAgentStub::configure(
+            shouldRespond: true,
+            advanceStage: false,
+            message: 'Priority wins over sticky.',
+            reason: 'priority_only',
+        );
+
+        $outcome = new FollowUpLeadAction(
+            app: $this->testApp,
+            company: $this->company,
+            lead: $lead,
+            agent: $this->seedFollowUpAgent(),
+        )->execute();
+
+        $this->assertSame(FollowUpOutcomeKindEnum::SENT, $outcome->kind);
+        $lead->refresh();
+        $this->assertContains('email', $lead->getFollowUpChannelsUsed());
+        $this->assertNotContains('sms', $lead->getFollowUpChannelsUsed());
+    }
+
+    public function testStickyFallsBackToPriorityWhenStickyChannelNotInConfig(): void
+    {
+        // Stage enables only [email]. Last inbound on whatsapp. sticky has
+        // no match → falls back to priority → picks email.
+        $cfg = $this->defaultStageConfig();
+        $cfg['follow_up']['channels'] = [
+            ['type' => 'email', 'enabled' => true, 'template_name' => null],
+        ];
+        $cfg['follow_up']['channel_selection'] = 'sticky_then_priority';
+        $lead = $this->seedLeadWithStageConfig($cfg);
+        $this->seedSessionAndChannel($lead, 'whatsapp');
+
+        FollowUpAgentStub::configure(
+            shouldRespond: true,
+            advanceStage: false,
+            message: 'Falls back cleanly.',
+            reason: 'sticky_fallback',
+        );
+
+        $outcome = new FollowUpLeadAction(
+            app: $this->testApp,
+            company: $this->company,
+            lead: $lead,
+            agent: $this->seedFollowUpAgent(),
+        )->execute();
+
+        $this->assertSame(FollowUpOutcomeKindEnum::SENT, $outcome->kind);
+    }
+
+    public function testRespectsOptOutOnContact(): void
+    {
+        // Person's email contact is opted out + no phones eligible →
+        // no_reachable_channel skip.
+        $cfg = $this->defaultStageConfig();
+        $cfg['follow_up']['channels'] = [
+            ['type' => 'email', 'enabled' => true, 'template_name' => null],
+        ];
+        $lead = $this->seedLeadWithStageConfig($cfg);
+        $this->seedSessionAndChannel($lead, 'email');
+
+        // Wipe phones, opt out the email.
+        $lead->people->contacts()->whereIn('contacts_types_id', [2, 3, 8])->delete();
+        $lead->people->contacts()->where('contacts_types_id', 1)->update(['is_opt_out' => 1]);
+
+        $outcome = new FollowUpLeadAction(
+            app: $this->testApp,
+            company: $this->company,
+            lead: $lead,
+            agent: $this->seedFollowUpAgent(),
+        )->execute();
+
+        $this->assertSame(FollowUpOutcomeKindEnum::SKIPPED, $outcome->kind);
+        $this->assertSame('no_reachable_channel', $outcome->reason);
     }
 }

--- a/tests/Intelligence/FollowUp/Actions/FollowUpLeadActionTest.php
+++ b/tests/Intelligence/FollowUp/Actions/FollowUpLeadActionTest.php
@@ -756,4 +756,53 @@ class FollowUpLeadActionTest extends TestCase
         $this->assertSame(FollowUpOutcomeKindEnum::SKIPPED, $outcome->kind);
         $this->assertSame('no_reachable_channel', $outcome->reason);
     }
+
+    public function testFanOutAllDispatchesToEveryReachableChannelOnSingleTouch(): void
+    {
+        // Stage enables [email, sms]. Person has both contacts. fan_out_all
+        // should dispatch the same body to BOTH channels and bump count by 1.
+        $cfg = $this->defaultStageConfig();
+        $cfg['follow_up']['channels'] = [
+            ['type' => 'email', 'enabled' => true, 'template_name' => null],
+            ['type' => 'sms', 'enabled' => true, 'template_name' => null],
+        ];
+        $cfg['follow_up']['channel_selection'] = 'fan_out_all';
+        $lead = $this->seedLeadWithStageConfig($cfg);
+        $this->seedSessionAndChannel($lead, 'sms');
+
+        FollowUpAgentStub::configure(
+            shouldRespond: true,
+            advanceStage: false,
+            message: 'Cross-channel ping.',
+            reason: 'fan_out',
+        );
+
+        $outcome = new FollowUpLeadAction(
+            app: $this->testApp,
+            company: $this->company,
+            lead: $lead,
+            agent: $this->seedFollowUpAgent(),
+        )->execute();
+
+        $this->assertSame(FollowUpOutcomeKindEnum::SENT, $outcome->kind);
+
+        $lead->refresh();
+        // One touch — count bumps by 1, not 2.
+        $this->assertSame(1, $lead->getFollowUpStateCount());
+        // Both channels recorded in follow_up_state.channels_used.
+        $this->assertContains('email', $lead->getFollowUpChannelsUsed());
+        $this->assertContains('sms', $lead->getFollowUpChannelsUsed());
+
+        // Ledger event lists both channels in payload.
+        $event = Event::query()
+            ->where('apps_id', $this->testApp->getId())
+            ->where('event_type', 'lead.follow_up.sent')
+            ->where('source_entity_id', $lead->getId())
+            ->latest('id')
+            ->first();
+        $this->assertNotNull($event);
+        $this->assertSame('fan_out_all', $event->payload['channel_selection_strategy']);
+        $this->assertContains('email', $event->payload['channels']);
+        $this->assertContains('sms', $event->payload['channels']);
+    }
 }

--- a/tests/Intelligence/FollowUp/Services/LeadOutboundChannelResolverTest.php
+++ b/tests/Intelligence/FollowUp/Services/LeadOutboundChannelResolverTest.php
@@ -7,7 +7,6 @@ namespace Tests\Intelligence\FollowUp\Services;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
-use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\FollowUp\DataTransferObject\ChannelConfig;
 use Kanvas\Intelligence\FollowUp\DataTransferObject\FollowUpConfig;

--- a/tests/Intelligence/FollowUp/Services/LeadOutboundChannelResolverTest.php
+++ b/tests/Intelligence/FollowUp/Services/LeadOutboundChannelResolverTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Intelligence\FollowUp\Services;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\FollowUp\DataTransferObject\ChannelConfig;
+use Kanvas\Intelligence\FollowUp\DataTransferObject\FollowUpConfig;
+use Kanvas\Intelligence\FollowUp\Enums\ChannelSelectionEnum;
+use Kanvas\Intelligence\FollowUp\Enums\ExhaustedActionEnum;
+use Kanvas\Intelligence\FollowUp\Enums\FollowUpModeEnum;
+use Kanvas\Intelligence\FollowUp\Services\LeadOutboundChannelResolver;
+use Tests\TestCase;
+
+/**
+ * Pure unit coverage on the resolver — no agent, no session, no action.
+ * Verifies contact-driven channel selection in isolation.
+ */
+class LeadOutboundChannelResolverTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected array $connectionsToTransact = ['mysql', 'crm'];
+
+    public function testReturnsEmptyWhenPersonHasOnlyEmailButOnlyWhatsAppEnabled(): void
+    {
+        $lead = $this->makeLead();
+        $this->stripAllContacts($lead);
+        $lead->people->addEmail('only@example.com');
+
+        $config = $this->makeConfig([['type' => 'whatsapp', 'enabled' => true]]);
+
+        $candidates = new LeadOutboundChannelResolver()->resolve($lead, $config);
+
+        $this->assertSame([], $candidates);
+    }
+
+    public function testReturnsEmailCandidateWhenPersonHasEmailAndEmailIsEnabled(): void
+    {
+        $lead = $this->makeLead();
+        $this->stripAllContacts($lead);
+        $lead->people->addEmail('lead@example.com');
+
+        $config = $this->makeConfig([['type' => 'email', 'enabled' => true]]);
+
+        $candidates = new LeadOutboundChannelResolver()->resolve($lead, $config);
+
+        $this->assertCount(1, $candidates);
+        $this->assertSame('email', $candidates[0]->channelType);
+        $this->assertSame('lead@example.com', $candidates[0]->contact->value);
+    }
+
+    public function testPrefersPrimaryEmailOverPlainEmailOverSecondaryEmail(): void
+    {
+        $lead = $this->makeLead();
+        $this->stripAllContacts($lead);
+        $lead->people->contacts()->create([
+            'contacts_types_id' => ContactTypeEnum::SECONDARY_EMAIL->value,
+            'value' => 'secondary@example.com',
+            'weight' => 0,
+            'is_opt_out' => 0,
+        ]);
+        $lead->people->contacts()->create([
+            'contacts_types_id' => ContactTypeEnum::EMAIL->value,
+            'value' => 'plain@example.com',
+            'weight' => 0,
+            'is_opt_out' => 0,
+        ]);
+        $lead->people->contacts()->create([
+            'contacts_types_id' => ContactTypeEnum::PRIMARY_EMAIL->value,
+            'value' => 'primary@example.com',
+            'weight' => 0,
+            'is_opt_out' => 0,
+        ]);
+
+        $config = $this->makeConfig([['type' => 'email', 'enabled' => true]]);
+
+        $candidates = new LeadOutboundChannelResolver()->resolve($lead, $config);
+
+        $this->assertSame('primary@example.com', $candidates[0]->contact->value);
+        $this->assertSame('primary_email', $candidates[0]->reason);
+    }
+
+    public function testSkipsOptedOutContact(): void
+    {
+        $lead = $this->makeLead();
+        $this->stripAllContacts($lead);
+        $lead->people->addEmail('out@example.com', isOptOut: 1);
+
+        $config = $this->makeConfig([['type' => 'email', 'enabled' => true]]);
+
+        $candidates = new LeadOutboundChannelResolver()->resolve($lead, $config);
+
+        $this->assertSame([], $candidates);
+    }
+
+    public function testWhatsAppRequiresCellphoneNotJustAnyPhone(): void
+    {
+        $lead = $this->makeLead();
+        $this->stripAllContacts($lead);
+        // Home phone only — not cellphone-eligible for WhatsApp.
+        $lead->people->addPhone('+1-555-100-2000');
+
+        $config = $this->makeConfig([['type' => 'whatsapp', 'enabled' => true]]);
+
+        $candidates = new LeadOutboundChannelResolver()->resolve($lead, $config);
+
+        $this->assertSame([], $candidates);
+    }
+
+    public function testHigherWeightWinsWithinSameContactType(): void
+    {
+        $lead = $this->makeLead();
+        $this->stripAllContacts($lead);
+        $lead->people->contacts()->create([
+            'contacts_types_id' => ContactTypeEnum::EMAIL->value,
+            'value' => 'low@example.com',
+            'weight' => 0,
+            'is_opt_out' => 0,
+        ]);
+        $lead->people->contacts()->create([
+            'contacts_types_id' => ContactTypeEnum::EMAIL->value,
+            'value' => 'high@example.com',
+            'weight' => 50,
+            'is_opt_out' => 0,
+        ]);
+
+        $config = $this->makeConfig([['type' => 'email', 'enabled' => true]]);
+
+        $candidates = new LeadOutboundChannelResolver()->resolve($lead, $config);
+
+        $this->assertSame('high@example.com', $candidates[0]->contact->value);
+    }
+
+    public function testReturnsCandidatesInStageConfigOrder(): void
+    {
+        $lead = $this->makeLead();   // factory's withContacts() seeds email + phone + cellphone
+        $config = $this->makeConfig([
+            ['type' => 'sms', 'enabled' => true],
+            ['type' => 'email', 'enabled' => true],
+        ]);
+
+        $candidates = new LeadOutboundChannelResolver()->resolve($lead, $config);
+
+        $this->assertCount(2, $candidates);
+        $this->assertSame('sms', $candidates[0]->channelType);
+        $this->assertSame('email', $candidates[1]->channelType);
+    }
+
+    private function makeLead(): Lead
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        return Lead::factory()
+            ->withAppAndCompany($app->getId(), $company->getId())
+            ->create();
+    }
+
+    private function stripAllContacts(Lead $lead): void
+    {
+        $lead->people->contacts()->delete();
+        // Cached relation must drop so re-reads hit DB fresh.
+        $lead->people->unsetRelation('contacts');
+    }
+
+    private function makeConfig(array $channels): FollowUpConfig
+    {
+        $channelConfigs = array_map(
+            fn (array $c) => new ChannelConfig(
+                type: $c['type'],
+                enabled: $c['enabled'] ?? true,
+                templateName: null,
+            ),
+            $channels,
+        );
+
+        return new FollowUpConfig(
+            enabled: true,
+            mode: FollowUpModeEnum::TIME_BASED,
+            timeBased: null,
+            goalBased: null,
+            maxRetries: 5,
+            exhaustedAction: ExhaustedActionEnum::STOP,
+            agentName: null,
+            promptTemplate: null,
+            channels: $channelConfigs,
+            channelSelection: ChannelSelectionEnum::STICKY_THEN_PRIORITY,
+            respectWorkHours: true,
+            respectLeadOptOuts: true,
+            writeSystemMessageOnStageChange: true,
+        );
+    }
+}


### PR DESCRIPTION
Replaces session-driven channel selection in FollowUpLeadAction with a contact-driven LeadOutboundChannelResolver. The session remains the agent's memory (channel-agnostic) but stops being authoritative for which channel the outbound nudge goes on.

Behavior change:
- A lead whose latest Session is on whatsapp but whose stage config only enables email no longer skips with channel_not_configured. The resolver inspects the person's contacts, finds the email address, and sends.
- Opted-out contacts (is_opt_out = 1) are now filtered out at the resolver level — leads who unsubscribed but were still being nudged on opted-out contacts will now skip with no_reachable_channel if no other channel is reachable.
- channel_selection enum is now honored: priority_only ignores sticky signal; sticky_then_priority prefers session channel if it matches a candidate; agent_picks aliases to sticky_then_priority pending v1.5.
- New skip reason: no_reachable_channel (replaces the dead channel_not_configured path).
- Ledger lead.follow_up.sent payload gains channel_selection_strategy, channel_selection_reason, contact_id for outbound audit.

Session::getChannel() marked @deprecated for outbound channel selection. SendMessageToLeadAction::sendEmailMessage now accepts the existing $to arg from execute() (was dropped on the floor before).

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
