### PR TITLE
fix(intelligence): rollup tolerant of input_tokens/output_tokens usag…

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/RollupLocalAgentUsageAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/RollupLocalAgentUsageAction.php
@@ -47,10 +47,12 @@ class RollupLocalAgentUsageAction
             ->where('m.created_at', '<', $dayEnd)
             ->groupBy('c.agent_id', 'c.apps_id', 'c.companies_id', 't.provider')
             ->selectRaw('c.agent_id, c.apps_id, c.companies_id, t.provider as agent_provider')
-            ->selectRaw("COALESCE(SUM(CAST(COALESCE(JSON_EXTRACT(m.`usage`, '$.prompt_tokens'), 0) AS UNSIGNED)), 0) as input_tokens")
-            ->selectRaw("COALESCE(SUM(CAST(COALESCE(JSON_EXTRACT(m.`usage`, '$.completion_tokens'), 0) AS UNSIGNED)), 0) as output_tokens")
-            ->selectRaw("COALESCE(SUM(CAST(COALESCE(JSON_EXTRACT(m.`usage`, '$.cache_read_input_tokens'), 0) AS UNSIGNED)), 0) as cache_read")
-            ->selectRaw("COALESCE(SUM(CAST(COALESCE(JSON_EXTRACT(m.`usage`, '$.cache_write_input_tokens'), 0) AS UNSIGNED)), 0) as cache_write")
+            // usage key names vary by runtime/version: prompt_tokens/completion_tokens/
+            // cache_*_input_tokens OR input_tokens/output_tokens/cache_*. Accept both.
+            ->selectRaw("COALESCE(SUM(CAST(COALESCE(JSON_EXTRACT(m.`usage`, '$.prompt_tokens'), JSON_EXTRACT(m.`usage`, '$.input_tokens'), 0) AS UNSIGNED)), 0) as input_tokens")
+            ->selectRaw("COALESCE(SUM(CAST(COALESCE(JSON_EXTRACT(m.`usage`, '$.completion_tokens'), JSON_EXTRACT(m.`usage`, '$.output_tokens'), 0) AS UNSIGNED)), 0) as output_tokens")
+            ->selectRaw("COALESCE(SUM(CAST(COALESCE(JSON_EXTRACT(m.`usage`, '$.cache_read_input_tokens'), JSON_EXTRACT(m.`usage`, '$.cache_read'), 0) AS UNSIGNED)), 0) as cache_read")
+            ->selectRaw("COALESCE(SUM(CAST(COALESCE(JSON_EXTRACT(m.`usage`, '$.cache_write_input_tokens'), JSON_EXTRACT(m.`usage`, '$.cache_write'), 0) AS UNSIGNED)), 0) as cache_write")
             ->selectRaw('COUNT(DISTINCT c.id) as total_sessions')
             ->havingRaw('input_tokens > 0 OR output_tokens > 0')
             ->get();

--- a/tests/Intelligence/Actions/RollupLocalAgentUsageActionTest.php
+++ b/tests/Intelligence/Actions/RollupLocalAgentUsageActionTest.php
@@ -117,6 +117,38 @@ class RollupLocalAgentUsageActionTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function testHandlesInputOutputTokenKeyVariant(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 9, 12));
+        $app = app(Apps::class);
+
+        $agent = $this->makeAgent('neuron');
+        $conv = $this->makeConversation($agent);
+
+        // Some runtimes/versions emit input_tokens/output_tokens instead of
+        // prompt_tokens/completion_tokens — both must sum.
+        $this->makeMessage($conv, 'assistant', [
+            'input_tokens' => 5935,
+            'output_tokens' => 152,
+            'cache_read' => 100,
+            'model' => 'gemini-3.5-flash',
+        ], Carbon::create(2026, 6, 9, 10));
+
+        new RollupLocalAgentUsageAction($app, Carbon::create(2026, 6, 9))->execute();
+
+        $snapshot = AgentUsageSnapshot::query()
+            ->where('agent_id', $agent->getId())
+            ->where('snapshot_date', '2026-06-09')
+            ->firstOrFail();
+
+        $this->assertSame(5935, $snapshot->input_tokens);
+        $this->assertSame(152, $snapshot->output_tokens);
+        $this->assertSame(100, $snapshot->cache_read_tokens);
+        $this->assertSame('gemini-3.5-flash', $snapshot->model);
+
+        Carbon::setTestNow();
+    }
+
     public function testIgnoresContainerRuntimeAgents(): void
     {
         Carbon::setTestNow(Carbon::create(2026, 6, 9, 12));


### PR DESCRIPTION
…e keys

Local agent usage JSON uses either prompt_tokens/completion_tokens/ cache_*_input_tokens or input_tokens/output_tokens/cache_* depending on the runtime/version. The rollup only summed the former, so newer turns rolled up to zero. COALESCE both spellings for input/output/cache token sums.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
