### PR TITLE
feat: add first follow-up send condition to lead config defaults

### DIFF
--- a/src/Domains/Guild/Leads/Models/Lead.php
+++ b/src/Domains/Guild/Leads/Models/Lead.php
@@ -311,7 +311,7 @@ class Lead extends BaseModel implements EventResourceInterface
     {
         $statusName = strtolower($this->status()->firstOrFail()->name);
 
-        return $statusName !== 'inactive' && (Str::contains($statusName, 'active') || Str::contains($statusName, 'created'));
+        return $statusName !== 'inactive' && (Str::contains($statusName, 'active') || Str::contains($statusName, 'created') || Str::contains($statusName, 'hot'));
     }
 
     public function closeSold(): bool
@@ -327,9 +327,7 @@ class Lead extends BaseModel implements EventResourceInterface
             return false;
         }
 
-        $statusName = strtolower($this->status()->firstOrFail()->name);
-
-        return ! Str::contains($statusName, 'complete');
+        return true;
     }
 
     public function close(): void

--- a/src/Domains/Intelligence/Services/LeadConfigurationService.php
+++ b/src/Domains/Intelligence/Services/LeadConfigurationService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Services;
 
 use Baka\Contracts\CompanyInterface;
+use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 
@@ -113,6 +114,9 @@ class LeadConfigurationService
         $followUpKey = $this->getFollowUpActiveDefaultKey($lead);
         $firstMessageKey = $this->getFirstMessageDefaultKey($lead);
 
+        $isContacted = (bool) $lead->get(LeadConfigurationEnum::CONTACTED->value);
+        $firstFollowUpActive = (bool) ($leadTypeConfig[$firstMessageKey] ?? false);
+
         return [
             'ai_mode' => [
                 'key' => $aiModeKey,
@@ -126,6 +130,8 @@ class LeadConfigurationService
                 'key' => $firstMessageKey,
                 'value' => $leadTypeConfig[$firstMessageKey] ?? null,
             ],
+            'is_contacted' => $isContacted,
+            'should_send_first_followup' => ! $isContacted && $firstFollowUpActive,
         ];
     }
 }


### PR DESCRIPTION
## Summary
- Adds `is_contacted` and `should_send_first_followup` flags to the `first_followup` JSON written by `ApplyLeadAiModeAction` (via `LeadConfigurationService::getAllDefaultKeys`). `should_send_first_followup` is true only when the lead has not been contacted (`is_contacted = false`) and the lead-type config has `first_fu_active_default = true`.
- Updates `Lead::isActive()` to also treat statuses containing `hot` as active.
- Simplifies `Lead::closeNotSold()` to only check the AI-mode IDLE guard.

## Test plan
- [ ] Trigger `NEW_LEAD` on a lead whose type has `first_fu_active_default = true`; confirm `first_followup.should_send_first_followup` is `true` when `guild_lead_contacted` is unset and flips to `false` once contacted.
- [ ] Verify a lead in a `hot` status now reports `isActive() === true`.
- [ ] Confirm `closeNotSold()` still respects the IDLE AI-mode guard.