### PR TITLE
fix: allow global regions in integration company setup

### DIFF
--- a/app/GraphQL/Workflow/Mutations/Integrations/IntegrationsMutation.php
+++ b/app/GraphQL/Workflow/Mutations/Integrations/IntegrationsMutation.php
@@ -26,7 +26,7 @@ class IntegrationsMutation
     {
         $integration = Integrations::getById((int) $request['input']['integration']['id']);
         $company = CompaniesRepository::getById((int) $request['input']['company_id']);
-        $region = RegionRepository::getById((int) $request['input']['region']['id'], $company);
+        $region = RegionRepository::getByIdOrGlobal((int) $request['input']['region']['id'], $company, app(Apps::class));
         $user = auth()->user();
 
         if (! $user->isAppOwner()) {

--- a/src/Domains/Inventory/Regions/Repositories/RegionRepository.php
+++ b/src/Domains/Inventory/Regions/Repositories/RegionRepository.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Kanvas\Inventory\Regions\Repositories;
 
+use Baka\Contracts\AppInterface;
 use Baka\Contracts\CompanyInterface;
 use Baka\Traits\SearchableTrait;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Kanvas\Exceptions\ModelNotFoundException as ExceptionsModelNotFoundException;
 use Kanvas\Inventory\Regions\Models\Regions as RegionModel;
 
 class RegionRepository
@@ -15,6 +18,30 @@ class RegionRepository
     public static function getModel(): RegionModel
     {
         return new RegionModel();
+    }
+
+    /**
+     * Resolve a region by id within the company OR an app-global region (companies_id = 0).
+     * Unlike the Souk `fromCompanyOrGlobal` scope, global inclusion here is unconditional —
+     * it is not gated by ALLOW_CROSS_COMPANY_VARIANTS, since integration setup legitimately
+     * uses shared global regions regardless of the product-variants flag.
+     */
+    public static function getByIdOrGlobal(int $id, CompanyInterface $company, ?AppInterface $app = null): RegionModel
+    {
+        try {
+            return self::getModel()
+                ->fromApp($app)
+                ->notDeleted()
+                ->where('id', $id)
+                ->where(
+                    fn ($query) => $query
+                        ->where('companies_id', $company->getId())
+                        ->orWhere('companies_id', 0)
+                )
+                ->firstOrFail();
+        } catch (ModelNotFoundException $e) {
+            throw new ExceptionsModelNotFoundException($e->getMessage());
+        }
     }
 
     public static function getDefault(CompanyInterface $company): RegionModel

--- a/tests/Inventory/Integration/RegionGetByIdOrGlobalTest.php
+++ b/tests/Inventory/Integration/RegionGetByIdOrGlobalTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Inventory\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Exceptions\ModelNotFoundException;
+use Kanvas\Inventory\Regions\Models\Regions;
+use Kanvas\Inventory\Regions\Repositories\RegionRepository;
+use Kanvas\Souk\Enums\ConfigurationEnum as SoukConfigurationEnum;
+use Tests\TestCase;
+
+final class RegionGetByIdOrGlobalTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $connectionsToTransact = ['ecosystem', 'inventory'];
+
+    private Apps $currentApp;
+    private mixed $originalFlag = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->currentApp = app(Apps::class);
+        $this->originalFlag = $this->currentApp->get(SoukConfigurationEnum::ALLOW_CROSS_COMPANY_VARIANTS->value);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->currentApp->set(SoukConfigurationEnum::ALLOW_CROSS_COMPANY_VARIANTS->value, $this->originalFlag);
+        parent::tearDown();
+    }
+
+    private function createCompany(): Companies
+    {
+        return Companies::factory()->create(['users_id' => auth()->user()->getId()]);
+    }
+
+    private function createGlobalRegion(): Regions
+    {
+        return Regions::create([
+            'companies_id' => 0,
+            'apps_id' => $this->currentApp->getId(),
+            'currency_id' => 1,
+            'name' => fake()->unique()->city() . ' Global Region',
+            'is_default' => 0,
+            'is_deleted' => 0,
+        ]);
+    }
+
+    public function testResolvesGlobalRegionEvenWhenFlagDisabled(): void
+    {
+        // The variants flag OFF is the exact condition under which the old getById() threw
+        // "No query results for [Regions]" during integration setup.
+        $this->currentApp->set(SoukConfigurationEnum::ALLOW_CROSS_COMPANY_VARIANTS->value, 0);
+        $company = $this->createCompany();
+        $global = $this->createGlobalRegion();
+
+        $resolved = RegionRepository::getByIdOrGlobal($global->getId(), $company, $this->currentApp);
+
+        $this->assertSame($global->getId(), $resolved->getId());
+        $this->assertSame(0, (int) $resolved->companies_id);
+    }
+
+    public function testResolvesCompanyOwnedRegion(): void
+    {
+        $company = $this->createCompany();
+        $companyRegion = Regions::create([
+            'companies_id' => $company->getId(),
+            'apps_id' => $this->currentApp->getId(),
+            'currency_id' => 1,
+            'name' => fake()->unique()->city() . ' Company Region',
+            'is_default' => 1,
+            'is_deleted' => 0,
+        ]);
+
+        $resolved = RegionRepository::getByIdOrGlobal($companyRegion->getId(), $company, $this->currentApp);
+
+        $this->assertSame($companyRegion->getId(), $resolved->getId());
+        $this->assertSame($company->getId(), (int) $resolved->companies_id);
+    }
+
+    public function testThrowsWhenRegionBelongsToAnotherCompany(): void
+    {
+        $company = $this->createCompany();
+        $otherCompany = $this->createCompany();
+        $otherRegion = Regions::create([
+            'companies_id' => $otherCompany->getId(),
+            'apps_id' => $this->currentApp->getId(),
+            'currency_id' => 1,
+            'name' => fake()->unique()->city() . ' Other Region',
+            'is_default' => 1,
+            'is_deleted' => 0,
+        ]);
+
+        $this->expectException(ModelNotFoundException::class);
+        RegionRepository::getByIdOrGlobal($otherRegion->getId(), $company, $this->currentApp);
+    }
+}


### PR DESCRIPTION
RegionRepository::getById scoped strictly to the company, so selecting a global region (companies_id = 0) during integration setup threw 'No query results for [Regions]'. Add getByIdOrGlobal that resolves a region within the company OR global unconditionally (not gated by the Souk ALLOW_CROSS_COMPANY_VARIANTS flag) and use it in createIntegrationCompany.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
