### PR TITLE
fix: cap movipass late fee at a single one-time charge

### DIFF
--- a/src/Domains/Connectors/Movipass/Actions/GenerateOrderLateFee.php
+++ b/src/Domains/Connectors/Movipass/Actions/GenerateOrderLateFee.php
@@ -98,32 +98,28 @@ class GenerateOrderLateFee
                 return;
             }
 
-            $feeCount = (int) max(1, ceil($order->days_late / 30));
-
             // Lock the order row so overlapping runs of the hourly command serialize here.
             // Without it two concurrent runs both pass the "late-fee item already exists?"
             // check and insert duplicate late-fee items with the same created_at second.
-            $completeOrder->getConnection()->transaction(function () use ($completeOrder, $lateFee, $lateFeePrice, $feeCount, $order, $timeZonedNow): void {
+            $completeOrder->getConnection()->transaction(function () use ($completeOrder, $lateFee, $lateFeePrice, $order, $timeZonedNow): void {
                 Order::query()->whereKey($completeOrder->getKey())->lockForUpdate()->first();
 
                 // FOR UPDATE read so a serialized run sees the item the other run just committed
                 // (a plain read would use this transaction's older snapshot and miss it).
                 $hasLateFee = $completeOrder->items()->where('variant_id', $lateFee->id)->lockForUpdate()->first();
 
+                // Late fee is a one-time charge: once the order has it, leave it untouched.
                 if ($hasLateFee) {
-                    if ((int) $hasLateFee->quantity !== $feeCount) {
-                        $hasLateFee->quantity = $feeCount;
-                        $hasLateFee->saveOrFail();
-                    }
-                } else {
-                    $orderItem = OrderItem::from($this->apps, $completeOrder->company, $completeOrder->region, [
-                        'variant_id' => $lateFee->id,
-                        'quantity' => $feeCount,
-                        'price' => $lateFeePrice,
-                    ]);
-
-                    $completeOrder->addItem($orderItem);
+                    return;
                 }
+
+                $orderItem = OrderItem::from($this->apps, $completeOrder->company, $completeOrder->region, [
+                    'variant_id' => $lateFee->id,
+                    'quantity' => 1,
+                    'price' => $lateFeePrice,
+                ]);
+
+                $completeOrder->addItem($orderItem);
 
                 // Record the latest snapshot every late run so business_days_late stays current,
                 // even when the fee quantity itself didn't change.


### PR DESCRIPTION
Late fee no longer accumulates one unit per 30 days late. Once an order has the late-fee item it is left untouched instead of re-adjusting quantity every hourly run.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
