### PR TITLE
feat(intelligence): record resolved model on Laravel/Neuron turns for…

### DIFF
--- a/app/Console/Commands/Intelligence/CollectAgentDeploymentUsageCommand.php
+++ b/app/Console/Commands/Intelligence/CollectAgentDeploymentUsageCommand.php
@@ -14,16 +14,10 @@ use Kanvas\Intelligence\Agents\Models\AgentDeployment;
 use Throwable;
 
 /**
- * Provider-routed usage collection for every running container-runtime deployment.
- *
- * Replaces the OpenClaw-only kanvas:openclaw-collect-deployment-usage, which
- * hardcoded the OpenClaw action and silently never collected Hermes. Routing
- * through AgentRuntimeProviderFactory::forDeployment dispatches each deployment
- * to its own runtime's collectUsage() (OpenClaw status --usage, Hermes sessions
- * DB), so all container runtimes land in agent_usage_snapshots.
- *
- * In-process backends (Neuron, Laravel) have no deployment row and are handled
- * by RollupLocalAgentUsageCommand instead.
+ * Provider-routed usage collection for every running container-runtime deployment:
+ * AgentRuntimeProviderFactory dispatches each to its own collectUsage() (OpenClaw
+ * status --usage, Hermes sessions DB), so OpenClaw AND Hermes land in
+ * agent_usage_snapshots. In-process backends use RollupLocalAgentUsageCommand.
  */
 class CollectAgentDeploymentUsageCommand extends Command
 {

--- a/app/Console/Commands/Intelligence/RollupLocalAgentUsageCommand.php
+++ b/app/Console/Commands/Intelligence/RollupLocalAgentUsageCommand.php
@@ -15,13 +15,9 @@ use Kanvas\Intelligence\Agents\Enums\AgentProviderEnum;
 use Throwable;
 
 /**
- * Daily usage rollup for in-process backends (Neuron, Laravel). These have no
- * deployment row, so the container-runtime collector never sees them — their
- * tokens live in agent_conversation_messages.usage. This sums a day per agent
- * into agent_usage_snapshots so AgentCostService (keyed on agent_id) reports them.
- *
- * Defaults to yesterday so a full day's conversations are settled. Pass --date to
- * backfill a specific day, or {app_id} to scope to one app.
+ * Rolls up a day of Neuron/Laravel token usage into agent_usage_snapshots
+ * (see RollupLocalAgentUsageAction). Defaults to yesterday so the day's
+ * conversations are settled; pass {app_id} to scope to one app.
  */
 class RollupLocalAgentUsageCommand extends Command
 {

--- a/src/Domains/Intelligence/Agents/Actions/Chat/RunLaravelAgentChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/RunLaravelAgentChatAction.php
@@ -66,6 +66,14 @@ class RunLaravelAgentChatAction
             // Forward the tool calls/results/usage so the agent_conversation_messages
             // row mirrors what the Neuron + RemembersConversations paths persist —
             // without this the Laravel-agent turn lands with empty tool_calls.
+            // Fold the concrete model the runtime actually used (laravel-ai exposes
+            // it on the response meta) into the usage blob so the daily rollup can
+            // price the turn — Laravel agents don't persist the model anywhere else.
+            $usage = $response->usage->toArray();
+            if ($response->meta->model !== null) {
+                $usage['model'] = $response->meta->model;
+            }
+
             new KanvasConversationStore()->logTurn(
                 userId: $this->user->getId(),
                 sessionId: $sessionId,
@@ -75,7 +83,7 @@ class RunLaravelAgentChatAction
                 agentId: $this->agent->getId(),
                 toolCalls: $response->toolCalls->toArray(),
                 toolResults: $response->toolResults->toArray(),
-                usage: $response->usage->toArray(),
+                usage: $usage,
             );
         }
 

--- a/src/Domains/Intelligence/Agents/Actions/Chat/RunLaravelAgentChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/RunLaravelAgentChatAction.php
@@ -63,17 +63,15 @@ class RunLaravelAgentChatAction
         }
 
         if (! $usesMemory) {
-            // Forward the tool calls/results/usage so the agent_conversation_messages
-            // row mirrors what the Neuron + RemembersConversations paths persist —
-            // without this the Laravel-agent turn lands with empty tool_calls.
-            // Fold the concrete model the runtime actually used (laravel-ai exposes
-            // it on the response meta) into the usage blob so the daily rollup can
-            // price the turn — Laravel agents don't persist the model anywhere else.
+            // Fold the model laravel-ai used (response meta) into the usage blob so
+            // the daily rollup can price the turn — Laravel doesn't persist it elsewhere.
             $usage = $response->usage->toArray();
             if ($response->meta->model !== null) {
                 $usage['model'] = $response->meta->model;
             }
 
+            // Forward tool calls/results/usage so the agent_conversation_messages row
+            // mirrors the Neuron + RemembersConversations paths (else empty tool_calls).
             new KanvasConversationStore()->logTurn(
                 userId: $this->user->getId(),
                 sessionId: $sessionId,

--- a/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
@@ -104,6 +104,12 @@ class RunNeuronChatAction
         $content = $responseMessage->getContent() ?? '';
         $response = ChatHelper::extractTextFromResponse($content);
 
+        // Record the model the agent resolved to so the daily rollup can price the
+        // turn — Neuron doesn't surface the model on the response itself.
+        if (is_object($this->handler) && method_exists($this->handler, 'resolvedModelName')) {
+            $usage['model'] = $this->handler->resolvedModelName();
+        }
+
         new KanvasConversationStore()->logTurn(
             userId: $this->user->getId(),
             sessionId: $sessionId,

--- a/src/Domains/Intelligence/Agents/Actions/RollupLocalAgentUsageAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/RollupLocalAgentUsageAction.php
@@ -12,15 +12,11 @@ use Kanvas\Intelligence\Agents\Models\AgentUsageSnapshot;
 use Kanvas\Intelligence\Agents\Services\ModelPricingCalculator;
 
 /**
- * Daily usage rollup for in-process backends (Neuron, Laravel) that have no
- * deployment row. Their per-turn token usage is written into
- * agent_conversation_messages.usage; this sums a day's worth per agent and
- * writes one agent_usage_snapshot (agent_deployment_id = null), so the unified
- * agent_id-keyed read in AgentCostService sees them alongside container runtimes.
+ * Daily rollup of Neuron/Laravel token usage (recorded per-turn in
+ * agent_conversation_messages) into agent_usage_snapshots, so the agent_id-keyed
+ * AgentCostService sees in-process backends alongside container runtimes.
  *
- * Only neuron/laravel are rolled up here. Hermes/OpenClaw are container runtimes
- * collected via collectUsage() into snapshots already, and ADK is remote — folding
- * any of them in would double-count.
+ * ADK is excluded — it's metered remotely, so rolling it up here would double-count.
  */
 class RollupLocalAgentUsageAction
 {
@@ -113,10 +109,9 @@ class RollupLocalAgentUsageAction
     }
 
     /**
-     * Most-used model across this agent's messages in the window. The Laravel and
-     * Neuron chat paths fold the resolved model into each message's usage JSON
-     * (usage.model); drives pricing. Null when no message carries a model (cost
-     * falls through to 0, tokens are still recorded).
+     * Most-used model across the agent's messages in the window. The Laravel/Neuron
+     * chat paths record it in each message's usage JSON (usage.model). Null → cost 0,
+     * tokens still recorded.
      */
     private function dominantModel(int $agentId, Carbon $dayStart, Carbon $dayEnd): ?string
     {

--- a/src/Domains/Intelligence/Agents/Actions/RollupLocalAgentUsageAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/RollupLocalAgentUsageAction.php
@@ -113,19 +113,21 @@ class RollupLocalAgentUsageAction
     }
 
     /**
-     * Most-used model across this agent's conversations in the window, read from
-     * the conversation's runtime meta. Drives pricing; null when meta carries no
-     * model (cost falls through to 0, tokens are still recorded).
+     * Most-used model across this agent's messages in the window. The Laravel and
+     * Neuron chat paths fold the resolved model into each message's usage JSON
+     * (usage.model); drives pricing. Null when no message carries a model (cost
+     * falls through to 0, tokens are still recorded).
      */
     private function dominantModel(int $agentId, Carbon $dayStart, Carbon $dayEnd): ?string
     {
         $row = DB::connection('intelligence')
-            ->table('agent_conversations')
-            ->where('agent_id', $agentId)
-            ->where('updated_at', '>=', $dayStart)
-            ->where('updated_at', '<', $dayEnd)
-            ->whereNotNull('meta')
-            ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(meta, '$.model')) as model, COUNT(*) as c")
+            ->table('agent_conversation_messages as m')
+            ->join('agent_conversations as c', 'c.id', '=', 'm.conversation_id')
+            ->where('c.agent_id', $agentId)
+            ->where('m.created_at', '>=', $dayStart)
+            ->where('m.created_at', '<', $dayEnd)
+            ->whereRaw("JSON_EXTRACT(m.`usage`, '$.model') IS NOT NULL")
+            ->selectRaw("JSON_UNQUOTE(JSON_EXTRACT(m.`usage`, '$.model')) as model, COUNT(*) as c")
             ->groupBy('model')
             ->orderByDesc('c')
             ->first();

--- a/src/Domains/Intelligence/Agents/Neuron/BaseKanvasAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/BaseKanvasAgent.php
@@ -84,12 +84,24 @@ class BaseKanvasAgent extends NeuronAIAgent
             ?? ($this->entity instanceof Lead ? $this->entity : null);
     }
 
+    /**
+     * The concrete model this agent will call (agent config → app default →
+     * hard default). Exposed so the chat path can record it on the turn for
+     * usage/cost rollups.
+     */
+    public function resolvedModelName(): string
+    {
+        $config = $this->agent->config ?? [];
+
+        return $config['model'] ?? $this->app->get(ConfigurationEnum::GEMINI_MODEL->value) ?? 'gemini-2.5-pro';
+    }
+
     #[Override]
     protected function provider(): AIProviderInterface
     {
         $config = $this->agent->config ?? [];
         $key = $config['key'] ?? $this->app->get(ConfigurationEnum::GEMINI_KEY->value);
-        $model = $config['model'] ?? $this->app->get(ConfigurationEnum::GEMINI_MODEL->value) ?? 'gemini-2.5-pro';
+        $model = $this->resolvedModelName();
 
         if (! is_string($key) || $key === '') {
             throw new ValidationException(

--- a/src/Domains/Intelligence/Agents/Services/AgentCostService.php
+++ b/src/Domains/Intelligence/Agents/Services/AgentCostService.php
@@ -17,12 +17,8 @@ class AgentCostService
     private const int CACHE_TTL_SECONDS = 6 * 60 * 60;
 
     /**
-     * Tokens + cost an agent burned in a calendar month. Aggregates every
-     * usage snapshot tied to any of the agent's deployments (an agent can be
-     * relaunched, spawning new deployment rows — all of them count).
-     *
-     * "This month" = the calendar month containing $when (defaults to today),
-     * server-time UTC, from the 1st up to and including today.
+     * Tokens + cost an agent burned in the calendar month containing $when
+     * (defaults to today), server-time UTC, from the 1st up to and including today.
      *
      * @return array{period_start: string, tokens: int, cost_usd: float}
      */

--- a/tests/Intelligence/Actions/RollupLocalAgentUsageActionTest.php
+++ b/tests/Intelligence/Actions/RollupLocalAgentUsageActionTest.php
@@ -55,7 +55,7 @@ class RollupLocalAgentUsageActionTest extends TestCase
     }
 
     /**
-     * @param array<string, int>|null $usage
+     * @param array<string, mixed>|null $usage
      */
     private function makeMessage(string $conversationId, string $role, ?array $usage, Carbon $at): void
     {
@@ -147,22 +147,24 @@ class RollupLocalAgentUsageActionTest extends TestCase
     }
 
     /**
-     * The rollup's job is to resolve the model used (from conversation meta) and
-     * the LLM provider, and hand them to ModelPricingCalculator. The cost math
-     * itself is covered by ModelPricingCalculatorTest — not re-asserted here
-     * because the intelligence connection's read/write split (sticky=false) means
-     * a test-inserted pricing row isn't visible to the calculator's read PDO.
+     * The rollup's job is to resolve the model used (from the message usage blob,
+     * where the Laravel/Neuron chat paths record it) and the LLM provider, and
+     * hand them to ModelPricingCalculator. The cost math itself is covered by
+     * ModelPricingCalculatorTest — not re-asserted here because the intelligence
+     * connection's read/write split (sticky=false) means a test-inserted pricing
+     * row isn't visible to the calculator's read PDO.
      */
-    public function testResolvesModelAndProviderFromConversationMeta(): void
+    public function testResolvesModelAndProviderFromMessageUsage(): void
     {
         Carbon::setTestNow(Carbon::create(2026, 6, 9, 12));
         $app = app(Apps::class);
 
         $agent = $this->makeAgent('laravel');
-        $conv = $this->makeConversation($agent, 'gemini-3.1-pro-preview');
+        $conv = $this->makeConversation($agent);
         $this->makeMessage($conv, 'assistant', [
             'prompt_tokens' => 1200,
             'completion_tokens' => 300,
+            'model' => 'gemini-3.1-pro-preview',
         ], Carbon::create(2026, 6, 9, 10));
 
         new RollupLocalAgentUsageAction($app, Carbon::create(2026, 6, 9))->execute();


### PR DESCRIPTION
… cost

Laravel/Neuron agents don't persist the concrete model anywhere queryable, so the local usage rollup couldn't price them (cost_usd = 0). Capture the model the runtime actually used and fold it into each message's usage JSON:

- Laravel: from the laravel-ai response meta ($response->meta->model)
- Neuron: BaseKanvasAgent::resolvedModelName() (agent config -> app default), reused by provider() and recorded on the turn in RunNeuronChatAction
- rollup dominantModel() now reads usage.model from messages (the rollup only handles neuron/laravel, whose model now lands there) instead of conversation meta

