### PR TITLE
fix(movipass): relink variant warehouses when a user upgrades to corp…

### DIFF
--- a/app/Console/Commands/Movipass/RelinkCorporateVariantWarehousesCommand.php
+++ b/app/Console/Commands/Movipass/RelinkCorporateVariantWarehousesCommand.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Movipass;
+
+use Baka\Traits\KanvasJobsTrait;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Movipass\Actions\RelinkVariantsToCompanyWarehouseAction;
+use Kanvas\Inventory\Products\Models\Products;
+use Kanvas\Inventory\Variants\Models\Variants;
+use Throwable;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\table;
+use function Laravel\Prompts\warning;
+
+class RelinkCorporateVariantWarehousesCommand extends Command
+{
+    use KanvasJobsTrait;
+
+    protected $signature = 'kanvas-movipass:relink-corporate-variant-warehouses
+        {app_id : The app the products belong to}
+        {--company_id= : Only repair this company}
+        {--dry-run : List what would be relinked without making changes}';
+
+    protected $description = 'Repoint variants whose product changed company (corporate migration) to a warehouse of their own company, so they can be ordered again.';
+
+    public function handle(): int
+    {
+        /** @var Apps $app */
+        $app = Apps::getById((int) $this->argument('app_id'));
+        $this->overwriteAppService($app);
+
+        $companyIds = Products::query()
+            ->where('apps_id', $app->getId())
+            ->when(
+                $this->option('company_id'),
+                fn ($query, $companyId) => $query->where('companies_id', (int) $companyId)
+            )
+            ->distinct()
+            ->pluck('companies_id');
+
+        $totalBroken = 0;
+        $totalRelinked = 0;
+
+        foreach ($companyIds as $companyId) {
+            $variants = $this->variantsWithoutOwnWarehouse($app, (int) $companyId);
+
+            if ($variants->isEmpty()) {
+                continue;
+            }
+
+            $totalBroken += $variants->count();
+
+            /** @var Companies $company */
+            $company = Companies::getById((int) $companyId);
+
+            info(sprintf('%s (ID %d) — %d variant(s) without a warehouse of their own company', $company->name, $company->getId(), $variants->count()));
+            table(
+                ['variant_id', 'sku', 'name'],
+                $variants->take(10)->map(fn (Variants $variant) => [
+                    $variant->getId(),
+                    $variant->sku,
+                    $variant->name,
+                ])->toArray()
+            );
+
+            if ($this->option('dry-run')) {
+                continue;
+            }
+
+            $owner = $company->user;
+
+            if ($owner === null) {
+                warning("Company {$company->getId()} has no owner user — skipped.");
+
+                continue;
+            }
+
+            try {
+                $totalRelinked += new RelinkVariantsToCompanyWarehouseAction(
+                    app: $app,
+                    company: $company,
+                    user: $owner,
+                )->execute($variants);
+            } catch (Throwable $e) {
+                warning("Company {$company->getId()} failed: {$e->getMessage()}");
+            }
+        }
+
+        if ($totalBroken === 0) {
+            info('No variants found without a warehouse of their own company. Nothing to do.');
+
+            return self::SUCCESS;
+        }
+
+        if ($this->option('dry-run')) {
+            info("Dry run — {$totalBroken} variant(s) would be relinked.");
+
+            return self::SUCCESS;
+        }
+
+        info("Relinked {$totalRelinked} of {$totalBroken} variant(s).");
+
+        return self::SUCCESS;
+    }
+
+    private function variantsWithoutOwnWarehouse(Apps $app, int $companyId): Collection
+    {
+        return Variants::query()
+            ->whereHas(
+                'product',
+                fn ($query) => $query->where('apps_id', $app->getId())->where('companies_id', $companyId)
+            )
+            ->whereDoesntHave(
+                'variantWarehouses.warehouse',
+                fn ($query) => $query->where('companies_id', $companyId)
+            )
+            ->get();
+    }
+}

