### PR TITLE
feat: external AI channel response activity (SMS/email/WhatsApp)

### DIFF
--- a/src/Domains/Intelligence/Workflows/ExternalAgentChannelResponseActivity.php
+++ b/src/Domains/Intelligence/Workflows/ExternalAgentChannelResponseActivity.php
@@ -23,8 +23,8 @@ use Kanvas\Workflow\KanvasActivity;
  * Sibling of {@see \Kanvas\Connectors\Twilio\Workflows\HumanAgentChannelResponseActivity}: same
  * channel routing (SMS / email / WhatsApp, picked from the message verb) and same delivery path
  * (SendMessageToLeadAction), but gated on the external-AI flags `from_ia` / `from_orchestrator`
- * (set on `messages.message`) instead of `from_human`. The external orchestrator sends
- * `from_me=true`, `from_ia=true`, `from_orchestrator=true`.
+ * (set on `messages.message`) instead of `from_human` — for now BOTH must be true. The external
+ * orchestrator sends `from_me=true`, `from_ia=true`, `from_orchestrator=true`.
  *
  * Unlike the human variant it does NOT fire HUMAN_TAKEOVER / pause the local AI — the author is
  * another AI, not a person stepping in. It only delivers the message, marks the thread responded,
@@ -63,7 +63,7 @@ class ExternalAgentChannelResponseActivity extends KanvasActivity
         $content = $messageData['content'] ?? [];
         $fromIa = (bool) ($messageData['from_ia'] ?? false);
         $fromOrchestrator = (bool) ($messageData['from_orchestrator'] ?? false);
-        $fromExternalAi = $fromIa || $fromOrchestrator;
+        $fromExternalAi = $fromIa && $fromOrchestrator;
 
         $fromPhone = $params['from'] ?? null;
 

