### PR TITLE
feat: voiceAgentSpec query for the external voice runtime

### DIFF
--- a/app/GraphQL/Intelligence/Queries/Agent/VoiceAgentSpecQuery.php
+++ b/app/GraphQL/Intelligence/Queries/Agent/VoiceAgentSpecQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Intelligence\Queries\Agent;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Intelligence\Agents\Repositories\AgentsRepository;
+use Kanvas\Intelligence\Agents\Services\VoiceAgentSpecService;
+
+/**
+ * Returns the compiled voice-agent spec for the external voice runtime to apply
+ * at the start of a call. Guarded by @guardByAppKey (server-to-server), so the
+ * runtime authenticates with the X-Kanvas-App + X-Kanvas-App-Key headers.
+ *
+ * @return array<string, mixed>
+ */
+class VoiceAgentSpecQuery
+{
+    public function __invoke(mixed $root, array $args): array
+    {
+        $app = app(Apps::class);
+        $agent = AgentsRepository::getByUuidFromApp((string) $args['uuid'], $app);
+
+        return (new VoiceAgentSpecService($agent, $app))->compile();
+    }
+}

--- a/database/migrations/Intelligence/2026_07_21_000000_add_voice_config_to_agents_table.php
+++ b/database/migrations/Intelligence/2026_07_21_000000_add_voice_config_to_agents_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::connection('intelligence')->table('agents', function (Blueprint $table) {
+            $table->json('voice_config')->nullable()->after('tools_config');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection('intelligence')->table('agents', function (Blueprint $table) {
+            $table->dropColumn('voice_config');
+        });
+    }
+};

--- a/graphql/schemas/Intelligence/agent.graphql
+++ b/graphql/schemas/Intelligence/agent.graphql
@@ -20,6 +20,7 @@ type AgentAi {
     identity: Mixed
     user_context: String
     tools_config: String
+    voice_config: Mixed
     deployment_status: String!
     activeDeployment: AgentDeploymentType @hasOne
     agent_model_id: ID
@@ -312,5 +313,74 @@ extend type Mutation @guardByAppKey {
     removeAgentKanvasModule(agent_id: ID!, kanvas_module_id: ID!): Boolean!
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Mutations\\AgentKanvasModuleMutation@remove"
+        )
+}
+
+"""
+Compiled agent spec consumed by the external voice runtime (Pipecat / Cloud Run)
+at the start of each call. Read-only, server-to-server (@guardByAppKey).
+"""
+type VoiceAgentSpec {
+    "The agent uuid; the runtime caches by agent_id + version."
+    agent_id: String!
+    "Changes whenever the agent is edited, so the runtime refreshes its cache."
+    version: String!
+    language: String
+    prompts: VoiceAgentPrompts!
+    models: VoiceAgentModels!
+    telephony: VoiceAgentTelephony
+    context_schema: [VoiceAgentContextField!]!
+}
+
+type VoiceAgentPrompts {
+    system_instruction: String!
+    greeting: String
+    voicemail_message: String
+}
+
+type VoiceAgentModels {
+    stt: VoiceAgentSttModel
+    llm: VoiceAgentLlmModel!
+    tts: VoiceAgentTtsModel
+}
+
+type VoiceAgentSttModel {
+    provider: String
+    model: String
+    language: String
+}
+
+type VoiceAgentLlmModel {
+    provider: String
+    model: String
+}
+
+type VoiceAgentTtsModel {
+    provider: String
+    voice_id: String
+    model: String
+    stability: Float
+    similarity: Float
+    style: Float
+    speed: Float
+    use_speaker_boost: Boolean
+}
+
+"Dealership caller-id number. Credentials are intentionally excluded."
+type VoiceAgentTelephony {
+    from_number: String
+}
+
+type VoiceAgentContextField {
+    key: String!
+    required: Boolean
+    default: String
+}
+
+extend type Query @guardByAppKey {
+    "Fetch the compiled voice spec for an agent by uuid (voice runtime → Kanvas)."
+    voiceAgentSpec(uuid: String!): VoiceAgentSpec!
+        @field(
+            resolver: "App\\GraphQL\\Intelligence\\Queries\\Agent\\VoiceAgentSpecQuery"
         )
 }

--- a/src/Domains/Intelligence/Agents/Models/Agent.php
+++ b/src/Domains/Intelligence/Agents/Models/Agent.php
@@ -60,6 +60,7 @@ use Override;
  * @property array|null $identity
  * @property string|null $user_context
  * @property string|null $tools_config
