### PR TITLE
feat: mirror wallet payments into the payments table

### DIFF
--- a/app/GraphQL/Souk/Mutations/Orders/OrderManagementMutation.php
+++ b/app/GraphQL/Souk/Mutations/Orders/OrderManagementMutation.php
@@ -121,6 +121,10 @@ class OrderManagementMutation
             ])
             ->log('User attempted to create order from cart');
 
+        $parentOrder = isset($request['input']['parent_id'])
+            ? Order::getByIdFromCompanyApp((int) $request['input']['parent_id'], $company, $app)
+            : null;
+
         $ipAddress = IPInfo::getClientIp();
         $createOrder = new $actionClass(
             $cart,
@@ -133,7 +137,7 @@ class OrderManagementMutation
             $billing,
             $shippingAddress,
             $request,
-            null,
+            $parentOrder,
             $ipAddress
         )->execute();
 

--- a/src/Domains/Connectors/Movipass/Actions/EnableCorporateModeAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/EnableCorporateModeAction.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kanvas\Connectors\Movipass\Actions;
 
 use Baka\Contracts\AppInterface;
-use Bouncer;
 use Illuminate\Support\Facades\DB;
 use Kanvas\AccessControlList\Actions\AssignRoleAction;
 use Kanvas\AccessControlList\Enums\RolesEnums;
@@ -108,11 +107,15 @@ class EnableCorporateModeAction
     private function associateUserAsAdmin(Companies $company, Apps $app): void
     {
         $branch = $company->branch()->firstOrFail();
+        $adminRole = RolesRepository::getByNameFromApp(RolesEnums::ADMIN->value, $app);
 
-        new AssignCompanyAction($this->user, $branch)->execute();
+        new AssignCompanyAction(
+            user: $this->user,
+            branch: $branch,
+            role: $adminRole,
+            app: $app,
+        )->execute();
 
-        Bouncer::scope()->to(RolesEnums::getScope($app, $company));
-        $adminRole = RolesRepository::getByMixedParamFromCompany(RolesEnums::ADMIN->value, $company, $app);
         new AssignRoleAction($this->user, $adminRole)->execute();
     }
 }

--- a/src/Domains/Souk/Wallet/Actions/PayFromWalletAction.php
+++ b/src/Domains/Souk/Wallet/Actions/PayFromWalletAction.php
@@ -8,7 +8,10 @@ use Bavix\Wallet\Objects\Cart;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Exceptions\ValidationException;
 use Kanvas\Souk\Orders\Models\Order;
+use Kanvas\Souk\Payments\Enums\PaymentMethodTypesEnum;
+use Kanvas\Souk\Payments\Enums\PaymentStatusEnum;
 use Kanvas\Souk\Payments\Models\PaymentLogs;
+use Kanvas\Souk\Payments\Models\Payments;
 use Kanvas\Souk\Wallet\Enums\ConfigurationEnum;
 use Kanvas\Souk\Wallet\Enums\TransactionSourceEnum;
 use Kanvas\Souk\Wallet\Traits\HasWalletHolderTrait;
@@ -45,6 +48,7 @@ class PayFromWalletAction
         $tag = ConfigurationEnum::WALLET_DEFAULT_NAME->value;
         $wallet = $walletHolder->createAppWallet($this->order->app, ['name' => $tag]);
         $cart = app(Cart::class);
