### PR TITLE
feat: generate_slots flag + date range for setResourceSchedule

### DIFF
--- a/app/GraphQL/Event/Mutations/Schedule/ResourceScheduleMutation.php
+++ b/app/GraphQL/Event/Mutations/Schedule/ResourceScheduleMutation.php
@@ -33,6 +33,9 @@ class ResourceScheduleMutation
 
         $scheduleType = ScheduleTypeEnum::from(strtolower($input['schedule_type']));
 
+        $startAt = ($input['start_at'] ?? null)?->clone()->startOfDay();
+        $endAt = ($input['end_at'] ?? null)?->clone()->endOfDay();
+
         $rules = new SetResourceScheduleAction(
             resource: $resource,
             app: $app,
@@ -41,6 +44,9 @@ class ResourceScheduleMutation
             scheduleType: $scheduleType,
             slotDurationMin: $input['slot_duration_min'] ?? 60,
             capacityOverride: $input['capacity_override'] ?? null,
+            generateSlots: $input['generate_slots'] ?? true,
+            startAt: $startAt,
+            endAt: $endAt,
         )->execute();
 
         new CreateScheduleHistoryAction(

--- a/app/GraphQL/Event/Mutations/ScheduleRules/ScheduleRulesManagementMutation.php
+++ b/app/GraphQL/Event/Mutations/ScheduleRules/ScheduleRulesManagementMutation.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\GraphQL\Event\Mutations\ScheduleRules;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Carbon;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Event\Events\Jobs\GenerateTimeSlots;
 use Kanvas\Event\Events\Models\ScheduleRules;
@@ -36,7 +35,7 @@ class ScheduleRulesManagementMutation
             'metadata' => $req['input']['metadata'] ?? null,
         ]);
 
-        [$windowFrom, $windowTo] = $this->generationWindow($scheduleRule);
+        [$windowFrom, $windowTo] = GenerateTimeSlots::resolveWindow($scheduleRule->start_at, $scheduleRule->end_at);
 
         dispatch(new GenerateTimeSlots(
             $entity->id,
@@ -72,7 +71,7 @@ class ScheduleRulesManagementMutation
             'metadata' => $req['input']['metadata'] ?? $scheduleRule->metadata,
         ]);
 
-        [$windowFrom, $windowTo] = $this->generationWindow($scheduleRule);
+        [$windowFrom, $windowTo] = GenerateTimeSlots::resolveWindow($scheduleRule->start_at, $scheduleRule->end_at);
 
         dispatch(new GenerateTimeSlots(
             $scheduleRule->resources_id,
@@ -82,25 +81,6 @@ class ScheduleRulesManagementMutation
         ));
 
         return $scheduleRule;
-    }
-
-    /**
-     * Slots are generated from the rule's start_at forward (never in the past) up to its
-     * end_at, falling back to a year out when the rule is open-ended.
-     *
-     * @return array{0: Carbon, 1: Carbon}
-     */
-    private function generationWindow(ScheduleRules $scheduleRule): array
-    {
-        $now = Carbon::now();
-
-        $windowFrom = $scheduleRule->start_at && $scheduleRule->start_at->greaterThan($now)
-            ? $scheduleRule->start_at->clone()
-            : $now;
-
-        $windowTo = $scheduleRule->end_at?->clone() ?? $now->clone()->addYear();
-
-        return [$windowFrom, $windowTo];
     }
 
     public function delete(mixed $root, array $req): bool

