### PR TITLE
fix(reynolds): anchor inbound People sync to prevent duplicates

### DIFF
--- a/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
+++ b/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
@@ -6,9 +6,11 @@ namespace Kanvas\Connectors\Reynolds\Actions;
 
 use Baka\Contracts\AppInterface;
 use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Reynolds\Entities\Customer as CustomerEntity;
 use Kanvas\Connectors\Reynolds\Entities\Lead as LeadEntity;
 use Kanvas\Connectors\Reynolds\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Reynolds\Exceptions\ReynoldsException;
+use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
 use Kanvas\Guild\Leads\Actions\SyncLeadByThirdPartyCustomFieldAction;
 use Kanvas\Guild\Leads\DataTransferObject\Lead as LeadData;
 use Kanvas\Guild\Leads\Models\Lead as LeadModel;
@@ -47,6 +49,12 @@ class PullLeadAction
         if ($entity->prospectId === null || $entity->customer === null) {
             throw new ReynoldsException('Lead Update payload missing ProspectId or Customer');
         }
+
+        // Anchor the People sync so consecutive envelopes (e.g. OSL without a
+        // NameRecId immediately followed by an LDU that carries the real one)
+        // update the same People row instead of creating a duplicate. Lookup
+        // order: existing Lead by ProspectId → People matched by email/phone.
+        $existingPeopleId = $this->resolveExistingPeopleId($entity);
 
         $customFields = [
             CustomFieldEnum::PROSPECT_ID->value => $entity->prospectId,
@@ -102,9 +110,10 @@ class PullLeadAction
                 app: $this->app,
                 branch: $this->company->defaultBranch,
                 user: $this->user,
+                existingPeopleId: $existingPeopleId,
                 // OSL envelopes don't always carry a NameRecId — fall back to a
                 // ProspectId-derived synthetic so People dedup still has a stable
-                // key per Reynolds prospect.
+                // key per Reynolds prospect when the anchor lookups miss too.
                 fallbackNameRecId: 'prospect:' . $entity->prospectId,
             ),
             'leads_owner_id' => $this->resolveOwnerId($entity) ?? $this->user->getId(),
@@ -117,6 +126,60 @@ class PullLeadAction
         ]);
 
         return new SyncLeadByThirdPartyCustomFieldAction($leadData)->execute();