+        $totalDebited = 0.0;
         $useVariantCreditInsteadOfVariantPrice = $this->order->app->get(ConfigurationEnum::USE_VARIANT_CREDIT_INSTEAD_OF_VARIANT_PRICE_SLUG->value);
 
         foreach ($this->order->items as $item) {
@@ -66,6 +70,8 @@ class PayFromWalletAction
             if ($quantity < 1) {
                 continue;
             }
+
+            $totalDebited += $price * $quantity;
 
             $cart = $cart->withItem(
                 product: $item->variant,
@@ -95,7 +101,9 @@ class PayFromWalletAction
 
         $this->order->addTag(ConfigurationEnum::WALLET_CREDIT_TAG->value);
 
-        $this->logPaymentEvent();
+        $payment = $this->recordWalletPayment($wallet, $tag, $totalDebited);
+
+        $this->logPaymentEvent($payment);
 
         $this->order->payment_status = 'paid';
         $this->order->saveOrFail();
@@ -130,20 +138,65 @@ class PayFromWalletAction
         return $this->getWalletHolder($this->order->app, $this->order->user);
     }
 
-    protected function logPaymentEvent(): void
+    /**
+     * Mirror the wallet debit as a row in the payments table so wallet payments
+     * are visible to the same source-of-truth as external processors (azul, cardnet, ...).
+     *
+     * We create the PAID row directly instead of routing through CreatePaymentAction
+     * because that action's PAID branch calls Order::markAsPaid (which marks the order
+     * completed and fires WorkflowEnum::UPDATED) — the wallet flow intentionally only
+     * sets payment_status and fires AFTER_PAYMENT_INTENT.
+     */
+    protected function recordWalletPayment(Wallet $wallet, string $tag, float $amount): Payments
+    {
+        $idempotencyKey = $this->idempotencyKey
+            ?? ('wallet_' . ($this->order->uuid ?? (string) $this->order->getId()));
+
+        $existing = Payments::where('idempotency_key', $idempotencyKey)
+            ->where('apps_id', $this->order->apps_id)
+            ->first();
+
+        if ($existing) {
+            return $existing;
+        }
+
+        return $this->order->payments()->create([
+            'amount' => $amount > 0.0 ? $amount : (float) $this->order->total_gross_amount,
+            'payment_date' => date('Y-m-d'),
+            'concept' => 'Wallet payment for order #' . (string) $this->order->number,
+            'users_id' => $this->order->users_id,
+            'companies_id' => $this->order->companies_id,
+            'currency' => $this->order->currency,
+            'status' => PaymentStatusEnum::PAID->value,
+            'payment_method' => PaymentMethodTypesEnum::WALLET->value,
+            'processor' => PaymentMethodTypesEnum::WALLET->value,
+            'idempotency_key' => $idempotencyKey,
+            'metadata' => [
+                'data' => [
+                    'wallet_tag' => $tag,
+                    'wallet_id' => $wallet->getKey(),
+                    'wallet_holder_type' => $wallet->holder_type,
+                    'wallet_holder_id' => $wallet->holder_id,
+                    'source' => ($this->source ?? TransactionSourceEnum::PAYMENT)->value,
+                ],
+            ],
+        ]);
+    }
+
+    protected function logPaymentEvent(Payments $payment): void
     {
         PaymentLogs::create([
             'apps_id' => $this->order->apps_id,
             'companies_id' => $this->order->companies_id,
             'users_id' => $this->order->users_id,
-            'payments_id' => 0,
+            'payments_id' => $payment->getId(),
             'payment_methods_id' => 0,
             'payable_id' => $this->order->getId(),
             'payable_type' => $this->order::class,
             'status' => 'wallet_payment',
             'metadata' => [
-                'amount' => (float) $this->order->total_gross_amount,
-                'tag' => ConfigurationEnum::WALLET_DEFAULT_NAME->value,
+                'amount' => (float) $payment->amount,
+                'tag' => $payment->getMetadata('wallet_tag') ?? ConfigurationEnum::WALLET_DEFAULT_NAME->value,
                 'order_number' => (string) $this->order->number,
             ],
         ]);

--- a/src/Domains/Souk/Wallet/Actions/PayFromWalletAction.php
+++ b/src/Domains/Souk/Wallet/Actions/PayFromWalletAction.php
@@ -48,7 +48,6 @@ class PayFromWalletAction
         $tag = ConfigurationEnum::WALLET_DEFAULT_NAME->value;
         $wallet = $walletHolder->createAppWallet($this->order->app, ['name' => $tag]);
         $cart = app(Cart::class);
-        $totalDebited = 0.0;
         $useVariantCreditInsteadOfVariantPrice = $this->order->app->get(ConfigurationEnum::USE_VARIANT_CREDIT_INSTEAD_OF_VARIANT_PRICE_SLUG->value);
 
         foreach ($this->order->items as $item) {
@@ -70,8 +69,6 @@ class PayFromWalletAction
             if ($quantity < 1) {
                 continue;
             }
-
-            $totalDebited += $price * $quantity;
 
             $cart = $cart->withItem(
                 product: $item->variant,
@@ -101,9 +98,7 @@ class PayFromWalletAction
 
         $this->order->addTag(ConfigurationEnum::WALLET_CREDIT_TAG->value);
 
-        $payment = $this->recordWalletPayment($wallet, $tag, $totalDebited);
-
-        $this->logPaymentEvent($payment);
+        $this->recordWalletPayment($wallet, $tag);
 
         $this->order->payment_status = 'paid';
         $this->order->saveOrFail();
@@ -138,16 +133,7 @@ class PayFromWalletAction
         return $this->getWalletHolder($this->order->app, $this->order->user);
     }
 
-    /**
-     * Mirror the wallet debit as a row in the payments table so wallet payments
-     * are visible to the same source-of-truth as external processors (azul, cardnet, ...).
-     *
-     * We create the PAID row directly instead of routing through CreatePaymentAction
-     * because that action's PAID branch calls Order::markAsPaid (which marks the order
-     * completed and fires WorkflowEnum::UPDATED) — the wallet flow intentionally only
-     * sets payment_status and fires AFTER_PAYMENT_INTENT.
-     */
-    protected function recordWalletPayment(Wallet $wallet, string $tag, float $amount): Payments
+    protected function recordWalletPayment(Wallet $wallet, string $tag): Payments
     {
         $idempotencyKey = $this->idempotencyKey
             ?? ('wallet_' . ($this->order->uuid ?? (string) $this->order->getId()));
@@ -160,8 +146,10 @@ class PayFromWalletAction
             return $existing;
         }
 
-        return $this->order->payments()->create([
-            'amount' => $amount > 0.0 ? $amount : (float) $this->order->total_gross_amount,
+        // Direct create, not CreatePaymentAction: its PAID branch runs Order::markAsPaid (completes
+        // the order + fires UPDATED). Amount = order total (gross) so isPaid()/status sync see it paid.
+        $payment = $this->order->payments()->create([
+            'amount' => (float) $this->order->getTotalAmount(),
             'payment_date' => date('Y-m-d'),
             'concept' => 'Wallet payment for order #' . (string) $this->order->number,
             'users_id' => $this->order->users_id,
@@ -181,6 +169,10 @@ class PayFromWalletAction
                 ],
             ],
         ]);
+
+        $this->logPaymentEvent($payment);
+
+        return $payment;
     }
 
     protected function logPaymentEvent(Payments $payment): void

--- a/src/Domains/Souk/Wallet/Actions/PayFromWalletAction.php
+++ b/src/Domains/Souk/Wallet/Actions/PayFromWalletAction.php
@@ -48,6 +48,7 @@ class PayFromWalletAction
         $tag = ConfigurationEnum::WALLET_DEFAULT_NAME->value;
         $wallet = $walletHolder->createAppWallet($this->order->app, ['name' => $tag]);
         $cart = app(Cart::class);
+        $totalDebited = 0.0;
         $useVariantCreditInsteadOfVariantPrice = $this->order->app->get(ConfigurationEnum::USE_VARIANT_CREDIT_INSTEAD_OF_VARIANT_PRICE_SLUG->value);
 
         foreach ($this->order->items as $item) {
@@ -69,6 +70,8 @@ class PayFromWalletAction
             if ($quantity < 1) {
                 continue;
             }
+
+            $totalDebited += $price * $quantity;
 
             $cart = $cart->withItem(
                 product: $item->variant,
@@ -98,7 +101,7 @@ class PayFromWalletAction
 
         $this->order->addTag(ConfigurationEnum::WALLET_CREDIT_TAG->value);
 
-        $this->recordWalletPayment($wallet, $tag);
+        $this->recordWalletPayment($wallet, $tag, $totalDebited);
 
         $this->order->payment_status = 'paid';
         $this->order->saveOrFail();
@@ -133,7 +136,7 @@ class PayFromWalletAction
         return $this->getWalletHolder($this->order->app, $this->order->user);
     }
 
-    protected function recordWalletPayment(Wallet $wallet, string $tag): Payments
+    protected function recordWalletPayment(Wallet $wallet, string $tag, float $amount): Payments
     {
         $idempotencyKey = $this->idempotencyKey
             ?? ('wallet_' . ($this->order->uuid ?? (string) $this->order->getId()));
@@ -147,9 +150,10 @@ class PayFromWalletAction
         }
 
         // Direct create, not CreatePaymentAction: its PAID branch runs Order::markAsPaid (completes
-        // the order + fires UPDATED). Amount = order total (gross) so isPaid()/status sync see it paid.
+        // the order + fires UPDATED). Amount is the actual wallet debit — order totals aren't
+        // aggregated for wallet carts and can be 0.
         $payment = $this->order->payments()->create([
-            'amount' => (float) $this->order->getTotalAmount(),
+            'amount' => $amount,
             'payment_date' => date('Y-m-d'),
             'concept' => 'Wallet payment for order #' . (string) $this->order->number,
             'users_id' => $this->order->users_id,

--- a/src/Domains/Souk/Wallet/Actions/RefundOrderToWalletAction.php
+++ b/src/Domains/Souk/Wallet/Actions/RefundOrderToWalletAction.php
@@ -68,6 +68,9 @@ class RefundOrderToWalletAction
             ],
         )->execute();
 
+        // Refund row created before the wallet credit so a post-deposit failure leaves a visible
+        // PENDING row, not a silent credit. No outer DB transaction: bavix wallet ops manage their
+        // own and the balance sync breaks when nested.
         $walletPayment = $this->findRefundableWalletPayment($order, $refundAmount);
         $refund = null;
 
@@ -113,12 +116,6 @@ class RefundOrderToWalletAction
         return $wallet->refresh();
     }
 
-    /**
-     * Locate the PAID wallet payment row for this order with enough remaining
-     * refundable balance to cover the requested amount. Returns null for orders
-     * paid before wallet payments were mirrored into the payments table (no backfill),
-     * so those refunds keep working through the metadata-based path.
-     */
     protected function findRefundableWalletPayment(Order $order, float $refundAmount): ?Payments
     {
         $payment = $order->payments()

--- a/src/Domains/Souk/Wallet/Actions/RefundOrderToWalletAction.php
+++ b/src/Domains/Souk/Wallet/Actions/RefundOrderToWalletAction.php
@@ -6,7 +6,12 @@ namespace Kanvas\Souk\Wallet\Actions;
 
 use Kanvas\Exceptions\ValidationException;
 use Kanvas\Souk\Orders\Models\Order;
+use Kanvas\Souk\Payments\Actions\CreateRefundAction;
+use Kanvas\Souk\Payments\DataTransferObject\RefundPayment;
+use Kanvas\Souk\Payments\Enums\PaymentMethodTypesEnum;
+use Kanvas\Souk\Payments\Enums\PaymentStatusEnum;
 use Kanvas\Souk\Payments\Models\PaymentLogs;
+use Kanvas\Souk\Payments\Models\Payments;
 use Kanvas\Souk\Wallet\DataTransferObject\WalletRefund;
 use Kanvas\Souk\Wallet\Enums\ConfigurationEnum;
 use Kanvas\Souk\Wallet\Enums\TransactionSourceEnum;
@@ -63,7 +68,28 @@ class RefundOrderToWalletAction
             ],
         )->execute();
 
+        $walletPayment = $this->findRefundableWalletPayment($order, $refundAmount);
+        $refund = null;
+
+        if ($walletPayment !== null && $order->company !== null) {
+            $refund = new CreateRefundAction(
+                new RefundPayment(
+                    app: $this->data->app,
+                    company: $order->company,
+                    user: $this->data->user,
+                    payment: $walletPayment,
+                    amount: $refundAmount,
+                    reason: $this->data->reason,
+                )
+            )->execute();
+        }
+
         $wallet->depositFloat($refundAmount, $audit);
+
+        $refund?->markAsCompleted([
+            'wallet_refund' => true,
+            'tag' => $this->data->tag,
+        ]);
 
         $totalRefunded = $previouslyRefunded + $refundAmount;
 
@@ -82,9 +108,32 @@ class RefundOrderToWalletAction
 
         $order->addTag('wallet_refunded');
 
-        $this->logRefundEvent($order, $refundAmount);
+        $this->logRefundEvent($order, $refundAmount, $walletPayment);
 
         return $wallet->refresh();
+    }
+
+    /**
+     * Locate the PAID wallet payment row for this order with enough remaining
+     * refundable balance to cover the requested amount. Returns null for orders
+     * paid before wallet payments were mirrored into the payments table (no backfill),
+     * so those refunds keep working through the metadata-based path.
+     */
+    protected function findRefundableWalletPayment(Order $order, float $refundAmount): ?Payments
+    {
+        $payment = $order->payments()
+            ->where('payment_method', PaymentMethodTypesEnum::WALLET->value)
+            ->where('status', PaymentStatusEnum::PAID->value)
+            ->latest()
+            ->first();
+
+        if ($payment === null) {
+            return null;
+        }
+
+        $remaining = (float) $payment->amount - $payment->getRefundedAmount();
+
+        return $refundAmount <= $remaining ? $payment : null;
     }
 
     protected function getMaxRefundableAmount(): float