+ * @property array|null $voice_config
  * @property string|null $deployment_status
  * @property int|null $agent_model_id
  * @property bool $is_active
@@ -103,6 +104,7 @@ class Agent extends BaseModel
         'identity',
         'user_context',
         'tools_config',
+        'voice_config',
         'deployment_status',
         'agent_model_id',
         'is_active',
@@ -130,6 +132,7 @@ class Agent extends BaseModel
             'config' => Json::class,
             'role' => Json::class,
             'identity' => Json::class,
+            'voice_config' => Json::class,
             'is_active' => 'boolean',
             'is_sub_agent' => 'boolean',
             'last_state_changed_at' => 'datetime',

--- a/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
+++ b/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Repositories;
+
+use Baka\Contracts\AppInterface;
+use Kanvas\Intelligence\Agents\Models\Agent;
+
+class AgentsRepository
+{
+    /**
+     * Fetch a single agent by uuid, scoped to the given app.
+     *
+     * Used by the voice runtime's spec fetch (server-to-server via app key), so
+     * one app's credentials can only resolve its own agents. Throws
+     * ModelNotFoundException when the uuid does not belong to the app.
+     */
+    public static function getByUuidFromApp(string $uuid, AppInterface $app): Agent
+    {
+        return Agent::where('uuid', $uuid)
+            ->where('apps_id', $app->getId())
+            ->firstOrFail();
+    }
+}

