### PR TITLE
feat: add agentRuntimeRetryDeployment mutation for failed deployments

### DIFF
--- a/app/GraphQL/Intelligence/Mutations/AgentRuntime/AgentDeploymentMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/AgentRuntime/AgentDeploymentMutation.php
@@ -42,6 +42,39 @@ class AgentDeploymentMutation
         return $provider->dispatchDeployment($agent, $machine, $app, $company);
     }
 
+    /**
+     * Retry a failed deployment on the same agent + machine it already targeted.
+     *
+     * `dispatchDeployment` (via BaseDispatchAgentDeploymentAction) already looks up
+     * the existing row by (agent_machine_id, system_user) and reuses it — resetting
+     * status to `provisioning`, clearing error_message, and reassigning ports — so
+     * this doesn't need any new dedup logic. It just re-derives agent/machine from
+     * the failed deployment itself (rather than asking the caller to resupply them)
+     * and reuses the provider that deployment is actually pinned to, not whatever
+     * the agent's current default happens to be.
+     */
+    public function retry(mixed $root, array $request): AgentDeployment
+    {
+        $deployment = $this->loadDeployment((int) $request['deployment_id']);
+
+        if ($deployment->status !== DeploymentStatusEnum::FAILED->value) {
+            throw new ValidationException('Only a failed deployment can be retried.');
+        }
+
+        $agent = $deployment->agent;
+        $machine = $deployment->machine;
+
+        if ($agent === null || $machine === null) {
+            throw new ValidationException('Cannot retry: the agent or machine no longer exists.');
+        }
+
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        return AgentRuntimeProviderFactory::forDeployment($deployment)
+            ->dispatchDeployment($agent, $machine, $app, $company);
+    }
+
     public function terminate(mixed $root, array $request): bool
     {
         $deployment = $this->loadDeployment((int) $request['deployment_id']);

--- a/graphql/schemas/Intelligence/agentRuntime.graphql
+++ b/graphql/schemas/Intelligence/agentRuntime.graphql
@@ -95,6 +95,11 @@ extend type Mutation @guard {
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Mutations\\AgentRuntime\\AgentDeploymentMutation@launch"
         )
+    "Retry a failed deployment on the same agent + machine it already targeted."
+    agentRuntimeRetryDeployment(deployment_id: ID!): AgentDeploymentType!
+        @field(
+            resolver: "App\\GraphQL\\Intelligence\\Mutations\\AgentRuntime\\AgentDeploymentMutation@retry"
+        )
     agentRuntimeTerminateAgent(deployment_id: ID!): Boolean!
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Mutations\\AgentRuntime\\AgentDeploymentMutation@terminate"

--- a/tests/Intelligence/NervousSystem/EventAnalyticsServiceTest.php
+++ b/tests/Intelligence/NervousSystem/EventAnalyticsServiceTest.php
@@ -44,12 +44,12 @@ final class EventAnalyticsServiceTest extends TestCase
 
         $service = new EventAnalyticsService();
 
-        $enriched = $this->query($app, $company, ['people.enriched']);
+        $enriched = $this->analyticsQuery($app, $company, ['people.enriched']);
 
         $this->assertSame(4, $service->count($enriched), 'Four people.enriched events.');
         $this->assertSame(3, $service->countDistinctEntities($enriched), 'Three distinct entities (1001 counted once).');
 
-        $employerOnly = $this->query($app, $company, ['people.enriched'], ['changes.current_employer']);
+        $employerOnly = $this->analyticsQuery($app, $company, ['people.enriched'], ['changes.current_employer']);
         $this->assertSame(3, $service->count($employerOnly), 'Three events carry changes.current_employer.');
         $this->assertSame(2, $service->countDistinctEntities($employerOnly), 'Across two distinct entities.');
 
@@ -58,7 +58,7 @@ final class EventAnalyticsServiceTest extends TestCase
         $this->assertSame(3, $byKey['changes.current_employer']->count);
         $this->assertSame(2, $byKey['changes.title']->count);
 
-        $byType = $service->groupBy($this->query($app, $company), EventGroupByEnum::EVENT_TYPE)
+        $byType = $service->groupBy($this->analyticsQuery($app, $company), EventGroupByEnum::EVENT_TYPE)
             ->keyBy('key');
         $this->assertSame(4, $byType['people.enriched']->count);
         $this->assertSame(1, $byType['people.other']->count);
@@ -115,12 +115,12 @@ final class EventAnalyticsServiceTest extends TestCase
             )->execute();
         }
 
-        $count = new EventAnalyticsService()->count($this->query($app, $company, ['people.enriched']));
+        $count = new EventAnalyticsService()->count($this->analyticsQuery($app, $company, ['people.enriched']));
 
         $this->assertSame(1, $count, 'Only this app\'s event is counted, never the other app\'s.');
     }
 
-    private function query(Apps $app, Companies $company, array $eventTypes = [], array $payloadHasKeys = []): EventAnalyticsQuery
+    private function analyticsQuery(Apps $app, Companies $company, array $eventTypes = [], array $payloadHasKeys = []): EventAnalyticsQuery
     {
         return new EventAnalyticsQuery(
             app: $app,


### PR DESCRIPTION
## What & why

There was no working recovery path for a `failed` deployment. The existing `agentRuntimeRestartContainer` mutation explicitly requires the deployment to already be running (`BaseRestartAgentContainerAction::execute()` throws `"Cannot restart a deployment that is not running"` otherwise), so it never actually works on a failed one — the only real recovery was Terminate + re-pick a machine from scratch.

## Changes

- New `agentRuntimeRetryDeployment(deployment_id: ID!): AgentDeploymentType!` mutation (`AgentDeploymentMutation@retry`), guarded to only accept a deployment currently in `failed` status.
- Re-derives `agent`/`machine` from the failed deployment's own relations and dispatches through the provider that deployment is *already pinned to* (`AgentRuntimeProviderFactory::forDeployment`), rather than asking the caller to resupply agent_id/machine_id/provider.
- No new dedup/idempotency logic needed: `dispatchDeployment` (via `BaseDispatchAgentDeploymentAction`) already looks up an existing row by `(agent_machine_id, system_user)` regardless of its prior status and reuses it — resetting `status` to `provisioning`, clearing `error_message`, and reassigning ports.

## Companion PR

Frontend "Retry" button that consumes this: mctekk/kanvas-core-admin-v2 (branch `feat/agent-deployment-retry`, PR to follow).

## Test plan

- [x] `php -l` clean
- [ ] Manual: force a deployment into `failed` (e.g. bad machine), call `agentRuntimeRetryDeployment`, confirm it reuses the same row (not a duplicate) and successfully relaunches
- [ ] Confirm retry on a non-`failed` deployment is rejected with `ValidationException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)