@@ -107,13 +156,13 @@ class RefundOrderToWalletAction
         return $totalRefunded !== null ? (float) $totalRefunded : 0.0;
     }
 
-    protected function logRefundEvent(Order $order, float $refundAmount): void
+    protected function logRefundEvent(Order $order, float $refundAmount, ?Payments $payment = null): void
     {
         PaymentLogs::create([
             'apps_id' => $this->data->app->getId(),
             'companies_id' => $order->companies_id,
             'users_id' => $this->data->user->getId(),
-            'payments_id' => 0,
+            'payments_id' => $payment?->getId() ?? 0,
             'payment_methods_id' => 0,
             'payable_id' => $order->getId(),
             'payable_type' => $order::class,

--- a/src/Domains/Souk/Wallet/Actions/RefundOrderToWalletAction.php
+++ b/src/Domains/Souk/Wallet/Actions/RefundOrderToWalletAction.php
@@ -136,6 +136,18 @@ class RefundOrderToWalletAction
     protected function getMaxRefundableAmount(): float
     {
         $order = $this->data->order;
+
+        // Prefer what actually landed in the payments table; wallet-cart order totals can be 0.
+        $walletPayment = $order->payments()
+            ->where('payment_method', PaymentMethodTypesEnum::WALLET->value)
+            ->where('status', PaymentStatusEnum::PAID->value)
+            ->latest()
+            ->first();
+
+        if ($walletPayment !== null) {
+            return (float) $walletPayment->amount;
+        }
+
         $walletCredit = $order->get(ConfigurationEnum::WALLET_CREDIT->value);
 
         if (is_array($walletCredit) && isset($walletCredit['amount'])) {

--- a/tests/Connectors/Integration/Movipass/EnableCorporateModeActionTest.php
+++ b/tests/Connectors/Integration/Movipass/EnableCorporateModeActionTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Connectors\Integration\Movipass;
 
+use Bouncer;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Bus;
+use Kanvas\AccessControlList\Enums\RolesEnums;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\Movipass\Actions\EnableCorporateModeAction;
 use Kanvas\Connectors\Movipass\Jobs\MigrateCorporateUserVariantsJob;
@@ -29,6 +31,11 @@ final class EnableCorporateModeActionTest extends TestCase
 
         $user = Auth::user();
         $app = app(Apps::class);
+
+        // Mirror a real GraphQL request: middleware leaves the Bouncer tenant scope on the
+        // user's current company, not the app-global company_0 where roles live. This is the
+        // exact condition that made the admin-role lookup throw "No query results for Role".
+        Bouncer::scope()->to(RolesEnums::getScope($app, $user->getCurrentCompany()));
 
         $company = new EnableCorporateModeAction(
             user: $user,

--- a/tests/GraphQL/Souk/ChildOrderTest.php
+++ b/tests/GraphQL/Souk/ChildOrderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\GraphQL\Souk;
+
+class ChildOrderTest extends OrderBase
+{
+    protected string $variantId;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $productResponse = $this->createProduct()->json()['data']['createProduct'];
+
+        $variantResponse = $this->createVariant(
+            productId: $productResponse['id'],
+            warehouseData: [
+                'id' => $this->warehouseResponse['id'],
+            ]
+        )->json()['data']['createVariant'];
+
+        $this->addVariantToChannel(
+            variantId: $variantResponse['id'],
+            channelId: $this->channelResponse['id'],
+            warehouseData: [
+                'id' => $this->warehouseResponse['id'],
+            ]
+        );
+
+        $this->addVariantToWarehouse(
+            variantId: $variantResponse['id'],
+            warehouseId: $this->warehouseResponse['id'],
+            amount: 100
+        );
+
+        $this->variantId = $variantResponse['id'];
+    }
+
+    public function testCreateOrderFromCartLinksParent(): void
+    {
+        $parent = $this->createOrderFromCart(
+            metadata: ['data' => []],
+            variantId: $this->variantId,
+            orderType: 'roadside_assistance',
+        );
+
+        $this->assertNull($parent->parent_id);
+
+        $child = $this->createOrderFromCart(
+            metadata: ['data' => []],
+            variantId: $this->variantId,
+            orderType: 'roadside_assistance',
+            parentId: $parent->getId(),
+        );
+
+        $this->assertEquals($parent->getId(), $child->parent_id);
+        $this->assertNotEquals($parent->getId(), $child->getId());
+    }
+
+    public function testCreateOrderFromCartWithoutParentStaysRoot(): void
+    {
+        $order = $this->createOrderFromCart(
+            metadata: ['data' => []],
+            variantId: $this->variantId,
+        );
+
+        $this->assertNull($order->parent_id);
+    }
+}

--- a/tests/GraphQL/Souk/OrderBase.php
+++ b/tests/GraphQL/Souk/OrderBase.php
@@ -88,7 +88,8 @@ class OrderBase extends TestCase
         string $variantId,
         int $quantity = 1,
         string $orderType = 'order',
-        string $currency = 'USD'
+        string $currency = 'USD',
+        ?int $parentId = null
     ): Order {
         $data = [
             'cartId' => 0,
@@ -111,6 +112,10 @@ class OrderBase extends TestCase
             ],
             'order_type' => $orderType,
         ];
+
+        if ($parentId !== null) {
+            $data['parent_id'] = $parentId;
+        }
 
         // Perform GraphQL mutation to create a draft order
         $response = $this->graphQL('

--- a/tests/GraphQL/Souk/OrderWalletTest.php
+++ b/tests/GraphQL/Souk/OrderWalletTest.php
@@ -13,7 +13,12 @@ use Kanvas\Inventory\Variants\Models\VariantsWarehouses;
 use Kanvas\Inventory\Warehouses\Models\Warehouses;
 use Kanvas\Souk\Enums\ConfigurationEnum;
 use Kanvas\Souk\Orders\Models\Order;
+use Kanvas\Souk\Payments\Enums\PaymentMethodTypesEnum;
+use Kanvas\Souk\Payments\Enums\PaymentStatusEnum;
+use Kanvas\Souk\Payments\Enums\RefundStatusEnum;
 use Kanvas\Souk\Payments\Models\PaymentLogs;
+use Kanvas\Souk\Payments\Models\PaymentRefund;
+use Kanvas\Souk\Payments\Models\Payments;
 use Kanvas\Souk\Wallet\Actions\AddFundsToUserWalletAction;
 use Kanvas\Souk\Wallet\Enums\ConfigurationEnum as WalletConfigurationEnum;
 use Tests\GraphQL\Inventory\Traits\InventoryCases;
@@ -1172,5 +1177,181 @@ class OrderWalletTest extends TestCase
         } finally {
             $app->del(WalletConfigurationEnum::USE_VARIANT_CREDIT_INSTEAD_OF_VARIANT_PRICE_SLUG->value);
         }
+    }
+
+    private function placeWalletOrder(float $unitPrice = 100.0, int $quantity = 1): int
+    {
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+        $app = app(Apps::class);
+
+        $app->del(WalletConfigurationEnum::USE_USER_WALLET->value);
+
+        $productData = new Product(
+            app: $app,
+            company: $company,
+            user: $user,
+            name: fake()->name(),
+            sku: fake()->unique()->uuid(),
+            warehouses: [[
+                'quantity' => 100,
+                'price' => $unitPrice,
+            ]]
+        );
+        $product = (new CreateProductAction($productData, $user))->execute();
+        $variant = $product->variants()->first();
+        $warehouse = Warehouses::fromApp($app)->fromCompany($company)->first();
+        $channel = Channels::fromApp($app)->fromCompany($company)->first();
+        $variant->updatePriceInWarehouse($warehouse, $unitPrice);
+        $variant->updatePriceInChannel($channel, $unitPrice);
+
+        $app->del(ConfigurationEnum::SEND_NEW_ORDER_NOTIFICATION->value);
+        $app->del(ConfigurationEnum::SEND_NEW_ORDER_TO_OWNER_NOTIFICATION->value);
+
+        $wallet = $company->createAppWallet($app, ['name' => 'default']);
+        $wallet->deposit(100000, [
+            'description' => 'Deposit for wallet payment row test',
+        ]);
+
+        $response = $this->graphQL('
+            mutation createOrderFromWalletCart($input: OrderCartInput!) {
+                createOrderFromWalletCart(input: $input) {
+                    order {
+                        id
+                    }
+                }
+            }
+        ', [
+            'input' => [
+                'cartId' => 'default',
+                'customer' => [
+                    'email' => $user->email,
+                    'phone' => $user->phone,
+                ],
+                'items' => [
+                    [
+                        'variant_id' => $variant->getId(),
+                        'quantity' => $quantity,
+                    ],
+                ],
+                'shipping_address' => [
+                    'address' => fake()->address(),
+                    'address_2' => fake()->postcode(),
+                    'city' => fake()->city(),
+                    'state' => fake()->state(),
+                ],
+                'metadata' => [
+                    'user_company_id' => $company->getId(),
+                ],
+            ],
+        ]);
+
+        $response->assertSuccessful();
+
+        return (int) $response->json('data.createOrderFromWalletCart.order.id');
+    }
+
+    public function testWalletPaymentCreatesPaymentRow(): void
+    {
+        $orderId = $this->placeWalletOrder(100.0, 1);
+
+        $payment = Payments::where('payable_id', $orderId)
+            ->where('payable_type', Order::class)
+            ->where('payment_method', PaymentMethodTypesEnum::WALLET->value)
+            ->first();
+
+        $this->assertNotNull($payment, 'Wallet payment should create a row in the payments table');
+        $this->assertEquals(PaymentStatusEnum::PAID->value, $payment->status);
+        $this->assertEquals(PaymentMethodTypesEnum::WALLET->value, $payment->payment_method);
+        $this->assertEquals(PaymentMethodTypesEnum::WALLET->value, $payment->processor);
+        $this->assertGreaterThan(0.0, (float) $payment->amount);
+
+        $log = PaymentLogs::where('payable_id', $orderId)
+            ->where('payable_type', Order::class)
+            ->where('status', 'wallet_payment')
+            ->first();
+
+        $this->assertNotNull($log);
+        $this->assertEquals($payment->getId(), (int) $log->payments_id, 'wallet_payment log must reference the real payment row');
+    }
+
+    public function testWalletPaymentCountsTowardOrderPaidAmount(): void
+    {
+        $orderId = $this->placeWalletOrder(100.0, 1);
+
+        /** @var Order $order */
+        $order = Order::getById($orderId);
+
+        $this->assertTrue($order->isPaid(), 'Order should report paid from the payments table');
+        $this->assertGreaterThan(0.0, $order->getPaidAmount());
+    }
+
+    public function testWalletRefundCreatesPaymentRefundAndReversesPayment(): void
+    {
+        $orderId = $this->placeWalletOrder(100.0, 1);
+
+        $payment = Payments::where('payable_id', $orderId)
+            ->where('payable_type', Order::class)
+            ->where('payment_method', PaymentMethodTypesEnum::WALLET->value)
+            ->firstOrFail();
+
+        $this->graphQL('
+            mutation refundOrderToWallet($input: WalletRefundInput!) {
+                refundOrderToWallet(input: $input) {
+                    balance
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'order_id' => $orderId,
+                'amount' => (float) $payment->amount,
+                'reason' => 'Full wallet refund',
+            ],
+        ], [], $this->getAppKeyHeader())->assertSuccessful();
+
+        $refund = PaymentRefund::where('payments_id', $payment->getId())->first();
+
+        $this->assertNotNull($refund, 'Wallet refund should create a payment_refunds row against the wallet payment');
+        $this->assertEquals(RefundStatusEnum::COMPLETED->value, $refund->status);
+        $this->assertEquals((float) $payment->amount, (float) $refund->amount);
+
+        $payment->refresh();
+        $this->assertEquals(PaymentStatusEnum::REVERSED->value, $payment->status, 'Fully refunded wallet payment must be reversed');
+    }
+
+    public function testPartialWalletRefundKeepsPaymentPaid(): void
+    {
+        $orderId = $this->placeWalletOrder(100.0, 1);
+
+        $payment = Payments::where('payable_id', $orderId)
+            ->where('payable_type', Order::class)
+            ->where('payment_method', PaymentMethodTypesEnum::WALLET->value)
+            ->firstOrFail();
+
+        $partial = round((float) $payment->amount / 2, 2);
+
+        $this->graphQL('
+            mutation refundOrderToWallet($input: WalletRefundInput!) {
+                refundOrderToWallet(input: $input) {
+                    balance
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'order_id' => $orderId,
+                'amount' => $partial,
+                'reason' => 'Partial wallet refund',
+            ],
+        ], [], $this->getAppKeyHeader())->assertSuccessful();
+
+        $refund = PaymentRefund::where('payments_id', $payment->getId())->first();
+
+        $this->assertNotNull($refund);
+        $this->assertEquals($partial, (float) $refund->amount);
+
+        $payment->refresh();
+        $this->assertEquals(PaymentStatusEnum::PAID->value, $payment->status, 'Partially refunded wallet payment stays paid');
     }
 }

--- a/tests/GraphQL/Souk/OrderWalletTest.php
+++ b/tests/GraphQL/Souk/OrderWalletTest.php
@@ -1354,4 +1354,46 @@ class OrderWalletTest extends TestCase
         $payment->refresh();
         $this->assertEquals(PaymentStatusEnum::PAID->value, $payment->status, 'Partially refunded wallet payment stays paid');
     }
