### PR TITLE
fix(social): cast Message searchable created_at/updated_at to int64

### DIFF
--- a/src/Domains/Social/Messages/Models/Message.php
+++ b/src/Domains/Social/Messages/Models/Message.php
@@ -470,6 +470,9 @@ class Message extends BaseModel
             ] : null,
             'is_public' => $this->is_public,
             'is_deleted' => $this->is_deleted,
+            // Typesense schema declares these as int64; toArray() emits ISO-8601 strings, so cast to Unix timestamps
+            'created_at' => $this->created_at?->getTimestamp(),
+            'updated_at' => $this->updated_at?->getTimestamp(),
         ];
 
         // Add parent reference for child messages

--- a/tests/Social/Search/MessageSearchableArrayTest.php
+++ b/tests/Social/Search/MessageSearchableArrayTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Social\Search;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Social\MessagesTypes\Models\MessageType;
+use Tests\TestCase;
+
+/**
+ * The Message Typesense schema declares created_at/updated_at as int64. toArray() emits them as
+ * ISO-8601 strings, which makes Typesense reject the import with "Field `updated_at` must be an
+ * int64." (Sentry KANVAS-ECOSYSTEM-628). toSearchableArray() must cast them to Unix timestamps.
+ */
+class MessageSearchableArrayTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function testToSearchableArrayEmitsInt64Timestamps(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        $messageType = MessageType::factory()->create();
+
+        $message = Message::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->withMessageTypeId($messageType->getId())
+            ->create(['is_public' => 1]);
+
+        $doc = $message->fresh()->toSearchableArray();
+
+        $this->assertIsInt($doc['created_at'], 'created_at must be an int64 timestamp, not a date string.');
+        $this->assertIsInt($doc['updated_at'], 'updated_at must be an int64 timestamp, not a date string.');
+        $this->assertSame($message->created_at->getTimestamp(), $doc['created_at']);
+        $this->assertSame($message->updated_at->getTimestamp(), $doc['updated_at']);
+    }
+}


### PR DESCRIPTION
## General Description

The Message Typesense collection schema declares `created_at` and `updated_at` as `int64` (`Message::typesenseCollectionSchema()`), but `toSearchableArray()` built its document by spreading `...$this->toArray()`, which serializes those columns as ISO-8601 strings (e.g. `2026-06-21T17:56:12.000000Z`). Typesense rejected the import with **`Field 'updated_at' must be an int64.`**

This casts both timestamps to Unix ints via `getTimestamp()`, overriding the string values from the spread, so the emitted document matches the declared `int64` schema. This mirrors the existing convention used by `People`, `Order`, `Discount`, `Companies`, and the Scribe models.

```php
'created_at' => $this->created_at?->getTimestamp(),
'updated_at' => $this->updated_at?->getTimestamp(),
```

Note: this is the code-side fix. If the production Typesense collection was created from an older schema where these fields were auto-detected as strings, a reindex may still be needed for full alignment — but the documents this change emits now conform to the `int64` schema, which stops the import failures.

## Related Issue

Sentry KANVAS-ECOSYSTEM-628 — `Typesense\Exceptions\TypesenseClientError: Error importing document: Field 'updated_at' must be an int64.` (thrown from `Baka\Search\Jobs\TenantAwareMakeSearchable::handle`).

