### PR TITLE
fix(movipass): switch default company and provision inventory on corp…

### DIFF
--- a/src/Domains/Connectors/Movipass/Actions/EnableCorporateModeAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/EnableCorporateModeAction.php
@@ -16,7 +16,9 @@ use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\Movipass\Jobs\MigrateCorporateUserVariantsJob;
 use Kanvas\Connectors\Movipass\Workflows\Activities\AutoApproveCorporateLeadActivity;
 use Kanvas\Exceptions\ValidationException;
+use Kanvas\Services\SetupService;
 use Kanvas\Users\Actions\AssignCompanyAction;
+use Kanvas\Users\Actions\SwitchCompanyBranchAction;
 use Kanvas\Users\Models\Users;
 
 class EnableCorporateModeAction
@@ -48,6 +50,10 @@ class EnableCorporateModeAction
             $this->setCompanyFields($company);
             $this->setUserFields();
             $this->associateUserAsAdmin($company, $appsModel);
+            // Same onboarding the registration/lead-accept path runs — provisions the
+            // company's default inventory (region + warehouse) via OnBoardingJob.
+            new SetupService()->onBoarding($this->user, $appsModel, $company);
+            $this->switchToCorporateCompany($company);
 
             dispatch(new MigrateCorporateUserVariantsJob(
                 userId: $this->user->getId(),
@@ -117,5 +123,12 @@ class EnableCorporateModeAction
         )->execute();
 
         new AssignRoleAction($this->user, $adminRole)->execute();
+    }
+
+    private function switchToCorporateCompany(Companies $company): void
+    {
+        $branch = $company->branch()->firstOrFail();
+
+        new SwitchCompanyBranchAction($this->user, $branch->getId())->execute();
     }
 }

--- a/tests/Connectors/Integration/Movipass/EnableCorporateModeActionTest.php
+++ b/tests/Connectors/Integration/Movipass/EnableCorporateModeActionTest.php
@@ -12,6 +12,7 @@ use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\Movipass\Actions\EnableCorporateModeAction;
 use Kanvas\Connectors\Movipass\Jobs\MigrateCorporateUserVariantsJob;
 use Kanvas\Exceptions\ValidationException;
+use Kanvas\Users\Jobs\OnBoardingJob;
 use Tests\TestCase;
 
 final class EnableCorporateModeActionTest extends TestCase
@@ -55,6 +56,54 @@ final class EnableCorporateModeActionTest extends TestCase
         $this->assertEquals('Gerente', $user->get('contact_role'));
 
         Bus::assertDispatched(MigrateCorporateUserVariantsJob::class);
+    }
+
+    public function testSwitchesUserDefaultCompanyToTheNewCorporateCompany(): void
+    {
+        Bus::fake();
+
+        $user = Auth::user();
+        $app = app(Apps::class);
+
+        Bouncer::scope()->to(RolesEnums::getScope($app, $user->getCurrentCompany()));
+
+        $previousCompanyId = $user->getCurrentCompany()->getId();
+
+        $company = new EnableCorporateModeAction(
+            user: $user,
+            app: $app,
+            fields: $this->validFields(),
+        )->execute();
+
+        $branch = $company->branch()->firstOrFail();
+
+        $user->refresh();
+        $this->assertNotEquals($previousCompanyId, $company->getId());
+        $this->assertEquals($company->getId(), $user->default_company);
+        $this->assertEquals($branch->getId(), $user->default_company_branch);
+    }
+
+    public function testDispatchesOnboardingForTheCorporateCompany(): void
+    {
+        Bus::fake();
+
+        $user = Auth::user();
+        $app = app(Apps::class);
+
+        Bouncer::scope()->to(RolesEnums::getScope($app, $user->getCurrentCompany()));
+
+        $company = new EnableCorporateModeAction(
+            user: $user,
+            app: $app,
+            fields: $this->validFields(),
+        )->execute();
+
+        // Region + warehouse are provisioned by OnBoardingJob (Inventory Setup), the same
+        // path the user-registration/lead-accept flow runs.
+        Bus::assertDispatched(
+            OnBoardingJob::class,
+            fn (OnBoardingJob $job) => $job->branch->companies_id === $company->getId(),
+        );
     }
 
     public function testRejectsInvalidRnc(): void


### PR DESCRIPTION
…orate enable

enableCorporateMode created the corporate company but left the user on their old default company and never provisioned a region/warehouse.

- Switch the user to the new corporate company via SwitchCompanyBranchAction (sets default_company / default_company_branch + cache keys).
- Run the standard onboarding (SetupService -> OnBoardingJob -> Inventory Setup) so the company gets its default region + warehouse, matching the user-registration / lead-accept flow.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
