### PR TITLE
fix(intelligence): add cost_usd to AgentUsageSnapshot fillable

### DIFF
--- a/src/Domains/Intelligence/Agents/Models/AgentUsageSnapshot.php
+++ b/src/Domains/Intelligence/Agents/Models/AgentUsageSnapshot.php
@@ -26,6 +26,7 @@ use Kanvas\Intelligence\Models\BaseModel;
  * @property int $total_tokens
  * @property int $cache_read_tokens
  * @property int $cache_write_tokens
+ * @property string $cost_usd
  * @property string|null $provider
  * @property string|null $model
  * @property int $total_sessions
@@ -52,6 +53,7 @@ class AgentUsageSnapshot extends BaseModel
         'total_tokens',
         'cache_read_tokens',
         'cache_write_tokens',
+        'cost_usd',
         'provider',
         'model',
         'total_sessions',

--- a/tests/Intelligence/Actions/RollupLocalAgentUsageActionTest.php
+++ b/tests/Intelligence/Actions/RollupLocalAgentUsageActionTest.php
@@ -149,6 +149,33 @@ class RollupLocalAgentUsageActionTest extends TestCase
         Carbon::setTestNow();
     }
 
+    public function testCostUsdSurvivesMassAssignment(): void
+    {
+        // Regression: cost_usd was missing from $fillable, so updateOrCreate
+        // silently dropped it and every snapshot persisted cost as 0.
+        $agent = $this->makeAgent('laravel');
+
+        $snapshot = AgentUsageSnapshot::updateOrCreate(
+            [
+                'apps_id' => $agent->apps_id,
+                'companies_id' => $agent->companies_id,
+                'agent_id' => $agent->getId(),
+                'agent_deployment_id' => null,
+                'snapshot_date' => '2026-06-01',
+                'source' => 'laravel',
+            ],
+            [
+                'cost_usd' => 1.234567,
+                'input_tokens' => 10,
+                'output_tokens' => 5,
+                'total_tokens' => 15,
+                'raw_output' => '',
+            ]
+        );
+
+        $this->assertEqualsWithDelta(1.234567, (float) $snapshot->fresh()->cost_usd, 0.0000001);
+    }
+
     public function testIgnoresContainerRuntimeAgents(): void
     {
         Carbon::setTestNow(Carbon::create(2026, 6, 9, 12));


### PR DESCRIPTION
cost_usd was absent from $fillable, so updateOrCreate silently dropped it via mass-assignment protection and every snapshot persisted cost as 0.000000 — for both the local rollup and the container-runtime collectors. The calculator was correct; the write threw the value away. Add cost_usd to $fillable + @property, and a regression test asserting it survives mass assignment.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