--- a/graphql/schemas/Event/resourceSchedule.graphql
+++ b/graphql/schemas/Event/resourceSchedule.graphql
@@ -33,6 +33,12 @@ input ResourceScheduleInput {
     days: [DayScheduleInput!]!
     slot_duration_min: Int
     capacity_override: Int
+    "When false, the schedule is saved and upcoming slots are cleared, but no new slots are generated (regenerate later)."
+    generate_slots: Boolean = true
+    "First day to generate slots for. Defaults to today."
+    start_at: Date
+    "Last day to generate slots for. Defaults to one year out."
+    end_at: Date
 }
 
 input DayScheduleInput {

--- a/src/Domains/Event/Events/Actions/CreateScheduleRulesFromOperationDaysAction.php
+++ b/src/Domains/Event/Events/Actions/CreateScheduleRulesFromOperationDaysAction.php
@@ -35,6 +35,9 @@ class CreateScheduleRulesFromOperationDaysAction
         protected int $cutoffTimeMin = 0,
         protected string $frequency = 'WEEKLY',
         protected ?string $scheduleType = null,
+        protected bool $generateSlots = true,
+        protected ?Carbon $startAt = null,
+        protected ?Carbon $endAt = null,
     ) {
     }
 
@@ -62,7 +65,10 @@ class CreateScheduleRulesFromOperationDaysAction
 
             if ($rule) {
                 $upsertedRules[] = $rule;
-                $this->dispatchTimeSlotGeneration($rule);
+
+                if ($this->generateSlots) {
+                    $this->dispatchTimeSlotGeneration($rule);
+                }
             }
         }
 
@@ -88,7 +94,8 @@ class CreateScheduleRulesFromOperationDaysAction
     protected function upsertRuleForDay(string $dayName, string $dayCode, array $periods): ?ScheduleRules
     {
         $firstPeriod = $periods[0];
-        $startAt = Carbon::parse('today ' . $firstPeriod['open']);
+        $baseDate = $this->startAt?->toDateString() ?? 'today';
+        $startAt = Carbon::parse($baseDate . ' ' . $firstPeriod['open']);
         $dtstart = $startAt->format('Ymd\THis');
         $rrule = "DTSTART:{$dtstart}\nRRULE:FREQ={$this->frequency};BYDAY={$dayCode}";
 
@@ -132,7 +139,7 @@ class CreateScheduleRulesFromOperationDaysAction
             $this->naturalKey($dayName),
             [
                 'start_at' => $startAt,
-                'end_at' => null,
+                'end_at' => $this->endAt?->clone(),
                 'rrule' => $rrule,
                 'day_rrule' => $dayRrule,
                 'slot_duration_min' => $this->slotDurationMinutes,
@@ -176,11 +183,13 @@ class CreateScheduleRulesFromOperationDaysAction
 
     protected function dispatchTimeSlotGeneration(ScheduleRules $scheduleRule): void
     {
+        [$windowFrom, $windowTo] = GenerateTimeSlots::resolveWindow($scheduleRule->start_at, $scheduleRule->end_at);
+
         dispatch(new GenerateTimeSlots(
             $this->resource->getId(),
             $scheduleRule->id,
-            Carbon::now(),
-            Carbon::now()->addYear()
+            $windowFrom,
+            $windowTo
         ));
     }
 

--- a/src/Domains/Event/Events/Actions/SetResourceScheduleAction.php
+++ b/src/Domains/Event/Events/Actions/SetResourceScheduleAction.php
@@ -7,6 +7,7 @@ namespace Kanvas\Event\Events\Actions;
 use Baka\Contracts\AppInterface;
 use Baka\Contracts\CompanyInterface;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 use Kanvas\Event\Events\Enums\ScheduleTypeEnum;
 
 class SetResourceScheduleAction
@@ -18,7 +19,10 @@ class SetResourceScheduleAction
         protected array $days,
         protected ScheduleTypeEnum $scheduleType,
         protected int $slotDurationMin = 60,
-        protected ?int $capacityOverride = null
+        protected ?int $capacityOverride = null,
+        protected bool $generateSlots = true,
+        protected ?Carbon $startAt = null,
+        protected ?Carbon $endAt = null,
     ) {
     }
 
@@ -33,6 +37,9 @@ class SetResourceScheduleAction
             capacityOverride: $this->capacityOverride,
             frequency: $this->scheduleType === ScheduleTypeEnum::MONTHLY ? 'MONTHLY' : 'WEEKLY',
             scheduleType: $this->scheduleType->value,
+            generateSlots: $this->generateSlots,
+            startAt: $this->startAt,
+            endAt: $this->endAt,
         )->execute();
     }
 }

