### PR TITLE
feat(reynolds): SalesAssist CRM connector (Push/Pull/Notes + Webhook)

### DIFF
--- a/src/Domains/Connectors/Reynolds/Actions/PushLeadAction.php
+++ b/src/Domains/Connectors/Reynolds/Actions/PushLeadAction.php
@@ -8,7 +8,6 @@ use Kanvas\Connectors\Reynolds\Client;
 use Kanvas\Connectors\Reynolds\DataTransferObject\Lead as LeadData;
 use Kanvas\Connectors\Reynolds\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Reynolds\Enums\TransactionCodeEnum;
-use Kanvas\Connectors\Reynolds\Exceptions\ReynoldsException;
 use Kanvas\Connectors\Reynolds\Services\ApplicationAreaBuilder;
 use Kanvas\Guild\Leads\Models\Lead as LeadModel;
 
@@ -23,14 +22,14 @@ class PushLeadAction
 
     public function execute(): array
     {
-        $client = new Client($this->lead->app, $this->lead->company);
-
+        // Upsert semantics: if the lead already carries a REYNOLDS_PROSPECT_ID
+        // it exists in R&R and can only be Updated (USL) — re-sending an ISL
+        // for the same prospect makes R&R reject the request.
         if ($this->lead->get(CustomFieldEnum::PROSPECT_ID->value)) {
-            throw new ReynoldsException(
-                'Lead already exists in Reynolds (ProspectId set). Use UpdateLeadAction instead.'
-            );
+            return new UpdateLeadAction($this->lead)->execute();
         }
 
+        $client = new Client($this->lead->app, $this->lead->company);
         $payload = $this->buildPayload($client);
 
         $response = $client->processMessage(self::ROOT_ELEMENT, $payload);

--- a/src/Domains/Connectors/Reynolds/Actions/UpdateLeadAction.php
+++ b/src/Domains/Connectors/Reynolds/Actions/UpdateLeadAction.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Reynolds\Actions;
+
+use Kanvas\Connectors\Reynolds\Client;
+use Kanvas\Connectors\Reynolds\DataTransferObject\Lead as LeadData;
+use Kanvas\Connectors\Reynolds\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Reynolds\Enums\TransactionCodeEnum;
+use Kanvas\Connectors\Reynolds\Exceptions\ReynoldsException;
+use Kanvas\Connectors\Reynolds\Services\ApplicationAreaBuilder;
+use Kanvas\Guild\Leads\Models\Lead as LeadModel;
+
+/**
+ * Reynolds Update Sales Lead (USL) — Customer sub-flow.
+ *
+ * Sends the same Customer/Address/Phones/Email/Consent projection that
+ * PushLeadAction (ISL) builds, but wrapped in the Update root element
+ * and carrying the existing ProspectId so R&R knows which prospect to
+ * mutate instead of creating a new one.
+ */
+class UpdateLeadAction
+{
+    private const ROOT_ELEMENT = 'rey_SalesAssistCRMUpdateSalesLead';
+
+    public function __construct(
+        protected LeadModel $lead
+    ) {
+    }
+
+    public function execute(): array
+    {
+        $client = new Client($this->lead->app, $this->lead->company);
+
+        $prospectId = $this->lead->get(CustomFieldEnum::PROSPECT_ID->value);
+        if (empty($prospectId)) {
+            throw new ReynoldsException(
+                'UpdateLeadAction requires REYNOLDS_PROSPECT_ID on the lead — call PushLeadAction (ISL) first.'
+            );
+        }
+
+        $payload = $this->buildPayload($client, (string) $prospectId);
+
+        $response = $client->processMessage(self::ROOT_ELEMENT, $payload);
+
+        return [
+            'prospect_id' => (string) $prospectId,
+            'response' => $response,
+        ];
+    }
+
+    private function buildPayload(Client $client, string $prospectId): array
+    {
+        $leadData = LeadData::fromLead($this->lead);
+        $peopleSection = new SyncPeopleAction($this->lead->people)->execute();
+
+        // USL puts ProspectId in a separate <Identifier> block inside Record
+        // (mirrors the shape used by inbound LDU envelopes and the working
+        // USL Note sub-flow — see AddNoteToLeadAction).
+        $record = array_filter([
+            'Identifier' => ['ProspectId' => $prospectId],
+            'Prospect' => $leadData->toProspect(),
+        ], fn ($v) => ! empty($v));
+
+        $record += $peopleSection;
+
+        return [
+            'ApplicationArea' => ApplicationAreaBuilder::build(
+                $client,
+                TransactionCodeEnum::UPDATE_SALES_LEAD,
+                'I'
+            ),
+            'Record' => $record,
+        ];
+    }
+}

--- a/src/Domains/Connectors/Reynolds/DataTransferObject/Lead.php
+++ b/src/Domains/Connectors/Reynolds/DataTransferObject/Lead.php
@@ -52,6 +52,11 @@ class Lead extends Data
 
     /**
      * Build the Prospect XML section.
+     *
+     * ProspectId is intentionally NOT included here — USL puts it in a
+     * separate `<Identifier>` sibling block inside Record (mirrors the
+     * shape LDU inbound envelopes use and what the USL Note sub-flow
+     * already does). ISL leaves it blank so R&R generates the id.
      */
     public function toProspect(): array
     {

--- a/src/Domains/Connectors/SalesAssist/Activities/PushLeadActivity.php
+++ b/src/Domains/Connectors/SalesAssist/Activities/PushLeadActivity.php
@@ -11,7 +11,6 @@ use Kanvas\Connectors\DriveCentric\Enums\ConfigurationEnum;
 use Kanvas\Connectors\Elead\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Reynolds\Actions\PushLeadAction as ReynoldsPushLeadAction;
 use Kanvas\Connectors\Reynolds\Enums\ConfigurationEnum as ReynoldsConfigurationEnum;
-use Kanvas\Connectors\Reynolds\Enums\CustomFieldEnum as ReynoldsCustomFieldEnum;
 use Kanvas\Connectors\VinSolution\Enums\CustomFieldEnum as EnumsCustomFieldEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Workflow\Attributes\WorkflowAction;
@@ -52,23 +51,16 @@ class PushLeadActivity extends KanvasActivity
                 } elseif ($isReynolds) {
                     $connectedCRM = 'Reynolds';
 
-                    // Reynolds rejects ISL re-sends for leads that already carry a
-                    // REYNOLDS_PROSPECT_ID. Short-circuit here so the workflow does
-                    // not blow up when it is wired to a generic "lead saved" trigger.
-                    if ($lead->get(ReynoldsCustomFieldEnum::PROSPECT_ID->value)) {
-                        $result = [
-                            'message' => 'Lead already exists in Reynolds — skipping ISL',
-                            'prospect_id' => (string) $lead->get(ReynoldsCustomFieldEnum::PROSPECT_ID->value),
-                        ];
-                    } else {
-                        try {
-                            $result = new ReynoldsPushLeadAction($lead)->execute();
-                        } catch (Throwable $e) {
-                            return $this->failWorkflow([
-                                'error' => 'Reynolds Insert Sales Lead failed: ' . $e->getMessage(),
-                                'crm' => $connectedCRM,
-                            ]);
-                        }
+                    // ReynoldsPushLeadAction upserts internally: it delegates to
+                    // UpdateLeadAction (USL) when the lead already carries a
+                    // REYNOLDS_PROSPECT_ID, else runs the ISL insert path.
+                    try {
+                        $result = new ReynoldsPushLeadAction($lead)->execute();
+                    } catch (Throwable $e) {
+                        return $this->failWorkflow([
+                            'error' => 'Reynolds push failed: ' . $e->getMessage(),
+                            'crm' => $connectedCRM,
+                        ]);
                     }
                 }
 


### PR DESCRIPTION
## Summary

Complete Reynolds & Reynolds SalesAssist CRM connector for the Kanvas Ecosystem API.

**Outbound (Kanvas → R&R):**
- `PushLeadAction` (ISL) — creates a new prospect in R&R. Upserts transparently: if the lead already carries a `REYNOLDS_PROSPECT_ID`, it delegates to `UpdateLeadAction` (USL Customer sub-flow) instead of re-inserting.
- `UpdateLeadAction` (USL) — updates an existing prospect's customer/address/phones/email/consent.
- `AddNoteToLeadAction` (USL Note sub-flow) — adds a note to an existing prospect; auto-pushes the lead first if it hasn't been sent yet.

**Inbound (R&R → Kanvas):**
- `ProcessReynoldsWebhookJob` extends `Kanvas\Workflow\Jobs\ProcessWebhookJob`, routed through the existing `ReceiverController` at `POST /v1/receiver/{uuid}`.
- Handles `OSL`/`USL`/`LDU`/`DSP`/`ACT` Task codes. OSL/USL/LDU upsert via `PullLeadAction`; DSP applies a lead-status change; ACT is stubbed until we have a real sample.
- Multi-tenant resolution: R&R publishes every dealer event to a single global URL, so the receiver resolves the target Company by matching a precomputed `REYNOLDS_DEALER_LOCATION_KEY` composite (`Dealer|Store|Area`) written by `ReynoldsHandler::setup()`.

**Workflow integration:**
- `PushLeadActivity` and `PullLeadActivity` under `Reynolds/Activities/` are thin subclasses of the SalesAssist meta-activities so global workflows can dispatch to Reynolds transparently via the existing routing.
- `PullPeopleActivity` inside the SalesAssist meta now has a Reynolds branch mirroring the PullLead one.

**Transport:**
- Guzzle HTTP client + hand-rolled SOAP envelope (WSSE UsernameToken auth, STAR standard namespaces, TLS 1.2 pinned).
- No `SoapClient` — R&R doesn't ship a WSDL and `SoapClient` doesn't support WSSE natively.

**Config:**
- All settings tenant-scoped on the Company: `REYNOLDS_USERNAME`, `REYNOLDS_PASSWORD`, `REYNOLDS_ENDPOINT`, `REYNOLDS_SENDER_NAME`, `REYNOLDS_DEALER_NUMBER`, `REYNOLDS_STORE_NUMBER`, `REYNOLDS_AREA_NUMBER`, `REYNOLDS_BUSINESS_UNIT_NAME`, plus the precomputed `REYNOLDS_DEALER_LOCATION_KEY` used for inbound routing.
- Catalog seeding at setup: LeadType × 4 (Internet/Phone/Other/List), LeadStatus × 4 (Active/Sold/Lost/Closed), LeadSource "Kanvas".

## Verified against the R&R sandbox

- ISL creates a real prospect (verified ProspectIds 2078686, 2079077, 2079078 during dev).
- USL updates an existing prospect (`Status=Success/StatusCode=0`, Task=USL echoed back).
- USL Note sub-flow — both auto-push case and reuse-existing-prospect case.
- Inbound receiver processed a real OSL envelope captured from R&R and upserted the corresponding Lead + People.

## Wire-shape gotchas discovered live (documented in code comments)

- USL `TransType` must be `'I'`, not `'U'` (R&R replies StatusCode 201 otherwise).
- USL `<ProspectId>` goes inside `<Record><Identifier>` — putting it inside `<Prospect>` is silently ignored.
- OSL envelopes from R&R don't carry `<NameRecId>`; `Customer::toPeopleData` accepts a `prospect:<ProspectId>` fallback so People dedup keeps a stable key.
- Root element for inbound is `rey_SalesAssistCRMSalesLead`, not `…PublishLeadUpdate` as the LDU spec example suggested; parser accepts both.

## Setup rows required in target env

- `workflow.integrations` row (`handler = Kanvas\\Connectors\\Reynolds\\Handlers\\ReynoldsHandler`).
- `workflow.actions` row for `Kanvas\\Connectors\\Reynolds\\Webhooks\\ProcessReynoldsWebhookJob`.
- `workflow.receiver_webhooks` row bound to that action so R&R's URL routes here.
- For dealers configured before the composite key existed, run the (local, gitignored) backfill command once to populate `REYNOLDS_DEALER_LOCATION_KEY`.

## Test plan

- [ ] `docker exec php php vendor/bin/phpunit tests/Connectors/Integration/Reynolds`
- [ ] `docker exec php php vendor/bin/phpunit --testsuite=Connectors`
- [ ] Live sandbox opt-in: `REYNOLDS_LIVE_TEST=1 REYNOLDS_TEST_*` env vars + `LivePushLeadTest` / `LiveAddNoteTest` (skipped by default in CI)
- [ ] Register the `integrations` and `receiver_webhooks` rows in the target env before enabling for a dealer
- [ ] For legacy dealers, run `debug:reynolds-webhook --list` after first inbound event to confirm tenant resolution succeeds