### PR TITLE
fix(reynolds): map real envelope shape + restore ActionEngine branches

### DIFF
--- a/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
+++ b/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
@@ -220,37 +220,48 @@ class PullLeadAction
             return 0;
         }
 
-        $type = LeadType::fromApp($this->app)
-            ->fromCompany($this->company)
-            ->where('name', $name)
-            ->first();
+        $type = LeadType::firstOrCreate(
+            [
+                'apps_id' => $this->app->getId(),
+                'companies_id' => $this->company->getId(),
+                'name' => $name,
+            ],
+            [
+                'description' => "Reynolds ProspectType: {$name}",
+                'is_active' => 1,
+            ],
+        );
 
-        return $type?->getId() ?? 0;
+        return $type->getId();
     }
 
     private function resolveStatusId(?string $name): int
     {
-        if ($name !== null) {
-            $status = LeadStatus::fromApp($this->app)
-                ->fromCompany($this->company)
-                ->where('name', $name)
-                ->first();
-
-            if ($status !== null) {
-                return $status->getId();
-            }
-        }
-
         // Reynolds Publish Lead Update does not include ProspectStatus, so most LDU
         // payloads land here. Fall back to the first available LeadStatus visible to
         // this app (including globally-seeded rows with apps_id=0) — leaving
         // leads_status_id = 0 breaks the LeadObserver which calls
         // status()->firstOrFail() on save.
-        $default = LeadStatus::query()
-            ->whereIn('apps_id', [0, $this->app->getId()])
-            ->first();
+        if ($name === null) {
+            $default = LeadStatus::query()
+                ->whereIn('apps_id', [0, $this->app->getId()])
+                ->first();
 
-        return $default?->getId() ?? 0;
+            return $default?->getId() ?? 0;
+        }
+
+        $status = LeadStatus::firstOrCreate(
+            [
+                'apps_id' => $this->app->getId(),
+                'companies_id' => $this->company->getId(),
+                'name' => $name,
+            ],
+            [
+                'is_default' => 0,
+            ],
+        );
+
+        return $status->getId();
     }
 
     private function resolveSourceId(?string $name): int
@@ -259,11 +270,18 @@ class PullLeadAction
             return 0;
         }
 
-        $source = LeadSource::fromApp($this->app)
-            ->fromCompany($this->company)
-            ->where('name', $name)
-            ->first();
+        $source = LeadSource::firstOrCreate(
+            [
+                'apps_id' => $this->app->getId(),
+                'companies_id' => $this->company->getId(),
+                'name' => $name,
+            ],
+            [
+                'description' => "Reynolds ProviderName: {$name}",
+                'is_active' => 1,
+            ],
+        );
 
-        return $source?->getId() ?? 0;
+        return $source->getId();
     }
 }

--- a/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
+++ b/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
@@ -119,7 +119,11 @@ class PullLeadAction
             ),
             'leads_owner_id' => $this->resolveOwnerId($entity) ?? $this->user->getId(),
             'type_id' => $this->resolveTypeId($entity->prospectType),
-            'status_id' => $this->resolveStatusId($entity->prospectStatus),
+            // Real R&R envelopes carry <ProspectStatusType> (e.g. "Open",
+            // "Closed", "Sold"), and the LDU spec's <ProspectStatus> field
+            // hardly ever shows up in production. Prefer the status type,
+            // fall back to prospectStatus for spec-shaped payloads.
+            'status_id' => $this->resolveStatusId($entity->prospectStatusType ?? $entity->prospectStatus),
             'source_id' => $this->resolveSourceId($entity->providerName),
             'receiver_id' => 0,
             'description' => $entity->prospectNote,
@@ -198,9 +202,16 @@ class PullLeadAction
             return null;
         }
 