--- a/src/Domains/Intelligence/Workflows/ExternalAgentChannelResponseActivity.php
+++ b/src/Domains/Intelligence/Workflows/ExternalAgentChannelResponseActivity.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Workflows;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Leads\Actions\SendMessageToLeadAction;
+use Kanvas\Guild\Leads\Enums\LeadCommunicationChannelEnum;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Guild\Leads\Services\NotifyLeadStakeholdersService;
+use Kanvas\Social\Channels\Models\Channel;
+use Kanvas\Social\Enums\ChannelCategoryEnum;
+use Kanvas\Social\Messages\Actions\MarkLeadMessagesAsRespondedAction;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Workflow\Attributes\WorkflowAction;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\KanvasActivity;
+
+/**
+ * Outbound channel delivery for messages authored by an EXTERNAL AI / orchestrator.
+ *
+ * Sibling of {@see \Kanvas\Connectors\Twilio\Workflows\HumanAgentChannelResponseActivity}: same
+ * channel routing (SMS / email / WhatsApp, picked from the message verb) and same delivery path
+ * (SendMessageToLeadAction), but gated on the external-AI flags `from_ia` / `from_orchestrator`
+ * (set on `messages.message`) instead of `from_human`. The external orchestrator sends
+ * `from_me=true`, `from_ia=true`, `from_orchestrator=true`.
+ *
+ * Unlike the human variant it does NOT fire HUMAN_TAKEOVER / pause the local AI — the author is
+ * another AI, not a person stepping in. It only delivers the message, marks the thread responded,
+ * and notifies stakeholders as a (non-human) agent reply.
+ */
+#[WorkflowAction]
+class ExternalAgentChannelResponseActivity extends KanvasActivity
+{
+    public $tries = 3;
+
+    public function execute(Channel $channel, Apps $app, array $params): array
+    {
+        $this->overwriteAppService($app);
+        $message = $params['message'] ?? null;
+
+        $channelContext = [
+            'channel_id' => $channel->getId(),
+            'channel_uuid' => $channel->uuid ?? null,
+            'channel_slug' => $channel->slug ?? null,
+            'channel_entity_type' => $channel->entity_namespace ?? null,
+            'channel_entity_id' => $channel->entity_id ?? null,
+            'app_id' => $app->getId(),
+            'company_id' => $channel->companies_id ?? null,
+            'from' => $params['from'] ?? null,
+        ];
+
+        if (! $message instanceof Message) {
+            return $this->failWorkflow([
+                'message' => 'Message not found',
+                'entity' => null,
+                'context' => $channelContext,
+            ]);
+        }
+
+        $messageData = $message->message;
+        $content = $messageData['content'] ?? [];
+        $fromIa = (bool) ($messageData['from_ia'] ?? false);
+        $fromOrchestrator = (bool) ($messageData['from_orchestrator'] ?? false);
+        $fromExternalAi = $fromIa || $fromOrchestrator;
+
+        $fromPhone = $params['from'] ?? null;
+
+        $messageContext = $channelContext + [
+            'message_id' => $message->getId(),
+            'message_uuid' => $message->uuid ?? null,
+            'message_type' => $message->messageType?->verb,
+            'message_from_ia' => $fromIa,
+            'message_from_orchestrator' => $fromOrchestrator,
+            'message_has_content' => ! empty($content),
+        ];
+
+        return $this->executeIntegration(
+            entity: $channel,
+            app: $app,
+            integration: IntegrationsEnum::INTERNAL,
+            integrationOperation: function ($channel, $app, $integrationCompany, $additionalParams) use ($message, $content, $fromPhone, $fromExternalAi, $params, $messageContext) {
+                $files = $message->getFiles();
+
+                $messageContext['message_has_files'] = $files->isNotEmpty();
+                $messageContext['message_files_count'] = $files->count();
+
+                if (empty($content) && $files->isEmpty()) {
+                    return $this->failWorkflow([
+                        'message' => 'Message content and files are both empty',
+                        'entity' => null,
+                        'context' => $messageContext,
+                    ]);
+                }
+
+                if (! $fromExternalAi) {
+                    return $this->failWorkflow([
+                        'message' => 'Message is not from an external AI (from_ia / from_orchestrator)',
+                        'entity' => null,
+                        'context' => $messageContext,
+                    ]);
+                }
+
+                $channelEntity = $channel->entityData();
+                $messageEntity = $message->entity();
+
+                $messageContext['channel_entity_class'] = $channelEntity ? $channelEntity::class : null;
+                $messageContext['message_entity_class'] = $messageEntity ? $messageEntity::class : null;
+
+                if (! $messageEntity instanceof Lead && $channelEntity instanceof Lead) {
+                    return $this->failWorkflow([
+                        'message' => 'Channel entity is not a Lead',
+                        'entity' => null,
+                        'context' => $messageContext,
+                    ]);
+                }
+
+                $lead = $messageEntity instanceof Lead ? $messageEntity : $channelEntity;
+
+                $messageContext['lead_id'] = $lead?->getId();
+                $messageContext['lead_uuid'] = $lead?->uuid ?? null;
+
+                $channelType = match ($message->messageType->verb) {
+                    ChannelCategoryEnum::WHATSAPP->value => LeadCommunicationChannelEnum::WHATSAPP->value,
+
+                    ChannelCategoryEnum::EMAIL->value,
+                    ChannelCategoryEnum::MAILGUN->value
+                        => LeadCommunicationChannelEnum::EMAIL->value,
+
+                    ChannelCategoryEnum::SMS->value => LeadCommunicationChannelEnum::SMS->value,
+                    default => LeadCommunicationChannelEnum::SMS->value,
+                };
+
+                $messageContext['channel_type'] = $channelType;
+
+                // Email delivery doesn't use a from-phone; only the phone-based channels require it.
+                $phoneChannels = [
+                    LeadCommunicationChannelEnum::SMS->value,
+                    LeadCommunicationChannelEnum::WHATSAPP->value,
+                ];
+                if (in_array($channelType, $phoneChannels, true) && empty($fromPhone)) {
+                    return $this->failWorkflow([
+                        'message' => 'From phone number is required for ' . $channelType,
+                        'entity' => null,
+                        'context' => $messageContext,
+                    ]);
+                }
+
+                $lastMessage = $channel->getLastMessage();
+                if ($lastMessage && $lastMessage->isLocked() && strtolower((string) $lastMessage->messageType?->verb) !== 'note') {
+                    $channel->deleteLastMessageLocked();
+                }
+
+                //we have a loop when you create a msg , its sent back via webhook, so we hide the msg that initiate everything
+                if ($message->messageType->verb === ChannelCategoryEnum::WHATSAPP->value) {
+                    $message->is_public = 0;
+                    $message->save();
+                }
+
+                $message->addTag('engagement');
+
+                $result = new SendMessageToLeadAction($lead)->execute(
+                    $channelType,
+                    $content,
+                    $fromPhone,
+                    $params['title'] ?? null,
+                    false,
+                    $files->isNotEmpty() ? $files : null
+                );
+
+                new MarkLeadMessagesAsRespondedAction($lead, $message)->execute();
+                new NotifyLeadStakeholdersService($lead)->onAgentReply($message, isHuman: false);
+
+                return [
+                    'message' => 'Message sent to lead via ' . $channelType,
+                    'result' => $result,
+                    'context' => $messageContext,
+                ];
+            },
+            company: $channel->company,
+            additionalParams: $params,
+        );
+    }
+}

