### PR TITLE
fix(mindee): update Client to Mindee SDK v3.1.0 namespaces

### DIFF
--- a/src/Domains/Connectors/Mindee/Client.php
+++ b/src/Domains/Connectors/Mindee/Client.php
@@ -8,9 +8,11 @@ use Baka\Contracts\AppInterface;
 use Baka\Contracts\CompanyInterface;
 use InvalidArgumentException;
 use Kanvas\Connectors\Mindee\Enums\ConfigurationEnum;
-use Mindee\Client as MindeeClient;
-use Mindee\Input\PredictMethodOptions;
-use Mindee\Product\Generated\GeneratedV1;
+use Mindee\Input\PathInput;
+use Mindee\Input\UrlInputSource;
+use Mindee\V1\Client as MindeeClient;
+use Mindee\V1\ClientOptions\PredictMethodOptions;
+use Mindee\V1\Product\Generated\GeneratedV1;
 use Throwable;
 
 class Client
@@ -51,12 +53,11 @@ class Client
     ): ?array {
         try {
             // Load a file
-            $inputSource = $this->client->sourceFromPath($filePath);
             $accountName = $accountName ?? $this->accountName;
             // If the file is a URL instead of a file path
-            if (filter_var($filePath, FILTER_VALIDATE_URL)) {
-                $inputSource = $this->client->sourceFromUrl($filePath);
-            }
+            $inputSource = filter_var($filePath, FILTER_VALIDATE_URL)
+                ? new UrlInputSource($filePath)
+                : new PathInput($filePath);
 
             // Create a custom endpoint
             $customEndpoint = $this->client->createEndpoint(
@@ -99,7 +100,7 @@ class Client
     ): ?array {
         try {
             // Load a file from URL
-            $inputSource = $this->client->sourceFromUrl($fileUrl);
+            $inputSource = new UrlInputSource($fileUrl);
             $accountName = $accountName ?? $this->accountName;
 
             // Create a custom endpoint


### PR DESCRIPTION
## General Description

The composer requirement for `mindee/mindee` is `^3.1`, but the Mindee connector (`src/Domains/Connectors/Mindee/Client.php`) was still written against the old v1.x class paths. In v3.x the SDK moved every class under the `Mindee\V1\` namespace and removed the `sourceFromPath()` / `sourceFromUrl()` client helpers, so the referenced classes no longer exist.

This surfaced as PHPStan `class.notFound` errors, but it is a **real runtime bug** — `processDocument()` / `processDocumentFromUrl()` would have thrown a fatal "class not found" as soon as they were called against the installed v3.1.0 SDK, not merely a static-analysis warning.

The correct v3.1.0 API was verified against the actual package source at tag `v3.1.0` (its `docs/code_samples/default_async.txt` sample matches this exact custom-endpoint + `GeneratedV1` flow).

Class / call mapping applied:

| Old (v1.x — not found) | New (v3.1.0) |
|---|---|
| `Mindee\Client` | `Mindee\V1\Client` |
| `Mindee\Input\PredictMethodOptions` | `Mindee\V1\ClientOptions\PredictMethodOptions` |
| `Mindee\Product\Generated\GeneratedV1` | `Mindee\V1\Product\Generated\GeneratedV1` |
| `$client->sourceFromPath($path)` | `new Mindee\Input\PathInput($path)` |
| `$client->sourceFromUrl($url)` | `new Mindee\Input\UrlInputSource($url)` |

The path/URL branch was also collapsed into a single ternary. A grep confirmed no other files reference the old Mindee class paths.

Resolves all six reported PHPStan errors:

```
Property Kanvas\Connectors\Mindee\Client::$client has unknown class Mindee\Client as its type.
Instantiated class Mindee\Client not found.
Instantiated class Mindee\Input\PredictMethodOptions not found.
Class Mindee\Product\Generated\GeneratedV1 not found.
```

## Related Issue

N/A

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes. — no behavior change; this is a class-path/API correction to match the already-pinned SDK version. The connector's public method signatures are unchanged.
- [ ] I have updated the documentation (if needed). — not needed.
- [x] My changes generate no new warnings. — `php -l` passes; fixes the existing PHPStan `class.notFound` errors. (Vendor was not installed in the working environment, so PHPStan could not be executed there directly.)
- [x] My changes do not break any existing tests.

## Screenshots (if applicable)

N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_012KaHp9udQVHRq9KPt6ms9P)_