-        $parts = explode(' ', trim($entity->primarySalesPerson), 2);
-        $firstname = $parts[0] ?? null;
-        $lastname = $parts[1] ?? null;
+        // R&R publishes PrimarySalesPerson as "LastName, FirstName" (comma-
+        // separated) — e.g. "Thomas, Erick". Some legacy dealer configs send
+        // "FirstName LastName" (space-separated) instead. Try comma first,
+        // fall back to whitespace for the legacy shape.
+        $raw = trim($entity->primarySalesPerson);
+        if (str_contains($raw, ',')) {
+            [$lastname, $firstname] = array_pad(array_map('trim', explode(',', $raw, 2)), 2, null);
+        } else {
+            [$firstname, $lastname] = array_pad(array_map('trim', explode(' ', $raw, 2)), 2, null);
+        }
 
         if (! $firstname || ! $lastname) {
             return null;

--- a/src/Domains/Connectors/Reynolds/Activities/PushLeadNotesActivity.php
+++ b/src/Domains/Connectors/Reynolds/Activities/PushLeadNotesActivity.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Kanvas\Connectors\Reynolds\Activities;
 
 use Exception;
-use Kanvas\ActionEngine\Tasks\Actions\ProcessMessageTaskUpdatesAction;
+use Kanvas\ActionEngine\Actions\Enums\ActionEnum;
+use Kanvas\ActionEngine\Enums\ActionStatusEnum;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\Reynolds\Actions\AddNoteToLeadAction;
 use Kanvas\Connectors\Reynolds\Enums\ConfigurationEnum;
+use Kanvas\Guild\Customers\DataTransferObject\Address;
+use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Workflow\Attributes\WorkflowAction;
@@ -19,12 +22,15 @@ use Throwable;
 /**
  * Reynolds counterpart of VinSolution's PushLeadNotesActivity.
  *
- * Minimal v1: pushes the message content to Reynolds as a USL Note via
- * AddNoteToLeadAction. The ActionEngine verb-based branches VinSolution
- * runs (trade / co-signer / credit / VOI / purchase / esign) are
- * intentionally not wired here yet — they all degrade to unstructured
- * notes under SalesAssist anyway, and we want to first confirm plain
- * message delivery lands in R&R before layering that in.
+ * If the message's ActionEngine verb matches one of the known cases, a
+ * formatted summary is pushed as a USL Note (SalesAssist has no structured
+ * sub-flows for co-buyer, credit-app, VOI, purchase or trade so those
+ * always degrade to text). ID verification and esign clean-up are Kanvas-
+ * local and never round-trip.
+ *
+ * If the verb doesn't match any known case, the raw message content is
+ * pushed as-is. That covers plain agent notes and any future verb we
+ * haven't wired yet, so nothing gets silently swallowed.
  */
 #[WorkflowAction]
 class PushLeadNotesActivity extends KanvasActivity
@@ -67,36 +73,127 @@ class PushLeadNotesActivity extends KanvasActivity
                     ]);
                 }
 
-                $note = $this->extractNoteContent($message);
-                if ($note === '') {
-                    return $this->failWorkflow([
-                        'message_id' => $message->getId(),
-                        'message' => 'Message content is empty, nothing to push.',
-                    ]);
-                }
-
-                $taskUpdates = new ProcessMessageTaskUpdatesAction(
-                    message: $message,
-                    lead: $lead,
-                    user: $message->user,
-                )->execute();
-
-                try {
-                    $noteResult = new AddNoteToLeadAction($lead, $note)->execute();
-                } catch (Throwable $e) {
-                    return $this->failWorkflow([
-                        'error' => 'Reynolds USL Note failed: ' . $e->getMessage(),
-                    ]);
-                }
+                $branch = $this->dispatchByVerb($message, $lead);
 
                 return [
-                    'note' => $noteResult,
-                    'message' => 'Reynolds note pushed successfully',
-                    'taskUpdates' => $taskUpdates,
+                    'branch' => $branch,
+                    'message' => 'Reynolds integration completed',
                 ];
             },
             company: $company,
         );