--- a/tests/Intelligence/Workflows/ExternalAgentChannelResponseActivityTest.php
+++ b/tests/Intelligence/Workflows/ExternalAgentChannelResponseActivityTest.php
@@ -36,12 +36,13 @@ class ExternalAgentChannelResponseActivityTest extends TestCase
     private const string FROM_PHONE = '+19998887777';
     private const string CUSTOMER_PHONE = '+15551234567';
 
-    public function testRejectsMessageNotFromExternalAi(): void
+    public function testRejectsMessageWithOnlyOneExternalAiFlag(): void
     {
+        // Both from_ia AND from_orchestrator are required for now — a single flag is not enough.
         [$app, $channel, $message] = $this->makeChannelMessage(
             verb: 'sms',
             content: 'Hello there',
-            fromIa: false,
+            fromIa: true,
             fromOrchestrator: false,
         );
 
@@ -77,7 +78,7 @@ class ExternalAgentChannelResponseActivityTest extends TestCase
         [$app, $channel, $message] = $this->makeChannelMessage(
             verb: 'email',
             content: 'Orchestrator email body',
-            fromIa: false,
+            fromIa: true,
             fromOrchestrator: true,
         );
 

--- a/tests/Intelligence/Workflows/ExternalAgentChannelResponseActivityTest.php
+++ b/tests/Intelligence/Workflows/ExternalAgentChannelResponseActivityTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Intelligence\Workflows;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Sessions\DataTransferObject\AiChatMessagePayload;
+use Kanvas\Intelligence\Workflows\ExternalAgentChannelResponseActivity;
+use Kanvas\Social\Channels\Actions\CreateChannelAction;
+use Kanvas\Social\Channels\DataTransferObject\Channel as ChannelDto;
+use Kanvas\Social\Channels\Models\Channel;
+use Kanvas\Social\Messages\Actions\CreateMessageAction;
+use Kanvas\Social\Messages\DataTransferObject\MessageInput;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Social\MessagesTypes\Models\MessageType;
+use Kanvas\SystemModules\Models\SystemModules;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\Models\StoredWorkflow;
+use Tests\Connectors\Traits\HasIntegrationCompany;
+use Tests\TestCase;
+
+/**
+ * Locks the gating behavior of ExternalAgentChannelResponseActivity: only messages flagged
+ * from_ia / from_orchestrator are delivered, and a from-phone is required only for the
+ * phone-based channels (SMS / WhatsApp), never for email.
+ */
+class ExternalAgentChannelResponseActivityTest extends TestCase
+{
+    use DatabaseTransactions;
+    use HasIntegrationCompany;
+
+    private const string FROM_PHONE = '+19998887777';
+    private const string CUSTOMER_PHONE = '+15551234567';
+
+    public function testRejectsMessageNotFromExternalAi(): void
+    {
+        [$app, $channel, $message] = $this->makeChannelMessage(
+            verb: 'sms',
+            content: 'Hello there',
+            fromIa: false,
+            fromOrchestrator: false,
+        );
+
+        $result = new ExternalAgentChannelResponseActivity(0, now()->toDateTimeString(), StoredWorkflow::make(), [])->execute(
+            $channel,
+            $app,
+            ['message' => $message, 'from' => self::FROM_PHONE],
+        );
+
+        $this->assertStringContainsString('not from an external AI', $result['message'] ?? '');
+    }
+
+    public function testRequiresFromPhoneForSms(): void
+    {
+        [$app, $channel, $message] = $this->makeChannelMessage(
+            verb: 'sms',
+            content: 'Orchestrator says hi',
+            fromIa: true,
+            fromOrchestrator: true,
+        );
+
+        $result = new ExternalAgentChannelResponseActivity(0, now()->toDateTimeString(), StoredWorkflow::make(), [])->execute(
+            $channel,
+            $app,
+            ['message' => $message],
+        );
+
+        $this->assertStringContainsString('From phone number is required for sms', $result['message'] ?? '');
+    }
+
+    public function testEmailDoesNotRequireFromPhone(): void
+    {
+        [$app, $channel, $message] = $this->makeChannelMessage(
+            verb: 'email',
+            content: 'Orchestrator email body',
+            fromIa: false,
+            fromOrchestrator: true,
+        );
+
+        $result = new ExternalAgentChannelResponseActivity(0, now()->toDateTimeString(), StoredWorkflow::make(), [])->execute(
+            $channel,
+            $app,
+            ['message' => $message],
+        );
+
+        // Email bypasses the phone gate — whatever the downstream send does, it must never be
+        // rejected for a missing from-phone.
+        $combined = ($result['message'] ?? '') . ($result['error'] ?? '');
+        $this->assertStringNotContainsString('From phone number is required', $combined);
+    }
+
+    public function testRejectsEmptyContentAndNoFiles(): void
+    {
+        [$app, $channel, $message] = $this->makeChannelMessage(
+            verb: 'sms',
+            content: '',
+            fromIa: true,
+            fromOrchestrator: true,
+        );
+
+        $result = new ExternalAgentChannelResponseActivity(0, now()->toDateTimeString(), StoredWorkflow::make(), [])->execute(
+            $channel,
+            $app,
+            ['message' => $message, 'from' => self::FROM_PHONE],
+        );
+
+        $this->assertStringContainsString('content and files are both empty', $result['message'] ?? '');
+    }
+
+    /**
+     * @return array{0: Apps, 1: Channel, 2: Message}
+     */
+    private function makeChannelMessage(
+        string $verb,
+        string $content,
+        bool $fromIa,
+        bool $fromOrchestrator,
+    ): array {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        $this->setIntegration($app, IntegrationsEnum::INTERNAL, 'internal', $company, $user);
+
+        SystemModules::firstOrCreate(
+            ['model_name' => Lead::class],
+            ['name' => 'Leads', 'slug' => 'leads', 'description' => 'Leads system module']
+        );
+
+        $lead = Lead::factory()
+            ->withAppAndCompany($app->getId(), $company->getId())
+            ->create();
+        $lead->people->contacts()->create([
+            'contacts_types_id' => ContactTypeEnum::CELLPHONE->value,
+            'value' => self::CUSTOMER_PHONE,
+            'weight' => 1,
+        ]);
+
+        $channel = new CreateChannelAction(
+            ChannelDto::from([
+                'apps' => $app,
+                'companies' => $company,
+                'users' => $lead->user,
+                'entity_id' => $lead->getId(),
+                'entity_namespace' => Lead::class,
+                'name' => 'External AI — ' . $lead->getId(),
+                'slug' => 'external-ai-' . $lead->getId(),
+            ])
+        )->execute();
+
+        $messageType = MessageType::firstOrCreate(
+            ['apps_id' => $app->getId(), 'languages_id' => 1, 'verb' => $verb],
+            ['name' => ucfirst($verb)]
+        );
+
+        $input = new MessageInput(
+            app: $app,
+            company: $company,
+            user: $user,
+            type: $messageType,
+            message: AiChatMessagePayload::from([
+                'content' => $content,
+                'from_me' => true,
+                'from_ia' => $fromIa,
+            ])->toArray() + ['from_orchestrator' => $fromOrchestrator],
+            is_public: 1,
+        );
+        $create = new CreateMessageAction($input);
+        $create->runWorkflow = false;
+        $message = $create->execute();
+
+        $message->addEntity($lead);
+        $channel->addMessage($message);
+
+        return [$app, $channel, $message];
+    }
+}


### PR DESCRIPTION
### What
New `ExternalAgentChannelResponseActivity` (`src/Domains/Intelligence/Workflows/`) lets EXTERNAL AIs / orchestrators send outbound messages through Kanvas channels — SMS, email and WhatsApp.

It mirrors `HumanAgentChannelResponseActivity` (same channel routing from the message verb, same delivery via `SendMessageToLeadAction`) with these differences:

- **Gated on the external-AI flags** `from_ia` / `from_orchestrator` (set on `messages.message`) instead of `from_human`. The orchestrator sends `from_me=true`, `from_ia=true`, `from_orchestrator=true`.
- **Does NOT fire HUMAN_TAKEOVER / pause the local AI** — the author is another AI, not a person stepping in. It only delivers the message, marks the thread responded, and notifies stakeholders as a (non-human) agent reply.
- **From-phone required only for phone channels** (SMS / WhatsApp), never for email — so email delivery works without a phone.

Registered via `#[WorkflowAction]` (auto-discovered; `WorkflowActionCoverageTest` green).

### Tests
`tests/Intelligence/Workflows/ExternalAgentChannelResponseActivityTest.php` — locks the gating: rejects non-external-AI messages, requires a from-phone for SMS, bypasses the phone gate for email, and rejects empty content + no files. 4/4 green.