### PR TITLE
 feat: update wasup key

### DIFF
--- a/src/Domains/Connectors/WaSender/Actions/ConnectWhatsAppSessionAction.php
+++ b/src/Domains/Connectors/WaSender/Actions/ConnectWhatsAppSessionAction.php
@@ -7,6 +7,7 @@ namespace Kanvas\Connectors\WaSender\Actions;
 use Baka\Contracts\AppInterface;
 use Baka\Contracts\CompanyInterface;
 use Baka\Users\Contracts\UserInterface;
+use Kanvas\Connectors\WaSender\Enums\ConfigurationEnum;
 use Kanvas\Connectors\WaSender\Enums\ConnectionFieldEnum;
 use Kanvas\Connectors\WaSender\Enums\WebhookEventEnum;
 use Kanvas\Connectors\WaSender\Services\SessionService;
@@ -169,6 +170,10 @@ class ConnectWhatsAppSessionAction
     ): void {
         $sessionId = $session['id'] ?? null;
         $secret = $session['webhook_secret'] ?? $connection['webhook_secret'] ?? null;
+        // WaSender returns this session's own api_key on create — the key that authorizes its
+        // /api/send-message (the account PAT can't send). Store it as the company's wasender_api_key
+        // so the existing send path (MessageService reads company API_KEY first) uses it unchanged.
+        $sessionApiKey = $session['api_key'] ?? $connection['api_key'] ?? null;
 
         $config = $receiver->configuration ?? [];
         $config['agent_id'] = $this->agent->getId();
@@ -180,6 +185,10 @@ class ConnectWhatsAppSessionAction
         }
         $receiver->configuration = $config;
         $receiver->saveOrFail();
+
+        if ($sessionApiKey !== null && $sessionApiKey !== '') {
+            $this->company->set(ConfigurationEnum::API_KEY->value, (string) $sessionApiKey);
+        }
 
         if ($sessionId !== null) {
             $this->agent->set(ConnectionFieldEnum::SESSION_ID->value, $sessionId);

--- a/src/Domains/Connectors/WaSender/Client.php
+++ b/src/Domains/Connectors/WaSender/Client.php
@@ -21,14 +21,19 @@ class Client
     public function __construct(
         protected AppInterface $app,
         protected CompanyInterface $company,
-        protected bool $outboundMode = false
+        protected bool $outboundMode = false,
+        ?string $apiKey = null,
     ) {
         $baseUrlEnum = $this->outboundMode
             ? ConfigurationEnum::BASE_URL_OUTBOUND
             : ConfigurationEnum::BASE_URL;
 
         $this->baseUrl = $app->get($baseUrlEnum->value);
-        $this->apiKey = $company->get(ConfigurationEnum::API_KEY->value) ?? $app->get(ConfigurationEnum::API_KEY->value);
+        // Session management uses the account PAT (config); per-session ops (send-message) must pass
+        // that session's own api_key. When given, it overrides the account key for this client.
+        $this->apiKey = $apiKey !== null && $apiKey !== ''
+            ? $apiKey
+            : ($company->get(ConfigurationEnum::API_KEY->value) ?? $app->get(ConfigurationEnum::API_KEY->value));
 
         if (empty($this->baseUrl) || empty($this->apiKey)) {
             throw new ValidationException('Wasender configuration is missing');

--- a/src/Domains/Connectors/WaSender/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/WaSender/Enums/ConfigurationEnum.php
@@ -10,7 +10,5 @@ enum ConfigurationEnum: string
     case BASE_URL = 'wasender_base_url';
     case API_KEY = 'wasender_api_key';
     case BASE_URL_OUTBOUND = 'wasender_base_url_outbound';
-    // Account-level Personal Access Token — authorizes session management (create/list/delete
-    // sessions). Distinct from API_KEY, which is a per-session key used for /api/send-message.
     case PERSONAL_ACCESS_TOKEN = 'wasender_personal_access_token';
 }

--- a/src/Domains/Connectors/WaSender/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/WaSender/Enums/ConfigurationEnum.php
@@ -10,4 +10,7 @@ enum ConfigurationEnum: string
     case BASE_URL = 'wasender_base_url';
     case API_KEY = 'wasender_api_key';
     case BASE_URL_OUTBOUND = 'wasender_base_url_outbound';
+    // Account-level Personal Access Token — authorizes session management (create/list/delete
+    // sessions). Distinct from API_KEY, which is a per-session key used for /api/send-message.
+    case PERSONAL_ACCESS_TOKEN = 'wasender_personal_access_token';
 }

--- a/src/Domains/Connectors/WaSender/Services/SessionService.php
+++ b/src/Domains/Connectors/WaSender/Services/SessionService.php
@@ -7,6 +7,7 @@ namespace Kanvas\Connectors\WaSender\Services;
 use Baka\Contracts\AppInterface;
 use Baka\Contracts\CompanyInterface;
 use Kanvas\Connectors\WaSender\Client;
+use Kanvas\Connectors\WaSender\Enums\ConfigurationEnum;
 use Kanvas\Exceptions\ValidationException;
 
 class SessionService
@@ -17,7 +18,12 @@ class SessionService
         protected AppInterface $app,
         protected CompanyInterface $company
     ) {
-        $this->client = new Client($app, $company);
+        $this->client = new Client(
+            $app,
+            $company,
+            false,
+            $app->get(ConfigurationEnum::PERSONAL_ACCESS_TOKEN->value)
+        );
     }
 
     /**

--- a/tests/Connectors/Integration/WaSender/ConnectWhatsAppSessionActionTest.php
+++ b/tests/Connectors/Integration/WaSender/ConnectWhatsAppSessionActionTest.php
@@ -78,7 +78,7 @@ class ConnectWhatsAppSessionActionTest extends TestCase
                 $captured = $args;
 
                 return [
-                    'session' => ['id' => 909, 'status' => 'need_scan', 'webhook_secret' => 'fb61be92ddb7935e0cedcec58e470f6c'],
+                    'session' => ['id' => 909, 'status' => 'need_scan', 'webhook_secret' => 'fb61be92ddb7935e0cedcec58e470f6c', 'api_key' => 'sess_909_send_key'],
                     'connection' => ['qr_code' => 'base64QRDATA', 'status' => 'need_scan'],
                 ];
             });
@@ -125,6 +125,10 @@ class ConnectWhatsAppSessionActionTest extends TestCase
         $this->assertSame('909', (string) $fresh->get('whatsapp_session_id'));
         $this->assertSame('18095551234', (string) $fresh->get('whatsapp_phone_number'));
         $this->assertSame((string) $receiver->getId(), (string) $fresh->get('whatsapp_receiver_id'));
+
+        // The session's own api_key becomes the company wasender_api_key, so the unchanged send path
+        // (MessageService reads company API_KEY first) authenticates /api/send-message with it.
+        $this->assertSame('sess_909_send_key', (string) $company->get('wasender_api_key'));
 
         // Agent bound on the AFTER_ADDING_MESSAGE_TO_CHANNEL rule
         $rule = Rule::query()


### PR DESCRIPTION
The spread operator expanded mapping_status_crm['active'] into positional
whereIn arguments, so whereIn received the first status as its $values
(a string) and threw 'count(): Argument #1 must be of type Countable|array,
string given'. Pass the array directly.## General Description
=