+    }
+
+    private function dispatchByVerb(Message $message, Lead $lead): array
+    {
+        $messageData = $message->getMessage();
+        $verb = (string) ($messageData['verb'] ?? '');
+        $status = (string) ($messageData['status'] ?? '');
+
+        switch ($verb) {
+            case ActionEnum::TRADE_WALK->value:
+            case ActionEnum::PAYOFF_FORM->value:
+            case ActionEnum::ADD_TRADE->value:
+                if ($status === ActionStatusEnum::SUBMITTED->value) {
+                    return $this->pushNote($lead, $this->buildTradeSummary($verb, $messageData), $verb);
+                }
+
+                break;
+            case ActionEnum::CO_SIGNER->value:
+                if ($status === ActionStatusEnum::SUBMITTED->value) {
+                    // SalesAssist has no co-buyer / second-customer field on
+                    // either ISL or USL — see CoBuyerParticipantTest. The best
+                    // we can offer is an unstructured Note describing the
+                    // co-signer so a human on the R&R side can see it.
+                    return $this->pushNote($lead, $this->buildCoBuyerSummary($messageData), $verb);
+                }
+
+                break;
+            case ActionEnum::CREDIT_APP->value:
+                if ($status === ActionStatusEnum::SUBMITTED->value) {
+                    return $this->pushNote(
+                        $lead,
+                        'Credit application submitted via Kanvas — see attached credit form on our side.',
+                        $verb,
+                    );
+                }
+
+                break;
+            case ActionEnum::ID_VERIFICATION->value:
+                if ($status === ActionStatusEnum::OPEN->value && ! empty($messageData['data']['address']['address'])) {
+                    $updated = $this->idVerificationUpdatePeople($lead->people, $messageData);
+                    $lead->set('dont-run-id-verification-manual', 1);
+
+                    return ['verb' => $verb, 'local' => true, 'idVerification' => $updated];
+                }
+
+                break;
+            case ActionEnum::VIEW_PRODUCT->value:
+                if ($status === ActionStatusEnum::SUBMITTED->value) {
+                    // See PushVoiToExistingLeadTest — USL has no Vehicle sub-flow,
+                    // so VOI updates on an existing prospect can only land as an
+                    // unstructured Note.
+                    return $this->pushNote($lead, $this->buildVehicleInterestSummary($messageData), $verb);
+                }
+
+                break;
+            case ActionEnum::PURCHASE_VEHICLE->value:
+                if ($status === ActionStatusEnum::SUBMITTED->value) {
+                    return $this->pushNote($lead, $this->buildPurchaseSummary($messageData), $verb);
+                }
+
+                break;
+            case ActionEnum::ESIGN_DOCS->value:
+                if ($status === ActionStatusEnum::SUBMITTED->value) {
+                    $this->cleanEsignature($lead);
+
+                    return ['verb' => $verb, 'local' => true, 'esignCleaned' => true];
+                }
+
+                break;
+        }
+
+        // No structured verb matched (or matched but status wasn't ready) —
+        // fall back to pushing the raw message content so nothing gets
+        // silently dropped.
+        return $this->pushNote($lead, $this->extractNoteContent($message), $verb !== '' ? $verb : 'raw');
+    }
+
+    private function pushNote(Lead $lead, string $note, string $verb): array
+    {
+        $note = trim($note);
+        if ($note === '') {
+            return ['verb' => $verb, 'skipped' => 'empty note'];
+        }
+
+        try {
+            $result = new AddNoteToLeadAction($lead, $note)->execute();
+        } catch (Throwable $e) {
+            return ['verb' => $verb, 'error' => 'Reynolds USL Note failed: ' . $e->getMessage()];
+        }
+
+        return ['verb' => $verb, 'note' => $result];
+    }
+
+    public function idVerificationUpdatePeople(People $people, array $message): array
+    {
+        $people->addDefaultAddress(Address::from([
+            'address' => $message['data']['address']['address'],
+            'city' => $message['data']['address']['city'],
+            'state' => $message['data']['address']['state'],
+            'zip' => $message['data']['address']['zipcode'],
+        ]));
+
+        return $message['data'];
+    }
+
+    public function cleanEsignature(Lead $lead): void
+    {
+        $lead->set('prefill-sign-docs-' . time(), $lead->get('prefill-sign-docs'));
+        $lead->set('actions_pdf_custom_form-' . time(), $lead->get('actions_pdf_custom_form'));
+
+        $lead->del('prefill-sign-docs');
+        $lead->del('actions_pdf_custom_form');
     }
 
     private function extractNoteContent(Message $message): string
@@ -104,5 +201,82 @@ class PushLeadNotesActivity extends KanvasActivity
         $content = $message->message['content'] ?? '';
 
         return is_string($content) ? trim($content) : '';
