### PR TITLE
fix(workflow): resolve integration company by tenant, not by region

### DIFF
--- a/src/Domains/Workflow/Traits/ActivityIntegrationTrait.php
+++ b/src/Domains/Workflow/Traits/ActivityIntegrationTrait.php
@@ -51,10 +51,19 @@ trait ActivityIntegrationTrait
     public function getIntegrationCompany(
         IntegrationsEnum $integration,
         Regions $region,
-        Status $status
+        Status $status,
+        ?Companies $company = null
     ): ?IntegrationsCompany {
+        // A global region (companies_id = 0) has no owning company, so it can only
+        // ever be a fallback — the integration belongs to the tenant, not the region.
+        $company ??= $region->company;
+
+        if (! $company instanceof Companies) {
+            return null;
+        }
+
         return IntegrationsCompany::getByIntegration(
-            company: $region->company,
+            company: $company,
             status: $status,
             region: $region,
             name: $integration->value
@@ -103,13 +112,22 @@ trait ActivityIntegrationTrait
         $this->overwriteAppService($app);
         $activeStatus = $this->getStatus(StatusEnum::ACTIVE);
         $company = $company ?? $entity->company;
-        $region = $region ?? Regions::getDefault($company ?? $entity->company, $app);
+
+        if (! $company instanceof Companies) {
+            return [
+                'error' => 'No company configured for this entity',
+                'integration' => $integration->value,
+                'entity_id' => $entity->getId(),
+            ];
+        }
+
+        $region = $region ?? Regions::getDefault($company, $app);
 
         if (! $region) {
             return [
                 'error' => 'No region configured for this company',
                 'integration' => $integration->value,
-                'company' => $company?->getId() ?? 'no company',
+                'company' => $company->getId(),
                 'entity_id' => $entity->getId(),
             ];
         }
@@ -117,7 +135,8 @@ trait ActivityIntegrationTrait
         $integrationCompany = $this->getIntegrationCompany(
             $integration,
             $region,
-            $activeStatus
+            $activeStatus,
+            $company
         );
 
         if (! $integrationCompany) {
@@ -125,7 +144,7 @@ trait ActivityIntegrationTrait
                 'error' => 'No integration configured for this company',
                 'region' => $region->getId(),
                 'integration' => $integration->value,
-                'company' => $company?->getId() ?? 'no company',
+                'company' => $company->getId(),
                 'entity_id' => $entity->getId(),
             ];
         }
@@ -162,7 +181,7 @@ trait ActivityIntegrationTrait
         if ($exception) {
             return [
                 'error' => $exception->getMessage(),
-                'company' => $company?->getId() ?? 'no company',
+                'company' => $company->getId(),
                 'integration' => $integration->value,
                 'entity_id' => $entity->getId(),
                 'trace' => $exception->getTraceAsString(),

--- a/tests/Workflow/Integration/ActivityIntegrationTraitTest.php
+++ b/tests/Workflow/Integration/ActivityIntegrationTraitTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Workflow\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Currencies\Models\Currencies;
+use Kanvas\Regions\Models\Regions;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\Enums\StatusEnum;
+use Kanvas\Workflow\Integrations\Models\IntegrationsCompany;
+use Kanvas\Workflow\Integrations\Models\Status;
+use Kanvas\Workflow\Models\Integrations;
+use Kanvas\Workflow\Traits\ActivityIntegrationTrait;
+use Tests\TestCase;
+
+final class ActivityIntegrationTraitTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $connectionsToTransact = ['workflow', 'ecosystem'];
+
+    public function testGetIntegrationCompanyResolvesWhenRegionIsGlobal(): void
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        $globalRegion = $this->createRegion($app, companiesId: 0);
+
+        // The regression: a global region has no owning company, so deriving the
+        // company from the region yields null and fatals on getByIntegration().
+        $this->assertNull($globalRegion->company);
+
+        $integrationCompany = $this->registerIntegration($company->getId(), $globalRegion);
+
+        $resolved = $this->activity()->getIntegrationCompany(
+            IntegrationsEnum::INTERNAL,
+            $globalRegion,
+            $this->activeStatus(),
+            $company
+        );
+
+        $this->assertNotNull($resolved);
+        $this->assertEquals($integrationCompany->getId(), $resolved->getId());
+    }
+
+    public function testGetIntegrationCompanyStillResolvesWhenRegionIsCompanyScoped(): void
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        $region = $this->createRegion($app, companiesId: $company->getId());
+        $integrationCompany = $this->registerIntegration($company->getId(), $region);
+
+        $resolved = $this->activity()->getIntegrationCompany(
+            IntegrationsEnum::INTERNAL,
+            $region,
+            $this->activeStatus(),
+            $company
+        );
+
+        $this->assertNotNull($resolved);
+        $this->assertEquals($integrationCompany->getId(), $resolved->getId());
+    }
+
+    public function testGetIntegrationCompanyDoesNotLeakAcrossCompanies(): void
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        $globalRegion = $this->createRegion($app, companiesId: 0);
+        $this->registerIntegration($company->getId(), $globalRegion);
+
+        $otherCompany = clone $company;
+        $otherCompany->id = $company->getId() + 100000;
+
+        $resolved = $this->activity()->getIntegrationCompany(
+            IntegrationsEnum::INTERNAL,
+            $globalRegion,
+            $this->activeStatus(),
+            $otherCompany
+        );
+
+        $this->assertNull($resolved);
+    }
+
+    public function testGetIntegrationCompanyFallsBackToRegionCompanyWhenNoneGiven(): void
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        $region = $this->createRegion($app, companiesId: $company->getId());
+        $integrationCompany = $this->registerIntegration($company->getId(), $region);
+
+        $resolved = $this->activity()->getIntegrationCompany(
+            IntegrationsEnum::INTERNAL,
+            $region,
+            $this->activeStatus()
+        );
+
+        $this->assertNotNull($resolved);
+        $this->assertEquals($integrationCompany->getId(), $resolved->getId());
+    }
+
+    public function testGetIntegrationCompanyReturnsNullWhenGlobalRegionAndNoCompanyGiven(): void
+    {
+        $app = app(Apps::class);
+        $globalRegion = $this->createRegion($app, companiesId: 0);
+
+        $resolved = $this->activity()->getIntegrationCompany(
+            IntegrationsEnum::INTERNAL,
+            $globalRegion,
+            $this->activeStatus()
+        );
+
+        $this->assertNull($resolved);
+    }
+
+    private function createRegion(Apps $app, int $companiesId): Regions
+    {
+        return Regions::create([
+            'apps_id' => $app->getId(),
+            'companies_id' => $companiesId,
+            'users_id' => 0,
+            'currency_id' => Currencies::getBaseCurrency()->getId(),
+            'name' => 'Region ' . uniqid(),
+            'is_default' => 0,
+            'is_deleted' => 0,
+        ]);
+    }
+
+    private function registerIntegration(int $companiesId, Regions $region): IntegrationsCompany
+    {
+        return IntegrationsCompany::create([
+            'companies_id' => $companiesId,
+            'integrations_id' => Integrations::getByName(IntegrationsEnum::INTERNAL->value)->getId(),
+            'region_id' => $region->getId(),
+            'status_id' => $this->activeStatus()->getId(),
+            'is_active' => 1,
+        ]);
+    }
+
+    private function activeStatus(): Status
+    {
+        return Status::where('slug', StatusEnum::ACTIVE->value)
+            ->where('apps_id', 0)
+            ->firstOrFail();
+    }
+
+    private function activity(): object
+    {
+        return new class () {
+            use ActivityIntegrationTrait;
+        };
+    }
+}


### PR DESCRIPTION
getIntegrationCompany() derived the company from $region->company. Since the region always came from Regions::getDefault($company, $app), that was an exact round-trip of a company we already had — harmless until regions could be global.

A global region has companies_id = 0 and no owning company row, so the round-trip yields null and getByIntegration(Companies $company) fatals with a TypeError, thrown outside executeIntegration's try/catch.

Pass the tenant company explicitly and keep $region->company as a fallback for callers that do not supply one. Guard the resolved company so a global region returns null (handled by the existing "No integration configured" path) instead of crashing the job.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
