### PR TITLE
fix: route per-tenant Algolia client to scout-extended jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ app/Console/Commands/Intelligence/FirstMessageCommand.php
 ansible/inventory.gcp.yaml
 .planning
 compose.local.yml
-src/Baka/Search/
 .ai-workflow-template/
 docs/
 .claude/skills/Intelligence/

--- a/src/Baka/Search/Engines/KanvasAlgoliaEngine.php
+++ b/src/Baka/Search/Engines/KanvasAlgoliaEngine.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Baka\Search\Engines;
+
+use Algolia\AlgoliaSearch\Api\SearchClient;
+use Algolia\ScoutExtended\Engines\AlgoliaEngine;
+use Algolia\ScoutExtended\Jobs\DeleteJob;
+use Algolia\ScoutExtended\Jobs\UpdateJob;
+
+class KanvasAlgoliaEngine extends AlgoliaEngine
+{
+    public function update($searchables)
+    {
+        $this->withTenantClient(fn () => dispatch_sync(new UpdateJob($searchables)));
+    }
+
+    public function delete($searchables)
+    {
+        $this->withTenantClient(fn () => dispatch_sync(new DeleteJob($searchables)));
+    }
+
+    /**
+     * Scout-Extended's UpdateJob/DeleteJob receive SearchClient via method
+     * injection from the container; without this swap they get the global
+     * client built from config('scout.algolia.*'), bypassing the per-tenant
+     * client this engine was constructed with.
+     */
+    protected function withTenantClient(callable $fn): void
+    {
+        $container = app();
+        $previous = $container->bound(SearchClient::class)
+            ? $container->make(SearchClient::class)
+            : null;
+
+        $container->instance(SearchClient::class, $this->algolia);
+
+        try {
+            $fn();
+        } finally {
+            if ($previous !== null) {
+                $container->instance(SearchClient::class, $previous);
+            } else {
+                $container->forgetInstance(SearchClient::class);
+            }
+        }
+    }
+}

--- a/src/Baka/Search/SearchEngineResolver.php
+++ b/src/Baka/Search/SearchEngineResolver.php
@@ -7,6 +7,7 @@ namespace Baka\Search;
 use Algolia\AlgoliaSearch\Api\SearchClient;
 use Algolia\ScoutExtended\Engines\AlgoliaEngine;
 use BadMethodCallException;
+use Baka\Search\Engines\KanvasAlgoliaEngine;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Eloquent\Model;
 use Kanvas\Apps\Models\Apps;
@@ -68,8 +69,7 @@ class SearchEngineResolver
         $appId = $searchSettings['algolia_app_id'] ?? config('scout.algolia.id');
         $apiKey = $searchSettings['algolia_api_key'] ?? config('scout.algolia.secret');
 
-        //$client = AlgoliaClient::create($appId, $apiKey);
-        return new AlgoliaEngine(SearchClient::create($appId, $apiKey));
+        return new KanvasAlgoliaEngine(SearchClient::create($appId, $apiKey));
     }
 
     protected function createTypesenseEngine(array $searchSettings): EnginesTypesenseEngine


### PR DESCRIPTION
## Summary

- `Scout-Extended`'s `UpdateJob` / `DeleteJob` resolve `SearchClient` via container method injection, which bypassed the per-tenant client built by `SearchEngineResolver` — writes were going to the global `config('scout.algolia.*')` account instead of the app's `algolia_search_settings`. Search worked because `Algolia4Engine::search()` uses the engine's own `$this->algolia` client directly.
- New `Baka\Search\Engines\KanvasAlgoliaEngine` swaps the `SearchClient` container binding to the per-tenant client right before dispatching the jobs and restores the previous binding in a `finally` block (Octane-safe).
- `SearchEngineResolver::createAlgoliaEngine()` now returns the new engine.
- `.gitignore` rule that was silently swallowing everything under `src/Baka/Search/` was removed so the new `Engines/` folder is trackable (existing files in that path were already tracked from before the rule was added).

## Test plan

- [x] Local: app with `leads_search_engine='algolia'` + custom `algolia_search_settings` → `\$lead->searchable()` lands in the per-tenant Algolia account (verified via Algolia browse API on index `local-leads`).
- [ ] Prod canary: pick one app with `algolia_search_settings` set, run `kanvas:index "Kanvas\\Guild\\Leads\\Models\\Lead" <app_id>`, confirm hits appear under that tenant's Algolia dashboard (not the global env account).
- [ ] Sanity: search still works for tenants using Algolia (no regression — search path was never broken).
- [ ] Sanity: Typesense / Meilisearch tenants unaffected (those engines call their client directly in `update()`, this path doesn't touch them).