### PR TITLE
fix(paso-rapido): usar el RNC de la empresa corporativa proveedora en…

### DIFF
--- a/src/Domains/Connectors/Movipass/Actions/BulkRechargeOrderTagsAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/BulkRechargeOrderTagsAction.php
@@ -53,7 +53,7 @@ class BulkRechargeOrderTagsAction
         }
 
         $bankTransaction = $this->resolveBankTransaction();
-        // tener RNC implica querer credito fiscal
+        // having a RNC means fiscal credit is wanted
         $fiscalCredit = $dni !== '' || (bool) ($this->order->metadata['data']['fiscal_credit'] ?? false);
 
         $service = $this->injectedService;

--- a/src/Domains/Connectors/Movipass/Actions/BulkRechargeOrderTagsAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/BulkRechargeOrderTagsAction.php
@@ -46,9 +46,15 @@ class BulkRechargeOrderTagsAction
 
         $wallet->depositFloat((float) $this->order->total_gross_amount, $creditMeta);
 
-        $dni = (string) ($company->get('rnc') ?? '');
+        $dni = trim((string) ($company->get('rnc') ?? ''));
+
+        if ($dni === '') {
+            $dni = trim((string) ($this->order->metadata['data']['rnc'] ?? ''));
+        }
+
         $bankTransaction = $this->resolveBankTransaction();
-        $fiscalCredit = (bool) ($this->order->metadata['data']['fiscal_credit'] ?? false);
+        // tener RNC implica querer credito fiscal
+        $fiscalCredit = $dni !== '' || (bool) ($this->order->metadata['data']['fiscal_credit'] ?? false);
 
         $service = $this->injectedService;
         $serviceError = null;

--- a/src/Domains/Connectors/PasoRapido/Actions/CreatePasoRapidoOrderAction.php
+++ b/src/Domains/Connectors/PasoRapido/Actions/CreatePasoRapidoOrderAction.php
@@ -54,7 +54,6 @@ class CreatePasoRapidoOrderAction
         }
 
         $tag = $this->order->metadata['data']['paso_rapido_tag'];
-        $fiscalCredit = (bool) ($this->order->metadata['data']['fiscal_credit'] ?? false);
 
         $company = $this->order->company;
 
@@ -63,16 +62,19 @@ class CreatePasoRapidoOrderAction
             ->first(fn (Companies $providerCompany) => (bool) $providerCompany->get('is_corporate'))
             ?? $company;
 
-        $dni = (bool) $fiscalCompany->get('is_corporate')
+        $rnc = (bool) $fiscalCompany->get('is_corporate')
             ? trim((string) ($fiscalCompany->get('rnc') ?? ''))
             : '';
 
