### PR TITLE
refact: fix current time

### DIFF
--- a/src/Domains/Intelligence/Agents/Laravel/Tools/Common/CurrentTimeTool.php
+++ b/src/Domains/Intelligence/Agents/Laravel/Tools/Common/CurrentTimeTool.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Laravel\Tools\Common;
+
+use Carbon\Carbon;
+use DateTimeZone;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Laravel\Contracts\KanvasToolInterface;
+use Kanvas\Intelligence\Agents\Laravel\Traits\HasKanvasContext;
+use Laravel\Ai\Tools\Request;
+use Override;
+use Stringable;
+use Throwable;
+
+#[AgentTool(name: 'Current Time')]
+class CurrentTimeTool implements KanvasToolInterface
+{
+    use HasKanvasContext;
+
+    #[Override]
+    public function description(): Stringable|string
+    {
+        return 'Get the current date and time. Use this to anchor any time-relative reasoning '
+            . '(e.g. interpreting "Sunday", "tomorrow", "yesterday" in the conversation history) '
+            . 'before deciding what to do. Pass an IANA timezone (e.g. "America/New_York") to get '
+            . 'time in a specific zone; defaults to UTC.';
+    }
+
+    #[Override]
+    public function handle(Request $request): Stringable|string
+    {
+        $tz = $this->resolveTimezone((string) $request->string('timezone'));
+        $now = Carbon::now($tz);
+
+        return (string) json_encode([
+            'timezone' => $tz,
+            'iso_8601' => $now->toIso8601String(),
+            'date' => $now->format('Y-m-d'),
+            'time' => $now->format('H:i:s'),
+            'day_of_week' => $now->englishDayOfWeek,
+            'human' => $now->format('l, F j, Y \\a\\t g:i A'),
+            'unix' => $now->getTimestamp(),
+            'is_weekend' => $now->isWeekend(),
+        ]);
+    }
+
+    #[Override]
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'timezone' => $schema
+                ->string()
+                ->description('Optional IANA timezone identifier (e.g. "America/New_York", "Europe/Madrid"). '
+                    . 'Defaults to UTC when omitted or invalid.'),
+        ];
+    }
+
+    private function resolveTimezone(string $timezone): string
+    {
+        $trimmed = trim($timezone);
+        if ($trimmed === '') {
+            return 'UTC';
+        }
+
+        try {
+            new DateTimeZone($trimmed);
+        } catch (Throwable) {
+            return 'UTC';
+        }
+
+        return $trimmed;
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Common/CurrentTimeTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Common/CurrentTimeTool.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Common;
+
+use Carbon\Carbon;
+use DateTimeZone;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use NeuronAI\Tools\PropertyType as ToolsPropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+#[AgentTool(name: 'Current Time')]
+class CurrentTimeTool extends Tool
+{
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'get_current_time',
+            description: 'Get the current date and time. Use this to anchor any time-relative reasoning '
+                . '(e.g. interpreting "Sunday", "tomorrow", "yesterday" in the conversation history) '
+                . 'before deciding what to do. Pass an IANA timezone (e.g. "America/New_York") to get '
+                . 'time in a specific zone; defaults to UTC.',
+        );
+    }
+
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'timezone',
+                type: ToolsPropertyType::STRING,
+                description: 'Optional IANA timezone identifier (e.g. "America/New_York", "Europe/Madrid"). '
+                    . 'Defaults to UTC when omitted or invalid.',
+                required: false,
+            ),
+        ];
+    }
+
+    public function __invoke(?string $timezone = null): array
+    {
+        $tz = $this->resolveTimezone($timezone);
+        $now = Carbon::now($tz);
+
+        return [
+            'timezone' => $tz,
+            'iso_8601' => $now->toIso8601String(),
+            'date' => $now->format('Y-m-d'),
+            'time' => $now->format('H:i:s'),
+            'day_of_week' => $now->englishDayOfWeek,
+            'human' => $now->format('l, F j, Y \\a\\t g:i A'),
+            'unix' => $now->getTimestamp(),
+            'is_weekend' => $now->isWeekend(),
+        ];
+    }
+
+    private function resolveTimezone(?string $timezone): string
+    {
+        $trimmed = $timezone !== null ? trim($timezone) : '';
+        if ($trimmed === '') {
+            return 'UTC';
+        }
+
+        try {
+            new DateTimeZone($trimmed);
+        } catch (Throwable) {
+            return 'UTC';
+        }
+
+        return $trimmed;
+    }
+}

