### PR TITLE
hotfix: respect IDLE mode on NEW_LEAD trigger in ApplyLeadAiModeAction

### DIFF
--- a/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
+++ b/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
@@ -122,9 +122,14 @@ class ApplyLeadAiModeAction
 
     protected function applyNewLead(): void
     {
-        $leadType = $this->lead->type()->first();
         $configService = new LeadConfigurationService();
         $aiModeKey = $configService->getAiModeKey($this->lead);
+
+        if ($this->lead->get($aiModeKey) === IntelligenceModeEnum::IDLE->value) {
+            return;
+        }
+
+        $leadType = $this->lead->type()->first();
         $aiFollowUpKey = $configService->getFollowUpModeKey($this->lead);
 
         $isOpen = $this->isCompanyWithinWorkingHours();


### PR DESCRIPTION
## Summary
- `ApplyLeadAiModeAction::applyNewLead()` now early-returns when the lead is already in `IntelligenceModeEnum::IDLE`, matching the behavior of `AI_TAKEOVER` / `HUMAN_HANDOFF` / `HUMAN_TAKEOVER` / `HANDOFF` (which were already no-ops via the `match`).
- Fixes a `TypeError: setMode(): Argument #1 ($aiMode) must be of type string, null given` that fired when neither the `LeadType` config nor the `Company` config provided a default AI mode and the lead was OFF.

## Test plan
- [x] `docker exec php bash -c "cd /var/www/html && php vendor/bin/phpunit tests/Intelligence/Commands/TriggerIntelligenceActivityTest.php"` — 24 tests / 51 assertions, all green (`testOffModeBlocksNewLeadTrigger` and `testOffModeBlocksAllNonManualTriggers` were the previously failing ones).