+    }
+
+    private function buildTradeSummary(string $verb, array $messageData): string
+    {
+        $trade = $messageData['data']['trade'] ?? $messageData['data'] ?? [];
+        $summary = array_filter([
+            'year' => $trade['year'] ?? null,
+            'make' => $trade['make'] ?? null,
+            'model' => $trade['model'] ?? null,
+            'vin' => $trade['vin'] ?? null,
+            'odometer' => $trade['odometer'] ?? null,
+        ], fn ($v) => $v !== null && $v !== '');
+
+        $label = match ($verb) {
+            ActionEnum::PAYOFF_FORM->value => 'Payoff form submitted',
+            ActionEnum::ADD_TRADE->value => 'Trade-in added',
+            default => 'Trade walk submitted',
+        };
+
+        return empty($summary)
+            ? $label . '.'
+            : $label . ': ' . $this->joinSummary($summary);
+    }
+
+    private function buildCoBuyerSummary(array $messageData): string
+    {
+        $co = $messageData['data']['co_signer'] ?? $messageData['data'] ?? [];
+        $parts = array_filter([
+            $co['firstname'] ?? null,
+            $co['lastname'] ?? null,
+            isset($co['phone']) ? 'phone ' . $co['phone'] : null,
+            isset($co['email']) ? 'email ' . $co['email'] : null,
+        ]);
+
+        return 'Co-signer submitted via Kanvas'
+            . (empty($parts) ? '' : ': ' . implode(' | ', $parts));
+    }
+
+    private function buildVehicleInterestSummary(array $messageData): string
+    {
+        $vehicle = $messageData['data']['vehicle'] ?? $messageData['data'] ?? [];
+        $summary = array_filter([
+            'stock_type' => $vehicle['stock_type'] ?? null,
+            'vin' => $vehicle['vin'] ?? null,
+            'year' => $vehicle['year'] ?? null,
+            'make' => $vehicle['make'] ?? null,
+            'model' => $vehicle['model'] ?? null,
+        ], fn ($v) => $v !== null && $v !== '');
+
+        return empty($summary)
+            ? 'Vehicle interest updated via Kanvas.'
+            : 'Vehicle interest updated: ' . $this->joinSummary($summary);
+    }
+
+    private function buildPurchaseSummary(array $messageData): string
+    {
+        $vehicle = $messageData['data']['vehicle'] ?? $messageData['data'] ?? [];
+        $summary = array_filter([
+            'vin' => $vehicle['vin'] ?? null,
+            'year' => $vehicle['year'] ?? null,
+            'make' => $vehicle['make'] ?? null,
+            'model' => $vehicle['model'] ?? null,
+            'price' => $vehicle['price'] ?? null,
+        ], fn ($v) => $v !== null && $v !== '');
+
+        return empty($summary)
+            ? 'Purchase agreement submitted via Kanvas.'
+            : 'Purchase agreement submitted: ' . $this->joinSummary($summary);
+    }
+
+    private function joinSummary(array $summary): string
+    {
+        return implode(' | ', array_map(
+            fn ($k, $v) => ucfirst((string) str_replace('_', ' ', (string) $k)) . '=' . (string) $v,
+            array_keys($summary),
+            $summary,
+        ));
     }
 }

--- a/src/Domains/Connectors/Reynolds/Activities/PushLeadNotesActivity.php
+++ b/src/Domains/Connectors/Reynolds/Activities/PushLeadNotesActivity.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\Reynolds\Activities;
 
+use Baka\Support\Url;
 use Exception;
 use Kanvas\ActionEngine\Actions\Enums\ActionEnum;
+use Kanvas\ActionEngine\Engagements\Repositories\EngagementRepository;
 use Kanvas\ActionEngine\Enums\ActionStatusEnum;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\Reynolds\Actions\AddNoteToLeadAction;
 use Kanvas\Connectors\Reynolds\Enums\ConfigurationEnum;
+use Kanvas\Connectors\SalesAssist\Services\MessageNoteService;
+use Kanvas\Connectors\SalesAssist\Services\MessageNotificationTextService;
 use Kanvas\Guild\Customers\DataTransferObject\Address;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Leads\Models\Lead;