--- a/src/Domains/Event/Events/Jobs/GenerateTimeSlots.php
+++ b/src/Domains/Event/Events/Jobs/GenerateTimeSlots.php
@@ -21,6 +21,23 @@ class GenerateTimeSlots implements ShouldQueue
     ) {
     }
 
+    /**
+     * Resolve the [from, to] generation window for a rule: never backfill the past, and bound
+     * the upper end by end_at when set (otherwise a year out). Shared by both schedule mutations
+     * so they behave identically.
+     *
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    public static function resolveWindow(?Carbon $startAt, ?Carbon $endAt): array
+    {
+        $now = Carbon::now();
+
+        $windowFrom = $startAt && $startAt->greaterThan($now) ? $startAt->clone() : $now;
+        $windowTo = $endAt?->clone() ?? $now->clone()->addYear();
+
+        return [$windowFrom, $windowTo];
+    }
+
     public function handle()
     {
         $rule       = ScheduleRules::findOrFail($this->ruleId);

--- a/tests/GraphQL/Event/ResourceScheduleGraphQLTest.php
+++ b/tests/GraphQL/Event/ResourceScheduleGraphQLTest.php
@@ -7,7 +7,10 @@ namespace Tests\GraphQL\Event;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Queue;
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Event\Events\Jobs\GenerateTimeSlots;
 use Kanvas\Event\Events\Models\ScheduleException;
+use Kanvas\Event\Events\Models\ScheduleRules;
+use Kanvas\Event\Events\Models\TimeSlots;
 use Kanvas\Event\Support\Setup;
 use Kanvas\Inventory\Products\Models\Products;
 use Kanvas\Regions\Models\Regions;
@@ -109,6 +112,143 @@ class ResourceScheduleGraphQLTest extends TestCase
         $this->assertEquals('WEEKLY', $data['schedule_type']);
         $this->assertEquals(3, $data['days_count']);
         $this->assertCount(7, $data['days']);
+    }
+
+    public function testSetResourceScheduleSkipsGenerationWhenFlagFalse(): void
+    {
+        Queue::fake();
+
+        $input = [
+            'resources_id' => $this->product->getId(),
+            'resources_type' => 'product',
+            'schedule_type' => 'WEEKLY',
+            'generate_slots' => false,
+            'days' => [
+                ['day' => 'monday', 'active' => true, 'open' => '08:00', 'close' => '18:00'],
+                ['day' => 'tuesday', 'active' => false],
+                ['day' => 'wednesday', 'active' => false],
+                ['day' => 'thursday', 'active' => false],
+                ['day' => 'friday', 'active' => false],
+                ['day' => 'saturday', 'active' => false],
+                ['day' => 'sunday', 'active' => false],
+            ],
+        ];
+
+        $this->graphQL('
+            mutation setResourceSchedule($input: ResourceScheduleInput!) {
+                setResourceSchedule(input: $input) { is_configured days_count }
+            }
+        ', ['input' => $input])
+            ->assertSuccessful()
+            ->assertJson(['data' => ['setResourceSchedule' => ['is_configured' => true]]]);
+
+        // The schedule rule is persisted, but no slot generation is dispatched.
+        $this->assertDatabaseHas('schedule_rules', [
+            'resources_id' => $this->product->getId(),
+            'operation_day' => 'monday',
+            'is_deleted' => 0,
+        ], 'event');
+        Queue::assertNotPushed(GenerateTimeSlots::class);
+    }
+
+    public function testGenerateSlotsFalseStillClearsUpcomingSlots(): void
+    {
+        Queue::fake();
+
+        $baseInput = [
+            'resources_id' => $this->product->getId(),
+            'resources_type' => 'product',
+            'schedule_type' => 'WEEKLY',
+            'slot_duration_min' => 60,
+            'days' => [
+                ['day' => 'monday', 'active' => true, 'open' => '08:00', 'close' => '18:00'],
+                ['day' => 'tuesday', 'active' => false],
+                ['day' => 'wednesday', 'active' => false],
+                ['day' => 'thursday', 'active' => false],
+                ['day' => 'friday', 'active' => false],
+                ['day' => 'saturday', 'active' => false],
+                ['day' => 'sunday', 'active' => false],
+            ],
+        ];
+
+        $this->graphQL('
+            mutation setResourceSchedule($input: ResourceScheduleInput!) {
+                setResourceSchedule(input: $input) { is_configured }
+            }
+        ', ['input' => $baseInput])->assertSuccessful();
+
+        $rule = ScheduleRules::withoutGlobalScopes()
+            ->where('resources_id', $this->product->getId())
+            ->where('resources_type', $this->product->getMorphClass())
+            ->where('operation_day', 'monday')
+            ->firstOrFail();
+
+        $slot = TimeSlots::create([
+            'apps_id' => $this->apps->getId(),
+            'companies_id' => $this->company->getId(),
+            'resources_id' => $this->product->getId(),
+            'resources_type' => $this->product->getMorphClass(),
+            'schedule_rules_id' => $rule->id,
+            'start_at' => now()->addDays(3),
+            'end_at' => now()->addDays(3)->addHour(),
+            'initial_capacity' => 5,
+        ]);
+
+        // Reset recorded jobs so the assertion targets only the config-only re-set below.
+        Queue::fake();
+
+        // Re-set with a changed slot duration (triggers the rule change) and generation off.
+        $changedInput = $baseInput;
+        $changedInput['slot_duration_min'] = 30;
+        $changedInput['generate_slots'] = false;
+
+        $this->graphQL('
+            mutation setResourceSchedule($input: ResourceScheduleInput!) {
+                setResourceSchedule(input: $input) { is_configured }
+            }
+        ', ['input' => $changedInput])->assertSuccessful();
+
+        // Upcoming slots are cleared even though no new ones are generated.
+        $this->assertDatabaseMissing('time_slots', ['id' => $slot->id], 'event');
+        Queue::assertNotPushed(GenerateTimeSlots::class);
+    }
+
+    public function testSetResourceScheduleRespectsStartAndEndDates(): void
+    {
+        Queue::fake();
+
+        $start = now()->addWeek();
+        $end = now()->addMonth();
+
+        $input = [
+            'resources_id' => $this->product->getId(),
+            'resources_type' => 'product',
+            'schedule_type' => 'WEEKLY',
+            'start_at' => $start->format('Y-m-d'),
+            'end_at' => $end->format('Y-m-d'),
+            'days' => [
+                ['day' => 'monday', 'active' => true, 'open' => '08:00', 'close' => '18:00'],
+                ['day' => 'tuesday', 'active' => false],
+                ['day' => 'wednesday', 'active' => false],
+                ['day' => 'thursday', 'active' => false],
+                ['day' => 'friday', 'active' => false],
+                ['day' => 'saturday', 'active' => false],
+                ['day' => 'sunday', 'active' => false],
+            ],
+        ];
+
+        $this->graphQL('
+            mutation setResourceSchedule($input: ResourceScheduleInput!) {
+                setResourceSchedule(input: $input) { is_configured }
+            }
+        ', ['input' => $input])->assertSuccessful();
+
+        // Future start_at bounds the generation window (not now()), and end_at caps it (not +1yr).
+        Queue::assertPushed(
+            GenerateTimeSlots::class,
+            fn ($job) => $job->windowFrom->format('Y-m-d') === $start->format('Y-m-d')
+                && $job->windowTo->format('Y-m-d') === $end->format('Y-m-d')
+        );
     }
 
     public function testQueryResourceSchedule(): void


### PR DESCRIPTION
- setResourceSchedule input: generate_slots (default true), start_at, end_at (Date)
- generate_slots=false persists rules and clears upcoming slots without regenerating
- bound generation window by start_at/end_at instead of hardcoded now()->addYear()
- GenerateTimeSlots::resolveWindow shared by both schedule mutations
- tests: flag skips generation, still clears slots, start/end date window respected

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
