### PR TITLE
feat(guild): track message timestamps on people

### DIFF
--- a/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
+++ b/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
@@ -35,6 +35,6 @@ class UpdatePeopleMessageTimestampsListener
         );
 
         $lead = $appModuleMessage->entity;
-        $lead?->people?->set('last_unread_reply_at', 1);
+        $lead?->people?->set('unread_message', 1);
     }
 }

--- a/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
+++ b/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
@@ -33,5 +33,8 @@ class UpdatePeopleMessageTimestampsListener
             SQL,
             [$messageAt, $messageAt, $messageAt, $appModuleMessage->entity_id],
         );
+
+        $lead = Lead::find($appModuleMessage->entity_id);
+        $lead?->people?->set('last_unread_reply_at', 1);
     }
 }

--- a/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
+++ b/src/Domains/Guild/Customers/Listeners/UpdatePeopleMessageTimestampsListener.php
@@ -34,7 +34,7 @@ class UpdatePeopleMessageTimestampsListener
             [$messageAt, $messageAt, $messageAt, $appModuleMessage->entity_id],
         );
 
-        $lead = Lead::find($appModuleMessage->entity_id);
+        $lead = $appModuleMessage->entity;
         $lead?->people?->set('last_unread_reply_at', 1);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `first_message_at` / `last_message_at` columns on `peoples` (with indexes) backfilled on every `AppModuleMessageCreatedEvent` for `Lead`-scoped messages.
- Stores `last_unread_reply_at` as a custom field on `People` via `->set()` so it can be tracked per tenant settings.
- Renames the listener class to `UpdatePeopleMessageTimestampsListener` for consistency.

Same change as #9832 (development).

## Test plan
- [ ] Create a message on a Lead → confirm the linked Person's `first_message_at` is set on first event and `last_message_at` advances on subsequent ones.
- [ ] Confirm `peoples.last_unread_reply_at` custom field is populated after the event fires.
- [ ] Re-run the migration `up`/`down` against the `crm` connection.