### PR TITLE
fix(reynolds): sequential People lookup + index ReceiverWebhookCall in Scout

### DIFF
--- a/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
+++ b/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
@@ -10,6 +10,7 @@ use Kanvas\Connectors\Reynolds\Entities\Customer as CustomerEntity;
 use Kanvas\Connectors\Reynolds\Entities\Lead as LeadEntity;
 use Kanvas\Connectors\Reynolds\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Reynolds\Exceptions\ReynoldsException;
+use Kanvas\Connectors\Reynolds\Services\SalespersonResolver;
 use Kanvas\Guild\Customers\Models\Contact;
 use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
 use Kanvas\Guild\Leads\Actions\SyncLeadByThirdPartyCustomFieldAction;
@@ -26,7 +27,7 @@ use Kanvas\Users\Models\Users;
  * Receives the parsed array of a `rey_SalesAssistCRMPublishLeadUpdate.Record` element
  * and creates/updates the corresponding Lead + People in Kanvas. Vehicle of interest
  * and trade-in are stored as Lead custom fields under the Kanvas-standard keys
- * `vehicle_of_interest` and `trade_in`.
+ * `vehicle_of_interest` and `vehicle_trade_id` (the VinSolution TradeIn shape).
  *
  * People sync is delegated entirely to SyncLeadByThirdPartyCustomFieldAction —
  * we build the PeopleData via Customer::toPeopleData() once and hand it off.
@@ -104,7 +105,7 @@ class PullLeadAction
         }
 
         if (! empty($entity->potentialTrade)) {
-            $customFields[CustomFieldEnum::TRADE_IN->value] = $entity->potentialTrade;
+            $customFields[CustomFieldEnum::TRADE_IN->value] = $this->buildTradeInCustomField($entity->potentialTrade);
         }
 
         $leadData = LeadData::from([
@@ -250,31 +251,35 @@ class PullLeadAction
 
     private function resolveOwnerId(LeadEntity $entity): ?int
     {
-        if ($entity->primarySalesPerson === null) {
-            return null;
-        }
+        return SalespersonResolver::resolveUserId($entity->primarySalesPerson, $this->company);
+    }
 
-        // R&R publishes PrimarySalesPerson as "LastName, FirstName" (comma-
-        // separated) — e.g. "Thomas, Erick". Some legacy dealer configs send
-        // "FirstName LastName" (space-separated) instead. Try comma first,
-        // fall back to whitespace for the legacy shape.
-        $raw = trim($entity->primarySalesPerson);
-        if (str_contains($raw, ',')) {
-            [$lastname, $firstname] = array_pad(array_map('trim', explode(',', $raw, 2)), 2, null);
-        } else {
-            [$firstname, $lastname] = array_pad(array_map('trim', explode(' ', $raw, 2)), 2, null);
-        }
-
-        if (! $firstname || ! $lastname) {
-            return null;
-        }
-
-        $user = Users::query()
-            ->where('firstname', $firstname)
-            ->where('lastname', $lastname)
-            ->first();
-
-        return $user?->getId();
+    /**
+     * Map R&R's five trade fields into the VinSolution TradeIn shape so the
+     * shared VehicleTradeInTool reads it; the rest default to VinSolution's
+     * neutral values.
+     */
+    private function buildTradeInCustomField(array $trade): array
+    {
+        return [
+            'vin' => $trade['vin'] ?? null,
+            'year' => isset($trade['year']) ? (string) $trade['year'] : null,
+            'make' => $trade['make'] ?? null,
+            'model' => $trade['model'] ?? null,
+            'trim' => null,
+            'exteriorColor' => null,
+            'interiorColor' => null,
+            'bodyStyle' => null,
+            'engineName' => null,
+            'transmission' => null,
+            'driveTrain' => null,
+            'doors' => null,
+            'mileage' => isset($trade['odometer']) ? (int) str_replace(',', '', (string) $trade['odometer']) : 0,
+            'value' => 0.0,
+            'condition' => 'UNKNOWN',
+            'description' => null,
+            'payOff' => 0.0,
+        ];
     }
 
     private function resolveTypeId(?string $name, ?int $currentId = null): int

--- a/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
+++ b/src/Domains/Connectors/Reynolds/Actions/PullLeadAction.php
@@ -181,6 +181,13 @@ class PullLeadAction
         // 2. First time we see this prospect — try to match an existing
         // customer by email or phone so we don't fork Peoples that Kanvas
         // already created from other sources (walk-ins, other CRMs, web forms).
+        //
+        // getMatchingEmailPhone AND's the two whereExists clauses, so passing
+        // both when a stored People only carries one of them misses the match
+        // and forks a duplicate. Run the lookups sequentially — email first
+        // (higher signal, customers keep it across phone swaps), phone as a
+        // fallback only when email didn't hit. Two queries in the worst case,
+        // one when the email match works.
         $email = $entity->customer?->email;
         $phone = $this->firstUsablePhone($entity->customer);
 
@@ -188,12 +195,25 @@ class PullLeadAction
             return null;
         }
 
-        $existing = PeoplesRepository::getMatchingEmailPhone(
-            app: $this->app,
-            company: $this->company,
-            email: $email !== null ? strtolower((string) $email) : null,
-            phone: $phone,
-        );
+        $existing = null;
+
+        if (! empty($email)) {
+            $existing = PeoplesRepository::getMatchingEmailPhone(
+                app: $this->app,
+                company: $this->company,
+                email: strtolower((string) $email),
+                phone: null,
+            );
+        }
+
+        if ($existing === null && ! empty($phone)) {
+            $existing = PeoplesRepository::getMatchingEmailPhone(
+                app: $this->app,
+                company: $this->company,
+                email: null,
+                phone: $phone,
+            );
+        }
 
         return $existing?->getId();
     }