--- a/src/Domains/Intelligence/FollowUp/Actions/FollowUpLeadAction.php
+++ b/src/Domains/Intelligence/FollowUp/Actions/FollowUpLeadAction.php
@@ -402,8 +402,18 @@ final class FollowUpLeadAction
                 ->cascade()
                 ->forHumans(['parts' => 1, 'syntax' => CarbonInterface::DIFF_ABSOLUTE]) . '.';
 
+        // Defensive ?? despite the docblock — production configs can carry
+        // null/bad timezone values; see feedback_validate_timezone_strings.
+        $timezone = $this->company->timezone ?? 'UTC';
+        $now = Carbon::now($timezone);
+        $currentTimeLine = 'Current time: ' . $now->format('l, F j, Y — H:i') . ' (' . $timezone . ').'
+            . ' Use this to interpret time-relative references in the conversation history'
+            . ' (e.g. "Sunday", "tomorrow", "next week"). Relative dates mentioned in PRIOR'
+            . ' messages may now be in the PAST — if so, acknowledge that and adjust.';
+
         $lines = [
             'Decide what to do for this lead in pipeline stage "' . $context['stage_name'] . '".',
+            $currentTimeLine,
             $silenceLine,
             'Follow-up count so far in this stage: ' . $context['follow_up_count'] . ' of ' . $context['max_retries'] . '.',
             'Outbound channel: ' . $context['channel'] . '.',

--- a/tests/Intelligence/FollowUp/Actions/FollowUpLeadActionTest.php
+++ b/tests/Intelligence/FollowUp/Actions/FollowUpLeadActionTest.php
@@ -1020,6 +1020,53 @@ class FollowUpLeadActionTest extends TestCase
         $this->assertStringContainsString('Best,', $prompt);
     }
 
