### PR TITLE
feat: external AI channel response activity

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentChannelReplyAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentChannelReplyAction.php
@@ -16,7 +16,6 @@ use Kanvas\Guild\Leads\Services\NotifyLeadStakeholdersService;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Traits\DispatchesAttachmentDescriptionTrait;
 use Kanvas\Intelligence\Agents\Types\ADKAgent;
-use Kanvas\Intelligence\Enums\ConfigurationEnum;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\Services\LeadConfigurationService;
 use Kanvas\Intelligence\Sessions\DataTransferObject\AiChatMessagePayload;
@@ -207,9 +206,7 @@ class BaseAgentChannelReplyAction
 
     protected function companyRequiresHumanApproval(): bool
     {
-        return IntelligenceModeEnum::tryFrom(
-            (string) $this->message->company->get(ConfigurationEnum::AGENT_AI_MODE->value)
-        )?->requiresHumanApproval() ?? false;
+        return $this->message->company->requiresAgentHumanApproval();
     }
 
     protected function hijackMessagePhone(string $channelId): string

--- a/src/Domains/Intelligence/Agents/Actions/Outreach/AgentReachOutOnChannelAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Outreach/AgentReachOutOnChannelAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Actions\Outreach;
 
+use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\RespondIO\Enums\MessageTypeEnum as RespondIoMessageTypeEnum;
 use Kanvas\Connectors\Twilio\Enums\MessageTypeEnum as TwilioMessageTypeEnum;
 use Kanvas\Guild\Leads\Actions\SendMessageToLeadAction;
@@ -38,6 +39,7 @@ class AgentReachOutOnChannelAction
 
     public function execute(): Message
     {
+        /** @var Companies $company */
         $company = $this->lead->company;
         $aiAgentUser = $company->getAiAgentUserOrFail();
 
@@ -132,22 +134,33 @@ class AgentReachOutOnChannelAction
             $aiAgentUser,
         );
 
+        // Company in APPROVAL
+        if (
+            $this->channelType === ChannelCategoryEnum::EMAIL->value
+            && $company->requiresAgentHumanApproval()
+        ) {
+            $outbound->setLock();
+        }
+
         $outbound->fireWorkflow(
             WorkflowEnum::CREATED->value,
             true,
             ['app' => $this->lead->app],
         );
 
-        // Deliver via the canonical Lead-level dispatcher (SMS/email/WhatsApp/voice).
-        new SendMessageToLeadAction($this->lead)->execute(
-            channel: $this->channelType,
-            message: $responseText,
-            from: null,
-            title: $emailSubject,
-            signature: false,
-            files: null,
-            to: $this->recipient,
-        );
+        // Deliver via the canonical Lead-level dispatcher (SMS/email/WhatsApp/voice),
+        // unless the draft is held for human approval.
+        if (! $outbound->isLocked()) {
+            new SendMessageToLeadAction($this->lead)->execute(
+                channel: $this->channelType,
+                message: $responseText,
+                from: null,
+                title: $emailSubject,
+                signature: false,
+                files: null,
+                to: $this->recipient,
+            );
+        }
 
         return $outbound;
     }

--- a/src/Domains/Intelligence/Workflows/ExternalAgentChannelResponseActivity.php
+++ b/src/Domains/Intelligence/Workflows/ExternalAgentChannelResponseActivity.php
@@ -23,8 +23,8 @@ use Kanvas\Workflow\KanvasActivity;
  * Sibling of {@see \Kanvas\Connectors\Twilio\Workflows\HumanAgentChannelResponseActivity}: same
  * channel routing (SMS / email / WhatsApp, picked from the message verb) and same delivery path
  * (SendMessageToLeadAction), but gated on the external-AI flags `from_ia` / `from_orchestrator`
- * (set on `messages.message`) instead of `from_human`. The external orchestrator sends
- * `from_me=true`, `from_ia=true`, `from_orchestrator=true`.
+ * (set on `messages.message`) instead of `from_human` — for now BOTH must be true. The external
+ * orchestrator sends `from_me=true`, `from_ia=true`, `from_orchestrator=true`.
  *
  * Unlike the human variant it does NOT fire HUMAN_TAKEOVER / pause the local AI — the author is
  * another AI, not a person stepping in. It only delivers the message, marks the thread responded,
@@ -63,7 +63,7 @@ class ExternalAgentChannelResponseActivity extends KanvasActivity
         $content = $messageData['content'] ?? [];
         $fromIa = (bool) ($messageData['from_ia'] ?? false);
         $fromOrchestrator = (bool) ($messageData['from_orchestrator'] ?? false);
