### PR TITLE
fix: charge net total (with order discount) in payment flows

### DIFF
--- a/src/Domains/Connectors/Stripe/Services/StripePaymentLinkService.php
+++ b/src/Domains/Connectors/Stripe/Services/StripePaymentLinkService.php
@@ -21,8 +21,15 @@ class StripePaymentLinkService
 
     public function __construct(
         protected AppInterface $app,
-        protected ?Companies $company = null
+        protected ?Companies $company = null,
+        ?StripeClient $stripe = null
     ) {
+        if ($stripe !== null) {
+            $this->stripe = $stripe;
+
+            return;
+        }
+
         $stripeKey = $company ? $company->get(ConfigurationEnum::STRIPE_SECRET_KEY->value) : null;
         $this->stripe = new StripeClient($stripeKey ?? $this->app->get(ConfigurationEnum::STRIPE_SECRET_KEY->value));
     }
@@ -93,6 +100,13 @@ class StripePaymentLinkService
         // Add custom fields if provided
         if (isset($options['custom_fields'])) {
             $paymentLinkData['custom_fields'] = $options['custom_fields'];
+        }
+
+        // Line items are built from item gross prices, so the order-level discount
+        // (stored in order_discounts, reflected in discount_amount) is not yet applied.
+        // Attach it as a Stripe coupon so the customer is charged the net total.
+        if ($couponId = $this->createDiscountCoupon($order)) {
+            $paymentLinkData['discounts'] = [['coupon' => $couponId]];
         }
 
         // Create the payment link
@@ -226,6 +240,34 @@ class StripePaymentLinkService
         $orderItem->addMetadata($priceKey, $price->id);
 
         return $price->id;
+    }
+
+    /**
+     * Create a one-time Stripe coupon for the order-level discount.
+     *
+     * Returns null when the order has no discount. The coupon's amount_off carries the
+     * discount in the order's currency so Stripe subtracts it from the gross line items.
+     */
+    protected function createDiscountCoupon(Order $order): ?string
+    {
+        $discountAmount = (float) $order->discount_amount;
+
+        if ($discountAmount <= 0) {
+            return null;
+        }
+
+        $coupon = $this->stripe->coupons->create([
+            'amount_off' => $this->convertToStripeAmount($discountAmount, $order->currency),
+            'currency' => strtolower($order->currency ?? 'usd'),
+            'duration' => 'once',
+            'name' => $order->translated_discount_name ?? $order->discount_name ?? 'Discount',
+            'metadata' => [
+                'order_id' => $order->id,
+                'voucher_id' => $order->voucher_id,
+            ],
+        ]);
+
+        return $coupon->id;
     }
 
     /**

--- a/src/Domains/Souk/Orders/Models/Order.php
+++ b/src/Domains/Souk/Orders/Models/Order.php
@@ -220,6 +220,15 @@ class Order extends BaseModel
         return $this->getTotalAmount() - $this->getSubTotalAmount();
     }
 
+    /**
+     * Amount the customer must actually pay: the net total after order-level discounts.
+     * Payment processors must charge this, NOT getTotalAmount() (the pre-discount gross).
+     */
+    public function getTotalDueAmount(): float
+    {
+        return (float) $this->total_net_amount;
+    }
+
     public function addItems(DataCollection $items): void
     {
         foreach ($items as $item) {

--- a/src/Domains/Souk/Payments/Infrastructure/Processors/Azul/AzulProcessor.php
+++ b/src/Domains/Souk/Payments/Infrastructure/Processors/Azul/AzulProcessor.php
@@ -158,7 +158,7 @@ class AzulProcessor implements PaymentProcessorInterface, TokenizationProcessorI
                 'order_id' => $order->id,
                 'azul_order_id' => $response->azulOrderId,
                 'authorization_code' => $response->authorizationCode,
-                'amount' => $order->getTotalAmount(),
+                'amount' => $order->getTotalDueAmount(),
                 'response_time_ms' => $responseTimeMs,
                 'request' => $this->sanitizeRequest($request->toArray()),
                 'response' => $response->toArray(),
@@ -227,7 +227,7 @@ class AzulProcessor implements PaymentProcessorInterface, TokenizationProcessorI
             );
         }
 
