### PR TITLE
fix: return null from Session::getChannel instead of throwing

### DIFF
--- a/src/Domains/Intelligence/PipelinesStages/Actions/FollowUpEngagementAction.php
+++ b/src/Domains/Intelligence/PipelinesStages/Actions/FollowUpEngagementAction.php
@@ -102,7 +102,9 @@ class FollowUpEngagementAction
         $processedChannels = [];
         foreach ($sessions as $session) {
             $messageTemplateChannel = $session->getChannel();
-
+            if (! $messageTemplateChannel) {
+                continue;
+            }
             // Skip if this channel has already been processed
             if (in_array($messageTemplateChannel, $processedChannels)) {
                 continue;

--- a/src/Domains/Intelligence/Sessions/Models/Session.php
+++ b/src/Domains/Intelligence/Sessions/Models/Session.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Sessions\Models;
 
 use Baka\Casts\Json;
-use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Kanvas\Guild\Customers\Models\People;
@@ -82,7 +81,7 @@ class Session extends BaseModel
      *             method remains valid for "what channel did this conversation
      *             happen on?" inspection.
      */
-    public function getChannel(): string
+    public function getChannel(): ?string
     {
         if (str_contains($this->uuid, 'email')) {
             return 'email';
@@ -93,7 +92,7 @@ class Session extends BaseModel
         } elseif (str_contains($this->uuid, 'wa-chat')) {
             return 'whatsapp';
         } else {
-            throw new Exception('Channel unrecognized');
+            return null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- `Session::getChannel()` now returns `?string` and returns `null` for unrecognized UUIDs instead of throwing `Exception('Channel unrecognized')`.
- `FollowUpEngagementAction::execute()` skips sessions whose channel can't be resolved instead of aborting the whole run.

## Test plan
- [ ] Trigger follow-up engagement run with a mix of recognized and unrecognized session UUIDs and confirm the unrecognized ones are skipped without raising.