### PR TITLE
fix(intelligence): attribute local rollup snapshot to the agent's com…

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/RollupLocalAgentUsageAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/RollupLocalAgentUsageAction.php
@@ -45,8 +45,11 @@ class RollupLocalAgentUsageAction
             ->whereNotNull('c.agent_id')
             ->where('m.created_at', '>=', $dayStart)
             ->where('m.created_at', '<', $dayEnd)
-            ->groupBy('c.agent_id', 'c.apps_id', 'c.companies_id', 't.provider')
-            ->selectRaw('c.agent_id, c.apps_id, c.companies_id, t.provider as agent_provider')
+            // Attribute the snapshot to the agent's own app/company (matching the
+            // container collectors and AgentCostService's filter) — a conversation
+            // can be logged under a different company than the agent owns.
+            ->groupBy('c.agent_id', 'a.apps_id', 'a.companies_id', 't.provider')
+            ->selectRaw('c.agent_id, a.apps_id, a.companies_id, t.provider as agent_provider')
             // usage key names vary by runtime/version: prompt_tokens/completion_tokens/
             // cache_*_input_tokens OR input_tokens/output_tokens/cache_*. Accept both.
             ->selectRaw("COALESCE(SUM(CAST(COALESCE(JSON_EXTRACT(m.`usage`, '$.prompt_tokens'), JSON_EXTRACT(m.`usage`, '$.input_tokens'), 0) AS UNSIGNED)), 0) as input_tokens")

--- a/tests/Intelligence/Actions/RollupLocalAgentUsageActionTest.php
+++ b/tests/Intelligence/Actions/RollupLocalAgentUsageActionTest.php
@@ -36,13 +36,13 @@ class RollupLocalAgentUsageActionTest extends TestCase
             ->create(['agent_type_id' => $type->getId()]);
     }
 
-    private function makeConversation(Agent $agent, ?string $model = null): string
+    private function makeConversation(Agent $agent, ?string $model = null, ?int $companiesId = null): string
     {
         $id = 'conv_' . Str::random(20);
         DB::connection('intelligence')->table('agent_conversations')->insert([
             'id' => $id,
             'apps_id' => $agent->apps_id,
-            'companies_id' => $agent->companies_id,
+            'companies_id' => $companiesId ?? $agent->companies_id,
             'agent_id' => $agent->getId(),
             'user_id' => $agent->users_id,
             'title' => 'test',
@@ -145,6 +145,34 @@ class RollupLocalAgentUsageActionTest extends TestCase
         $this->assertSame(152, $snapshot->output_tokens);
         $this->assertSame(100, $snapshot->cache_read_tokens);
         $this->assertSame('gemini-3.5-flash', $snapshot->model);
+
+        Carbon::setTestNow();
+    }
+
+    public function testAttributesSnapshotToAgentCompanyNotConversation(): void
+    {
+        Carbon::setTestNow(Carbon::create(2026, 6, 9, 12));
+        $app = app(Apps::class);
+
+        $agent = $this->makeAgent('laravel');
+        // Conversation logged under a different company than the agent owns.
+        $conv = $this->makeConversation($agent, null, $agent->companies_id + 7777);
+        $this->makeMessage($conv, 'assistant', [
+            'prompt_tokens' => 100,
+            'completion_tokens' => 50,
+        ], Carbon::create(2026, 6, 9, 10));
+
+        new RollupLocalAgentUsageAction($app, Carbon::create(2026, 6, 9))->execute();
+
+        $snapshot = AgentUsageSnapshot::query()
+            ->where('agent_id', $agent->getId())
+            ->where('snapshot_date', '2026-06-09')
+            ->firstOrFail();
+
+        // Snapshot must carry the agent's company, so AgentCostService (which
+        // filters by the agent's company) finds it.
+        $this->assertSame((int) $agent->companies_id, (int) $snapshot->companies_id);
+        $this->assertSame((int) $agent->apps_id, (int) $snapshot->apps_id);
 
         Carbon::setTestNow();
     }


### PR DESCRIPTION
…pany

The rollup grouped/wrote apps_id + companies_id from the conversation, but a conversation can be logged under a different company than the agent owns. AgentCostService filters by the agent's company, so monthly_usage came back 0 even though the snapshot existed. Stamp the agent's apps_id/companies_id (a.*), matching the container collectors. Regression test included.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