--- a/src/Domains/Intelligence/Agents/Services/VoiceAgentSpecService.php
+++ b/src/Domains/Intelligence/Agents/Services/VoiceAgentSpecService.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Services;
+
+use Baka\Contracts\AppInterface;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Twilio\Enums\ConfigurationEnum as TwilioConfigurationEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Enums\ConfigurationEnum;
+
+/**
+ * Compiles an Agent into the "voice agent spec" the external voice runtime
+ * (Pipecat / Cloud Run) fetches at the start of each call.
+ *
+ * This is the read-only config-plane compilation: it assembles the same system
+ * prompt the in-process NeuronAI agent uses (soul → instructions →
+ * output_format, with AgentType fallback — see Agents\Types\BaseAgent), the
+ * resolved model name, the per-agent voice_config, and the company's telephony
+ * number. It never returns credentials — Twilio secrets stay out of this payload.
+ */
+class VoiceAgentSpecService
+{
+    public function __construct(
+        private readonly Agent $agent,
+        private readonly AppInterface $app,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function compile(): array
+    {
+        $voice = $this->agent->voice_config ?? [];
+        $tts = $voice['tts'] ?? [];
+        $stt = $voice['stt'] ?? [];
+        $language = $voice['language'] ?? 'es';
+
+        return [
+            'agent_id' => $this->agent->uuid,
+            // Changes whenever the agent is edited, so the runtime can cache by
+            // agent_id:version and pick up updates on the next call.
+            'version' => (string) ($this->agent->updated_at?->getTimestamp() ?? $this->agent->id),
+            'language' => $language,
+            'prompts' => [
+                'system_instruction' => $this->systemInstruction(),
+                'greeting' => $voice['greeting'] ?? null,
+                'voicemail_message' => $voice['voicemail_message'] ?? null,
+            ],
+            'models' => [
+                'stt' => [
+                    'provider' => $stt['provider'] ?? 'deepgram',
+                    'model' => $stt['model'] ?? null,
+                    'language' => $stt['language'] ?? $language,
+                ],
+                'llm' => [
+                    'provider' => 'google',
+                    'model' => $this->resolvedModelName(),
+                ],
+                'tts' => [
+                    'provider' => $tts['provider'] ?? 'elevenlabs',
+                    'voice_id' => $tts['voice_id'] ?? ($voice['voice_id'] ?? null),
+                    'model' => $tts['model'] ?? null,
+                    'stability' => $this->floatOrNull($tts['stability'] ?? null),
+                    'similarity' => $this->floatOrNull($tts['similarity'] ?? null),
+                    'style' => $this->floatOrNull($tts['style'] ?? null),
+                    'speed' => $this->floatOrNull($tts['speed'] ?? null),
+                    'use_speaker_boost' => $tts['use_speaker_boost'] ?? null,
+                ],
+            ],
+            'telephony' => $this->telephony(),
+            'context_schema' => array_values($voice['context_schema'] ?? []),
+        ];
+    }
+
+    /**
+     * Same coalescing as Agents\Types\BaseAgent::instructions(): prefer the
+     * per-field prompt on the agent, fall back per-field to the AgentType so a
+     * type acts as the base persona, then legacy structured `role`.
+     */
+    private function systemInstruction(): string
+    {
+        $type = $this->agent->type;
+        $coalesce = static fn (?string $a, ?string $b): ?string => ($a !== null && $a !== '') ? $a : $b;
+
+        $parts = array_filter([
+            $coalesce($this->agent->soul, $type?->soul),
+            $coalesce($this->agent->instructions, $type?->instructions),
+            $coalesce($this->agent->output_format, $type?->output_format),
+        ]);
+
+        if ($parts !== []) {
+            return implode("\n\n", $parts);
+        }
+
+        $role = $this->agent->role;
+        if (is_array($role) && isset($role['background'])) {
+            return trim(implode("\n", array_merge(
+                (array) $role['background'],
+                (array) ($role['steps'] ?? []),
+                (array) ($role['output'] ?? []),
+            )));
+        }
+
+        return '';
+    }
+
+    /**
+     * Per-agent model override → app default → hardcoded default. Mirrors
+     * BaseKanvasAgent::resolvedModelName().
+     */
+    private function resolvedModelName(): string
+    {
+        $config = $this->agent->config ?? [];
+
+        if (! empty($config['model'])) {
+            return (string) $config['model'];
+        }
+
+        $appModel = $this->app->get(ConfigurationEnum::GEMINI_MODEL->value);
+
+        return $appModel !== null && $appModel !== '' ? (string) $appModel : 'gemini-2.5-flash';
+    }
+
+    /**
+     * The dealership's outbound caller-id number, read from company settings.
+     * Credentials (account sid / auth token) are deliberately NOT included here.
+     *
+     * @return array<string, mixed>
+     */
+    private function telephony(): array
+    {
+        $company = $this->agent->companies_id > 0
+            ? Companies::getById($this->agent->companies_id)
+            : null;
+
+        return [
+            'from_number' => $company?->get(TwilioConfigurationEnum::TWILIO_FROM_PHONE_NUMBER->value),
+        ];
+    }
+
+    private function floatOrNull(mixed $value): ?float
+    {
+        return $value === null ? null : (float) $value;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a GraphQL query that exposes an agent's **compiled voice spec** so the external voice runtime (Pipecat / Cloud Run) can fetch its agent by `uuid` at the start of a call — instead of baking prompt/voice/model config into the runtime.

This is Milestone 1 of the voice-agent integration. It **extends the existing `Agent`** (Intelligence domain) rather than introducing a parallel structure.

## Changes

- **`voice_config` column** — nullable JSON on `agents` (intelligence connection): `voice_id`, TTS/STT provider + tuning, `greeting`, `voicemail_message`, `language`, `context_schema`. Added to `Agent` `$fillable`/`casts()` and the `AgentAi` GraphQL type.
- **`VoiceAgentSpecService`** — compiles the spec:
  - `system_instruction` via the same `soul → instructions → output_format` coalescing (with `AgentType` fallback) as `Agents\Types\BaseAgent`, so the voice prompt matches the in-process persona;
  - resolved model name (per-agent `config.model` → app `GEMINI_MODEL` → default);
  - `voice_config` mapped into `models.stt/llm/tts`;
  - company Twilio **from-number** (`TWILIO_FROM_PHONE_NUMBER`) — credentials intentionally excluded.
- **`voiceAgentSpec(uuid: String!)` query** — under `extend type Query @guardByAppKey` (server-to-server, `X-Kanvas-App` + `X-Kanvas-App-Key`), mirroring the existing `agentRuntime*` pattern. Resolved via `AgentsRepository::getByUuidFromApp`, scoped by `apps_id`.

## Design notes

- **Multi-tenant:** one product app; per-dealer isolation is by the agent's `companies_id` (dealership = Company under one App).
- **`{{placeholders}}`** in prompts/greeting/voicemail are filled per call by the runtime from `context`; `context_schema` defaults cover omitted keys.
- No new deployment machinery — this is a read query; the SSH/`AgentMachine` runtime is untouched.

## Pairs with
`kanvas-voice-agents` runtime PR (fetches this via `agents.py::_fetch_from_kanvas`).

## Verification
`php -l` clean on all files; imports ordered for StyleCI. Full `lighthouse:validate-schema` + migration should run in CI / a checkout with `vendor/` (the worktree has none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)