### PR TITLE
refact(reynolds): drop dead PROSPECT_ID short-circuit in SalesAssist meta

### DIFF
--- a/src/Domains/Connectors/SalesAssist/Activities/PushLeadActivity.php
+++ b/src/Domains/Connectors/SalesAssist/Activities/PushLeadActivity.php
@@ -11,7 +11,6 @@ use Kanvas\Connectors\DriveCentric\Enums\ConfigurationEnum;
 use Kanvas\Connectors\Elead\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Reynolds\Actions\PushLeadAction as ReynoldsPushLeadAction;
 use Kanvas\Connectors\Reynolds\Enums\ConfigurationEnum as ReynoldsConfigurationEnum;
-use Kanvas\Connectors\Reynolds\Enums\CustomFieldEnum as ReynoldsCustomFieldEnum;
 use Kanvas\Connectors\VinSolution\Enums\CustomFieldEnum as EnumsCustomFieldEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Workflow\Attributes\WorkflowAction;
@@ -52,23 +51,16 @@ class PushLeadActivity extends KanvasActivity
                 } elseif ($isReynolds) {
                     $connectedCRM = 'Reynolds';
 
-                    // Reynolds rejects ISL re-sends for leads that already carry a
-                    // REYNOLDS_PROSPECT_ID. Short-circuit here so the workflow does
-                    // not blow up when it is wired to a generic "lead saved" trigger.
-                    if ($lead->get(ReynoldsCustomFieldEnum::PROSPECT_ID->value)) {
-                        $result = [
-                            'message' => 'Lead already exists in Reynolds — skipping ISL',
-                            'prospect_id' => (string) $lead->get(ReynoldsCustomFieldEnum::PROSPECT_ID->value),
-                        ];
-                    } else {
-                        try {
-                            $result = new ReynoldsPushLeadAction($lead)->execute();
-                        } catch (Throwable $e) {
-                            return $this->failWorkflow([
-                                'error' => 'Reynolds Insert Sales Lead failed: ' . $e->getMessage(),
-                                'crm' => $connectedCRM,
-                            ]);
-                        }
+                    // ReynoldsPushLeadAction upserts internally: it delegates to
+                    // UpdateLeadAction (USL) when the lead already carries a
+                    // REYNOLDS_PROSPECT_ID, else runs the ISL insert path.
+                    try {
+                        $result = new ReynoldsPushLeadAction($lead)->execute();
+                    } catch (Throwable $e) {
+                        return $this->failWorkflow([
+                            'error' => 'Reynolds push failed: ' . $e->getMessage(),
+                            'crm' => $connectedCRM,
+                        ]);
                     }
                 }
 


### PR DESCRIPTION
## Summary

Follow-up to #10221 (Reynolds connector, merged). `ReynoldsPushLeadAction` now upserts internally by delegating to `UpdateLeadAction` (USL) when the lead already carries a `REYNOLDS_PROSPECT_ID`, so the meta activity's "lead already exists — skipping ISL" branch is dead code.

## Changes

- Collapse the Reynolds branch in `SalesAssist\Activities\PushLeadActivity` to a single `ReynoldsPushLeadAction` call — the Action decides ISL vs USL internally.
- Drop the misleading "skipping ISL" result message that made it look like updates were being silently discarded.
- Remove the now-unused `ReynoldsCustomFieldEnum` import.

## Test plan

- [ ] `docker exec php php vendor/bin/phpunit tests/Connectors/Integration/Reynolds`
- [ ] Verify a generic "lead saved" workflow that fires Reynolds updates arrives at USL (not the skipped path)