### PR TITLE
hotfix: make company nullable in SessionRepository lookup

### DIFF
--- a/app/GraphQL/Intelligence/Queries/AgentSessionQuery.php
+++ b/app/GraphQL/Intelligence/Queries/AgentSessionQuery.php
@@ -21,9 +21,9 @@ class AgentSessionQuery
         $company = app(CompaniesBranches::class)->company;
 
         $session = SessionRepository::getByUuidAndNamespaceFromCompanyApp(
-            $request['id'],
-            $company,
-            $app,
+            uuid: $request['id'],
+            app: $app,
+            company: $company,
         );
 
         if ($session->agent->role !== ($session->content['background'] ?? null)) {

--- a/src/Domains/Intelligence/Sessions/Repositories/SessionRepository.php
+++ b/src/Domains/Intelligence/Sessions/Repositories/SessionRepository.php
@@ -14,14 +14,14 @@ class SessionRepository
 {
     public static function getByUuidAndNamespaceFromCompanyApp(
         string $uuid,
-        CompanyInterface $company,
         AppInterface $app,
         string $namespace = Lead::class,
+        ?CompanyInterface $company = null,
     ): Session {
         $session = Session::query()
             ->where('uuid', $uuid)
             ->where('entity_namespace', $namespace)
-            ->where('companies_id', $company->getId())
+            ->when($company, fn ($q) => $q->where('companies_id', $company->getId()))
             ->where('apps_id', $app->getId())
             ->where('is_deleted', 0)
             ->orderByDesc('id')
@@ -29,7 +29,7 @@ class SessionRepository
 
         if (! $session) {
             throw new ModelNotFoundException(
-                "Session not found for uuid {$uuid} and namespace {$namespace} in company {$company->getId()} and app {$app->getId()}"
+                "Session not found for uuid {$uuid} and namespace {$namespace} in company {$company?->getId()} and app {$app->getId()}"
             );
         }
 


### PR DESCRIPTION
## Summary
- Make `$company` optional in `SessionRepository::getByUuidAndNamespaceFromCompanyApp` and only filter by `companies_id` when provided
- Fix broken closure syntax and `throsw` typo
- Update caller in `AgentSessionQuery` to use named arguments after signature reorder

## Test plan
- [ ] Query `agentSession` resolver and confirm it still resolves a session
- [ ] Confirm lookup still scopes by company when `$company` is passed