### PR TITLE
fix(region): restore settings as String for backward compat, add sett…

### DIFF
--- a/graphql/schemas/Inventory/region.graphql
+++ b/graphql/schemas/Inventory/region.graphql
@@ -16,7 +16,8 @@ type Region {
     name: String!
     slug: String!
     short_slug: String!
-    settings: RegionSettings
+    settings: String @rename(attribute: "settings_string")
+    settingsData: RegionSettings @rename(attribute: "settings")
     is_default: Boolean!
     lat: Float
     lng: Float

--- a/src/Kanvas/Regions/Models/Regions.php
+++ b/src/Kanvas/Regions/Models/Regions.php
@@ -52,6 +52,13 @@ class Regions extends BaseModel
         ];
     }
 
+    // Backward-compat: clients queried Region.settings as a raw JSON string before
+    // it was typed as RegionSettings. Expose the encoded string so old apps don't break.
+    public function getSettingsStringAttribute(): ?string
+    {
+        return $this->settings !== null ? json_encode($this->settings) : null;
+    }
+
     public function currencies(): BelongsTo
     {
         return $this->belongsTo(Currencies::class, 'currency_id');


### PR DESCRIPTION
…ingsData

Region.settings was changed from String to RegionSettings (object), a breaking change for apps querying settings as a scalar JSON string. Revert the field to String via a settings_string accessor (json_encode of the Json-cast array) and expose the structured form under a new additive settingsData: RegionSettings.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
