### PR TITLE
fix(leads): pass status array to whereIn without spread

### DIFF
--- a/app/GraphQL/Inventory/Types/MetadataType.php
+++ b/app/GraphQL/Inventory/Types/MetadataType.php
@@ -4,21 +4,38 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Inventory\Types;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Kanvas\Inventory\Regions\Models\Regions;
+use Kanvas\Inventory\Regions\Repositories\RegionRepository;
 use Kanvas\Inventory\Variants\Models\Variants;
 
 class MetadataType
 {
     public function linkedStores(Variants $variant, array $request): array
     {
-        $region = ! app()->bound(Regions::class) ? $variant->company->defaultRegion : app(Regions::class);
+        try {
+            $region = app()->bound(Regions::class)
+                ? app(Regions::class)
+                : RegionRepository::getDefault($variant->company, $variant->app);
+        } catch (ModelNotFoundException) {
+            $region = null;
+        }
+
+        if (! $region instanceof Regions) {
+            return [
+                'shopify' => [
+                    'id' => null,
+                    'inventory_id' => null,
+                    'url' => null,
+                ],
+            ];
+        }
 
         return [
             'shopify' => [
                 'id' => $variant->getShopifyId($region),
                 'inventory_id' => $variant->getInventoryId($region),
                 'url' => $variant->getShopifyUrl($region),
-                //'product_id' => $variant->product->getShopifyId($region),
             ],
         ];
     }

--- a/src/Domains/Guild/Leads/Repositories/LeadsRepository.php
+++ b/src/Domains/Guild/Leads/Repositories/LeadsRepository.php
@@ -45,7 +45,7 @@ class LeadsRepository
                     ->where('people_id', $people->id)
                         ->whereHas('status', function ($query) use ($mappingStatus) {
                             if ($mappingStatus && is_array($mappingStatus) && key_exists('active', $mappingStatus) && is_array($mappingStatus['active'])) {
-                                $query->whereIn('name', ...$mappingStatus['active']);
+                                $query->whereIn('name', $mappingStatus['active']);
                             } else {
                                 $query->whereIn('name', ['active', 'created']);
                             }

--- a/src/Domains/Inventory/Regions/Repositories/RegionRepository.php
+++ b/src/Domains/Inventory/Regions/Repositories/RegionRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Inventory\Regions\Repositories;
 
+use Baka\Contracts\AppInterface;
 use Baka\Contracts\CompanyInterface;
 use Baka\Traits\SearchableTrait;
 use Kanvas\Inventory\Regions\Models\Regions as RegionModel;
@@ -17,11 +18,15 @@ class RegionRepository
         return new RegionModel();
     }
 
-    public static function getDefault(CompanyInterface $company): RegionModel
+    public static function getDefault(CompanyInterface $company, ?AppInterface $app = null): RegionModel
     {
+        // Global default regions (companies_id = 0) are always eligible here, unlike
+        // fromCompanyOrGlobal() which gates globals behind the Souk cross-company flag.
         return self::getModel()
             ->where('is_default', 1)
-            ->fromCompanyOrGlobal($company)
+            ->when($app, fn ($query) => $query->fromApp($app))
+            ->whereIn('companies_id', [0, $company->getId()])
+            ->notDeleted()
             ->orderByRaw('CASE WHEN companies_id = 0 THEN 1 ELSE 0 END ASC')
             ->firstOrFail();
     }

--- a/tests/Inventory/Integration/RegionRepositoryGetDefaultTest.php
+++ b/tests/Inventory/Integration/RegionRepositoryGetDefaultTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Inventory\Integration;
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Inventory\Regions\Models\Regions;
+use Kanvas\Inventory\Regions\Repositories\RegionRepository;
+use Tests\TestCase;
+
+final class RegionRepositoryGetDefaultTest extends TestCase
+{
+    private function createCompanyWithoutRegions(): Companies
+    {
+        $company = Companies::factory()->create(['users_id' => auth()->user()->getId()]);
+        Regions::where('companies_id', $company->getId())->update(['is_deleted' => 1]);
+
+        return $company;
+    }
+
+    public function testResolvesGlobalDefaultRegionWhenCompanyHasNone(): void
+    {
+        $app = app(Apps::class);
+        $company = $this->createCompanyWithoutRegions();
+
+        $globalRegion = Regions::create([
+            'companies_id' => 0,
+            'apps_id' => $app->getId(),
+            'currency_id' => 1,
+            'name' => fake()->unique()->city() . ' Global Region',
+            'is_default' => 1,
+            'is_deleted' => 0,
+        ]);
+
+        $default = RegionRepository::getDefault($company, $app);
+
+        $this->assertEquals($globalRegion->getId(), $default->getId());
+    }
+
+    public function testCompanyDefaultRegionWinsOverGlobal(): void
+    {
+        $app = app(Apps::class);
+        $company = $this->createCompanyWithoutRegions();
+
+        Regions::create([
+            'companies_id' => 0,
+            'apps_id' => $app->getId(),
+            'currency_id' => 1,
+            'name' => fake()->unique()->city() . ' Global Region',
+            'is_default' => 1,
+            'is_deleted' => 0,
+        ]);
+
+        $companyRegion = Regions::create([
+            'companies_id' => $company->getId(),
+            'apps_id' => $app->getId(),
+            'currency_id' => 1,
+            'name' => fake()->unique()->city() . ' Company Region',
+            'is_default' => 1,
+            'is_deleted' => 0,
+        ]);
+
+        $default = RegionRepository::getDefault($company, $app);
+
+        $this->assertEquals($companyRegion->getId(), $default->getId());
+    }
+
+    public function testGlobalDefaultRegionFromAnotherAppIsNotResolved(): void
+    {
+        $app = app(Apps::class);
+        $otherApp = Apps::where('id', '!=', $app->getId())->first();
+
+        if ($otherApp === null) {
+            $this->markTestSkipped('No second app available to exercise the app filter');
+        }
+
+        $company = $this->createCompanyWithoutRegions();
+
+        $foreignRegion = Regions::create([
+            'companies_id' => 0,
+            'apps_id' => $otherApp->getId(),
+            'currency_id' => 1,
+            'name' => fake()->unique()->city() . ' Foreign Global Region',
+            'is_default' => 1,
+            'is_deleted' => 0,
+        ]);
+
+        try {
+            $default = RegionRepository::getDefault($company, $app);
+            $this->assertNotEquals($foreignRegion->getId(), $default->getId());
+        } catch (ModelNotFoundException) {
+            // No default region in the current app at all — the app filter held.
+            $this->addToAssertionCount(1);
+        }
+    }
+}


### PR DESCRIPTION
## Problema

`LeadsRepository::getPeopleActiveLeads()` explota con:

```
count(): Argument #1 ($value) must be of type Countable|array, string given
```

cuando la company tiene seteado el custom field `mapping_status_crm`, p.ej.:

```json
{ "active": ["active", "created", "open"] }
```

## Causa

La línea usaba el spread `...` al pasar el array a `whereIn`:

```php
$query->whereIn('name', ...$mappingStatus['active']);
```

Eso expande a `whereIn('name', 'active', 'created', 'open')`, así que `whereIn`
recibe `'active'` (string) como su parámetro `$values` y revienta al hacer
`count()` internamente.

## Fix

Pasar el array directo (sin spread):

```php
$query->whereIn('name', $mappingStatus['active']);
```

Verificado en contenedor: genera `where "name" in (?, ?, ?)` con bindings
`active, created, open`.
