### PR TITLE
feat: facet only is_filtrable attributes in typesense product index

### DIFF
--- a/src/Domains/Inventory/Products/Models/Products.php
+++ b/src/Domains/Inventory/Products/Models/Products.php
@@ -1105,7 +1105,38 @@ class Products extends BaseModel implements EntityIntegrationInterface, EntityIm
             ];
         }
 
+        foreach ($this->filterableAttributeFacetFields() as $facetField) {
+            $schema['fields'][] = $facetField;
+        }
+
         return $schema;
+    }
+
+    /**
+     * Typesense facets each nested key of the `attributes` object only if it's declared explicitly.
+     * We expose as facets ONLY the attributes flagged `is_filtrable` (the "Use as Filter" toggle),
+     * scoped to the app that owns this collection. `type: auto` tolerates both scalar and array values.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function filterableAttributeFacetFields(): array
+    {
+        return Attributes::query()
+            ->fromApp($this->app)
+            ->where('is_filtrable', 1)
+            ->where('is_deleted', 0)
+            ->get()
+            ->map(fn (Attributes $attribute) => $attribute->name)
+            ->unique()
+            ->filter()
+            ->map(fn (string $name) => [
+                'name' => 'attributes.' . $name,
+                'type' => 'auto',
+                'optional' => true,
+                'facet' => true,
+            ])
+            ->values()
+            ->all();
     }
 
     #[Override]


### PR DESCRIPTION
Declare an explicit facetable schema field per attribute flagged is_filtrable (the 'Use as Filter' toggle), scoped to the app, so those override Typesense's auto-detected facet:false. type:auto tolerates both scalar and array attribute values. Runs once at collection creation.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