--- a/src/Domains/Connectors/Reynolds/Enums/CustomFieldEnum.php
+++ b/src/Domains/Connectors/Reynolds/Enums/CustomFieldEnum.php
@@ -19,10 +19,10 @@ enum CustomFieldEnum: string
 
     // Shared Kanvas custom-field keys — matches what every other CRM connector
     // (VinSolution, DriveCentric, DealerSocket, SalesAssist) writes, so the AI
-    // tooling (CreateContentSession, LeadIntentTool, VoiceBridge, ElevenLabs)
-    // picks them up automatically without per-connector wiring.
+    // tooling picks them up automatically without per-connector wiring. Trade-in
+    // must be `vehicle_trade_id` (not `trade_in`) for VehicleTradeInTool to read it.
     case VEHICLE_OF_INTEREST = 'vehicle_of_interest';
-    case TRADE_IN = 'trade_in';
+    case TRADE_IN = 'vehicle_trade_id';
 
     case CONSENT_EMAIL = 'REYNOLDS_CONSENT_EMAIL';
     case CONSENT_TEXT = 'REYNOLDS_CONSENT_TEXT';

--- a/src/Domains/Connectors/Reynolds/Services/SalespersonResolver.php
+++ b/src/Domains/Connectors/Reynolds/Services/SalespersonResolver.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Reynolds\Services;
+
+use Kanvas\Companies\Models\Companies;
+
+class SalespersonResolver
+{
+    /**
+     * R&R ships the name in two shapes: "LastName, FirstName" (LDU/OSL
+     * PrimarySalesPerson) and "FirstName LastName" (RCI disposition
+     * RCIDispositionPrimarySalesperson). Scoped to the dealer's users so a
+     * cross-tenant name collision can't reassign ownership to another company.
+     */
+    public static function resolveUserId(?string $name, Companies $company): ?int
+    {
+        [$firstname, $lastname] = self::splitName($name);
+
+        if ($firstname === null || $lastname === null) {
+            return null;
+        }
+
+        // Qualify the columns — users() is a HasManyThrough join and
+        // users_associated_apps also carries firstname/lastname, so an
+        // unqualified where is ambiguous.
+        $user = $company->users()
+            ->where('users.firstname', $firstname)
+            ->where('users.lastname', $lastname)
+            ->first();
+
+        return $user?->getId();
+    }
+
+    /**
+     * @return array{0: ?string, 1: ?string} [firstname, lastname]
+     */
+    private static function splitName(?string $name): array
+    {
+        $raw = trim((string) $name);
+        if ($raw === '') {
+            return [null, null];
+        }
+
+        if (str_contains($raw, ',')) {
+            [$lastname, $firstname] = array_pad(array_map('trim', explode(',', $raw, 2)), 2, null);
+        } else {
+            [$firstname, $lastname] = array_pad(array_map('trim', explode(' ', $raw, 2)), 2, null);
+        }
+
+        if (empty($firstname) || empty($lastname)) {
+            return [null, null];
+        }
+
+        return [$firstname, $lastname];
+    }
+}

