### PR TITLE
fix(salesassist): email fallback in Reynolds PullLead meta branch

### DIFF
--- a/src/Domains/Connectors/SalesAssist/Activities/PullLeadActivity.php
+++ b/src/Domains/Connectors/SalesAssist/Activities/PullLeadActivity.php
@@ -105,7 +105,9 @@ class PullLeadActivity extends KanvasActivity implements WorkflowActivityInterfa
                 : null;
 
             if ($lead === null) {
-                $people = PeoplesRepository::getByPhoneNumber($app, $company, [$phone])->first();
+                $people = PeoplesRepository::getByPhoneNumber($app, $company, [$phone])->first() ??
+                    PeoplesRepository::getByEmail($email, $company, $app);
+
                 $lead = $people ? LeadsRepository::getPeopleActiveLeads($people)->first() : null;
                 $lead?->set(ReynoldsCustomFieldEnum::CLIENT_ID->value, $leadId);
             }


### PR DESCRIPTION
## Summary

Follow-up to the merged Reynolds connector PRs. Ships against \`1.x\` in parallel with the \`development\` PR (#10273).

When the SalesAssist meta \`PullLeadActivity\` Reynolds branch can't find a Lead by ProspectId, it was matching People by phone only and giving up if that missed. Real dealer data has plenty of leads whose phone came in on the OSL but got overwritten later, or was never captured, while the email survived — those were dropping into the "no lead" path and never getting linked back.

## Changes

- Add an email fallback second lookup after the phone match misses, so we exhaust the phone match first (higher-confidence for the Reynolds Walk-In / Phone flows) then try email before giving up.

## Test plan

- [ ] Replay a captured OSL for a lead with no phone but a valid email through \`debug:reynolds-webhook --latest\`; confirm it matches the existing People and the resulting Lead links back rather than orphaning.