-        if ($dni === '') {
-            $metadataRnc = trim((string) ($this->order->metadata['data']['rnc'] ?? ''));
-            $dni = $metadataRnc !== ''
-                ? $metadataRnc
-                : trim((string) ($this->order->get(CustomFieldEnum::PASO_RAPIDO_DNI->value) ?? ''));
+        if ($rnc === '') {
+            $rnc = trim((string) ($this->order->metadata['data']['rnc'] ?? ''));
         }
+
+        // tener RNC (corporativo o en la orden) implica querer credito fiscal; la cedula no
+        $fiscalCredit = $rnc !== '' || (bool) ($this->order->metadata['data']['fiscal_credit'] ?? false);
+        $dni = $rnc !== ''
+            ? $rnc
+            : trim((string) ($this->order->get(CustomFieldEnum::PASO_RAPIDO_DNI->value) ?? ''));
 
         try {
             $pasoRapidoService = $this->pasoRapidoService ?? new PasoRapidoService($this->app, $company);

--- a/src/Domains/Connectors/PasoRapido/Actions/CreatePasoRapidoOrderAction.php
+++ b/src/Domains/Connectors/PasoRapido/Actions/CreatePasoRapidoOrderAction.php
@@ -5,6 +5,7 @@ namespace Kanvas\Connectors\PasoRapido\Actions;
 use Exception;
 use GuzzleHttp\Exception\RequestException;
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\EchoPay\Enums\CustomFieldEnum as EchoPayCustomFieldEnum;
 use Kanvas\Connectors\PasoRapido\DataTransferObject\PaymentConfirmData;
 use Kanvas\Connectors\PasoRapido\Enums\CustomFieldEnum;
@@ -56,15 +57,21 @@ class CreatePasoRapidoOrderAction
         $fiscalCredit = (bool) ($this->order->metadata['data']['fiscal_credit'] ?? false);
 
         $company = $this->order->company;
-        $isCorporate = (bool) ($company->get('is_corporate') ?? false);
 
-        if ($isCorporate) {
-            $dni = trim((string) ($company->get('rnc') ?? ''));
-        } else {
+        // en compras corporativas la orden se factura a la empresa proveedora, no a la del branch
+        $fiscalCompany = $this->order->providerCompanies
+            ->first(fn (Companies $providerCompany) => (bool) $providerCompany->get('is_corporate'))
+            ?? $company;
+
+        $dni = (bool) $fiscalCompany->get('is_corporate')
+            ? trim((string) ($fiscalCompany->get('rnc') ?? ''))
+            : '';
+
+        if ($dni === '') {
             $metadataRnc = trim((string) ($this->order->metadata['data']['rnc'] ?? ''));
             $dni = $metadataRnc !== ''
                 ? $metadataRnc
-                : (string) ($this->order->get(CustomFieldEnum::PASO_RAPIDO_DNI->value) ?? '');
+                : trim((string) ($this->order->get(CustomFieldEnum::PASO_RAPIDO_DNI->value) ?? ''));
         }
 
         try {

--- a/src/Domains/Connectors/PasoRapido/Actions/CreatePasoRapidoOrderAction.php
+++ b/src/Domains/Connectors/PasoRapido/Actions/CreatePasoRapidoOrderAction.php
@@ -57,7 +57,7 @@ class CreatePasoRapidoOrderAction
 
         $company = $this->order->company;
 
-        // en compras corporativas la orden se factura a la empresa proveedora, no a la del branch
+        // corporate purchases are invoiced to the provider company, not the branch one
         $fiscalCompany = $this->order->providerCompanies
             ->first(fn (Companies $providerCompany) => (bool) $providerCompany->get('is_corporate'))
             ?? $company;
@@ -70,7 +70,7 @@ class CreatePasoRapidoOrderAction
             $rnc = trim((string) ($this->order->metadata['data']['rnc'] ?? ''));
         }
 
-        // tener RNC (corporativo o en la orden) implica querer credito fiscal; la cedula no
+        // having a RNC (corporate or on the order) means fiscal credit is wanted; a cedula does not
         $fiscalCredit = $rnc !== '' || (bool) ($this->order->metadata['data']['fiscal_credit'] ?? false);
         $dni = $rnc !== ''
             ? $rnc

--- a/src/Domains/Connectors/PasoRapido/DataTransferObject/PaymentConfirmData.php
+++ b/src/Domains/Connectors/PasoRapido/DataTransferObject/PaymentConfirmData.php
@@ -16,7 +16,7 @@ class PaymentConfirmData extends Data
         public readonly bool $fiscalCredit,
         public readonly string $dni
     ) {
-        // el spec marca rnc_Cedula como requerido solo si creditoFiscal es true
+        // the spec marks rnc_Cedula as required only when creditoFiscal is true
         if ($fiscalCredit && trim($dni) === '') {
             throw new InvalidArgumentException('PasoRapido requires a RNC/cedula when fiscal credit is requested');
         }

--- a/src/Domains/Connectors/PasoRapido/DataTransferObject/PaymentConfirmData.php
+++ b/src/Domains/Connectors/PasoRapido/DataTransferObject/PaymentConfirmData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\PasoRapido\DataTransferObject;
 
+use InvalidArgumentException;
 use Spatie\LaravelData\Data;
 
 class PaymentConfirmData extends Data
@@ -15,6 +16,10 @@ class PaymentConfirmData extends Data
         public readonly bool $fiscalCredit,
         public readonly string $dni
     ) {
+        // el spec marca rnc_Cedula como requerido solo si creditoFiscal es true
+        if ($fiscalCredit && trim($dni) === '') {
+            throw new InvalidArgumentException('PasoRapido requires a RNC/cedula when fiscal credit is requested');
+        }
     }
 
     public static function fromArray(array $data): self

--- a/tests/Connectors/Integration/Movipass/BulkRechargeTagsActivityTest.php
+++ b/tests/Connectors/Integration/Movipass/BulkRechargeTagsActivityTest.php
@@ -266,6 +266,50 @@ final class BulkRechargeTagsActivityTest extends TestCase
         $this->assertTrue($entry['reversed'] ?? false);
     }
 
+    public function testBulkRechargeRequestsFiscalCreditWhenCompanyHasRnc(): void
+    {
+        $company = $this->kanvasUser->getCurrentCompany();
+        $rnc = '130987654';
+        $company->set('rnc', $rnc);
+
+        [$tag1] = $this->createTagVariants(1);
+        $order = $this->createBulkRechargeOrder([
+            ['variant' => $tag1, 'tag_number' => '941001', 'amount' => 500.00],
+        ]);
+
+        $captured = [];
+        $mockService = Mockery::mock(PasoRapidoService::class);
+        $mockService->shouldReceive('confirmPayment')
+            ->andReturnUsing(function (PaymentConfirmData $data) use (&$captured) {
+                $captured[] = $data;
+
+                return PaymentConfirmResponse::from([
+                    'message' => 'ok',
+                    'amount' => (int) round($data->amount),
+                    'order' => 'ord-' . $data->reference,
+                    'tag' => $data->reference,
+                    'account' => '1234',
+                    'creditDate' => '2026-06-01',
+                    'invoiceDetails' => InvoiceDetails::from([
+                        'commercialName' => '',
+                        'document' => $data->dni,
+                        'fiscalCredit' => $data->fiscalCredit,
+                        'invoice' => '',
+                        'pdf' => '',
+                        'reference' => '',
+                    ]),
+                ]);
+            });
+
+        new BulkRechargeOrderTagsAction($order, $this->kanvasApp, $mockService)->execute();
+
+        $this->assertNotEmpty($captured, 'PasoRapidoService::confirmPayment was never called');
+        $this->assertTrue($captured[0]->fiscalCredit);
+        $this->assertSame($rnc, $captured[0]->dni);
+
+        $company->del('rnc');
+    }
+
     public function testBankTransactionStaysWithinPasoRapidoFiftyCharLimit(): void
     {
         // PasoRapido rejects transaccionBanco > 50 chars. The wallet-paid bulk path

--- a/tests/Connectors/Integration/PasoRapido/PasoRapidoOrderTest.php
+++ b/tests/Connectors/Integration/PasoRapido/PasoRapidoOrderTest.php
@@ -6,6 +6,7 @@ namespace Tests\Connectors\Integration\PasoRapido;
 
 use Illuminate\Support\Facades\Auth;
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\EchoPay\Enums\CustomFieldEnum as EnumsCustomFieldEnum;
 use Kanvas\Connectors\PasoRapido\Actions\CreatePasoRapidoOrderAction;
 use Kanvas\Connectors\PasoRapido\DataTransferObject\InvoiceDetails;
@@ -407,6 +408,73 @@ final class PasoRapidoOrderTest extends TestCase
         $this->assertInstanceOf(PaymentConfirmData::class, $capturedConfirmData);
         $this->assertFalse($capturedConfirmData->fiscalCredit);
         $this->assertSame($legacyDni, $capturedConfirmData->dni);
+    }
+
+    public function testCreatePasoRapidoOrderUsesRncOfCorporateProviderCompany(): void
+    {
+        $app = app(Apps::class);
+        $user = Auth::user();
+        $company = $user->getCurrentCompany();
+
+        $corporateRnc = '130123456';
+        $corporateCompany = Companies::factory()->create();
+        $corporateCompany->set('is_corporate', true);
+        $corporateCompany->set('rnc', $corporateRnc);
+
+        $people = People::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->withUserId($user->getId())
+            ->create();
+
+        $order = Order::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->withUserId($user->getId())
+            ->withPeopleId($people->getId())
+            ->create([
+                'metadata' => [
+                    'data' => [
+                        'paso_rapido_tag' => '317169',
+                        'rnc' => '99999999',
+                    ],
+                ],
+            ]);
+
+        $order->providerCompanies()->attach($corporateCompany->getId());
+        $order->set(EnumsCustomFieldEnum::ECHO_PAY_PAYMENT_INTENT_ID->value, 'intentId:7478925724996114' . rand(100000, 999999));
+        $order->set(CustomFieldEnum::PASO_RAPIDO_DNI->value, '40212345678');
+
+        $capturedConfirmData = null;
+        $serviceMock = Mockery::mock(PasoRapidoService::class);
+        $serviceMock->shouldReceive('confirmPayment')
+            ->once()
+            ->with(Mockery::on(function (PaymentConfirmData $data) use (&$capturedConfirmData) {
+                $capturedConfirmData = $data;
+
+                return true;
+            }))
+            ->andReturn(new PaymentConfirmResponse(
+                message: 'OK',
+                amount: 100.0,
+                order: 1,
+                tag: '317169',
+                account: 1,
+                creditDate: now()->toDateTimeString(),
+                invoiceDetails: new InvoiceDetails(
+                    commercialName: 'Test',
+                    document: $corporateRnc,
+                    fiscalCredit: true,
+                    invoice: 'INV-1',
+                    pdf: 'http://example.com/inv.pdf',
+                    reference: '317169',
+                ),
+            ));
+
+        $result = new CreatePasoRapidoOrderAction($app, $order, $serviceMock)->execute();
+
+        $this->assertSame('success', $result['status']);
+        $this->assertSame($corporateRnc, $capturedConfirmData->dni);
     }
 
     public function testCreatePasoRapidoOrderRejectsBulkRechargeOrders(): void

--- a/tests/Connectors/Integration/PasoRapido/PasoRapidoOrderTest.php
+++ b/tests/Connectors/Integration/PasoRapido/PasoRapidoOrderTest.php
@@ -19,6 +19,7 @@ use Kanvas\Connectors\PasoRapido\Services\PasoRapidoService;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Regions\Models\Regions;
 use Kanvas\Souk\Orders\Models\Order;
+use Kanvas\Souk\Payments\Enums\PaymentStatusEnum;
 use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Mockery;
 use Tests\Connectors\Traits\HasIntegrationCompany;
@@ -475,6 +476,46 @@ final class PasoRapidoOrderTest extends TestCase
 
         $this->assertSame('success', $result['status']);
         $this->assertSame($corporateRnc, $capturedConfirmData->dni);
+        $this->assertTrue($capturedConfirmData->fiscalCredit);
+    }
+
+    public function testCreatePasoRapidoOrderFailsWhenFiscalCreditHasNoDocument(): void
+    {
+        $app = app(Apps::class);
+        $user = Auth::user();
+        $company = $user->getCurrentCompany();
+
+        $people = People::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->withUserId($user->getId())
+            ->create();
+
+        $order = Order::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->withUserId($user->getId())
+            ->withPeopleId($people->getId())
+            ->create([
+                'metadata' => [
+                    'data' => [
+                        'paso_rapido_tag' => '317169',
+                        'fiscal_credit' => true,
+                    ],
+                ],
+            ]);
+
+        $order->set(EnumsCustomFieldEnum::ECHO_PAY_PAYMENT_INTENT_ID->value, 'intentId:7478925724996114' . rand(100000, 999999));
+
+        $serviceMock = Mockery::mock(PasoRapidoService::class);
+        $serviceMock->shouldNotReceive('confirmPayment');
+
+        $result = new CreatePasoRapidoOrderAction($app, $order, $serviceMock)->execute();
+
+        $this->assertSame('error', $result['status']);
+        $this->assertStringContainsString('RNC', (string) $result['message']);
+        $this->assertSame(PaymentStatusEnum::FAILED->value, $order->fresh()->get(CustomFieldEnum::PASO_RAPIDO_PAYMENT_STATUS->value));
+        $this->assertSame('0', (string) $order->fresh()->get(EnumsCustomFieldEnum::ECHO_PAY_SHOULD_CAPTURE->value));
     }
 
     public function testCreatePasoRapidoOrderRejectsBulkRechargeOrders(): void


### PR DESCRIPTION
… la factura

- resuelve la empresa fiscal desde providerCompanies (is_corporate) con fallback a order->company
- corrige $dni indefinido cuando la empresa no era corporativa (faltaba el else)
- cae al rnc de metadata / custom field cuando la empresa corporativa no tiene rnc
- test de regresion: testCreatePasoRapidoOrderUsesRncOfCorporateProviderCompany

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
