### PR TITLE
toggle CSV order item stock validation via app config

### DIFF
--- a/src/Domains/Souk/Enums/ConfigurationEnum.php
+++ b/src/Domains/Souk/Enums/ConfigurationEnum.php
@@ -23,4 +23,5 @@ enum ConfigurationEnum: string
     case CANCEL_STALE_PAYMENTS = 'souk_cancel_stale_payments';
     case STALE_PAYMENT_TTL_MINUTES = 'souk_stale_payment_ttl_minutes';
     case DEFAULT_COMMISSION_RATE = 'default_commission_rate';
+    case DISABLE_ORDER_ITEM_STOCK_VALIDATION = 'souk_disable_order_item_stock_validation';
 }

--- a/src/Domains/Souk/Orders/Services/OrderItemService.php
+++ b/src/Domains/Souk/Orders/Services/OrderItemService.php
@@ -8,6 +8,7 @@ use Illuminate\Http\UploadedFile;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Inventory\Variants\Models\Variants;
+use Kanvas\Souk\Enums\ConfigurationEnum;
 use Kanvas\Users\Models\Users;
 use League\Csv\Reader;
 
@@ -83,6 +84,8 @@ class OrderItemService
         $cartItems = [];
         $errors = [];
 
+        $validateStock = ! (bool) $this->app->get(ConfigurationEnum::DISABLE_ORDER_ITEM_STOCK_VALIDATION->value);
+
         foreach ($orderItems as $orderItem) {
             $variant = Variants::where('id', $orderItem['variant_id'])->first();
             $channel = $variant->variantChannels()->where('channels_id', $channelId)->first();
@@ -100,7 +103,7 @@ class OrderItemService
              * @todo validate overselling
              */
             $barcode = "<b>($variant->barcode)</b>";
-            if ($currentStock < $orderItem['quantity']) {
+            if ($validateStock && $currentStock < $orderItem['quantity']) {
                 $errors[] = "$barcode: You only have $currentStock in stock for $variant->name.";
 
                 continue;

--- a/tests/GraphQL/Souk/ImportOrderItemsCsvTest.php
+++ b/tests/GraphQL/Souk/ImportOrderItemsCsvTest.php
@@ -6,6 +6,7 @@ namespace Tests\GraphQL\Souk;
 
 use Illuminate\Http\UploadedFile;
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Souk\Enums\ConfigurationEnum;
 use Tests\GraphQL\Inventory\Traits\InventoryCases;
 use Tests\TestCase;
 
@@ -275,6 +276,114 @@ class ImportOrderItemsCsvTest extends TestCase
         $this->assertStringContainsString($variantResponse['name'], $message);
     }
 
+
+    public function testImportOrderItemsWithStockValidationDisabled(): void
+    {
+        $freshUser = $this->createUser();
+        $this->actingAs($freshUser, 'api');
+
+        $app = app(Apps::class);
+        $app->set(ConfigurationEnum::DISABLE_ORDER_ITEM_STOCK_VALIDATION->value, 1);
+
+        try {
+            $regionResponse = $this->createRegion()->json()['data']['createRegion'];
+            $warehouseResponse = $this->createWarehouses($regionResponse['id'])->json()['data']['createWarehouse'];
+            $productResponse = $this->createProduct()->json()['data']['createProduct'];
+
+            $warehouseData = [
+                'id' => $warehouseResponse['id'],
+            ];
+
+            $variantResponse = $this->createVariant(
+                productId: $productResponse['id'],
+                warehouseData: $warehouseData
+            )->json()['data']['createVariant'];
+
+            $variantResponse2 = $this->createVariant(
+                productId: $productResponse['id'],
+                warehouseData: $warehouseData
+            )->json()['data']['createVariant'];
+
+            $channelResponse = $this->createChannel()->json()['data']['createChannel'];
+
+            $this->addVariantToChannel(
+                variantId: $variantResponse['id'],
+                channelId: $channelResponse['id'],
+                warehouseData: $warehouseData
+            );
+
+            $this->addVariantToChannel(
+                variantId: $variantResponse2['id'],
+                channelId: $channelResponse['id'],
+                warehouseData: $warehouseData
+            );
+
+            $this->addVariantToWarehouse(
+                variantId: $variantResponse['id'],
+                warehouseId: $warehouseResponse['id'],
+                amount: 2
+            );
+
+            $this->addVariantToWarehouse(
+                variantId: $variantResponse2['id'],
+                warehouseId: $warehouseResponse['id'],
+                amount: 2
+            );
+
+            $operations = [
+                'query' => self::IMPORT_ORDER_CSV_MUTATION,
+                'variables' => [
+                    'file' => null,
+                    'channel_id' => $channelResponse['id'],
+                ],
+            ];
+
+            $map = [
+                '0' => ['variables.file'],
+            ];
+
+            $csv = $this->getValidProductsCsvContent([
+                [
+                    'id' => $variantResponse['id'],
+                    'name' => $variantResponse['name'],
+                    'ean' => $variantResponse['ean'],
+                ],
+                [
+                    'id' => $variantResponse2['id'],
+                    'name' => $variantResponse2['name'],
+                    'ean' => $variantResponse2['ean'],
+                ],
+            ], 5);
+
+            $file = [
+                '0' => UploadedFile::fake()->createWithContent('products.csv', $csv),
+            ];
+
+            $response = $this->multipartGraphQL($operations, $map, $file);
+            $response->assertJson([
+                'data' => [
+                    'importOrderCsv' => [
+                        'message' => 'Items processed successfully',
+                        'status' => 'success',
+                    ],
+                ],
+            ]);
+
+            $cartQuery = $this->graphQL(/** @lang GraphQL */ '
+                {
+                    cart {
+                        items {
+                            quantity
+                        }
+                    }
+                }
+            ');
+
+            $this->assertCount(2, $cartQuery->json()['data']['cart']['items']);
+        } finally {
+            $app->del(ConfigurationEnum::DISABLE_ORDER_ITEM_STOCK_VALIDATION->value);
+        }
+    }
 
     public function testImportOrderItemsWithAvailableGlobalStock(): void
     {


### PR DESCRIPTION
feat(souk): toggle CSV order item stock validation via app config

Add `souk_disable_order_item_stock_validation` app setting. When truthy, the CSV order import skips the available-stock check in OrderItemService::processOrderItems, allowing overselling for apps that manage stock externally. Validation stays enabled by default. @

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