-        $fromExternalAi = $fromIa || $fromOrchestrator;
+        $fromExternalAi = $fromIa && $fromOrchestrator;
 
         $fromPhone = $params['from'] ?? null;
 

--- a/src/Domains/Intelligence/Workflows/ExternalAgentChannelResponseActivity.php
+++ b/src/Domains/Intelligence/Workflows/ExternalAgentChannelResponseActivity.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Workflows;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Leads\Actions\SendMessageToLeadAction;
+use Kanvas\Guild\Leads\Enums\LeadCommunicationChannelEnum;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Guild\Leads\Services\NotifyLeadStakeholdersService;
+use Kanvas\Social\Channels\Models\Channel;
+use Kanvas\Social\Enums\ChannelCategoryEnum;
+use Kanvas\Social\Messages\Actions\MarkLeadMessagesAsRespondedAction;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Workflow\Attributes\WorkflowAction;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\KanvasActivity;
+
+/**
+ * Outbound channel delivery for messages authored by an EXTERNAL AI / orchestrator.
+ *
+ * Sibling of {@see \Kanvas\Connectors\Twilio\Workflows\HumanAgentChannelResponseActivity}: same
+ * channel routing (SMS / email / WhatsApp, picked from the message verb) and same delivery path
+ * (SendMessageToLeadAction), but gated on the external-AI flags `from_ia` / `from_orchestrator`
+ * (set on `messages.message`) instead of `from_human`. The external orchestrator sends
+ * `from_me=true`, `from_ia=true`, `from_orchestrator=true`.
+ *
+ * Unlike the human variant it does NOT fire HUMAN_TAKEOVER / pause the local AI — the author is
+ * another AI, not a person stepping in. It only delivers the message, marks the thread responded,
+ * and notifies stakeholders as a (non-human) agent reply.
+ */
+#[WorkflowAction]
+class ExternalAgentChannelResponseActivity extends KanvasActivity
+{
+    public $tries = 3;
+
+    public function execute(Channel $channel, Apps $app, array $params): array
+    {
+        $this->overwriteAppService($app);
+        $message = $params['message'] ?? null;
+
+        $channelContext = [
+            'channel_id' => $channel->getId(),
+            'channel_uuid' => $channel->uuid ?? null,
+            'channel_slug' => $channel->slug ?? null,
+            'channel_entity_type' => $channel->entity_namespace ?? null,
+            'channel_entity_id' => $channel->entity_id ?? null,
+            'app_id' => $app->getId(),
+            'company_id' => $channel->companies_id ?? null,
+            'from' => $params['from'] ?? null,
+        ];
+
+        if (! $message instanceof Message) {
+            return $this->failWorkflow([
+                'message' => 'Message not found',
+                'entity' => null,
+                'context' => $channelContext,
+            ]);
+        }
+
+        $messageData = $message->message;
+        $content = $messageData['content'] ?? [];
+        $fromIa = (bool) ($messageData['from_ia'] ?? false);
+        $fromOrchestrator = (bool) ($messageData['from_orchestrator'] ?? false);
+        $fromExternalAi = $fromIa || $fromOrchestrator;
+
+        $fromPhone = $params['from'] ?? null;
+
+        $messageContext = $channelContext + [
+            'message_id' => $message->getId(),
+            'message_uuid' => $message->uuid ?? null,
+            'message_type' => $message->messageType?->verb,
+            'message_from_ia' => $fromIa,
+            'message_from_orchestrator' => $fromOrchestrator,
+            'message_has_content' => ! empty($content),
+        ];
+
+        return $this->executeIntegration(
+            entity: $channel,
+            app: $app,
+            integration: IntegrationsEnum::INTERNAL,
+            integrationOperation: function ($channel, $app, $integrationCompany, $additionalParams) use ($message, $content, $fromPhone, $fromExternalAi, $params, $messageContext) {
+                $files = $message->getFiles();
+
+                $messageContext['message_has_files'] = $files->isNotEmpty();
+                $messageContext['message_files_count'] = $files->count();
+
+                if (empty($content) && $files->isEmpty()) {
+                    return $this->failWorkflow([
+                        'message' => 'Message content and files are both empty',
+                        'entity' => null,
+                        'context' => $messageContext,
+                    ]);
+                }
+
+                if (! $fromExternalAi) {
+                    return $this->failWorkflow([
+                        'message' => 'Message is not from an external AI (from_ia / from_orchestrator)',
+                        'entity' => null,
+                        'context' => $messageContext,
+                    ]);
+                }
+
+                $channelEntity = $channel->entityData();
+                $messageEntity = $message->entity();
+
+                $messageContext['channel_entity_class'] = $channelEntity ? $channelEntity::class : null;
+                $messageContext['message_entity_class'] = $messageEntity ? $messageEntity::class : null;
+
+                if (! $messageEntity instanceof Lead && $channelEntity instanceof Lead) {
+                    return $this->failWorkflow([
+                        'message' => 'Channel entity is not a Lead',
+                        'entity' => null,
+                        'context' => $messageContext,
+                    ]);
+                }
+
+                $lead = $messageEntity instanceof Lead ? $messageEntity : $channelEntity;
+
+                $messageContext['lead_id'] = $lead?->getId();
+                $messageContext['lead_uuid'] = $lead?->uuid ?? null;
+
+                $channelType = match ($message->messageType->verb) {
+                    ChannelCategoryEnum::WHATSAPP->value => LeadCommunicationChannelEnum::WHATSAPP->value,
+
+                    ChannelCategoryEnum::EMAIL->value,
+                    ChannelCategoryEnum::MAILGUN->value
+                        => LeadCommunicationChannelEnum::EMAIL->value,
+
+                    ChannelCategoryEnum::SMS->value => LeadCommunicationChannelEnum::SMS->value,
+                    default => LeadCommunicationChannelEnum::SMS->value,
+                };
+
+                $messageContext['channel_type'] = $channelType;
+
+                // Email delivery doesn't use a from-phone; only the phone-based channels require it.
+                $phoneChannels = [
+                    LeadCommunicationChannelEnum::SMS->value,
+                    LeadCommunicationChannelEnum::WHATSAPP->value,
+                ];
+                if (in_array($channelType, $phoneChannels, true) && empty($fromPhone)) {
+                    return $this->failWorkflow([
+                        'message' => 'From phone number is required for ' . $channelType,
+                        'entity' => null,
+                        'context' => $messageContext,
+                    ]);
+                }
+
+                $lastMessage = $channel->getLastMessage();
+                if ($lastMessage && $lastMessage->isLocked() && strtolower((string) $lastMessage->messageType?->verb) !== 'note') {
+                    $channel->deleteLastMessageLocked();
+                }
+
+                //we have a loop when you create a msg , its sent back via webhook, so we hide the msg that initiate everything
+                if ($message->messageType->verb === ChannelCategoryEnum::WHATSAPP->value) {
+                    $message->is_public = 0;
+                    $message->save();
+                }
+
+                $message->addTag('engagement');
+
+                $result = new SendMessageToLeadAction($lead)->execute(
+                    $channelType,
+                    $content,
+                    $fromPhone,
+                    $params['title'] ?? null,
+                    false,
+                    $files->isNotEmpty() ? $files : null
+                );
+
+                new MarkLeadMessagesAsRespondedAction($lead, $message)->execute();
+                new NotifyLeadStakeholdersService($lead)->onAgentReply($message, isHuman: false);
+
+                return [
+                    'message' => 'Message sent to lead via ' . $channelType,
+                    'result' => $result,
+                    'context' => $messageContext,
+                ];
+            },
+            company: $channel->company,
+            additionalParams: $params,
+        );
+    }
+}