@@ -22,15 +26,19 @@ use Throwable;
 /**
  * Reynolds counterpart of VinSolution's PushLeadNotesActivity.
  *
- * If the message's ActionEngine verb matches one of the known cases, a
- * formatted summary is pushed as a USL Note (SalesAssist has no structured
- * sub-flows for co-buyer, credit-app, VOI, purchase or trade so those
- * always degrade to text). ID verification and esign clean-up are Kanvas-
- * local and never round-trip.
+ * Note text is built the same way every SalesAssist-family connector
+ * builds it: MessageNotificationTextService renders the stage's card
+ * template (with sendingUser / contact / messageData / etc. bindings),
+ * MessageNoteService appends file links or previews. That keeps notes
+ * consistent across Elead / VinSolution / DealerSocket / Reynolds and
+ * lets the dealer / admin edit the templates without touching code.
  *
- * If the verb doesn't match any known case, the raw message content is
- * pushed as-is. That covers plain agent notes and any future verb we
- * haven't wired yet, so nothing gets silently swallowed.
+ * When the engagement lookup fails (no stage template configured, or
+ * plain agent notes that never went through ActionEngine), the raw
+ * message content is pushed as-is so nothing gets silently dropped.
+ *
+ * ID verification and esign clean-up are Kanvas-local and never reach
+ * R&R — same shape as VinSolution.
  */
 #[WorkflowAction]
 class PushLeadNotesActivity extends KanvasActivity
@@ -90,73 +98,75 @@ class PushLeadNotesActivity extends KanvasActivity
         $verb = (string) ($messageData['verb'] ?? '');
         $status = (string) ($messageData['status'] ?? '');
 