+    }
+
+    private function resolveExistingPeopleId(LeadEntity $entity): ?int
+    {
+        // 1. Same Reynolds prospect already synced → reuse its People.
+        $existingLead = LeadModel::query()
+            ->fromApp($this->app)
+            ->fromCompany($this->company)
+            ->notDeleted()
+            ->whereHas(
+                'customFields',
+                fn ($q) => $q->where('name', CustomFieldEnum::PROSPECT_ID->value)
+                    ->where('value', (string) $entity->prospectId)
+            )
+            ->first();
+
+        if ($existingLead?->people_id) {
+            return (int) $existingLead->people_id;
+        }
+
+        // 2. First time we see this prospect — try to match an existing
+        // customer by email or phone so we don't fork Peoples that Kanvas
+        // already created from other sources (walk-ins, other CRMs, web forms).
+        $email = $entity->customer?->email;
+        $phone = $this->firstUsablePhone($entity->customer);
+
+        if (empty($email) && empty($phone)) {
+            return null;
+        }
+
+        $existing = PeoplesRepository::getMatchingEmailPhone(
+            app: $this->app,
+            company: $this->company,
+            email: $email !== null ? strtolower((string) $email) : null,
+            phone: $phone,
+        );
+
+        return $existing?->getId();
+    }
+
+    private function firstUsablePhone(?CustomerEntity $customer): ?string
+    {
+        if ($customer === null) {
+            return null;
+        }
+
+        foreach ($customer->phones as $phone) {
+            $normalized = preg_replace('/\D+/', '', (string) ($phone['num'] ?? ''));
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
     }
 
     private function buildTitle(LeadEntity $entity): string

--- a/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
+++ b/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
@@ -10,6 +10,7 @@ use Kanvas\Connectors\Reynolds\Entities\Customer as CustomerEntity;
 use Kanvas\Connectors\Reynolds\Entities\Lead as LeadEntity;
 use Kanvas\Connectors\Reynolds\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Reynolds\Exceptions\ReynoldsException;
+use Kanvas\Guild\Customers\Models\Contact;
 use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
 use Kanvas\Guild\Leads\Actions\SyncLeadByThirdPartyCustomFieldAction;
 use Kanvas\Guild\Leads\DataTransferObject\Lead as LeadData;
@@ -168,7 +169,10 @@ class PullLeadAction
         }
 
         foreach ($customer->phones as $phone) {
-            $normalized = preg_replace('/\D+/', '', (string) ($phone['num'] ?? ''));
+            // Contact::cleanPhone is the canonical normalizer used by the
+            // ContactObserver on write, so the value we match against in
+            // peoples_contacts is comparable byte-for-byte.
+            $normalized = Contact::cleanPhone((string) ($phone['num'] ?? ''));
             if ($normalized !== '') {
                 return $normalized;
             }

--- a/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
+++ b/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
@@ -131,16 +131,11 @@ class PullLeadAction
     private function resolveExistingPeopleId(LeadEntity $entity): ?int
     {
         // 1. Same Reynolds prospect already synced → reuse its People.
-        $existingLead = LeadModel::query()
-            ->fromApp($this->app)
-            ->fromCompany($this->company)
-            ->notDeleted()
-            ->whereHas(
-                'customFields',
-                fn ($q) => $q->where('name', CustomFieldEnum::PROSPECT_ID->value)
-                    ->where('value', (string) $entity->prospectId)
-            )
-            ->first();
+        $existingLead = LeadModel::getByCustomField(
+            CustomFieldEnum::PROSPECT_ID->value,
+            (string) $entity->prospectId,
+            $this->company,
+        );
 
         if ($existingLead?->people_id) {
             return (int) $existingLead->people_id;

--- a/tests/Connectors/Integration/Reynolds/PushVoiToExistingLeadTest.php
+++ b/tests/Connectors/Integration/Reynolds/PushVoiToExistingLeadTest.php
@@ -4,13 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Connectors\Integration\Reynolds;
 
-use Kanvas\Apps\Models\Apps;
-use Kanvas\Connectors\Reynolds\Actions\PushLeadAction;
-use Kanvas\Connectors\Reynolds\Enums\CustomFieldEnum;
-use Kanvas\Connectors\Reynolds\Exceptions\ReynoldsException;
-use Kanvas\Guild\Customers\Models\People;
-use Kanvas\Guild\Leads\Models\Lead;
-use Tests\Connectors\Traits\HasReynoldsConfiguration;
 use Tests\TestCase;
 
 /**
@@ -23,68 +16,38 @@ use Tests\TestCase;
  * Why it does not work:
  *   - Outbound to R&R there are exactly two transactions:
  *       * ISL (Insert Sales Lead): includes <DesiredVehicle> but only fires
- *         for a brand-new prospect. Re-sending ISL for a lead that already
- *         has a REYNOLDS_PROSPECT_ID is explicitly rejected by our
- *         PushLeadAction and would be a logical no-op even if it wasn't.
+ *         for a brand-new prospect. Once a lead already has a
+ *         REYNOLDS_PROSPECT_ID, PushLeadAction upserts by delegating to
+ *         UpdateLeadAction (USL) — which is the correct behaviour for the
+ *         general case but means the DesiredVehicle block never reaches R&R
+ *         via that path.
  *       * USL (Update Sales Lead): has four sub-flows defined in the spec
  *         (Activity / Appointment / Note / Consent). There is NO Vehicle
  *         or DesiredVehicle sub-flow. The XSD does not surface a vehicle
- *         section on the Update Sales Lead schema.
+ *         section on the Update Sales Lead schema, and UpdateLeadAction
+ *         accordingly does not include one in its payload.
  *   - The only workaround inside SalesAssist is a USL Note transaction
  *     carrying free-text like "Customer now interested in 2024 Malibu",
  *     which we do support via AddNoteToLeadAction. That is unstructured
  *     and does not update the prospect's DesiredVehicle on the R&R side.
  *
- * The test is kept (and runs the negative assertion) so a future spec
- * revision that adds Vehicle to USL would surface the gap immediately —
- * if R&R publishes a USL Vehicle sub-flow we would replace the
- * markTestSkipped with the actual assertion and implement the action.
+ * Both tests are skipped by design — the file exists to keep the
+ * constraint discoverable from the test suite so a future spec revision
+ * that adds a Vehicle sub-flow to USL surfaces the gap immediately.
  */
 final class PushVoiToExistingLeadTest extends TestCase
 {
-    use HasReynoldsConfiguration;
-
-    public function testPushingPushLeadActionRefusesLeadsThatAlreadyExistOnReynoldsSide(): void
+    public function testUslDoesNotCarryDesiredVehicleForExistingProspects(): void
     {
-        $app = app(Apps::class);
-        $user = auth()->user();
-        $company = $user->getCurrentCompany();
-
-        $this->setupReynoldsConfiguration($app, $company);
-
-        $people = People::factory()
-            ->withAppId($app->getId())
-            ->withUserId($user->getId())
-            ->withCompanyId($company->getId())
-            ->withContacts(canUseFakeInfo: false)
-            ->create();
-
-        $lead = Lead::factory()
-            ->withUserId($user->getId())
-            ->withAppId($app->getId())
-            ->withCompanyId($company->getId())
-            ->withPeopleId($people->getId())
-            ->create();
-
-        // Mark the lead as already-pushed-to-Reynolds. PushLeadAction must
-        // refuse to re-submit it — there is no way to update Vehicle on an
-        // existing prospect via SalesAssist.
-        $lead->set(CustomFieldEnum::PROSPECT_ID->value, '2078595');
-
-        // Even with a vehicle_of_interest set, PushLeadAction must short-
-        // circuit before attempting any Reynolds round-trip.
-        $lead->set('vehicle_of_interest', [
-            'vin' => '1G1ZE5ST8RF111640',
-            'year' => '2024',
-            'make' => 'Chevrolet',
-            'model' => 'Malibu',
-            'stock_type' => 'New',
-        ]);
-
-        $this->expectException(ReynoldsException::class);
-        $this->expectExceptionMessageMatches('/already exists in Reynolds/i');
-
-        new PushLeadAction($lead)->execute();
+        $this->markTestSkipped(
+            'Per SalesAssist Update Sales Lead Spec v1.1, USL has no Vehicle '
+            . 'sub-flow. PushLeadAction upserts by delegating to UpdateLeadAction '
+            . 'when a lead already carries REYNOLDS_PROSPECT_ID, and that USL '
+            . 'payload intentionally omits <DesiredVehicle>. Re-enable this test '
+            . 'after R&R publishes a USL Vehicle sub-flow — the assertion would '
+            . 'become: the built payload must include <DesiredVehicle> when '
+            . 'vehicle_of_interest is set on the lead.'
+        );
     }
 
     public function testUslHasNoVehicleSubFlowAvailableAsAnActionInTheConnector(): void


### PR DESCRIPTION
R&R commonly sends an OSL first (no <NameRecId>) and then an LDU seconds later carrying the real <NameRecId>. Without anchoring, the two envelopes would key off different NAME_REC_ID values and SyncPeopleByThirdPartyCustomFieldAction would create a second People row for the same customer.

PullLeadAction now resolves an existing People id before building the DTO, using a two-step lookup:

  1. Existing Lead by REYNOLDS_PROSPECT_ID  → reuse its people_id (covers OSL→LDU on the same prospect + any prior ISL from our side)
  2. PeoplesRepository::getMatchingEmailPhone by email or phone (covers first-time OSL for a customer that Kanvas already knows from another CRM, a walk-in, or a web form)

The resolved id is passed to Customer::toPeopleData(existingPeopleId) so downstream sync overwrites that specific row instead of falling back to NAME_REC_ID-based dedup, which fails whenever the envelope's NameRecId differs from what the prior envelope carried.

Verified with the OSL+LDU pair captured from prod (ProspectId 1213912 Wright, Elmer): OSL creates Lead + People with NAME_REC_ID='prospect:X'. LDU with real NameRecId (19835 in prod, REAL* in the local repro) reuses the same Lead and People and updates NAME_REC_ID to the real value. No duplicate rows created.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