--- a/src/Kanvas/Companies/Models/Companies.php
+++ b/src/Kanvas/Companies/Models/Companies.php
@@ -41,6 +41,7 @@ use Kanvas\Filesystem\Models\FilesystemEntities;
 use Kanvas\Filesystem\Repositories\FilesystemEntitiesRepository;
 use Kanvas\Filesystem\Traits\HasFilesystemTrait;
 use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
+use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Inventory\Regions\Models\Regions;
 use Kanvas\KanvasModules\Enums\CompanyKanvasModuleStatusEnum;
 use Kanvas\KanvasModules\Enums\KanvasModuleEnum;
@@ -527,6 +528,13 @@ class Companies extends BaseModel implements CompanyInterface, Customer
         }
 
         return $user;
+    }
+
+    public function requiresAgentHumanApproval(): bool
+    {
+        return IntelligenceModeEnum::tryFrom(
+            (string) $this->get(IntelligenceConfigurationEnum::AGENT_AI_MODE->value)
+        )?->requiresHumanApproval() ?? false;
     }
 
     public function hasCompanyPermission(UserInterface $user): void

--- a/tests/Intelligence/Agents/Outreach/AgentReachOutApprovalLockTest.php
+++ b/tests/Intelligence/Agents/Outreach/AgentReachOutApprovalLockTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Intelligence\Agents\Outreach;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Notification;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Agents\Actions\Outreach\AgentReachOutOnChannelAction;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Models\AgentType;
+use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
+use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
+use Kanvas\Notifications\Templates\Blank;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\SystemModules\Models\SystemModules;
+use Tests\Stubs\Intelligence\SalesEmailEnvelopeNeuronAgentStub;
+use Tests\TestCase;
+use Throwable;
+
+/**
+ * Human-approval gate on outbound reach-out: when the company AI mode is APPROVAL, an email
+ * reach-out must persist as a locked draft and NOT ship — a human approves it later via
+ * ApproveAgentMessageAction. Scoped to email (the only verb that approval path actuates today).
+ */
+class AgentReachOutApprovalLockTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function testEmailReachOutIsLockedAndNotSentWhenCompanyRequiresApproval(): void
+    {
+        Notification::fake();
+
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+        $company->set(IntelligenceConfigurationEnum::AI_AGENT_USER_ID->value, $user->getId());
+        $company->set(IntelligenceConfigurationEnum::AGENT_AI_MODE->value, IntelligenceModeEnum::APPROVAL->value);
+
+        SystemModules::firstOrCreate(
+            ['model_name' => Lead::class],
+            ['name' => 'Leads', 'slug' => 'leads', 'description' => 'Leads system module']
+        );
+
+        $lead = Lead::factory()
+            ->withAppAndCompany($app->getId(), $company->getId())
+            ->create();
+        $lead->people->contacts()->create([
+            'contacts_types_id' => ContactTypeEnum::EMAIL->value,
+            'value' => 'alan@kanvas.dev',
+            'weight' => 1,
+        ]);
+
+        $agentType = AgentType::factory()
+            ->withAppId($app->getId())
+            ->create([
+                'name' => 'Sales Email Approval (Neuron Test)',
+                'provider' => 'neuron',
+                'handler' => SalesEmailEnvelopeNeuronAgentStub::class,
+            ]);
+        $agent = Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create([
+                'name' => 'Sally Outreach',
+                'agent_type_id' => $agentType->getId(),
+                'soul' => 'Test',
+                'instructions' => 'Return the structured email envelope',
+                'output_format' => 'json',
+            ]);
+
+        $outbound = null;
+        try {
+            $outbound = new AgentReachOutOnChannelAction(
+                lead: $lead,
+                agent: $agent,
+                channelType: 'email',
+                recipient: 'alan@kanvas.dev',
+            )->execute();
+        } catch (Throwable) {
+            // No post-persist hook should throw on the locked path, but stay defensive.
+        }
+
+        $this->assertNotNull($outbound);
+        $this->assertTrue($outbound->isLocked(), 'Email draft must be locked in APPROVAL mode');
+
+        // Held for review → nothing ships until a human approves it.
+        Notification::assertNothingSent();
+
+        $persisted = Message::query()
+            ->where('apps_id', $app->getId())
+            ->where('companies_id', $company->getId())
+            ->whereJsonContains('message->from_ia', true)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($persisted);
+        $this->assertSame(1, (int) $persisted->is_locked);
+    }
+
+    public function testEmailReachOutShipsImmediatelyWhenApprovalModeOff(): void
+    {
+        Notification::fake();
+
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+        $company->set(IntelligenceConfigurationEnum::AI_AGENT_USER_ID->value, $user->getId());
+        $company->set(IntelligenceConfigurationEnum::AGENT_AI_MODE->value, IntelligenceModeEnum::FULL_ON->value);
+
+        SystemModules::firstOrCreate(
+            ['model_name' => Lead::class],
+            ['name' => 'Leads', 'slug' => 'leads', 'description' => 'Leads system module']
+        );
+
+        $lead = Lead::factory()
+            ->withAppAndCompany($app->getId(), $company->getId())
+            ->create();
+        $lead->people->contacts()->create([
+            'contacts_types_id' => ContactTypeEnum::EMAIL->value,
+            'value' => 'alan@kanvas.dev',
+            'weight' => 1,
+        ]);
+
+        $agentType = AgentType::factory()
+            ->withAppId($app->getId())
+            ->create([
+                'name' => 'Sales Email No Approval (Neuron Test)',
+                'provider' => 'neuron',
+                'handler' => SalesEmailEnvelopeNeuronAgentStub::class,
+            ]);
+        $agent = Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create([
+                'name' => 'Sally Outreach',
+                'agent_type_id' => $agentType->getId(),
+                'soul' => 'Test',
+                'instructions' => 'Return the structured email envelope',
+                'output_format' => 'json',
+            ]);
+
+        $outbound = null;
+        try {
+            $outbound = new AgentReachOutOnChannelAction(
+                lead: $lead,
+                agent: $agent,
+                channelType: 'email',
+                recipient: 'alan@kanvas.dev',
+            )->execute();
+        } catch (Throwable) {
+            // Persistence + the faked mail dispatch run before any post-send hook.
+        }
+
+        $this->assertNotNull($outbound);
+        $this->assertFalse($outbound->isLocked(), 'Draft must not be locked when approval mode is off');
+        Notification::assertSentOnDemand(Blank::class);
+    }
+}

