### PR TITLE
feat: live container status polling + broadcast on drift

### DIFF
--- a/app/GraphQL/Intelligence/Queries/AgentRuntime/AgentDeploymentContainerStatusQuery.php
+++ b/app/GraphQL/Intelligence/Queries/AgentRuntime/AgentDeploymentContainerStatusQuery.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Intelligence\Queries\AgentRuntime;
+
+use Illuminate\Support\Facades\Cache;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Intelligence\AgentRuntime\Providers\AgentRuntimeProviderFactory;
+use Kanvas\Intelligence\Agents\Models\AgentDeployment;
+
+/**
+ * Live container heartbeat — SSHes into the deployment's machine (via the resolved
+ * provider) and runs `docker compose ps` to check the container's actual state,
+ * independent of whatever Kanvas last recorded.
+ *
+ * This exists because status changes made *outside* Kanvas (an operator manually
+ * restarting a crashed container over SSH) never reach the admin UI otherwise:
+ * `AgentDeploymentStatusChanged` only broadcasts on Kanvas-initiated transitions
+ * (launch/restart/terminate/migrate), so a container that comes back on its own
+ * leaves the DB row — and every open admin tab — stuck on the stale status until
+ * something asks the machine directly. The frontend polls this on an interval
+ * while a deployment's status view is open, same pattern as agentCurrentTelemetry.
+ *
+ * 30s cache matches the existing agentRuntimeContainerStatus mutation so a poll
+ * and a manual refresh click within the same window share one SSH round trip.
+ */
+class AgentDeploymentContainerStatusQuery
+{
+    public function __invoke(mixed $root, array $args): AgentDeployment
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        /** @var AgentDeployment $deployment */
+        $deployment = AgentDeployment::getByIdFromCompanyApp((int) $args['deployment_id'], $company, $app);
+
+        return Cache::remember(
+            'agent-runtime:container-status:' . $deployment->id,
+            30,
+            fn (): AgentDeployment => AgentRuntimeProviderFactory::forDeployment($deployment)->fetchContainerStatus($deployment),
+        );
+    }
+}

--- a/graphql/schemas/Intelligence/agentRuntime.graphql
+++ b/graphql/schemas/Intelligence/agentRuntime.graphql
@@ -32,6 +32,12 @@ type AgentLogEntry {
 }
 
 extend type Query @guardByAdmin {
+    "Live SSH-checked container status — poll this to detect state changes made outside Kanvas (e.g. a manual restart on the machine)."
+    agentDeploymentContainerStatus(deployment_id: ID!): AgentDeploymentType!
+        @field(
+            resolver: "App\\GraphQL\\Intelligence\\Queries\\AgentRuntime\\AgentDeploymentContainerStatusQuery"
+        )
+
     agentCurrentTelemetry(deployment_id: ID!): AgentTelemetryData
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Queries\\AgentRuntime\\AgentTelemetryQuery"

--- a/src/Domains/Intelligence/AgentRuntime/Actions/BaseGetAgentContainerStatusAction.php
+++ b/src/Domains/Intelligence/AgentRuntime/Actions/BaseGetAgentContainerStatusAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\AgentRuntime\Actions;
 
 use Kanvas\Intelligence\AgentRuntime\Enums\DeploymentStatusEnum;
+use Kanvas\Intelligence\AgentRuntime\Events\AgentDeploymentStatusChanged;
 use Kanvas\Intelligence\AgentRuntime\SshClient;
 use Kanvas\Intelligence\Agents\Models\AgentDeployment;
 use Kanvas\Intelligence\Agents\Models\AgentMachine;
@@ -21,6 +22,7 @@ abstract class BaseGetAgentContainerStatusAction
     public function execute(): AgentDeployment
     {
         $client = $this->createSshClient($this->deployment->machine);
+        $previousStatus = $this->deployment->status;
 
         try {
             $providerDir = $this->deployment->home_directory . '/.' . $client::makeProviderConfig()->dotDir;
@@ -32,6 +34,15 @@ abstract class BaseGetAgentContainerStatusAction
             $this->syncStatusFromOutput($result);
             $this->deployment->last_health_check = now();
             $this->deployment->saveOrFail();
+
+            // A poll-detected transition (e.g. an operator restarting a crashed container
+            // by hand, outside Kanvas) still needs to reach every open admin tab, not just
+            // whichever one happened to poll — so broadcast the same event the lifecycle
+            // jobs (launch/restart/terminate) fire. Guarded on an actual change since this
+            // runs on a recurring poll, unlike those one-shot jobs.
+            if ($this->deployment->status !== $previousStatus) {
+                AgentDeploymentStatusChanged::dispatch($this->deployment, $previousStatus);
+            }
         } finally {
             $client->disconnect();
         }


### PR DESCRIPTION
## What & why

Kanvas only learns about an `AgentDeployment`'s status via `AgentDeploymentStatusChanged` Pusher broadcasts — but those only fire from Kanvas-initiated lifecycle jobs (launch/restart/terminate/migrate). If an operator restarts a crashed container by hand over SSH, outside Kanvas, nothing tells Kanvas the container came back — the DB row and every open admin tab stay stuck on the stale status indefinitely.

There was already a live SSH-based status check (`docker compose ps` via `fetchContainerStatus`), exposed as `agentRuntimeContainerStatus` — but only as a `Mutation`, manually triggered by a button click. Nothing polled it automatically.

## Changes

- **New Query**: `agentDeploymentContainerStatus(deployment_id: ID!): AgentDeploymentType!` (`graphql/schemas/Intelligence/agentRuntime.graphql`, `@guardByAdmin`) — a poll-friendly read wrapping the same SSH check + 30s cache as the existing mutation. New resolver class `App\GraphQL\Intelligence\Queries\AgentRuntime\AgentDeploymentContainerStatusQuery`, following the exact convention of the existing `AgentDeploymentEventsQuery`/`AgentTelemetryQuery` (tenant-scoped lookup via `getByIdFromCompanyApp`, `Cache::remember`).
- **`BaseGetAgentContainerStatusAction`**: now captures the previous status before the SSH check and dispatches `AgentDeploymentStatusChanged::dispatch($deployment, $previousStatus)` when a poll detects an actual transition — guarded so it only fires on a real change (this runs on a recurring poll, unlike the one-shot lifecycle jobs that always dispatch). This means a poll-detected recovery (or an unexpected crash) reaches every open admin tab via Pusher, not just the tab that happened to poll.

## Companion PR

Frontend polling that consumes this: mctekk/kanvas-core-admin-v2#878 (adds a 20s-interval poll wired into the deployment status panel).

## Reviewer notes

- Reused the existing `fetchContainerStatus()` provider method and 30s cache key (`agent-runtime:container-status:<id>`) verbatim — a poll and a manual "refresh status" click within the same 30s window share one SSH round trip, no double cost.
- The broadcast-on-change guard is intentional: without it, every 20s poll from every open tab would re-broadcast even when nothing changed.

## Test plan

- [ ] `php -l` clean on all 3 touched/new files (done locally)
- [ ] Manual: open an agent's deployment tab, SSH into the machine and `docker compose restart` the container outside Kanvas, confirm the admin UI's status badge updates within ~20-30s without a manual refresh
- [ ] Confirm `agentRuntimeContainerStatus` mutation (existing manual refresh path) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)