### PR TITLE
refact: lead close-sold and close-not-sold status classification

### DIFF
--- a/src/Domains/Guild/Leads/Models/Lead.php
+++ b/src/Domains/Guild/Leads/Models/Lead.php
@@ -304,6 +304,24 @@ class Lead extends BaseModel implements EventResourceInterface
         return $statusName !== 'inactive' && (Str::contains($statusName, 'active') || Str::contains($statusName, 'created'));
     }
 
+    public function closeSold(): bool
+    {
+        $statusName = strtolower($this->status()->firstOrFail()->name);
+
+        return ! Str::contains($statusName, 'not') && Str::contains($statusName, 'sold');
+    }
+
+    public function closeNotSold(): bool
+    {
+        if ($this->isActive() || $this->closeSold()) {
+            return false;
+        }
+
+        $statusName = strtolower($this->status()->firstOrFail()->name);
+
+        return ! Str::contains($statusName, 'complete');
+    }
+
     public function close(): void
     {
         //LeadStatus::getByName('close')->id

--- a/src/Domains/Guild/Leads/Observers/LeadObserver.php
+++ b/src/Domains/Guild/Leads/Observers/LeadObserver.php
@@ -129,8 +129,7 @@ class LeadObserver
         }
 
         if ($lead->wasChanged('leads_status_id')) {
-            $leadStatus = $lead->status()->first();
-            if (strtolower($leadStatus->name) === 'sold') {
+            if ($lead->closeSold()) {
                 $lead->fireWorkflow(
                     WorkflowEnum::TRIGGER_AI->value,
                     true,
@@ -138,7 +137,7 @@ class LeadObserver
                         'trigger_type' => TriggersEnum::SOLD_LEAD->value,
                     ]
                 );
-            } elseif (strtolower($leadStatus->name) === 'close') {
+            } elseif ($lead->closeNotSold()) {
                 $lead->fireWorkflow(
                     WorkflowEnum::TRIGGER_AI->value,
                     true,

--- a/src/Domains/Intelligence/Services/LeadConfigurationService.php
+++ b/src/Domains/Intelligence/Services/LeadConfigurationService.php
@@ -6,7 +6,6 @@ namespace Kanvas\Intelligence\Services;
 
 use Baka\Contracts\CompanyInterface;
 use Kanvas\Guild\Leads\Models\Lead;
-use Kanvas\Guild\Leads\Models\LeadType;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 
 class LeadConfigurationService
@@ -25,21 +24,6 @@ class LeadConfigurationService
         return $this->isV2;
     }
 
-    private function getTypePrefix(?LeadType $leadType): string
-    {
-        $name = strtolower($leadType?->name ?? '');
-
-        if (str_contains($name, 'showroom')) {
-            return 'showroom';
-        }
-
-        if (str_contains($name, 'phone')) {
-            return 'phone';
-        }
-
-        return 'internet';
-    }
-
     private function getStatusSuffix(Lead $lead): string
     {
         $statusName = strtolower($lead->status()->first()?->name ?? '');
@@ -55,6 +39,19 @@ class LeadConfigurationService
         return '';
     }
 
+    private function findConfigKeyBySuffix(Lead $lead, string $suffix): string
+    {
+        $leadTypeConfig = $lead->type()->first()?->config ?? [];
+
+        foreach (array_keys($leadTypeConfig) as $key) {
+            if ($key === $suffix || str_ends_with((string) $key, '_' . $suffix)) {
+                return (string) $key;
+            }
+        }
+
+        return $suffix;
+    }
+
     public function getAiModeKey(Lead $lead): string
     {
         return 'ai_mode';
@@ -67,54 +64,44 @@ class LeadConfigurationService
 
     public function getFirstMessageDefaultKey(Lead $lead): string
     {
-        $prefix = $this->getTypePrefix($lead->type()->first());
-
-        return "{$prefix}_first_fu_active_default";
+        return $this->findConfigKeyBySuffix($lead, 'first_fu_active_default');
     }
 
     public function getAiModeDefaultKey(Lead $lead, bool $isOpen = true): string
     {
-        $prefix = $this->getTypePrefix($lead->type()->first());
-        $state = $isOpen ? 'open' : 'closed';
+        $suffix = $isOpen ? 'ai_mode_open_default' : 'ai_mode_closed_default';
 
-        return "{$prefix}_ai_mode_{$state}_default";
+        return $this->findConfigKeyBySuffix($lead, $suffix);
     }
 
     public function getFollowUpDefaultKey(Lead $lead): string
     {
-        $prefix = $this->getTypePrefix($lead->type()->first());
         $statusSuffix = $this->getStatusSuffix($lead);
 
         if ($statusSuffix === 'closed-not-sold') {
-            return "{$prefix}_con_fu_cns_default";
+            return $this->findConfigKeyBySuffix($lead, 'con_fu_cns_default');
         }
 
         if ($statusSuffix === 'closed-sold') {
-            return "{$prefix}_con_fu_closed-sold_default";
+            return $this->findConfigKeyBySuffix($lead, 'con_fu_closed-sold_default');
         }
 
-        return "{$prefix}_con_fu_active_default";
+        return $this->findConfigKeyBySuffix($lead, 'con_fu_active_default');
     }
 
     public function getFollowUpActiveDefaultKey(Lead $lead): string
     {
-        $prefix = $this->getTypePrefix($lead->type()->first());
-
-        return "{$prefix}_con_fu_active_default";
+        return $this->findConfigKeyBySuffix($lead, 'con_fu_active_default');
     }
 
     public function getFollowUpClosedNotSoldDefaultKey(Lead $lead): string
     {
-        $prefix = $this->getTypePrefix($lead->type()->first());
-
-        return "{$prefix}_con_fu_cns_default";
+        return $this->findConfigKeyBySuffix($lead, 'con_fu_cns_default');
     }
 
     public function getFollowUpClosedSoldDefaultKey(Lead $lead): string
     {
-        $prefix = $this->getTypePrefix($lead->type()->first());
-
-        return "{$prefix}_con_fu_closed-sold_default";
+        return $this->findConfigKeyBySuffix($lead, 'con_fu_closed-sold_default');
     }
 
     public function getAllDefaultKeys(Lead $lead, bool $isOpen = true): array

--- a/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
+++ b/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
@@ -35,13 +35,6 @@ class ApplyLeadAiModeAction
         $followUpKey = $configService->getFollowUpModeKey($this->lead);
 
         $currentMode = IntelligenceModeEnum::tryFrom((string) $this->lead->get($aiModeKey));
-        if ($currentMode?->isOff()
-            && ! in_array($this->triggerType, TriggersEnum::manualTriggerValues(), true)) {
-            return [
-                'changed' => false,
-                'message' => 'Currently Lead is in OFF mode',
-            ];
-        }
 
         $previousMode = $this->lead->get($aiModeKey);
         $previousFollowUp = $this->lead->get($followUpKey);

--- a/tests/Intelligence/Services/LeadConfigurationServiceV2Test.php
+++ b/tests/Intelligence/Services/LeadConfigurationServiceV2Test.php
@@ -19,7 +19,7 @@ class LeadConfigurationServiceV2Test extends TestCase
         $app->set('search_engine', 'database');
     }
 
-    private function createLead(string $leadTypeName = ''): Lead
+    private function createLead(string $leadTypeName = '', array $config = []): Lead
     {
         $user = auth()->user();
         $company = $user->getCurrentCompany();
@@ -40,8 +40,14 @@ class LeadConfigurationServiceV2Test extends TestCase
                 ['description' => $leadTypeName . ' Lead', 'is_active' => 1]
             );
 
+            if ($config !== []) {
+                $leadType->config = $config;
+                $leadType->saveOrFail();
+            }
+
             $lead->leads_types_id = $leadType->getId();
             $lead->saveOrFail();
+            $lead->refresh();
         }
 
         return $lead;
@@ -84,162 +90,169 @@ class LeadConfigurationServiceV2Test extends TestCase
 
     public function testGetAiModeDefaultKeyReturnsOpenKeyWhenOpen(): void
     {
-        $lead = $this->createLead('Internet');
+        $lead = $this->createLead('Internet', ['internet_ai_mode_open_default' => 'FULL_ON']);
 
         $this->assertEquals('internet_ai_mode_open_default', new LeadConfigurationService(true)->getAiModeDefaultKey($lead, true));
     }
 
     public function testGetAiModeDefaultKeyReturnsClosedKeyWhenClosed(): void
     {
-        $lead = $this->createLead('Internet');
+        $lead = $this->createLead('Internet', ['internet_ai_mode_closed_default' => 'SUPPORT']);
 
         $this->assertEquals('internet_ai_mode_closed_default', new LeadConfigurationService(true)->getAiModeDefaultKey($lead, false));
     }
 
-    public function testGetAiModeDefaultKeyUsesCorrectPrefixPerType(): void
+    public function testGetAiModeDefaultKeyResolvesPrefixFromConfigKeys(): void
     {
         $cases = [
-            'Internet' => 'internet_ai_mode_open_default',
-            'Showroom' => 'showroom_ai_mode_open_default',
-            'Phone' => 'phone_ai_mode_open_default',
+            'internet' => 'internet_ai_mode_open_default',
+            'showroom' => 'showroom_ai_mode_open_default',
+            'phone' => 'phone_ai_mode_open_default',
+            'custom-channel' => 'custom-channel_ai_mode_open_default',
         ];
 
         $service = new LeadConfigurationService(true);
 
-        foreach ($cases as $typeName => $expectedKey) {
-            $lead = $this->createLead($typeName);
+        foreach ($cases as $prefix => $expectedKey) {
+            $lead = $this->createLead('Type-' . $prefix, [$expectedKey => 'FULL_ON']);
 
             $this->assertEquals(
                 $expectedKey,
                 $service->getAiModeDefaultKey($lead, true),
-                "{$typeName} lead should use key {$expectedKey}"
+                "Lead with config key {$expectedKey} should resolve to {$expectedKey}"
             );
         }
+    }
+
+    public function testGetAiModeDefaultKeyFallsBackToBareSuffixWhenConfigHasNoMatch(): void
+    {
+        $lead = $this->createLead('Internet');
+
+        $this->assertEquals(
+            'ai_mode_open_default',
+            new LeadConfigurationService(true)->getAiModeDefaultKey($lead, true)
+        );
     }
 
     public function testGetFollowUpDefaultKeyReturnsActiveKeyForActiveStatus(): void
     {
-        $lead = $this->createLead('Internet');
+        $lead = $this->createLead('Internet', ['internet_con_fu_active_default' => 1]);
 
         $this->assertEquals('internet_con_fu_active_default', new LeadConfigurationService(true)->getFollowUpDefaultKey($lead));
     }
 
-    public function testGetFollowUpDefaultKeyUsesCorrectPrefixPerType(): void
+    public function testGetFollowUpDefaultKeyResolvesPrefixFromConfigKeys(): void
     {
         $cases = [
-            'Internet' => 'internet_con_fu_active_default',
-            'Showroom' => 'showroom_con_fu_active_default',
-            'Phone' => 'phone_con_fu_active_default',
+            'internet' => 'internet_con_fu_active_default',
+            'showroom' => 'showroom_con_fu_active_default',
+            'phone' => 'phone_con_fu_active_default',
         ];
 
         $service = new LeadConfigurationService(true);
 
-        foreach ($cases as $typeName => $expectedKey) {
-            $lead = $this->createLead($typeName);
+        foreach ($cases as $prefix => $expectedKey) {
+            $lead = $this->createLead('Type-' . $prefix, [$expectedKey => 1]);
 
             $this->assertEquals(
                 $expectedKey,
                 $service->getFollowUpDefaultKey($lead),
-                "{$typeName} lead should use key {$expectedKey}"
+                "Lead with config key {$expectedKey} should resolve to {$expectedKey}"
             );
         }
     }
 
-    public function testGetFirstMessageDefaultKeyUsesCorrectPrefix(): void
+    public function testGetFirstMessageDefaultKeyResolvesPrefixFromConfigKeys(): void
     {
         $cases = [
-            'Internet' => 'internet_first_fu_active_default',
-            'Showroom' => 'showroom_first_fu_active_default',
-            'Phone' => 'phone_first_fu_active_default',
+            'internet' => 'internet_first_fu_active_default',
+            'showroom' => 'showroom_first_fu_active_default',
+            'phone' => 'phone_first_fu_active_default',
         ];
 
         $service = new LeadConfigurationService(true);
 
-        foreach ($cases as $typeName => $expectedKey) {
-            $lead = $this->createLead($typeName);
+        foreach ($cases as $prefix => $expectedKey) {
+            $lead = $this->createLead('Type-' . $prefix, [$expectedKey => true]);
 
             $this->assertEquals(
                 $expectedKey,
                 $service->getFirstMessageDefaultKey($lead),
-                "{$typeName} lead should use key {$expectedKey}"
+                "Lead with config key {$expectedKey} should resolve to {$expectedKey}"
             );
         }
     }
 
-    public function testGetFollowUpActiveDefaultKeyUsesCorrectPrefix(): void
+    public function testGetFollowUpActiveDefaultKeyResolvesPrefixFromConfigKeys(): void
     {
         $cases = [
-            'Internet' => 'internet_con_fu_active_default',
-            'Showroom' => 'showroom_con_fu_active_default',
-            'Phone' => 'phone_con_fu_active_default',
+            'internet' => 'internet_con_fu_active_default',
+            'showroom' => 'showroom_con_fu_active_default',
+            'phone' => 'phone_con_fu_active_default',
         ];
 
         $service = new LeadConfigurationService(true);
 
-        foreach ($cases as $typeName => $expectedKey) {
-            $lead = $this->createLead($typeName);
+        foreach ($cases as $prefix => $expectedKey) {
+            $lead = $this->createLead('Type-' . $prefix, [$expectedKey => 1]);
 
             $this->assertEquals(
                 $expectedKey,
                 $service->getFollowUpActiveDefaultKey($lead),
-                "{$typeName} lead should always use active key {$expectedKey}"
+                "Lead with config key {$expectedKey} should resolve to {$expectedKey}"
             );
         }
     }
 
-    public function testGetFollowUpClosedNotSoldDefaultKeyUsesCorrectPrefix(): void
+    public function testGetFollowUpClosedNotSoldDefaultKeyResolvesPrefixFromConfigKeys(): void
     {
         $cases = [
-            'Internet' => 'internet_con_fu_cns_default',
-            'Showroom' => 'showroom_con_fu_cns_default',
-            'Phone' => 'phone_con_fu_cns_default',
+            'internet' => 'internet_con_fu_cns_default',
+            'showroom' => 'showroom_con_fu_cns_default',
+            'phone' => 'phone_con_fu_cns_default',
         ];
 
         $service = new LeadConfigurationService(true);
 
-        foreach ($cases as $typeName => $expectedKey) {
-            $lead = $this->createLead($typeName);
+        foreach ($cases as $prefix => $expectedKey) {
+            $lead = $this->createLead('Type-' . $prefix, [$expectedKey => 0]);
 
             $this->assertEquals(
                 $expectedKey,
                 $service->getFollowUpClosedNotSoldDefaultKey($lead),
-                "{$typeName} lead should use closed-not-sold key {$expectedKey}"
+                "Lead with config key {$expectedKey} should resolve to {$expectedKey}"
             );
         }
     }
 
-    public function testGetFollowUpClosedSoldDefaultKeyUsesCorrectPrefix(): void
+    public function testGetFollowUpClosedSoldDefaultKeyResolvesPrefixFromConfigKeys(): void
     {
         $cases = [
-            'Internet' => 'internet_con_fu_closed-sold_default',
-            'Showroom' => 'showroom_con_fu_closed-sold_default',
-            'Phone' => 'phone_con_fu_closed-sold_default',
+            'internet' => 'internet_con_fu_closed-sold_default',
+            'showroom' => 'showroom_con_fu_closed-sold_default',
+            'phone' => 'phone_con_fu_closed-sold_default',
         ];
 
         $service = new LeadConfigurationService(true);
 
-        foreach ($cases as $typeName => $expectedKey) {
-            $lead = $this->createLead($typeName);
+        foreach ($cases as $prefix => $expectedKey) {
+            $lead = $this->createLead('Type-' . $prefix, [$expectedKey => 0]);
 
             $this->assertEquals(
                 $expectedKey,
                 $service->getFollowUpClosedSoldDefaultKey($lead),
-                "{$typeName} lead should use closed-sold key {$expectedKey}"
+                "Lead with config key {$expectedKey} should resolve to {$expectedKey}"
             );
         }
     }
 
     public function testGetAllDefaultKeysReturnsKeysAndResolvedValues(): void
     {
-        $lead = $this->createLead('Internet');
-        $leadType = $lead->type()->first();
-        $leadType->config = [
+        $lead = $this->createLead('Internet', [
             'internet_ai_mode_open_default' => 'full_on',
             'internet_con_fu_active_default' => 'on',
             'internet_first_fu_active_default' => true,
-        ];
-        $leadType->saveOrFail();
-        $lead->refresh();
+        ]);
 
         $result = new LeadConfigurationService(true)->getAllDefaultKeys($lead, true);
 
@@ -253,7 +266,7 @@ class LeadConfigurationServiceV2Test extends TestCase
 
     public function testGetAllDefaultKeysUsesClosedAiModeWhenIsOpenIsFalse(): void
     {
-        $lead = $this->createLead('Internet');
+        $lead = $this->createLead('Internet', ['internet_ai_mode_closed_default' => 'SUPPORT']);
 
         $result = new LeadConfigurationService(true)->getAllDefaultKeys($lead, false);
 
@@ -262,7 +275,7 @@ class LeadConfigurationServiceV2Test extends TestCase
 
     public function testGetAllDefaultKeysForcesActiveFollowUpRegardlessOfStatus(): void
     {
-        $lead = $this->createLead('Internet');
+        $lead = $this->createLead('Internet', ['internet_con_fu_active_default' => 1]);
 
         $result = new LeadConfigurationService(true)->getAllDefaultKeys($lead);
 


### PR DESCRIPTION
## Summary
- Add `closeSold()` and `closeNotSold()` helpers on `Lead` so callers can categorize a lead by status without re-implementing the heuristic.
  - `closeSold()` → status name contains `sold` but not `not` (e.g. `Sold`, `Sold Lead`).
  - `closeNotSold()` → not active, not closeSold, and not `complete`. Catches `Lost`, `Close`, `Bad Lead`, `Wrong Lead`, `Inactive`, `Closed Not Sold`, etc.
  - The three categorizations (`isActive` / `closeSold` / `closeNotSold`) are mutually exclusive.
- `LeadObserver::updated()` now fires `SOLD_LEAD` / `CLOSE_LEAD` workflows via the new helpers. Previously it only matched literal `sold` / `close` status names, so `Lost` / `Bad Lead` / `Wrong Lead` / `Inactive` never triggered the close workflow.
- `LeadConfigurationService::getStatusSuffix()` uses the same helpers, so the follow-up config keys (`*_con_fu_cns_default` / `*_con_fu_closed-sold_default`) resolve correctly for the full set of closed-not-sold statuses.

## Test plan
- [ ] `LeadConfigurationServiceV2Test` passes
- [ ] Manually mark a lead as `Lost` / `Bad Lead` / `Wrong Lead` → confirms `CLOSE_LEAD` workflow fires
- [ ] Manually mark a lead as `Sold` → confirms `SOLD_LEAD` workflow fires
- [ ] Mark a lead as `Active` / `Created` / `Complete` → confirms no close workflow fires