--- a/tests/Intelligence/Workflows/ExternalAgentChannelResponseActivityTest.php
+++ b/tests/Intelligence/Workflows/ExternalAgentChannelResponseActivityTest.php
@@ -36,12 +36,13 @@ class ExternalAgentChannelResponseActivityTest extends TestCase
     private const string FROM_PHONE = '+19998887777';
     private const string CUSTOMER_PHONE = '+15551234567';
 
-    public function testRejectsMessageNotFromExternalAi(): void
+    public function testRejectsMessageWithOnlyOneExternalAiFlag(): void
     {
+        // Both from_ia AND from_orchestrator are required for now — a single flag is not enough.
         [$app, $channel, $message] = $this->makeChannelMessage(
             verb: 'sms',
             content: 'Hello there',
-            fromIa: false,
+            fromIa: true,
             fromOrchestrator: false,
         );
 
@@ -77,7 +78,7 @@ class ExternalAgentChannelResponseActivityTest extends TestCase
         [$app, $channel, $message] = $this->makeChannelMessage(
             verb: 'email',
             content: 'Orchestrator email body',
-            fromIa: false,
+            fromIa: true,
             fromOrchestrator: true,
         );
 

--- a/tests/Intelligence/Workflows/ExternalAgentChannelResponseActivityTest.php
+++ b/tests/Intelligence/Workflows/ExternalAgentChannelResponseActivityTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Intelligence\Workflows;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Sessions\DataTransferObject\AiChatMessagePayload;
+use Kanvas\Intelligence\Workflows\ExternalAgentChannelResponseActivity;
+use Kanvas\Social\Channels\Actions\CreateChannelAction;
+use Kanvas\Social\Channels\DataTransferObject\Channel as ChannelDto;
+use Kanvas\Social\Channels\Models\Channel;
+use Kanvas\Social\Messages\Actions\CreateMessageAction;
+use Kanvas\Social\Messages\DataTransferObject\MessageInput;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Social\MessagesTypes\Models\MessageType;
+use Kanvas\SystemModules\Models\SystemModules;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\Models\StoredWorkflow;
+use Tests\Connectors\Traits\HasIntegrationCompany;
+use Tests\TestCase;
+
+/**
+ * Locks the gating behavior of ExternalAgentChannelResponseActivity: only messages flagged
+ * from_ia / from_orchestrator are delivered, and a from-phone is required only for the
+ * phone-based channels (SMS / WhatsApp), never for email.
+ */
+class ExternalAgentChannelResponseActivityTest extends TestCase
+{
+    use DatabaseTransactions;
+    use HasIntegrationCompany;
+
+    private const string FROM_PHONE = '+19998887777';
+    private const string CUSTOMER_PHONE = '+15551234567';
+
+    public function testRejectsMessageNotFromExternalAi(): void
+    {
+        [$app, $channel, $message] = $this->makeChannelMessage(
+            verb: 'sms',
+            content: 'Hello there',
+            fromIa: false,
+            fromOrchestrator: false,
+        );
+
+        $result = new ExternalAgentChannelResponseActivity(0, now()->toDateTimeString(), StoredWorkflow::make(), [])->execute(
+            $channel,
+            $app,
+            ['message' => $message, 'from' => self::FROM_PHONE],
+        );
+
+        $this->assertStringContainsString('not from an external AI', $result['message'] ?? '');
+    }
+
+    public function testRequiresFromPhoneForSms(): void
+    {
+        [$app, $channel, $message] = $this->makeChannelMessage(
+            verb: 'sms',
+            content: 'Orchestrator says hi',
+            fromIa: true,
+            fromOrchestrator: true,
+        );
+
+        $result = new ExternalAgentChannelResponseActivity(0, now()->toDateTimeString(), StoredWorkflow::make(), [])->execute(
+            $channel,
+            $app,
+            ['message' => $message],
+        );
+
+        $this->assertStringContainsString('From phone number is required for sms', $result['message'] ?? '');
+    }
+
+    public function testEmailDoesNotRequireFromPhone(): void
+    {
+        [$app, $channel, $message] = $this->makeChannelMessage(
+            verb: 'email',
+            content: 'Orchestrator email body',
+            fromIa: false,
+            fromOrchestrator: true,
+        );
+
+        $result = new ExternalAgentChannelResponseActivity(0, now()->toDateTimeString(), StoredWorkflow::make(), [])->execute(
+            $channel,
+            $app,
+            ['message' => $message],
+        );
+
+        // Email bypasses the phone gate — whatever the downstream send does, it must never be
+        // rejected for a missing from-phone.
+        $combined = ($result['message'] ?? '') . ($result['error'] ?? '');
+        $this->assertStringNotContainsString('From phone number is required', $combined);
+    }
+
+    public function testRejectsEmptyContentAndNoFiles(): void
+    {
+        [$app, $channel, $message] = $this->makeChannelMessage(
+            verb: 'sms',
+            content: '',
+            fromIa: true,
+            fromOrchestrator: true,
+        );
+
+        $result = new ExternalAgentChannelResponseActivity(0, now()->toDateTimeString(), StoredWorkflow::make(), [])->execute(
+            $channel,
+            $app,
+            ['message' => $message, 'from' => self::FROM_PHONE],
+        );
+
+        $this->assertStringContainsString('content and files are both empty', $result['message'] ?? '');
+    }
+
+    /**
+     * @return array{0: Apps, 1: Channel, 2: Message}
+     */
+    private function makeChannelMessage(
+        string $verb,
+        string $content,
+        bool $fromIa,
+        bool $fromOrchestrator,
+    ): array {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        $this->setIntegration($app, IntegrationsEnum::INTERNAL, 'internal', $company, $user);
+
+        SystemModules::firstOrCreate(
+            ['model_name' => Lead::class],
+            ['name' => 'Leads', 'slug' => 'leads', 'description' => 'Leads system module']
+        );
+
+        $lead = Lead::factory()
+            ->withAppAndCompany($app->getId(), $company->getId())
+            ->create();
+        $lead->people->contacts()->create([
+            'contacts_types_id' => ContactTypeEnum::CELLPHONE->value,
+            'value' => self::CUSTOMER_PHONE,
+            'weight' => 1,
+        ]);
+
+        $channel = new CreateChannelAction(
+            ChannelDto::from([
+                'apps' => $app,
+                'companies' => $company,
+                'users' => $lead->user,
+                'entity_id' => $lead->getId(),
+                'entity_namespace' => Lead::class,
+                'name' => 'External AI — ' . $lead->getId(),
+                'slug' => 'external-ai-' . $lead->getId(),
+            ])
+        )->execute();
+
+        $messageType = MessageType::firstOrCreate(
+            ['apps_id' => $app->getId(), 'languages_id' => 1, 'verb' => $verb],
+            ['name' => ucfirst($verb)]
+        );
+
+        $input = new MessageInput(
+            app: $app,
+            company: $company,
+            user: $user,
+            type: $messageType,
+            message: AiChatMessagePayload::from([
+                'content' => $content,
+                'from_me' => true,
+                'from_ia' => $fromIa,
+            ])->toArray() + ['from_orchestrator' => $fromOrchestrator],
+            is_public: 1,
+        );
+        $create = new CreateMessageAction($input);
+        $create->runWorkflow = false;
+        $message = $create->execute();
+
+        $message->addEntity($lead);
+        $channel->addMessage($message);
+
+        return [$app, $channel, $message];
+    }
+}


### PR DESCRIPTION
Add ExternalAgentChannelResponseActivity so external AIs / orchestrators can
deliver outbound messages through Kanvas channels (SMS, email, WhatsApp).
Modeled on HumanAgentChannelResponseActivity but gated on the external-AI
flags from_ia / from_orchestrator (set on messages.message) instead of
from_human, and it does not fire HUMAN_TAKEOVER / pause the local AI — the
author is another AI, not a person. A from-phone is required only for the
phone-based channels (SMS / WhatsApp), never for email.## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
