### PR TITLE
fix: use app key (not non-existent app uuid) in config-backup S3 path

### DIFF
--- a/src/Domains/Intelligence/Agents/Services/AgentConfigBackupService.php
+++ b/src/Domains/Intelligence/Agents/Services/AgentConfigBackupService.php
@@ -92,7 +92,7 @@ class AgentConfigBackupService
     public function upload(Agent $agent, Apps $app, array $data, ?AgentBackup $workspaceBackup = null): string
     {
         $timestamp = now()->format('Y-m-d_H-i-s');
-        $s3Path = "config-backups/{$app->uuid}/{$agent->uuid}/{$timestamp}.zip";
+        $s3Path = "config-backups/{$app->key}/{$agent->uuid}/{$timestamp}.zip";
 
         $tempPath = tempnam(sys_get_temp_dir(), 'agent_config_backup_') . '.zip';
 

--- a/tests/Intelligence/AgentConfigBackupServiceTest.php
+++ b/tests/Intelligence/AgentConfigBackupServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Intelligence;
+
+use Illuminate\Support\Facades\Storage;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Intelligence\Agents\Factories\AgentFactory;
+use Kanvas\Intelligence\Agents\Services\AgentConfigBackupService;
+use Tests\TestCase;
+
+final class AgentConfigBackupServiceTest extends TestCase
+{
+    public function testUploadKeyUsesAppKeyAndHasNoEmptySegment(): void
+    {
+        Storage::fake('agent-config-backups');
+
+        $app = app(Apps::class);
+        $agent = AgentFactory::new()
+            ->withAppId($app->getId())
+            ->withCompanyId(0)
+            ->create();
+
+        $path = new AgentConfigBackupService()->upload($agent, $app, ['manifest' => true]);
+
+        // The app segment must be the app's `key` (Apps has no `uuid` column) — a null
+        // segment produced the `config-backups//<agent-uuid>/...` double-slash bug.
+        $this->assertStringContainsString("config-backups/{$app->key}/{$agent->uuid}/", $path);
+        $this->assertStringNotContainsString('//', $path);
+        Storage::disk('agent-config-backups')->assertExists($path);
+    }
+}


### PR DESCRIPTION
## What & why

Follow-up fix for the config-backup feature merged in #10227.

`AgentConfigBackupService::upload()` built the S3 key as
`config-backups/{$app->uuid}/{$agent->uuid}/{timestamp}.zip`, but the `Apps`
model has **no `uuid` column** — an app's public identifier is the `key`
column (`Apps::getByUuid()` queries `where('key', ...)`, and every other
call site uses `$app->key`).

`$app->uuid` therefore resolved to `null`, producing a malformed key with an
empty app segment:

```
config-backups//019f42b1-4671-70ff-8320-c2d9f11c3d8d/2026-07-23_21-15-35.zip
```

The double slash broke the signed `download_url` (the stored `file_path` no
longer matched the actual object key after S3/Flysystem path normalization).

## Fix

- `$app->uuid` → `$app->key` in the S3 path.
- Regression test asserting the key uses `$app->key` and contains no empty
  segment (`//`).

## Note

Existing backups created before this fix have the malformed `file_path`
persisted and won't be downloadable — re-run the backup after deploy to get
a valid record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)