--- a/src/Domains/Connectors/Reynolds/Webhooks/ProcessReynoldsWebhookJob.php
+++ b/src/Domains/Connectors/Reynolds/Webhooks/ProcessReynoldsWebhookJob.php
@@ -11,6 +11,7 @@ use Kanvas\Connectors\Reynolds\Actions\PullLeadAction;
 use Kanvas\Connectors\Reynolds\Enums\ConfigurationEnum;
 use Kanvas\Connectors\Reynolds\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Reynolds\Enums\TransactionCodeEnum;
+use Kanvas\Connectors\Reynolds\Services\SalespersonResolver;
 use Kanvas\Connectors\Reynolds\Services\XmlParser;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Models\LeadStatus;
@@ -110,11 +111,16 @@ class ProcessReynoldsWebhookJob extends ProcessWebhookJob
 
     private function applyDisposition(Companies $company, array $record, TransactionCodeEnum $task): array
     {
-        $prospectId = (string) ($record['Prospect']['ProspectId'] ?? '');
-        $newStatusName = (string) ($record['Prospect']['ProspectStatusType'] ?? '');
+        // Two DSP shapes: the RCI disposition puts ProspectId under <Identifier>
+        // (with <RCIDispositionEventName>), the status-change shape under <Prospect>.
+        $prospectId = (string) (
+            $record['Identifier']['ProspectId']
+            ?? $record['Prospect']['ProspectId']
+            ?? ''
+        );
 
-        if ($prospectId === '' || $newStatusName === '') {
-            return ['status' => 'ignored', 'task' => $task->value, 'reason' => 'Missing ProspectId or ProspectStatusType'];
+        if ($prospectId === '') {
+            return ['status' => 'ignored', 'task' => $task->value, 'reason' => 'Missing ProspectId'];
         }
 
         $lead = Lead::query()
@@ -130,6 +136,57 @@ class ProcessReynoldsWebhookJob extends ProcessWebhookJob
 
         if ($lead === null) {
             return ['status' => 'ignored', 'task' => $task->value, 'reason' => 'Lead not found for ProspectId ' . $prospectId];
+        }
+
+        $eventName = $record['RCIDispositionEventName'] ?? null;
+        if ($eventName !== null) {
+            return $this->applyRciDisposition($company, $lead, $record, $task, (string) $eventName);
+        }
+
+        return $this->applyStatusDisposition($company, $lead, $record, $task);
+    }
+
+    /**
+     * Only the "Assigned" RCI disposition changes ownership. R&R sends the
+     * assigned salesperson as "FirstName LastName" in
+     * <RCIDispositionPrimarySalesperson>.
+     */
+    private function applyRciDisposition(
+        Companies $company,
+        Lead $lead,
+        array $record,
+        TransactionCodeEnum $task,
+        string $eventName
+    ): array {
+        if (! str_contains(strtolower($eventName), 'assign')) {
+            return ['status' => 'ignored', 'task' => $task->value, 'reason' => 'Unhandled RCI disposition: ' . $eventName];
+        }
+
+        $salesperson = (string) ($record['RCIDispositionPrimarySalesperson'] ?? '');
+        $ownerId = SalespersonResolver::resolveUserId($salesperson, $company);
+
+        if ($ownerId === null) {
+            return ['status' => 'ignored', 'task' => $task->value, 'reason' => 'Salesperson not found: ' . $salesperson];
+        }
+
+        $lead->leads_owner_id = $ownerId;
+        $lead->saveOrFail();
+
+        return [
+            'status' => 'success',
+            'task' => $task->value,
+            'lead_id' => $lead->getId(),
+            'event' => $eventName,
+            'owner_id' => $ownerId,
+        ];
+    }
+
+    private function applyStatusDisposition(Companies $company, Lead $lead, array $record, TransactionCodeEnum $task): array
+    {
+        $newStatusName = (string) ($record['Prospect']['ProspectStatusType'] ?? '');
+
+        if ($newStatusName === '') {
+            return ['status' => 'ignored', 'task' => $task->value, 'reason' => 'Missing ProspectStatusType'];
         }
 
         $status = LeadStatus::query()

--- a/src/Domains/Workflow/Models/ReceiverWebhookCall.php
+++ b/src/Domains/Workflow/Models/ReceiverWebhookCall.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace Kanvas\Workflow\Models;
 
 use Baka\Casts\Json;
-use Baka\Traits\DynamicSearchableTrait;
 use Baka\Traits\UuidTrait;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ReceiverWebhookCall extends BaseModel
 {
-    use DynamicSearchableTrait;
-    use HasFactory;
     use UuidTrait;
+    use HasFactory;
 
     protected $table = 'receiver_webhook_calls';
 
@@ -41,27 +39,5 @@ class ReceiverWebhookCall extends BaseModel
     public function receiverWebhook(): BelongsTo
     {
         return $this->belongsTo(ReceiverWebhook::class, 'receiver_webhooks_id');
-    }
-
-    /**
-     * Push the full row up as-is. Cast columns (headers / payload / results /
-     * exception) come back as arrays via Eloquent, which Scout serializes
-     * straight into the index record.
-     */
-    public function toSearchableArray(): array
-    {
-        return array_merge(
-            $this->attributesToArray(),
-            ['objectID' => self::class . "::{$this->id}"],
-        );
-    }
-
-    /**
-     * The searchable index name — respects Scout's configured prefix so
-     * per-env indices (dev / staging / prod) stay separate.
-     */
-    public function searchableAs(): string
-    {
-        return config('scout.prefix') . 'receiver_webhook_calls';
     }
 }

--- a/src/Domains/Workflow/Models/ReceiverWebhookCall.php
+++ b/src/Domains/Workflow/Models/ReceiverWebhookCall.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace Kanvas\Workflow\Models;
 
 use Baka\Casts\Json;
+use Baka\Traits\DynamicSearchableTrait;
 use Baka\Traits\UuidTrait;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ReceiverWebhookCall extends BaseModel
 {
-    use UuidTrait;
+    use DynamicSearchableTrait;
     use HasFactory;
+    use UuidTrait;
 
     protected $table = 'receiver_webhook_calls';
 
@@ -39,5 +41,27 @@ class ReceiverWebhookCall extends BaseModel
     public function receiverWebhook(): BelongsTo
     {
         return $this->belongsTo(ReceiverWebhook::class, 'receiver_webhooks_id');
+    }
+
+    /**
+     * Push the full row up as-is. Cast columns (headers / payload / results /
+     * exception) come back as arrays via Eloquent, which Scout serializes
+     * straight into the index record.
+     */
+    public function toSearchableArray(): array
+    {
+        return array_merge(
+            $this->attributesToArray(),
+            ['objectID' => self::class . "::{$this->id}"],
+        );
+    }
+
+    /**
+     * The searchable index name — respects Scout's configured prefix so
+     * per-env indices (dev / staging / prod) stay separate.
+     */
+    public function searchableAs(): string
+    {
+        return config('scout.prefix') . 'receiver_webhook_calls';
     }
 }

--- a/tests/Connectors/Integration/Reynolds/InboundWebhookTest.php
+++ b/tests/Connectors/Integration/Reynolds/InboundWebhookTest.php
@@ -7,6 +7,7 @@ namespace Tests\Connectors\Integration\Reynolds;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Queue;
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Reynolds\Actions\PullLeadAction;
 use Kanvas\Connectors\Reynolds\Enums\ConfigurationEnum;
 use Kanvas\Connectors\Reynolds\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Reynolds\Webhooks\ProcessReynoldsWebhookJob;
@@ -97,6 +98,109 @@ final class InboundWebhookTest extends TestCase
 
         $this->assertSame('ignored', $result['status'] ?? null);
         $this->assertStringContainsString('No matching company', (string) ($result['reason'] ?? ''));
+    }
+
+    public function testDispositionAssignedSetsLeadOwnerByProspectId(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        // companies_settings persists across runs (no DatabaseTransactions), so
+        // key the dealer on the company id to resolve only to this test's company.
+        $dealer = 'DSPDEALER' . $company->getId();
+        $prospectId = '30' . $company->getId();
+
+        $this->setupReynoldsConfiguration($app, $company);
+        $this->bindDealerLocationKey($company, $dealer, self::FIXTURE_STORE, self::FIXTURE_AREA);
+
+        // Create the lead directly so the assertion doesn't depend on webhook
+        // company resolution for the initial upsert.
+        $lead = new PullLeadAction($app, $company, $user)->execute([
+            'Prospect' => [
+                'ProspectId' => $prospectId,
+                'ProspectType' => 'Internet',
+                'ProspectStatusType' => 'Open',
+            ],
+            'IndividualCustomer' => ['FirstName' => 'Disp', 'LastName' => 'Tester'],
+            'Email' => ['MailTo' => 'disp.tester.' . $company->getId() . '@example.invalid'],
+        ]);
+
+        // R&R ships the assigned salesperson as "FirstName LastName". Make the
+        // authenticated (company-associated) user match so the scoped lookup hits.
+        $user->firstname = 'Tabitha';
+        $user->lastname = 'Sumner';
+        $user->saveOrFail();
+
+        $envelope = $this->buildDispositionEnvelope(
+            $dealer,
+            self::FIXTURE_STORE,
+            self::FIXTURE_AREA,
+            $prospectId,
+            'Assigned',
+            'Tabitha Sumner',
+        );
+
+        $result = $this->dispatchWebhookJob($envelope);
+
+        $this->assertSame('success', $result['status'] ?? null, 'Assigned disposition should update the lead owner.');
+        $this->assertSame('DSP', $result['task'] ?? null);
+        $this->assertSame('Assigned', $result['event'] ?? null);
+        $this->assertSame($user->getId(), $result['owner_id'] ?? null);
+
+        $lead->refresh();
+        $this->assertSame($user->getId(), $lead->leads_owner_id, 'Lead owner must be the resolved salesperson.');
+    }
+
+    private function buildDispositionEnvelope(
+        string $dealer,
+        string $store,
+        string $area,
+        string $prospectId,
+        string $event,
+        string $salesperson
+    ): string {
+        return <<<XML
+<?xml version="1.0" encoding="utf-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><soapenv:Header><payloadManifest xmlns="http://www.starstandards.org/webservices/2005/10/transport"><manifest contentID="Content0" namespaceURI="http://www.starstandards.org/STAR" element="rey_SalesAssistCRMPublishLeadDisposition" /></payloadManifest></soapenv:Header><soapenv:Body><PutMessage xmlns="http://www.starstandards.org/webservices/2005/10/transport"><payload><content id="Content0"><rey_SalesAssistCRMPublishLeadDisposition xmlns="http://www.starstandards.org/STAR"><ApplicationArea><BODId>990c453c-15a6-49fa-9185-d5c3b56716f0</BODId><CreationDateTime>2026-07-08T10:37:42</CreationDateTime><Sender><Component>RRCRM</Component><Task>DSP</Task><TransType>O</TransType><DealerNumber>{$dealer}</DealerNumber><StoreNumber>{$store}</StoreNumber><AreaNumber>{$area}</AreaNumber><BusinessUnitName>Fixture Dealership</BusinessUnitName></Sender><Destination><DestinationNameCode>RCI</DestinationNameCode></Destination></ApplicationArea><Record><Identifier><ProspectId>{$prospectId}</ProspectId><NameRecId>54783</NameRecId></Identifier><RCIDispositionEventId>29</RCIDispositionEventId><RCIDispositionEventName>{$event}</RCIDispositionEventName><IsAiGenerated>N</IsAiGenerated><RCIDispositionCompletedByUserId>{$salesperson}</RCIDispositionCompletedByUserId><RCIDispositionCompletedOn>2026-07-08T10:37:42</RCIDispositionCompletedOn><RCIDispositionPrimarySalesperson>{$salesperson}</RCIDispositionPrimarySalesperson></Record></rey_SalesAssistCRMPublishLeadDisposition></content></payload></PutMessage></soapenv:Body></soapenv:Envelope>
+XML;
+    }
+
+    public function testPullLeadStoresTradeInInVinSolutionShape(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        $record = [
+            'Prospect' => [
+                'ProspectId' => '9911001',
+                'ProspectType' => 'Internet',
+                'ProspectStatusType' => 'Open',
+            ],
+            'IndividualCustomer' => ['FirstName' => 'Trade', 'LastName' => 'Tester'],
+            'Email' => ['MailTo' => 'trade.tester@example.invalid'],
+            'PotentialTrade' => [
+                'TradeVehicleVin' => '1FTFW1E5XKFA00000',
+                'TradeVehicleYear' => '2019',
+                'TradeVehicleMake' => 'Ford',
+                'TradeVehicleModel' => 'F-150',
+                'TradeVehicleOdometer' => '45,000',
+            ],
+        ];
+
+        $lead = new PullLeadAction($app, $company, $user)->execute($record);
+
+        $tradeIn = $lead->get(CustomFieldEnum::TRADE_IN->value);
+
+        $this->assertSame('vehicle_trade_id', CustomFieldEnum::TRADE_IN->value);
+        $this->assertIsArray($tradeIn);
+        $this->assertSame('1FTFW1E5XKFA00000', $tradeIn['vin']);
+        $this->assertSame('2019', $tradeIn['year']);
+        $this->assertSame('Ford', $tradeIn['make']);
+        $this->assertSame('F-150', $tradeIn['model']);
+        $this->assertSame(45000, $tradeIn['mileage']);
+        $this->assertSame('UNKNOWN', $tradeIn['condition']);
+        $this->assertArrayHasKey('payOff', $tradeIn);
     }
 
     private function bindDealerLocationKey($company, string $dealer, string $store, string $area): void


### PR DESCRIPTION
## Summary

Follow-up to the merged Reynolds connector PRs. Ships against \`1.x\` in parallel with the \`development\` PR (#10298). Two independent, low-risk changes on the same branch:

**1. \`fix(reynolds)\`** — Sequential People lookup, email first, phone as fallback.

\`PeoplesRepository::getMatchingEmailPhone\` \`AND\`s its two \`whereExists\` clauses, so passing both when a stored People only carries one of them misses the match and forks a duplicate. Real dealer data has plenty of records where email survived a phone swap or vice-versa — the AND semantics were silently creating a second People row every time R&R shipped a full envelope for one of those customers.

Split into two sequential lookups on the connector side without touching the shared repository (other callers keep their AND semantics):

- If the envelope has an email → look up by email only.
- If step 1 missed and the envelope has a phone → look up by phone only.

Email wins ties because customers keep it across phone swaps. Happy path costs one query; worst case (email miss + phone hit) costs two.

**2. \`feat(workflow)\`** — Index \`ReceiverWebhookCall\` in Scout / Algolia.

Wire the model into \`Baka\Traits\DynamicSearchableTrait\` so \`receiver_webhook_calls\` rows are pushed to whichever Scout engine the tenant resolves to (Algolia by default, Typesense when the \`receiver_webhook_calls_search_engine\` app setting overrides).

\`toSearchableArray()\` spreads the full row + \`objectID\` — cast columns (headers / payload / results / exception) come back as arrays via Eloquent and serialize straight into the index record. \`searchableAs()\` respects Scout's configured prefix so per-env indices (dev / staging / prod) stay separate.

To backfill the initial index for existing rows:

\`\`\`
php artisan scout:import "Kanvas\Workflow\Models\ReceiverWebhookCall"
\`\`\`

New / updated calls auto-sync via Scout's model observer.

## Test plan

- [ ] Replay an OSL webhook against a People that has only an email (no phone) via \`debug:reynolds-webhook\` — confirm no duplicate People row is created.
- [ ] Same, but People has only a phone — confirm the phone-fallback branch finds it.
- [ ] \`scout:import\` the ReceiverWebhookCall model in dev, hit the Algolia dashboard and confirm the records show up under the \`{prefix}receiver_webhook_calls\` index.