### PR TITLE
feat: fall back to last lead on responder when no active lead

### DIFF
--- a/src/Domains/Connectors/Mailgun/Webhooks/AgentProcessEmailWebhookJob.php
+++ b/src/Domains/Connectors/Mailgun/Webhooks/AgentProcessEmailWebhookJob.php
@@ -34,6 +34,10 @@ class AgentProcessEmailWebhookJob extends ProcessWebhookJob
 
         if ($people !== null) {
             $lead = LeadsRepository::getPeopleActiveLead($people);
+
+            if ($lead === null && (bool) $this->webhookRequest->receiverWebhook->company->get('use_last_lead_on_responder')) {
+                $lead = LeadsRepository::getPeopleLastLead($people);
+            }
         }
 
         $message = new CreateMessageFromEmailAction($this->webhookRequest, $lead)

--- a/src/Domains/Connectors/Twilio/Webhooks/ProcessTwilioWebhookJob.php
+++ b/src/Domains/Connectors/Twilio/Webhooks/ProcessTwilioWebhookJob.php
@@ -249,6 +249,14 @@ class ProcessTwilioWebhookJob extends ProcessWebhookJob
             return $activeLead;
         }
 
+        if ((bool) $this->receiver->company->get('use_last_lead_on_responder')) {
+            $lastLead = LeadsRepository::getPeopleLastLead($people);
+
+            if ($lastLead) {
+                return $lastLead;
+            }
+        }
+
         $leadType = LeadType::fromApp($people->app)
         ->fromCompany($people->company)
         ->where('name', 'Warm')

--- a/src/Domains/Guild/Leads/Repositories/LeadsRepository.php
+++ b/src/Domains/Guild/Leads/Repositories/LeadsRepository.php
@@ -60,6 +60,17 @@ class LeadsRepository
                         ->first();
     }
 
+    public static function getPeopleLastLead(People $people): ?Lead
+    {
+        /** @psalm-suppress LessSpecificReturnStatement */
+        return Lead::fromApp($people->app)
+                    ->fromCompany($people->company)
+                    ->notDeleted()
+                    ->where('people_id', $people->id)
+                    ->orderBy('id', 'desc')
+                    ->first();
+    }
+
     public static function getPeopleClosedLeads(People $people): Builder
     {
         return Lead::fromApp($people->app)


### PR DESCRIPTION
## Summary
When an inbound email (Mailgun) or SMS (Twilio) arrives from a known person who has no active lead, optionally reuse their most recent lead instead of creating a new one / dropping the association.

## Changes
- `LeadsRepository::getPeopleLastLead()` — returns the person's most recent lead (any status), scoped by app/company, not deleted, ordered by `id desc`.
- **Mailgun** `AgentProcessEmailWebhookJob` — when there's no active lead and the company custom field `use_last_lead_on_responder` is enabled, fall back to the last lead.
- **Twilio** `ProcessTwilioWebhookJob::createLeadFromPeople` — same fallback, applied before creating a brand-new lead.

## Behavior
- Flag off (default): unchanged behavior.
- Flag on + person has past leads: responder attaches to the most recent lead.