### PR TITLE
fix: list each app once in userAssociated scope with paginatorInfo

### DIFF
--- a/src/Kanvas/Apps/Models/Apps.php
+++ b/src/Kanvas/Apps/Models/Apps.php
@@ -295,53 +295,26 @@ class Apps extends BaseModel implements AppInterface
     }
 
     /**
-     * Not deleted scope.
+     * Scope apps the current user is associated with.
+     *
+     * Uses a `whereIn` semi-join instead of a JOIN + groupBy: a user can be linked to the
+     * same app through many `users_associated_apps` rows (one per company), so a JOIN
+     * duplicates the app row and forces a groupBy to de-duplicate. That grouped query is handled
+     * inconsistently by Lighthouse `@paginate` — the count query and the data query disagree,
+     * which silently dropped high-cardinality apps when `paginatorInfo` was requested. The
+     * semi-join returns each app exactly once with no duplication, so pagination is stable.
      */
     public function scopeUserAssociated(Builder $query): Builder
     {
         $user = Auth::user();
 
-        return $query->select(
+        return $query->whereIn(
             'apps.id',
-            'apps.name',
-            'apps.description',
-            'apps.url',
-            'apps.domain',
-            'apps.default_apps_plan_id',
-            'apps.is_actived',
-            'apps.key',
-            'apps.payments_active',
-            'apps.ecosystem_auth',
-            'apps.is_public',
-            'apps.domain_based',
-            'apps.created_at',
-            'apps.updated_at'
-        )
-            ->join(
-                'users_associated_apps',
-                'users_associated_apps.apps_id',
-                '=',
-                'apps.id'
-            )
-            ->where('users_associated_apps.users_id', '=', $user->getKey())
-            ->where('users_associated_apps.is_deleted', '=', StateEnums::NO->getValue())
-            ->where('apps.is_deleted', '=', StateEnums::NO->getValue())
-            ->groupBy(
-                'apps.id',
-                'apps.name',
-                'apps.description',
-                'apps.url',
-                'apps.domain',
-                'apps.default_apps_plan_id',
-                'apps.is_actived',
-                'apps.key',
-                'apps.payments_active',
-                'apps.ecosystem_auth',
-                'apps.is_public',
-                'apps.domain_based',
-                'apps.created_at',
-                'apps.updated_at'
-            );
+            UsersAssociatedApps::query()
+                ->select('apps_id')
+                ->where('users_id', $user->getKey())
+                ->where('is_deleted', StateEnums::NO->getValue())
+        );
     }
 
     public function getLogo(): ?FilesystemEntities

--- a/tests/GraphQL/Ecosystem/Apps/AppsCrudTest.php
+++ b/tests/GraphQL/Ecosystem/Apps/AppsCrudTest.php
@@ -8,6 +8,7 @@ use Kanvas\AccessControlList\Enums\RolesEnums;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Enums\AppEnums;
 use Kanvas\Enums\StateEnums;
+use Kanvas\Users\Models\UsersAssociatedApps;
 use Tests\TestCase;
 
 class AppsCrudTest extends TestCase
@@ -86,6 +87,55 @@ class AppsCrudTest extends TestCase
             '
         );
         $this->assertArrayHasKey('data', $response);
+    }
+
+    public function testListedOncePerAppWithPaginatorInfo()
+    {
+        $user = auth()->user();
+        $app = Apps::orderBy('id', 'desc')->first();
+
+        foreach ([0, 999001, 999002, 999003] as $companyId) {
+            UsersAssociatedApps::firstOrCreate([
+                'users_id' => $user->getKey(),
+                'companies_id' => $companyId,
+                'apps_id' => $app->getKey(),
+            ], [
+                'identify_id' => $user->getKey(),
+                'user_active' => StateEnums::ON->getValue(),
+                'user_role' => $user->roles_id,
+                'password' => $user->password,
+            ]);
+        }
+
+        $response = $this->graphQL(
+            /** @lang GraphQL */
+            '
+            query {
+                apps(first: 50) {
+                    data {
+                        id
+                    }
+                    paginatorInfo {
+                        total
+                        currentPage
+                        lastPage
+                    }
+                }
+            }
+            '
+        );
+
+        $ids = array_column($response['data']['apps']['data'], 'id');
+
+        // The user is linked to the app through several users_associated_apps rows
+        // (one per company). Requesting paginatorInfo used to drop or duplicate such
+        // apps because the JOIN + groupBy made the data and count queries disagree.
+        $this->assertSame(
+            1,
+            count(array_keys($ids, (string) $app->getKey())),
+            'App associated through multiple companies must appear exactly once'
+        );
+        $this->assertSame($ids, array_values(array_unique($ids)), 'No app may be listed more than once');
     }
 
     /**


### PR DESCRIPTION
### Problem
`Apps::scopeUserAssociated` used a JOIN against `users_associated_apps` + a `groupBy` over every selected column. A user can be associated with the same app through multiple `users_associated_apps` rows (one per company), so the JOIN duplicated the app row. The `groupBy` de-duplicated the data query, but Lighthouse `@paginate` runs a separate count query that handled the grouping inconsistently — the data and count queries disagreed and high-cardinality apps were silently dropped (or duplicated) when `paginatorInfo` was requested.

### Fix
Replace the JOIN + groupBy with a `whereIn` semi-join against a subquery of `apps_id`. Each app is returned exactly once with no duplication, so pagination is stable.

### Tests
Adds `testListedOncePerAppWithPaginatorInfo` which links a user to one app through several companies and asserts the app appears exactly once when `paginatorInfo` is requested.