--- a/src/Domains/Connectors/Movipass/Actions/EnableCorporateModeAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/EnableCorporateModeAction.php
@@ -58,6 +58,7 @@ class EnableCorporateModeAction
             $this->switchToCorporateCompany($company);
 
             dispatch(new MigrateCorporateUserVariantsJob(
+                app: $appsModel,
                 userId: $this->user->getId(),
                 sourceCompanyId: $sourceCompanyId,
                 targetCompanyId: $company->getId(),

--- a/src/Domains/Connectors/Movipass/Actions/RelinkVariantsToCompanyWarehouseAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/RelinkVariantsToCompanyWarehouseAction.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Movipass\Actions;
+
+use Baka\Enums\StateEnums;
+use Illuminate\Support\Collection;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Movipass\Enums\CustomFieldEnum;
+use Kanvas\Enums\AppEnums;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Inventory\Status\Models\Status;
+use Kanvas\Inventory\Variants\Actions\AddToWarehouseAction;
+use Kanvas\Inventory\Variants\DataTransferObject\VariantsWarehouses as VariantsWarehousesDto;
+use Kanvas\Inventory\Variants\Models\Variants;
+use Kanvas\Inventory\Variants\Models\VariantsWarehouses;
+use Kanvas\Inventory\Warehouses\Actions\CreateWarehouseAction;
+use Kanvas\Inventory\Warehouses\DataTransferObject\Warehouses as WarehousesDto;
+use Kanvas\Inventory\Warehouses\Models\Warehouses;
+use Kanvas\Regions\Models\Regions;
+use Kanvas\Users\Models\Users;
+
+/**
+ * Moving a product to another company leaves its products_variants_warehouses rows
+ * pointing at the previous owner's warehouse, which makes OrderItem::fromMultiple
+ * reject the variant for having no warehouse in its own company.
+ */
+class RelinkVariantsToCompanyWarehouseAction
+{
+    public function __construct(
+        protected readonly Apps $app,
+        protected readonly Companies $company,
+        protected readonly Users $user,
+    ) {
+    }
+
+    public function execute(Collection $variants): int
+    {
+        if ($variants->isEmpty()) {
+            return 0;
+        }
+
+        $warehouse = $this->resolveWarehouse();
+
+        return $variants->reduce(
+            fn (int $relinked, Variants $variant) => $relinked + (int) $this->relink($variant, $warehouse),
+            0
+        );
+    }
+
+    private function relink(Variants $variant, Warehouses $warehouse): bool
+    {
+        $ownLink = VariantsWarehouses::withTrashed()
+            ->where('products_variants_id', $variant->getId())
+            ->whereHas(
+                'warehouse',
+                fn ($query) => $query->where('companies_id', $this->company->getId())
+            )
+            ->orderBy('is_deleted')
+            ->first();
+
+        if ($ownLink !== null) {
+            if (! $ownLink->is_deleted) {
+                return false;
+            }
+
+            $ownLink->is_deleted = 0;
+            $ownLink->save();
+
+            return true;
+        }
+
+        $foreignLinks = VariantsWarehouses::where('products_variants_id', $variant->getId())
+            ->orderBy('is_default', 'desc')
+            ->get();
+
+        if ($foreignLinks->isEmpty()) {
+            new AddToWarehouseAction(
+                $variant,
+                $warehouse,
+                VariantsWarehousesDto::viaRequest($variant, $warehouse, [
+                    'status_id' => Status::getDefault($this->company, $this->app)?->getId(),
+                ]),
+            )->execute();
+
+            return true;
+        }
+
+        // Move the row rather than recreating it so price, channel pricing and
+        // history follow the variant to its new owner.
+        $primary = $foreignLinks->shift();
+        $primary->warehouses_id = $warehouse->getId();
+        $primary->save();
+
+        // Leftovers sit in warehouses of a company that no longer owns the variant.
+        foreach ($foreignLinks as $stale) {
+            $stale->is_deleted = 1;
+            $stale->save();
+        }
+
+        return true;
+    }
+
+    private function resolveWarehouse(): Warehouses
+    {
+        $warehouse = Warehouses::query()
+            ->fromApp($this->app)
+            ->fromCompany($this->company)
+            ->notDeleted()
+            ->orderBy('is_default', 'desc')
+            ->first();
+
+        if ($warehouse !== null) {
+            return $warehouse;
+        }
+
+        return new CreateWarehouseAction(
+            new WarehousesDto(
+                company: $this->company,
+                app: $this->app,
+                user: $this->user,
+                region: $this->resolveRegion(),
+                name: StateEnums::DEFAULT_NAME->getValue(),
+                location: StateEnums::DEFAULT_NAME->getValue(),
+                is_default: true,
+            ),
+            $this->user,
+        )->execute();
+    }
+
+    private function resolveRegion(): Regions
+    {
+        $regionId = $this->company->get(CustomFieldEnum::COMPANY_REGION_ID->value);
+
+        if (! empty($regionId)) {
+            $region = Regions::query()
+                ->fromApp($this->app)
+                ->notDeleted()
+                ->where('id', (int) $regionId)
+                ->whereIn('companies_id', [AppEnums::GLOBAL_COMPANY_ID->getValue(), $this->company->getId()])
+                ->first();
+
+            if ($region !== null) {
+                return $region;
+            }
+        }
+
+        return Regions::getDefault($this->company, $this->app)
+            ?? throw new ValidationException(
+                "No region available for company '{$this->company->name}' — cannot provision its warehouse."
+            );
+    }
+}

--- a/src/Domains/Connectors/Movipass/Jobs/MigrateCorporateUserVariantsJob.php
+++ b/src/Domains/Connectors/Movipass/Jobs/MigrateCorporateUserVariantsJob.php
@@ -4,25 +4,32 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\Movipass\Jobs;
 
+use Baka\Traits\KanvasJobsTrait;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Movipass\Actions\RelinkVariantsToCompanyWarehouseAction;
 use Kanvas\Inventory\Products\Models\Products;
 use Kanvas\Inventory\Variants\Models\Variants;
+use Kanvas\Users\Models\Users;
 
 class MigrateCorporateUserVariantsJob implements ShouldQueue
 {
     use Dispatchable;
     use InteractsWithQueue;
+    use KanvasJobsTrait;
     use Queueable;
     use SerializesModels;
 
     public $tries = 3;
 
     public function __construct(
+        public readonly Apps $app,
         public readonly int $userId,
         public readonly int $sourceCompanyId,
         public readonly int $targetCompanyId,
@@ -32,15 +39,27 @@ class MigrateCorporateUserVariantsJob implements ShouldQueue
 
     public function handle(): void
     {
+        $this->overwriteAppService($this->app);
+
+        // Both companies are in scope so a retry still repairs a run that moved
+        // ownership but died before relinking the warehouses.
         $products = Products::where('users_id', $this->userId)
-            ->where('companies_id', $this->sourceCompanyId)
+            ->whereIn('companies_id', [$this->sourceCompanyId, $this->targetCompanyId])
             ->get();
+
+        if ($products->isEmpty()) {
+            return;
+        }
 
         $migratedProducts = 0;
         $migratedVariants = 0;
 
         foreach ($products as $product) {
-            $variantUpdates = Variants::where('products_id', $product->getId())
+            if ((int) $product->companies_id !== $this->sourceCompanyId) {
+                continue;
+            }
+
+            $migratedVariants += Variants::where('products_id', $product->getId())
                 ->where('companies_id', $this->sourceCompanyId)
                 ->update(['companies_id' => $this->targetCompanyId]);
 
@@ -48,8 +67,15 @@ class MigrateCorporateUserVariantsJob implements ShouldQueue
             $product->saveQuietly();
 
             $migratedProducts++;
-            $migratedVariants += $variantUpdates;
         }
+
+        $relinked = new RelinkVariantsToCompanyWarehouseAction(
+            app: $this->app,
+            company: Companies::getById($this->targetCompanyId),
+            user: Users::getById($this->userId),
+        )->execute(
+            Variants::whereIn('products_id', $products->pluck('id'))->get()
+        );
 
         Log::info('Movipass corporate migration completed', [
             'user_id' => $this->userId,
@@ -57,6 +83,7 @@ class MigrateCorporateUserVariantsJob implements ShouldQueue
             'target_company_id' => $this->targetCompanyId,
             'products' => $migratedProducts,
             'variants' => $migratedVariants,
+            'warehouse_links_relinked' => $relinked,
         ]);
     }
 }

--- a/tests/Connectors/Integration/Movipass/MigrateCorporateUserVariantsJobTest.php
+++ b/tests/Connectors/Integration/Movipass/MigrateCorporateUserVariantsJobTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Integration\Movipass;
+
+use Baka\Enums\StateEnums;
+use Illuminate\Support\Facades\Auth;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Movipass\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Movipass\Jobs\MigrateCorporateUserVariantsJob;
+use Kanvas\Currencies\Models\Currencies;
+use Kanvas\Inventory\Products\Models\Products;
+use Kanvas\Inventory\Regions\Actions\CreateRegionAction;
+use Kanvas\Inventory\Regions\DataTransferObject\Region as RegionDto;
+use Kanvas\Inventory\Variants\Actions\AddToWarehouseAction;
+use Kanvas\Inventory\Variants\DataTransferObject\VariantsWarehouses as VariantsWarehousesDto;
+use Kanvas\Inventory\Variants\Models\Variants;
+use Kanvas\Inventory\Variants\Models\VariantsWarehouses;
+use Kanvas\Inventory\Warehouses\Actions\CreateWarehouseAction;
+use Kanvas\Inventory\Warehouses\DataTransferObject\Warehouses as WarehousesDto;
+use Kanvas\Inventory\Warehouses\Models\Warehouses;
+use Kanvas\Regions\Models\Regions;
+use Kanvas\Users\Models\Users;
+use Tests\TestCase;
+
+final class MigrateCorporateUserVariantsJobTest extends TestCase
+{
+    private Apps $kanvasApp;
+    private Users $kanvasUser;
+    private Companies $sourceCompany;
+    private Warehouses $sourceWarehouse;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->kanvasApp = app(Apps::class);
+        /** @var Users $user */
+        $user = Auth::user();
+        $this->kanvasUser = $user;
+
+        $this->sourceCompany = $this->createCompany();
+        $this->sourceWarehouse = $this->createWarehouse($this->sourceCompany);
+    }
+
+    public function testMovesTheWarehouseLinkToTheTargetCompanyWarehouse(): void
+    {
+        $variant = $this->createVehicleVariant();
+        $link = $this->linkToWarehouse($variant, $this->sourceWarehouse, 250.00);
+
+        $targetCompany = $this->createCompany();
+        $targetWarehouse = $this->createWarehouse($targetCompany);
+
+        $this->migrateTo($targetCompany);
+
+        $variant->refresh();
+        $this->assertSame($targetCompany->getId(), (int) $variant->companies_id);
+        $this->assertSame($targetCompany->getId(), (int) $variant->product->companies_id);
+
+        $link->refresh();
+        $this->assertSame($targetWarehouse->getId(), (int) $link->warehouses_id);
+        $this->assertEqualsWithDelta(250.00, (float) $link->price, 0.001);
+
+        $this->assertHasWarehouseInOwnCompany($variant);
+    }
+
+    public function testProvisionsAWarehouseWhenTheTargetCompanyHasNone(): void
+    {
+        $variant = $this->createVehicleVariant();
+        $this->linkToWarehouse($variant, $this->sourceWarehouse, 0.00);
+
+        $targetCompany = $this->createCompany();
+        $this->assertNull($this->warehouseOf($targetCompany));
+
+        $this->migrateTo($targetCompany);
+
+        $this->assertNotNull($this->warehouseOf($targetCompany));
+        $this->assertHasWarehouseInOwnCompany($variant->refresh());
+    }
+
+    public function testLinksVariantsThatNeverHadAWarehouse(): void
+    {
+        $variant = $this->createVehicleVariant();
+        $this->assertSame(0, VariantsWarehouses::where('products_variants_id', $variant->getId())->count());
+
+        $targetCompany = $this->createCompany();
+        $this->createWarehouse($targetCompany);
+
+        $this->migrateTo($targetCompany);
+
+        $this->assertHasWarehouseInOwnCompany($variant->refresh());
+    }
+
+    public function testIsIdempotentWhenRetried(): void
+    {
+        $variant = $this->createVehicleVariant();
+        $this->linkToWarehouse($variant, $this->sourceWarehouse, 99.00);
+
+        $targetCompany = $this->createCompany();
+        $this->createWarehouse($targetCompany);
+
+        $this->migrateTo($targetCompany);
+        $this->migrateTo($targetCompany);
+
+        $this->assertSame(1, VariantsWarehouses::where('products_variants_id', $variant->getId())->count());
+        $this->assertHasWarehouseInOwnCompany($variant->refresh());
+    }
+
+    /**
+     * Mirrors the check OrderItem::fromMultiple runs before building a line item —
+     * the variant must reach a live warehouse owned by the product's own company.
+     */
+    private function assertHasWarehouseInOwnCompany(Variants $variant): void
+    {
+        $this->assertTrue(
+            $variant->variantWarehouses()
+                ->whereHas(
+                    'warehouse',
+                    fn ($query) => $query->where('companies_id', $variant->product->companies_id)
+                        ->where('is_deleted', 0)
+                )
+                ->exists(),
+            "Variant {$variant->sku} has no warehouse in company {$variant->product->companies_id}"
+        );
+    }
+
+    private function migrateTo(Companies $targetCompany): void
+    {
+        new MigrateCorporateUserVariantsJob(
+            app: $this->kanvasApp,
+            userId: $this->kanvasUser->getId(),
+            sourceCompanyId: $this->sourceCompany->getId(),
+            targetCompanyId: $targetCompany->getId(),
+        )->handle();
+    }
+
+    private function createCompany(): Companies
+    {
+        $company = Companies::factory()->create([
+            'users_id' => $this->kanvasUser->getId(),
+        ]);
+
+        $company->set(CustomFieldEnum::COMPANY_REGION_ID->value, $this->createRegion($company)->getId());
+
+        return $company;
+    }
+
+    private function createRegion(Companies $company): Regions
+    {
+        return new CreateRegionAction(
+            new RegionDto(
+                company: $company,
+                app: $this->kanvasApp,
+                user: $this->kanvasUser,
+                currency: Currencies::getBaseCurrency(),
+                name: StateEnums::DEFAULT_NAME->getValue(),
+                short_slug: StateEnums::DEFAULT_NAME->getValue(),
+                is_default: StateEnums::YES->getValue(),
+            ),
+            $this->kanvasUser,
+        )->execute();
+    }
+
+    private function createWarehouse(Companies $company): Warehouses
+    {
+        return new CreateWarehouseAction(
+            new WarehousesDto(
+                company: $company,
+                app: $this->kanvasApp,
+                user: $this->kanvasUser,
+                region: $this->createRegion($company),
+                name: StateEnums::DEFAULT_NAME->getValue(),
+                location: StateEnums::DEFAULT_NAME->getValue(),
+                is_default: true,
+            ),
+            $this->kanvasUser,
+        )->execute();
+    }
+
+    private function warehouseOf(Companies $company): ?Warehouses
+    {
+        return Warehouses::query()
+            ->fromApp($this->kanvasApp)
+            ->fromCompany($company)
+            ->notDeleted()
+            ->first();
+    }
+
+    private function createVehicleVariant(): Variants
+    {
+        $product = Products::factory()->state([
+            'apps_id' => $this->kanvasApp->getId(),
+            'companies_id' => $this->sourceCompany->getId(),
+            'users_id' => $this->kanvasUser->getId(),
+        ])->create();
+
+        return $product->variants()->firstOrFail();
+    }
+
+    private function linkToWarehouse(Variants $variant, Warehouses $warehouse, float $price): VariantsWarehouses
+    {
+        return new AddToWarehouseAction(
+            $variant,
+            $warehouse,
+            VariantsWarehousesDto::viaRequest($variant, $warehouse, ['price' => $price]),
+        )->execute();
+    }
+}


### PR DESCRIPTION
…orate

MigrateCorporateUserVariantsJob moved products.companies_id and products_variants.companies_id to the new corporate company but left products_variants_warehouses pointing at the source company's warehouse.

OrderItem::fromMultiple requires the variant to reach a warehouse owned by the product's own company, so every TAG recharge for a migrated vehicle failed with "No warehouse with pricing found for product ...".

RelinkVariantsToCompanyWarehouseAction repoints those rows to a warehouse of the target company (provisioning one in the company's region when it has none), moving the row rather than recreating it so price, channel pricing and history follow the variant. The job now takes the Apps model so it can call overwriteAppService before touching Bouncer-scoped lookups, and re-runs the relink on retry to repair partially applied runs.

Adds kanvas-movipass:relink-corporate-variant-warehouses to backfill the companies already migrated.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