+
+    public function testWalletRefundWithoutPaymentRowUsesMetadataFallback(): void
+    {
+        // createWalletPaidOrder bypasses PayFromWalletAction, so the order has no payments row.
+        $result = $this->createWalletPaidOrder(200.0);
+        $wallet = $result['wallet'];
+        $balanceAfterOrder = (float) $wallet->balanceFloat;
+
+        $this->graphQL('
+            mutation refundOrderToWallet($input: WalletRefundInput!) {
+                refundOrderToWallet(input: $input) {
+                    balance
+                    message
+                }
+            }
+        ', [
+            'input' => [
+                'order_id' => $result['order_id'],
+                'amount' => 50.0,
+                'reason' => 'Fallback refund',
+            ],
+        ], [], $this->getAppKeyHeader())->assertSuccessful();
+
+        $this->assertSame(
+            0,
+            PaymentRefund::where('apps_id', app(Apps::class)->getId())
+                ->whereHas(
+                    'payment',
+                    fn ($q) => $q->where('payable_id', $result['order_id'])
+                        ->where('payable_type', Order::class)
+                )
+                ->count(),
+            'Orders without a payments row must not create a PaymentRefund'
+        );
+
+        $wallet->refresh();
+        $this->assertEquals($balanceAfterOrder + 50.0, (float) $wallet->balanceFloat);
+
+        /** @var Order $order */
+        $order = Order::getById((int) $result['order_id']);
+        $this->assertEquals(50.0, $order->get('wallet_refund_total'));
+    }
 }


### PR DESCRIPTION
Wallet payments previously only wrote a PaymentLogs row with payments_id=0 and set order.payment_status manually, making them invisible to the payments table that azul/cardnet/payway use as the source of truth for money entries.

- PayFromWalletAction: after payCart(), create a real PAID payments row (payment_method/processor='wallet', amount=actually-debited, idempotency key per order, wallet metadata). The wallet_payment log now references the real payments_id. Kept the existing order lifecycle (manual payment_status
  + AFTER_PAYMENT_INTENT) by creating the row directly instead of routing through CreatePaymentAction (whose PAID branch runs Order::markAsPaid).
- RefundOrderToWalletAction: create a PaymentRefund against the wallet payment and complete it (full -> payment reversed + status sync; partial -> stays paid). Falls back to the metadata path for orders with no payments row (no historical backfill).
- Tests: 4 new in OrderWalletTest covering the payments row, paid-amount, full reversal and partial refund; existing wallet suite stays green.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