-        $captureAmount = $amount ?? $order->getTotalAmount();
+        $captureAmount = $amount ?? $order->getTotalDueAmount();
         $request = $this->buildCaptureRequest($azulOrderId, $captureAmount, $order);
         $start = hrtime(true);
 
@@ -306,7 +306,7 @@ class AzulProcessor implements PaymentProcessorInterface, TokenizationProcessorI
             );
         }
 
-        $refundAmount = $amount ?? $order->getTotalAmount();
+        $refundAmount = $amount ?? $order->getTotalDueAmount();
         $request = $this->buildRefundRequest($azulOrderId, $refundAmount, $order);
         $start = hrtime(true);
 
@@ -894,7 +894,7 @@ class AzulProcessor implements PaymentProcessorInterface, TokenizationProcessorI
             store: (string) ($this->app->get(ConfigurationEnum::AZUL_STORE->value) ?? ''),
             trxType: TransactionTypeEnum::POST,
             amount: $this->toCents($captureAmount),
-            itbis: $this->toCents($order->getTotalTaxAmount()) ?: '000',
+            itbis: '000',
             customOrderId: (string) $order->id,
             azulOrderId: $azulOrderId,
         );
@@ -919,7 +919,7 @@ class AzulProcessor implements PaymentProcessorInterface, TokenizationProcessorI
             store: (string) ($this->app->get(ConfigurationEnum::AZUL_STORE->value) ?? ''),
             trxType: TransactionTypeEnum::REFUND,
             amount: $this->toCents($refundAmount),
-            itbis: $this->toCents($order->getTotalTaxAmount()) ?: '000',
+            itbis: '000',
             customOrderId: (string) $order->id,
             azulOrderId: $azulOrderId,
         );
@@ -968,8 +968,8 @@ class AzulProcessor implements PaymentProcessorInterface, TokenizationProcessorI
             cvc: $cvc,
             posInputMode: 'E-Commerce',
             trxType: TransactionTypeEnum::SALE,
-            amount: $this->toCents($order->getTotalAmount()),
-            itbis: $this->toCents($order->getTotalTaxAmount()) ?: '000',
+            amount: $this->toCents($order->getTotalDueAmount()),
+            itbis: '000',
             orderNumber: (string) $order->order_number,
             customOrderId: (string) $order->id,
             dataVaultToken: $dataVaultToken,
@@ -1130,8 +1130,8 @@ class AzulProcessor implements PaymentProcessorInterface, TokenizationProcessorI
             cvc: $dataVaultToken ? null : $paymentMethod->getMetadata('cvc'),
             posInputMode: 'E-Commerce',
             trxType: TransactionTypeEnum::SALE,
-            amount: $this->toCents($order->getTotalAmount()),
-            itbis: $this->toCents($order->getTotalTaxAmount()) ?: '000',
+            amount: $this->toCents($order->getTotalDueAmount()),
+            itbis: '000',
             orderNumber: (string) $order->order_number,
             customOrderId: (string) $order->id,
             dataVaultToken: $dataVaultToken,

--- a/src/Domains/Souk/Payments/Infrastructure/Processors/CardNet/CardNetProcessor.php
+++ b/src/Domains/Souk/Payments/Infrastructure/Processors/CardNet/CardNetProcessor.php
@@ -115,7 +115,7 @@ class CardNetProcessor implements PaymentProcessorInterface, TokenizationProcess
                 'order_id' => $order->id,
                 'purchase_id' => $purchaseId,
                 'approval_code' => $approvalCode,
-                'amount' => $order->getTotalAmount(),
+                'amount' => $order->getTotalDueAmount(),
                 'response_time_ms' => $responseTimeMs,
                 'response' => $response->getResponseMessage(),
             ]);
@@ -206,7 +206,7 @@ class CardNetProcessor implements PaymentProcessorInterface, TokenizationProcess
                 'order_id' => $order->id,
                 'hold_purchase_id' => $purchaseId,
                 'capture_purchase_id' => $response->getPurchaseId(),
