### PR TITLE
fix: use agent firstname in lead ai mode note

### DIFF
--- a/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
+++ b/src/Domains/Intelligence/Triggers/Actions/ApplyLeadAiModeAction.php
@@ -197,7 +197,9 @@ class ApplyLeadAiModeAction
 
     protected function logModeChangeNote(string $newMode): void
     {
-        $this->logSystemNote('Sally Mode set to ' . $newMode);
+        $agentName = $this->lead->aiSession()->with('agent.user')->first()?->agent?->user?->firstname ?? 'Sally';
+
+        $this->logSystemNote($agentName . ' Mode set to ' . $newMode);
     }
 
     protected function logFollowUpChangeNote(mixed $currentFollowUp): void


### PR DESCRIPTION
Resolves the lead AI mode system note to use the agent's user firstname (via lead session → agent → user) instead of the hardcoded "Sally", falling back to "Sally" when unavailable.