### PR TITLE
fix(stripe): omit empty after_completion redirect URL on payment links (1.x)

### DIFF
--- a/src/Domains/Connectors/Stripe/Services/StripePaymentLinkService.php
+++ b/src/Domains/Connectors/Stripe/Services/StripePaymentLinkService.php
@@ -84,12 +84,8 @@ class StripePaymentLinkService
             }
         }
 
-        // Add success and cancel URLs if provided
-        if (isset($options['success_url'])) {
-            $paymentLinkData['after_completion'] = [
-                'type' => 'redirect',
-                'redirect' => ['url' => $options['success_url']],
-            ];
+        if ($afterCompletion = $this->buildAfterCompletion($options)) {
+            $paymentLinkData['after_completion'] = $afterCompletion;
         }
 
         // Add automatic tax calculation if enabled
@@ -168,12 +164,8 @@ class StripePaymentLinkService
             $paymentLinkData['metadata'] = $options['metadata'];
         }
 
-        // Add success URL if provided
-        if (isset($options['success_url'])) {
-            $paymentLinkData['after_completion'] = [
-                'type' => 'redirect',
-                'redirect' => ['url' => $options['success_url']],
-            ];
+        if ($afterCompletion = $this->buildAfterCompletion($options)) {
+            $paymentLinkData['after_completion'] = $afterCompletion;
         }
 
         $paymentLink = $this->stripe->paymentLinks->create($paymentLinkData);
@@ -183,6 +175,24 @@ class StripePaymentLinkService
         $message->set('stripe_payment_link_url', $paymentLink->url);
 
         return $paymentLink;
+    }
+
+    /**
+     * Stripe rejects an empty `after_completion[redirect][url]`
+     * (`parameter_invalid_empty`): it reads "" as an attempt to unset the
+     * param, which cannot be unset. Return null when no non-empty success_url
+     * is supplied so the block is omitted entirely instead of failing the request.
+     */
+    protected function buildAfterCompletion(array $options): ?array
+    {
+        if (empty($options['success_url'])) {
+            return null;
+        }
+
+        return [
+            'type' => 'redirect',
+            'redirect' => ['url' => $options['success_url']],
+        ];
     }
 
     /**

--- a/tests/Connectors/Stripe/StripePaymentLinkAfterCompletionTest.php
+++ b/tests/Connectors/Stripe/StripePaymentLinkAfterCompletionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Stripe;
+
+use Baka\Contracts\AppInterface;
+use Kanvas\Connectors\Stripe\Services\StripePaymentLinkService;
+use ReflectionMethod;
+use Tests\Connectors\Stripe\Fakes\FakeStripeClient;
+use Tests\TestCase;
+
+/**
+ * Stripe rejects an empty `after_completion[redirect][url]`
+ * (`parameter_invalid_empty` — it reads "" as an attempt to unset the param,
+ * which cannot be unset). When a lead message has no action_link, success_url
+ * arrives as "" and the after_completion block must be omitted, not sent empty.
+ */
+final class StripePaymentLinkAfterCompletionTest extends TestCase
+{
+    public function testReturnsNullWhenSuccessUrlIsEmptyString(): void
+    {
+        $this->assertNull($this->buildAfterCompletion(['success_url' => '']));
+    }
+
+    public function testReturnsNullWhenSuccessUrlIsMissing(): void
+    {
+        $this->assertNull($this->buildAfterCompletion([]));
+    }
+
+    public function testBuildsRedirectWhenSuccessUrlIsPresent(): void
+    {
+        $result = $this->buildAfterCompletion(['success_url' => 'https://example.com/thanks']);
+
+        $this->assertSame(
+            [
+                'type' => 'redirect',
+                'redirect' => ['url' => 'https://example.com/thanks'],
+            ],
+            $result
+        );
+    }
+
+    private function buildAfterCompletion(array $options): ?array
+    {
+        $app = $this->createMock(AppInterface::class);
+        $service = new StripePaymentLinkService($app, null, new FakeStripeClient());
+
+        $method = new ReflectionMethod($service, 'buildAfterCompletion');
+
+        return $method->invoke($service, $options);
+    }
+}


### PR DESCRIPTION
## General Description

Backport to `1.x` of the fix for the production `Stripe\Exception\InvalidRequestException` thrown from `StripePaymentLinkService::generatePaymentLinkFromLeadMessage` (`/graphql` `continueLeadEngagement`):

> You passed an empty string for 'after_completion[redirect][url]'. We assume empty values are an attempt to unset a parameter; however 'after_completion[redirect][url]' cannot be unset.

**Root cause:** both payment-link builders guarded the redirect with `isset($options['success_url'])`, which is `true` for an empty string. In the lead-message flow, `CreateEngagementAction::replaceLink()` sets `success_url` from `$messageData['action_link']`, which is empty when the message has no action link yet — so an empty `after_completion[redirect][url]` was sent and Stripe rejected the whole request.

**Fix:** extracted the redirect construction into `buildAfterCompletion()`, which returns `null` unless a non-empty `success_url` is supplied (`empty()` catches both `''` and missing). Applied it in both `generatePaymentLink()` (order path — had the same latent bug) and `generatePaymentLinkFromLeadMessage()` (the crashing path), removing the duplicated block.

Same change as #10425 (targets `development`); this PR cherry-picks it onto `1.x`.

## Related Issue

Sentry: `Stripe\Exception\InvalidRequestException` — empty `after_completion[redirect][url]` (production).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

> Note: the test suite must run inside the `phpkanvas-ecosystem` Docker container, which is not available in the authoring environment. The new test and the changed service both pass `php -l` and php-cs-fixer, but the suite has **not yet been run green** here — please run `tests/Connectors/Stripe/StripePaymentLinkAfterCompletionTest.php` in CI/container to confirm.

## Screenshots (if applicable)

N/A — backend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015fcLubgoYuAEEVCura4e7c

---
_Generated by [Claude Code](https://claude.ai/code/session_015fcLubgoYuAEEVCura4e7c)_