-        switch ($verb) {
-            case ActionEnum::TRADE_WALK->value:
-            case ActionEnum::PAYOFF_FORM->value:
-            case ActionEnum::ADD_TRADE->value:
-                if ($status === ActionStatusEnum::SUBMITTED->value) {
-                    return $this->pushNote($lead, $this->buildTradeSummary($verb, $messageData), $verb);
-                }
+        // Kanvas-local ops — don't round-trip to R&R.
+        if ($verb === ActionEnum::ID_VERIFICATION->value
+            && $status === ActionStatusEnum::OPEN->value
+            && ! empty($messageData['data']['address']['address'])) {
+            $updated = $this->idVerificationUpdatePeople($lead->people, $messageData);
+            $lead->set('dont-run-id-verification-manual', 1);
 
-                break;
-            case ActionEnum::CO_SIGNER->value:
-                if ($status === ActionStatusEnum::SUBMITTED->value) {
-                    // SalesAssist has no co-buyer / second-customer field on
-                    // either ISL or USL — see CoBuyerParticipantTest. The best
-                    // we can offer is an unstructured Note describing the
-                    // co-signer so a human on the R&R side can see it.
-                    return $this->pushNote($lead, $this->buildCoBuyerSummary($messageData), $verb);
-                }
-
-                break;
-            case ActionEnum::CREDIT_APP->value:
-                if ($status === ActionStatusEnum::SUBMITTED->value) {
-                    return $this->pushNote(
-                        $lead,
-                        'Credit application submitted via Kanvas — see attached credit form on our side.',
-                        $verb,
-                    );
-                }
-
-                break;
-            case ActionEnum::ID_VERIFICATION->value:
-                if ($status === ActionStatusEnum::OPEN->value && ! empty($messageData['data']['address']['address'])) {
-                    $updated = $this->idVerificationUpdatePeople($lead->people, $messageData);
-                    $lead->set('dont-run-id-verification-manual', 1);
-
-                    return ['verb' => $verb, 'local' => true, 'idVerification' => $updated];
-                }
-
-                break;
-            case ActionEnum::VIEW_PRODUCT->value:
-                if ($status === ActionStatusEnum::SUBMITTED->value) {
-                    // See PushVoiToExistingLeadTest — USL has no Vehicle sub-flow,
-                    // so VOI updates on an existing prospect can only land as an
-                    // unstructured Note.
-                    return $this->pushNote($lead, $this->buildVehicleInterestSummary($messageData), $verb);
-                }
-
-                break;
-            case ActionEnum::PURCHASE_VEHICLE->value:
-                if ($status === ActionStatusEnum::SUBMITTED->value) {
-                    return $this->pushNote($lead, $this->buildPurchaseSummary($messageData), $verb);
-                }
-
-                break;
-            case ActionEnum::ESIGN_DOCS->value:
-                if ($status === ActionStatusEnum::SUBMITTED->value) {
-                    $this->cleanEsignature($lead);
-
-                    return ['verb' => $verb, 'local' => true, 'esignCleaned' => true];
-                }
-
-                break;
+            return ['verb' => $verb, 'local' => true, 'idVerification' => $updated];
         }
 
-        // No structured verb matched (or matched but status wasn't ready) —
-        // fall back to pushing the raw message content so nothing gets
-        // silently dropped.
-        return $this->pushNote($lead, $this->extractNoteContent($message), $verb !== '' ? $verb : 'raw');
+        if ($verb === ActionEnum::ESIGN_DOCS->value
+            && $status === ActionStatusEnum::SUBMITTED->value) {
+            $this->cleanEsignature($lead);
+
+            return ['verb' => $verb, 'local' => true, 'esignCleaned' => true];
+        }
+
+        // Everything else — build a note the SalesAssist way: engagement
+        // template rendered via MessageNotificationTextService + file
+        // links from MessageNoteService. Falls back to the raw content of
+        // the message when there's no engagement template to render (plain
+        // agent notes, unwired verbs).
+        $note = $this->buildStructuredNote($message, $lead) ?? $this->extractNoteContent($message);
+
+        return $this->pushNote($lead, $note, $verb !== '' ? $verb : 'raw');
+    }
+
+    private function buildStructuredNote(Message $message, Lead $lead): ?string
+    {
+        $messageData = $message->getMessage();
+
+        try {
+            $linkPreview = Url::getShortUrl($messageData['link'] ?? '', $lead->app);
+        } catch (Throwable $e) {
+            $linkPreview = $messageData['link'] ?? null;
+        }
+
+        try {
+            if ($newLink = new MessageNoteService($message)->generateFileLinks()) {
+                $linkPreview = $newLink;
+            }
+        } catch (Throwable $e) {
+            // Files are optional context — keep whatever link preview we already have.
+        }
+
+        try {
+            $parentEngagement = $message->getEngagement();
+            $currentEngagement = EngagementRepository::findEngagementForLeadAndEntity(
+                $lead,
+                $messageData['verb'] ?? null,
+                $messageData['status'] ?? null,
+                $parentEngagement->entity_uuid,
+            );
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        try {
+            $engagementText = new MessageNotificationTextService($currentEngagement ?: $parentEngagement)->cardText();
+        } catch (Throwable $e) {
+            return null;
+        }
+
+        $engagementText = trim((string) $engagementText);
+        if ($engagementText === '' && empty($linkPreview)) {
+            return null;
+        }
+
+        return trim($engagementText . ' ' . (string) ($linkPreview ?? ''));
     }
 
     private function pushNote(Lead $lead, string $note, string $verb): array
@@ -201,82 +211,5 @@ class PushLeadNotesActivity extends KanvasActivity
         $content = $message->message['content'] ?? '';
 
         return is_string($content) ? trim($content) : '';
-    }
-
-    private function buildTradeSummary(string $verb, array $messageData): string
-    {
-        $trade = $messageData['data']['trade'] ?? $messageData['data'] ?? [];
-        $summary = array_filter([
-            'year' => $trade['year'] ?? null,
-            'make' => $trade['make'] ?? null,
-            'model' => $trade['model'] ?? null,
-            'vin' => $trade['vin'] ?? null,
-            'odometer' => $trade['odometer'] ?? null,
-        ], fn ($v) => $v !== null && $v !== '');
-
-        $label = match ($verb) {
-            ActionEnum::PAYOFF_FORM->value => 'Payoff form submitted',
-            ActionEnum::ADD_TRADE->value => 'Trade-in added',
-            default => 'Trade walk submitted',
-        };
-
-        return empty($summary)
-            ? $label . '.'
-            : $label . ': ' . $this->joinSummary($summary);
-    }
-
-    private function buildCoBuyerSummary(array $messageData): string
-    {
-        $co = $messageData['data']['co_signer'] ?? $messageData['data'] ?? [];
-        $parts = array_filter([
-            $co['firstname'] ?? null,
-            $co['lastname'] ?? null,
-            isset($co['phone']) ? 'phone ' . $co['phone'] : null,
-            isset($co['email']) ? 'email ' . $co['email'] : null,
-        ]);
-
-        return 'Co-signer submitted via Kanvas'
-            . (empty($parts) ? '' : ': ' . implode(' | ', $parts));
-    }
-
-    private function buildVehicleInterestSummary(array $messageData): string
-    {
-        $vehicle = $messageData['data']['vehicle'] ?? $messageData['data'] ?? [];
-        $summary = array_filter([
-            'stock_type' => $vehicle['stock_type'] ?? null,
-            'vin' => $vehicle['vin'] ?? null,
-            'year' => $vehicle['year'] ?? null,
-            'make' => $vehicle['make'] ?? null,
-            'model' => $vehicle['model'] ?? null,
-        ], fn ($v) => $v !== null && $v !== '');
-
-        return empty($summary)
-            ? 'Vehicle interest updated via Kanvas.'
-            : 'Vehicle interest updated: ' . $this->joinSummary($summary);
-    }
-
-    private function buildPurchaseSummary(array $messageData): string
-    {
-        $vehicle = $messageData['data']['vehicle'] ?? $messageData['data'] ?? [];
-        $summary = array_filter([
-            'vin' => $vehicle['vin'] ?? null,
-            'year' => $vehicle['year'] ?? null,
-            'make' => $vehicle['make'] ?? null,
-            'model' => $vehicle['model'] ?? null,
-            'price' => $vehicle['price'] ?? null,
-        ], fn ($v) => $v !== null && $v !== '');
-
-        return empty($summary)
-            ? 'Purchase agreement submitted via Kanvas.'
-            : 'Purchase agreement submitted: ' . $this->joinSummary($summary);
-    }
-
-    private function joinSummary(array $summary): string
-    {
-        return implode(' | ', array_map(
-            fn ($k, $v) => ucfirst((string) str_replace('_', ' ', (string) $k)) . '=' . (string) $v,
-            array_keys($summary),
-            $summary,
-        ));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to the merged Reynolds connector PRs (#10220, #10224). Two shape mismatches surfaced once real production envelopes started landing, plus a scope fix on the notes activity that the previous minimal version had stripped out.

## Changes

**PullLeadAction — envelope shape corrections**

- `<ProspectStatusType>` is what real R&R envelopes ship (`"Open"`, `"Sold"`, `"Closed"`). The spec's `<ProspectStatus>` never shows up in production. `resolveStatusId` now prefers `prospectStatusType`, with `prospectStatus` as a spec-shaped fallback, so LeadStatus resolves off the real value instead of always defaulting.
- `<PrimarySalesPerson>` arrives as `"LastName, FirstName"` (e.g. `"Thomas, Erick"`), not `"FirstName LastName"`. `resolveOwnerId` splits on the comma when present; falls back to whitespace-split for legacy configs. Fixes the case where every Lead was defaulting its owner to the AI agent user because the user lookup was matching on the wrong fields.

**PushLeadNotesActivity — restored branches + safer fallback**

- Restores the seven ActionEngine verb branches (`TRADE_WALK` / `PAYOFF_FORM` / `ADD_TRADE` / `CO_SIGNER` / `CREDIT_APP` / `ID_VERIFICATION` / `VIEW_PRODUCT` / `PURCHASE_VEHICLE` / `ESIGN_DOCS`). Structured operations degrade to formatted USL Notes because SalesAssist has no sub-flow for them. `ID_VERIFICATION` and `ESIGN_DOCS` stay Kanvas-local.
- Adds a raw-message fallback: when the verb doesn't match or the status isn't ready, the message content is pushed as-is so plain agent notes and unwired verbs still land in R&R.
- Drops `ProcessMessageTaskUpdatesAction`. That's Kanvas-side ActionEngine task/engagement bookkeeping — nothing to do with reaching R&R. Worse, it `firstOrFail`'d on `Action.slug=verb`, so any plain agent note without an ActionEngine verb was throwing before the fallback could run. Task-side sync belongs in a separate activity wired alongside this one.

## Verified

- Real envelope repro: `ProspectType=Walk-In` + `ProspectStatusType=Open` → `LeadType.name=Walk-In` / `LeadStatus.name=Open` (both auto-created from the inbound values).
- `PrimarySalesPerson=Thomas, Erick` → `firstname=Erick / lastname=Thomas` → owner user lookup runs against the real names.

## Test plan

- [ ] `docker exec php php vendor/bin/phpunit tests/Connectors/Integration/Reynolds`
- [ ] Fire a captured OSL envelope through `debug:reynolds-webhook --latest`; confirm Lead lands with `leads_types_id` + `leads_status_id` populated by name, and `leads_owner_id` matches the rep if present in Kanvas.
- [ ] Send a plain agent message through PushLeadNotesActivity (no ActionEngine verb) and verify the content lands as a USL Note instead of throwing.