-                'amount' => $amount ?? $order->getTotalAmount(),
+                'amount' => $amount ?? $order->getTotalDueAmount(),
                 'response_time_ms' => $responseTimeMs,
                 'response' => $response->getResponseMessage(),
             ]);
@@ -617,7 +617,7 @@ class CardNetProcessor implements PaymentProcessorInterface, TokenizationProcess
         return new CardNetPurchaseRequest(
             trxToken: $trxToken,
             order: (string) $order->id,
-            amount: $this->toCardNetAmount($order->getTotalAmount()),
+            amount: $this->toCardNetAmount($order->getTotalDueAmount()),
             currency: (string) ($order->currency ?? 'DOP'),
             invoice: (string) ($order->order_number ?? $order->id),
             capture: $capture,

--- a/src/Domains/Souk/Traits/PayableTrait.php
+++ b/src/Domains/Souk/Traits/PayableTrait.php
@@ -37,7 +37,7 @@ trait PayableTrait
     {
         return $this->payments()
             ->where('status', PaymentStatusEnum::AUTHORIZED->value)
-            ->where('amount', '>=', $this->getTotalAmount())
+            ->where('amount', '>=', $this->getTotalDueAmount())
             ->exists();
     }
 

--- a/tests/Connectors/Stripe/Fakes/FakeStripeClient.php
+++ b/tests/Connectors/Stripe/Fakes/FakeStripeClient.php
@@ -26,6 +26,7 @@ final class FakeStripeClient extends StripeClient
     private FakeCustomersService $customersService;
     private FakePaymentMethodsService $paymentMethodsService;
     private FakeWebhooks $webhooksService;
+    private FakeCouponsService $couponsService;
 
     public function __construct(?string $apiKey = 'sk_test_fake')
     {
@@ -35,6 +36,7 @@ final class FakeStripeClient extends StripeClient
         $this->customersService = new FakeCustomersService();
         $this->paymentMethodsService = new FakePaymentMethodsService();
         $this->webhooksService = new FakeWebhooks();
+        $this->couponsService = new FakeCouponsService();
     }
 
     public function __get($name): mixed
@@ -45,8 +47,14 @@ final class FakeStripeClient extends StripeClient
             'customers' => $this->customersService,
             'paymentMethods' => $this->paymentMethodsService,
             'webhooks' => $this->webhooksService,
+            'coupons' => $this->couponsService,
             default => parent::__get($name),
         };
+    }
+
+    public function getCoupons(): FakeCouponsService
+    {
+        return $this->couponsService;
     }
 
     public function getPaymentIntents(): FakePaymentIntentsService
@@ -147,6 +155,16 @@ final class FakePaymentIntentsService
 }
 
 final class FakeRefundsService
