### PR TITLE
fix: pull latest base image when building the shared agent image

### DIFF
--- a/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
+++ b/src/Domains/Connectors/Hermes/Actions/MigrateFromOpenClawAction.php
@@ -433,9 +433,11 @@ class MigrateFromOpenClawAction
         $client->writeFileAsUser($imageDir . '/entrypoint.sh', $builder->buildEntrypoint(), 'root');
         $client->exec('sudo chmod +x ' . escapeshellarg($imageDir . '/entrypoint.sh'));
 
+        // --pull checks the registry for a newer base image before building, same
+        // reasoning as BaseLaunchAgentOnMachineAction::ensureSharedImage().
         $buildResult = $client->exec(
             'cd ' . escapeshellarg($imageDir)
-            . ' && sudo docker build --no-cache -t ' . escapeshellarg($imageName) . ' . 2>&1; echo "EXIT_CODE:$?"',
+            . ' && sudo docker build --no-cache --pull -t ' . escapeshellarg($imageName) . ' . 2>&1; echo "EXIT_CODE:$?"',
             900
         );
 

--- a/src/Domains/Connectors/OpenClaw/Actions/RebuildSharedImageAction.php
+++ b/src/Domains/Connectors/OpenClaw/Actions/RebuildSharedImageAction.php
@@ -47,7 +47,7 @@ class RebuildSharedImageAction
 
             $result = $client->exec(
                 'cd ' . escapeshellarg($imageDir)
-                . ' && sudo docker build --no-cache -t ' . escapeshellarg($imageName) . ' . 2>&1'
+                . ' && sudo docker build --no-cache --pull -t ' . escapeshellarg($imageName) . ' . 2>&1'
                 . '; echo "EXIT_CODE:$?"',
                 900,
             );

--- a/src/Domains/Intelligence/AgentRuntime/Actions/BaseLaunchAgentOnMachineAction.php
+++ b/src/Domains/Intelligence/AgentRuntime/Actions/BaseLaunchAgentOnMachineAction.php
@@ -127,8 +127,13 @@ abstract class BaseLaunchAgentOnMachineAction
         $client->writeFileAsUser($imageDir . '/entrypoint.sh', $builder->buildEntrypoint(), 'root');
         $client->exec('sudo chmod +x ' . escapeshellarg($imageDir . '/entrypoint.sh'));
 
+        // --pull forces Docker to check the registry for a newer base image before
+        // building, rather than silently reusing whatever's already cached locally
+        // under that tag (e.g. nousresearch/hermes-agent:latest) — otherwise a machine
+        // that has ever built this image before keeps using the version that happened
+        // to be current the first time, indefinitely.
         $result = $client->exec(
-            'cd ' . escapeshellarg($imageDir) . ' && sudo docker build -t ' . escapeshellarg($imageName) . ' . 2>&1; echo "EXIT_CODE:$?"',
+            'cd ' . escapeshellarg($imageDir) . ' && sudo docker build --pull -t ' . escapeshellarg($imageName) . ' . 2>&1; echo "EXIT_CODE:$?"',
             900,
         );
 

--- a/src/Domains/Intelligence/AgentRuntime/Actions/BaseMigrateAgentWorkspaceAction.php
+++ b/src/Domains/Intelligence/AgentRuntime/Actions/BaseMigrateAgentWorkspaceAction.php
@@ -243,8 +243,10 @@ abstract class BaseMigrateAgentWorkspaceAction
 
         $exists = $client->exec('docker image inspect ' . escapeshellarg($imageName) . ' &>/dev/null && echo "EXISTS" || echo "MISSING"');
         if (str_contains($exists, 'MISSING')) {
+            // --pull checks the registry for a newer base image before building, same
+            // reasoning as BaseLaunchAgentOnMachineAction::ensureSharedImage().
             $buildResult = $client->exec(
-                'sudo docker build --no-cache -t ' . escapeshellarg($imageName) . ' ' . escapeshellarg($imageDir) . ' 2>&1; echo "EXIT_CODE:$?"',
+                'sudo docker build --no-cache --pull -t ' . escapeshellarg($imageName) . ' ' . escapeshellarg($imageDir) . ' 2>&1; echo "EXIT_CODE:$?"',
                 900
             );
             if (! str_contains($buildResult, 'EXIT_CODE:0')) {


### PR DESCRIPTION
## What & why

Base images are pinned to `:latest` (`nousresearch/hermes-agent:latest`, OpenClaw's equivalent), but every shared-image build site except the explicit "Update Containers" job (`BaseUpdateAgentForUserJob`, which already does an explicit `docker pull` before building) used plain `docker build` or `--no-cache` — which only disables the build's own layer cache for `RUN`/`COPY` steps, it does **not** re-check the registry for a newer `FROM` image.

In practice: the first time a machine ever builds its shared image, it pulls whatever `:latest` resolves to at that moment. Every subsequent agent launched on that **same machine** reuses that same cached image indefinitely, since `ensureSharedImage()` short-circuits on `docker image inspect ... EXISTS` before ever reaching the build step. There was no way to tell it was stale short of manually running "Update Containers."

## Changes

Added `--pull` to the four sites that build the shared image:
- `BaseLaunchAgentOnMachineAction::ensureSharedImage()` — first agent launched on a machine
- `MigrateFromOpenClawAction::ensureSharedImage()` — OpenClaw→Hermes migration destination
- `BaseMigrateAgentWorkspaceAction` — same-provider workspace migration destination
- `RebuildSharedImageAction` — currently unused/unwired, fixed for consistency in case it's revived

## Scope note

This only helps the "image missing, building for the first time" branch on each of these paths. A machine whose shared image **already exists** is unaffected — `ensureSharedImage()`'s `docker image inspect ... EXISTS => skip` short-circuit means the build (and therefore `--pull`) never runs at all for an already-provisioned machine. The only way to refresh an existing machine's containers remains the explicit `agentRuntimeUpdateMachineContainers` mutation, which already does the right thing (explicit `docker pull` + `--no-cache` rebuild + recreate).

## Test plan

- [x] `php -l` clean on all 4 files
- [ ] Manual: on a machine with no cached `nousresearch/hermes-agent` image, launch an agent and confirm the build log shows a pull attempt (not silently reusing a stale local cache from an unrelated prior build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)