+    public function testPromptIncludesCurrentTimeWithTimezoneSoLlmCanReasonAboutDates(): void
+    {
+        // Bug: agent reading "ping me Sunday" in conversation history had no
+        // anchor for "today's date" so it assumed Sunday was upcoming. By
+        // then it was actually Monday and the customer was overdue. Fix:
+        // include the current time + timezone so the LLM can interpret
+        // relative date references from prior messages.
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 14, 32, 0, 'America/New_York'));
+        // $company->timezone reads the model attribute (column on companies table),
+        // not the custom-fields ->set('timezone', ...) value. Update directly.
+        $this->company->update(['timezone' => 'America/New_York']);
+
+        $cfg = $this->defaultStageConfig();
+        $cfg['follow_up']['channels'] = [
+            ['type' => 'sms', 'enabled' => true, 'template_name' => null],
+        ];
+        $lead = $this->seedLeadWithStageConfig($cfg);
+        $this->seedSessionAndChannel($lead, 'sms');
+
+        FollowUpAgentStub::configure(
+            shouldRespond: true,
+            advanceStage: false,
+            message: 'whatever',
+            reason: 'time_anchor',
+        );
+
+        new FollowUpLeadAction(
+            app: $this->testApp,
+            company: $this->company,
+            lead: $lead,
+            agent: $this->seedFollowUpAgent(),
+        )->execute();
+
+        $prompt = FollowUpAgentStub::lastPromptText();
+
+        // Concrete date + day-of-week + timezone in the prompt.
+        $this->assertStringContainsString('Current time: Monday', $prompt);
+        $this->assertStringContainsString('June 8, 2026', $prompt);
+        $this->assertStringContainsString('America/New_York', $prompt);
+        // The instruction telling the LLM to use it for time-relative references.
+        $this->assertStringContainsString('Use this to interpret time-relative references', $prompt);
+        // Explicit nudge that prior relative dates may be in the past.
+        $this->assertStringContainsString('may now be in the PAST', $prompt);
+
+        Carbon::setTestNow();
+    }
+
     public function testFollowUpKernelCallOptsOutOfThreadScopingForCrossSessionHistory(): void
     {
         // Regression: previously the kernel called setThreadId for the follow-up

--- a/tests/Intelligence/Tools/CurrentTimeToolTest.php
+++ b/tests/Intelligence/Tools/CurrentTimeToolTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Intelligence\Tools;
+
+use Carbon\Carbon;
+use Illuminate\JsonSchema\JsonSchemaTypeFactory;
+use Kanvas\Intelligence\Agents\Laravel\Tools\Common\CurrentTimeTool as LaravelCurrentTimeTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Common\CurrentTimeTool as NeuronCurrentTimeTool;
+use Laravel\Ai\Tools\Request;
+use Tests\TestCase;
+
+class CurrentTimeToolTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function testNeuronToolReturnsCurrentTimeInRequestedTimezone(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 14, 32, 0, 'America/New_York'));
+
+        $result = new NeuronCurrentTimeTool()('America/New_York');
+
+        $this->assertSame('America/New_York', $result['timezone']);
+        $this->assertSame('2026-06-08', $result['date']);
+        $this->assertSame('14:32:00', $result['time']);
+        $this->assertSame('Monday', $result['day_of_week']);
+        $this->assertStringContainsString('Monday, June 8, 2026', $result['human']);
+        $this->assertFalse($result['is_weekend']);
+    }
+
+    public function testNeuronToolFallsBackToUtcWhenTimezoneOmittedOrInvalid(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 12, 0, 0, 'UTC'));
+
+        $omitted = new NeuronCurrentTimeTool()();
+        $bogus = new NeuronCurrentTimeTool()('Mars/Olympus_Mons');
+        $empty = new NeuronCurrentTimeTool()('   ');
+
+        $this->assertSame('UTC', $omitted['timezone']);
+        $this->assertSame('UTC', $bogus['timezone']);
+        $this->assertSame('UTC', $empty['timezone']);
+        $this->assertSame('2026-06-08', $omitted['date']);
+    }
+
+    public function testNeuronToolFlagsWeekend(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 7, 10, 0, 0, 'UTC')); // Sunday
+
+        $result = new NeuronCurrentTimeTool()();
+
+        $this->assertSame('Sunday', $result['day_of_week']);
+        $this->assertTrue($result['is_weekend']);
+    }
+
+    public function testLaravelToolHandleReturnsJsonWithRequestedTimezone(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 14, 32, 0, 'America/New_York'));
+
+        $tool = new LaravelCurrentTimeTool();
+        $request = new Request(['timezone' => 'America/New_York']);
+        $raw = $tool->handle($request);
+
+        $decoded = json_decode((string) $raw, true);
+        $this->assertIsArray($decoded);
+        $this->assertSame('America/New_York', $decoded['timezone']);
+        $this->assertSame('2026-06-08', $decoded['date']);
+        $this->assertSame('Monday', $decoded['day_of_week']);
+        $this->assertFalse($decoded['is_weekend']);
+    }
+
+    public function testLaravelToolHandleFallsBackToUtcWhenTimezoneInvalid(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 8, 12, 0, 0, 'UTC'));
+
+        $tool = new LaravelCurrentTimeTool();
+        $request = new Request(['timezone' => 'Mars/Olympus_Mons']);
+        $decoded = json_decode((string) $tool->handle($request), true);
+
+        $this->assertSame('UTC', $decoded['timezone']);
+    }
+
+    public function testLaravelToolSchemaDeclaresOptionalTimezoneString(): void
+    {
+        $tool = new LaravelCurrentTimeTool();
+        $schema = $tool->schema(new JsonSchemaTypeFactory());
+
+        $this->assertArrayHasKey('timezone', $schema);
+        $array = $schema['timezone']->toArray();
+        $this->assertSame('string', $array['type']);
+        $this->assertStringContainsString('IANA timezone', $array['description']);
+    }
+}


### PR DESCRIPTION
Denormalize per-people message timestamps so peoples can be ordered by
activity without crossing the crm/social DB connection boundary.

A new listener reacts to AppModuleMessageCreatedEvent: when the entity is
a Lead, a single crm-side UPDATE peoples JOIN leads sets first_message_at
(COALESCE) and last_message_at (GREATEST). Both columns are also exposed
on the People GraphQL type and in the peoples query orderBy whitelist.## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