+{
+    use FakeServiceTrait;
+
+    public function create(array $params, ?array $options = null): mixed
+    {
+        return $this->recordAndShift('create', $params, $options);
+    }
+}
+
+final class FakeCouponsService
 {
     use FakeServiceTrait;
 

--- a/tests/Connectors/Stripe/StripePaymentLinkDiscountTest.php
+++ b/tests/Connectors/Stripe/StripePaymentLinkDiscountTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Stripe;
+
+use Baka\Contracts\AppInterface;
+use Kanvas\Connectors\Stripe\Services\StripePaymentLinkService;
+use Kanvas\Souk\Orders\Models\Order;
+use ReflectionMethod;
+use Stripe\Coupon;
+use Tests\Connectors\Stripe\Fakes\FakeStripeClient;
+use Tests\TestCase;
+
+/**
+ * The Stripe payment link builds its line items from item gross prices, so the
+ * order-level discount (order_discounts → discount_amount) must be re-applied as a
+ * one-time coupon, otherwise the customer is charged the full pre-discount total.
+ */
+final class StripePaymentLinkDiscountTest extends TestCase
+{
+    public function testCreatesCouponWithDiscountAmountInCents(): void
+    {
+        $client = new FakeStripeClient();
+        $client->getCoupons()->queueResponse('create', Coupon::constructFrom(['id' => 'coupon_001']));
+
+        $service = $this->makeService($client);
+
+        $order = new Order();
+        $order->id = 42;
+        $order->discount_amount = 1329.94;
+        $order->discount_name = 'Partner Discount';
+        $order->voucher_id = 7;
+        $order->currency = 'USD';
+
+        $couponId = $this->createDiscountCoupon($service, $order);
+
+        $this->assertSame('coupon_001', $couponId);
+
+        $calls = $client->getCoupons()->getCalls('create');
+        $this->assertCount(1, $calls);
+        $this->assertSame(132994, $calls[0]['params']['amount_off']);
+        $this->assertSame('usd', $calls[0]['params']['currency']);
+        $this->assertSame('once', $calls[0]['params']['duration']);
+        $this->assertSame('Partner Discount', $calls[0]['params']['name']);
+    }
+
+    public function testReturnsNullAndCreatesNoCouponWhenOrderHasNoDiscount(): void
+    {
+        $client = new FakeStripeClient();
+
+        $service = $this->makeService($client);
+
+        $order = new Order();
+        $order->id = 43;
+        $order->discount_amount = 0;
+        $order->currency = 'USD';
+
+        $couponId = $this->createDiscountCoupon($service, $order);
+
+        $this->assertNull($couponId);
+        $this->assertCount(0, $client->getCoupons()->getCalls('create'));
+    }
+
+    private function makeService(FakeStripeClient $client): StripePaymentLinkService
+    {
+        $app = $this->createMock(AppInterface::class);
+
+        return new StripePaymentLinkService($app, null, $client);
+    }
+
+    private function createDiscountCoupon(StripePaymentLinkService $service, Order $order): ?string
+    {
+        $method = new ReflectionMethod($service, 'createDiscountCoupon');
+
+        return $method->invoke($service, $order);
+    }
+}

--- a/tests/Souk/Integration/OrderTotalDueAmountTest.php
+++ b/tests/Souk/Integration/OrderTotalDueAmountTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Souk\Integration;
+
+use Kanvas\Souk\Orders\Models\Order;
+use Tests\TestCase;
+
+/**
+ * Pins the contract that payment processors charge the post-discount net total.
+ * Regression for payment links / Azul / CardNet charging the pre-discount gross.
+ */
+final class OrderTotalDueAmountTest extends TestCase
+{
+    public function testTotalDueAmountIsNetTotalAfterDiscount(): void
+    {
+        $order = new Order();
+        $order->total_gross_amount = 7643.32;
+        $order->discount_amount = 1329.94;
+        $order->total_net_amount = 6313.38;
+
+        $this->assertSame(6313.38, $order->getTotalDueAmount());
+        $this->assertSame(7643.32, $order->getTotalAmount());
+        $this->assertLessThan($order->getTotalAmount(), $order->getTotalDueAmount());
+        $this->assertSame(
+            round($order->getTotalAmount() - $order->discount_amount, 2),
+            round($order->getTotalDueAmount(), 2),
+        );
+    }
+
+    public function testTotalDueAmountEqualsGrossWhenNoDiscount(): void
+    {
+        $order = new Order();
+        $order->total_gross_amount = 500.00;
+        $order->discount_amount = 0.0;
+        $order->total_net_amount = 500.00;
+
+        $this->assertSame($order->getTotalAmount(), $order->getTotalDueAmount());
+    }
+}


### PR DESCRIPTION
calculateTotal redefined gross/net in Jan 2026 (c6a41fa6b): total_net_amount became gross minus the order-level discount, but the charging paths kept reading total_gross_amount, so discounted orders were charged the full pre-discount price.

- Add Order::getTotalDueAmount() returning the net (post-discount) payable
- Azul/CardNet processors charge net; Azul itbis -> '000' (getTotalTaxAmount actually returns the discount, not real ITBIS)
- hasAuthorizedPayment() compares against net, consistent with isPaid()
- Stripe payment link attaches a one-time coupon for the order discount (line items are built from item gross prices)
- Tests for the accessor contract and the Stripe coupon

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
