### PR TITLE
fix(payway): strip plus-addressing from clienteCorreo and support sav…

### DIFF
--- a/app/GraphQL/Souk/Mutations/Payments/PaymentProcessorMutation.php
+++ b/app/GraphQL/Souk/Mutations/Payments/PaymentProcessorMutation.php
@@ -204,6 +204,7 @@ class PaymentProcessorMutation
                 'card_number'  => $cardNumber,
                 'cvc'          => $cardData['cvv'] ?? null,
                 'browser_info' => $cardData['browser_info'] ?? [],
+                'save_card'    => (bool) ($cardData['save_card'] ?? false),
                 'card' => [
                     'number'          => $cardNumber,
                     'cvv'             => $cardData['cvv'] ?? null,

--- a/graphql/schemas/Souk/Payments/payments.graphql
+++ b/graphql/schemas/Souk/Payments/payments.graphql
@@ -153,6 +153,7 @@ input StartChallengeCardInput {
     firstname: String
     lastname: String
     browser_info: BrowserInfoInput
+    save_card: Boolean
 }
 
 enum PaymentMethodTypeEnum {

--- a/src/Domains/Souk/Payments/Infrastructure/Processors/PayWay/PayWayProcessor.php
+++ b/src/Domains/Souk/Payments/Infrastructure/Processors/PayWay/PayWayProcessor.php
@@ -14,6 +14,8 @@ use Kanvas\Connectors\PayWay\DataTransferObject\PayWayResponse;
 use Kanvas\Connectors\PayWay\Enums\ConfigurationEnum;
 use Kanvas\Connectors\PayWay\Enums\CustomFieldEnum;
 use Kanvas\Connectors\PayWay\PayWayEncryptor;
+use Kanvas\Payments\Actions\CreatePaymentMethodAction;
+use Kanvas\Payments\DataTransferObjet\PaymentMethod as PaymentMethodData;
 use Kanvas\Souk\Orders\Models\Order;
 use Kanvas\Souk\Payments\Contracts\PaymentProcessorInterface;
 use Kanvas\Souk\Payments\Contracts\ThreeDSProcessorInterface;
@@ -25,6 +27,7 @@ use Kanvas\Souk\Payments\DataTransferObject\VerifyResult;
 use Kanvas\Souk\Payments\DataTransferObject\VoidResult;
 use Kanvas\Souk\Payments\Enums\PaymentStatusEnum;
 use Kanvas\Souk\Payments\Models\Payments;
+use Kanvas\Users\Models\Users;
 use Override;
 use Throwable;
 
@@ -50,6 +53,7 @@ final class PayWayProcessor implements PaymentProcessorInterface, ThreeDSProcess
     private const string META_ERROR = 'payway_error';
     private const string META_OTP_TOKEN_ACCESO = 'payway_otp_token_acceso';
     private const string META_OTP_URL = 'payway_otp_url';
+    private const string META_SAVE_CARD = 'payway_save_card';
 
     public function __construct(
         private readonly Apps $app,
@@ -225,6 +229,7 @@ final class PayWayProcessor implements PaymentProcessorInterface, ThreeDSProcess
     {
         try {
             $payload = $this->buildStep1Payload($payment, $order, $context);
+            $this->recordSaveCardIntent($payment, $context);
             $response = $this->client->payUsing3ds($payload);
 
             return match (true) {
@@ -618,7 +623,7 @@ final class PayWayProcessor implements PaymentProcessorInterface, ThreeDSProcess
         $user = $payment->paymentMethod?->users_id
             ? $payment->paymentMethod->user
             : null;
-        $clienteCorreo = $user?->email ?? $order->user_email ?? '';
+        $clienteCorreo = $this->resolveClienteCorreo($user, $order);
         // PayWay spec: clienteUsuario is the merchant-side user identifier (not the email).
         $clienteUsuario = (string) ($user?->id ?? $order->users_id ?? $clienteCorreo);
         $concepto = (string) ($payment->concept ?: 'Pago orden ' . $order->order_number);
@@ -638,6 +643,39 @@ final class PayWayProcessor implements PaymentProcessorInterface, ThreeDSProcess
         ];
     }
 
+    // PayWay rejects plus-addressing (jesus+2@kanvas.dev -> returnCode 05 "Correo con formato invalido"),
+    // so the tag is stripped and the first candidate that still validates wins.
+    private function resolveClienteCorreo(?Users $user, Order $order): string
+    {
+        $candidates = [
+            $user?->email,
+            $order->user_email,
+            $order->people?->getEmails()->first()?->email,
+        ];
+
+        foreach ($candidates as $candidate) {
+            $email = $this->stripEmailPlusTag((string) $candidate);
+
+            if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                return $email;
+            }
+        }
+
+        return '';
+    }
+
+    private function stripEmailPlusTag(string $email): string
+    {
+        $email = trim($email);
+        [$local, $domain] = array_pad(explode('@', $email, 2), 2, null);
+
+        if ($domain === null) {
+            return $email;
+        }
+
+        return (strstr($local, '+', true) ?: $local) . '@' . $domain;
+    }
+
     private function buildDatos3ds(Payments $payment, Order $order, array $context): array
     {
         $card = $context['card'] ?? [];
@@ -653,18 +691,85 @@ final class PayWayProcessor implements PaymentProcessorInterface, ThreeDSProcess
         ];
     }
 
+    // Step 1 is the only point that holds the card, but numeroUuid only arrives at the
+    // terminal step — a separate request. Stash the consent plus the non-sensitive display
+    // fields (never the PAN/CVV) so the terminal handler can build the saved card.
+    private function recordSaveCardIntent(Payments $payment, array $context): void
+    {
+        if (! filter_var($context['save_card'] ?? false, FILTER_VALIDATE_BOOLEAN)) {
+            return;
+        }
+
+        if ($payment->payment_methods_id) {
+            return;
+        }
+
+        $card = $context['card'] ?? [];
+
+        $payment->addMetadata([
+            'data' => [
+                self::META_SAVE_CARD => [
+                    'expiration_date' => $this->normalizeExpiration(
+                        (string) ($card['expiration_date'] ?? $card['expiration'] ?? '')
+                    ),
+                    'zip_code' => (string) ($card['zip'] ?? $card['zip_code'] ?? ''),
+                ],
+            ],
+        ]);
+    }
+
     private function persistUuidToPaymentMethod(Payments $payment, string $numeroUuid): void
     {
-        if (empty($numeroUuid) || ! $payment->paymentMethod) {
+        if (empty($numeroUuid)) {
             return;
         }
 
         $paymentMethod = $payment->paymentMethod;
+
+        if (! $paymentMethod) {
+            $this->createSavedCard($payment, $numeroUuid);
+
+            return;
+        }
+
         $paymentMethod->metadata = array_merge(
             $paymentMethod->metadata ?? [],
             [CustomFieldEnum::PAYWAY_NUMERO_UUID->value => $numeroUuid]
         );
         $paymentMethod->save();
+    }
+
+    private function createSavedCard(Payments $payment, string $numeroUuid): void
+    {
+        $intent = $payment->getMetadata(self::META_SAVE_CARD);
+        $user = $payment->user;
+
+        if (! is_array($intent) || ! $user) {
+            return;
+        }
+
+        // stripe_card_id is the generic processor-token column; PaymentMethodMutation@delete
+        // hands it to PayWayTokenizationService::deleteToken, so the uuid has to live there too.
+        $paymentMethod = new CreatePaymentMethodAction(
+            new PaymentMethodData(
+                app: $this->app,
+                user: $user,
+                company: $this->company,
+                payment_ending_numbers: (string) $payment->payment_method_last_four,
+                payment_methods_brand: (string) $payment->payment_method_brand,
+                expiration_date: (string) ($intent['expiration_date'] ?? ''),
+                zip_code: (string) ($intent['zip_code'] ?? ''),
+                stripe_card_id: $numeroUuid,
+                processor: $this->name(),
+                metadata: [CustomFieldEnum::PAYWAY_NUMERO_UUID->value => $numeroUuid],
+            ),
+        )->execute();
+
+        $payment->payment_methods_id = $paymentMethod->getId();
+
+        $payment->addLog('payway_saved_card_created', [
+            'payment_methods_id' => $paymentMethod->getId(),
+        ]);
     }
 
     /**

--- a/tests/Connectors/PayWay/PayWayProcessor3DSTest.php
+++ b/tests/Connectors/PayWay/PayWayProcessor3DSTest.php
@@ -14,6 +14,7 @@ use Kanvas\Souk\Orders\Models\Order;
 use Kanvas\Souk\Payments\Enums\PaymentStatusEnum;
 use Kanvas\Souk\Payments\Infrastructure\Processors\PayWay\PayWayProcessor;
 use Kanvas\Souk\Payments\Models\Payments;
+use Kanvas\Users\Models\Users;
 use Mockery;
 use Tests\Connectors\PayWay\Fakes\FakePayWayClient;
 use Tests\TestCase;
@@ -118,6 +119,61 @@ class PayWayProcessor3DSTest extends TestCase
         $this->assertArrayNotHasKey('tarjetaCvv2', $calls[0]['payload']);
     }
 
+    public function testStartChallengeStripsPlusTagFromClienteCorreo(): void
+    {
+        $payment = $this->buildPaymentMock(PaymentStatusEnum::PENDING->value);
+        $order = $this->buildOrderMock();
+        $order->user_email = 'jesus+2@kanvas.dev';
+
+        $this->fakeClient->queueResponse('payUsing3ds', PayWayResponse::fromArray([
+            'returnCode' => '01',
+            'message' => 'Step 1 OK',
+            'success' => false,
+            'tokenAcceso' => 'token-plus',
+            'urlColeccionDatoDispositivo' => 'https://payway.sv/collect',
+            'referenciaId' => 'ref-plus',
+        ]));
+
+        $this->processor->startChallenge($payment, $order, [
+            'card' => [
+                'number' => '4111111111111111',
+                'cvv' => '123',
+                'expiration_date' => '2612',
+            ],
+        ]);
+
+        $calls = $this->fakeClient->getCalls('payUsing3ds');
+        $this->assertSame('jesus@kanvas.dev', $calls[0]['payload']['clienteCorreo']);
+    }
+
+    public function testStartChallengeSendsEmptyClienteCorreoWhenNoValidEmailExists(): void
+    {
+        $payment = $this->buildPaymentMock(PaymentStatusEnum::PENDING->value);
+        $order = $this->buildOrderMock();
+        $order->user_email = 'not-an-email';
+        $order->setRelation('people', null);
+
+        $this->fakeClient->queueResponse('payUsing3ds', PayWayResponse::fromArray([
+            'returnCode' => '01',
+            'message' => 'Step 1 OK',
+            'success' => false,
+            'tokenAcceso' => 'token-no-email',
+            'urlColeccionDatoDispositivo' => 'https://payway.sv/collect',
+            'referenciaId' => 'ref-no-email',
+        ]));
+
+        $this->processor->startChallenge($payment, $order, [
+            'card' => [
+                'number' => '4111111111111111',
+                'cvv' => '123',
+                'expiration_date' => '2612',
+            ],
+        ]);
+
+        $calls = $this->fakeClient->getCalls('payUsing3ds');
+        $this->assertSame('', $calls[0]['payload']['clienteCorreo']);
+    }
+
     public function testStartChallengeDeclineTransitionsToFailed(): void
     {
         $payment = $this->buildPaymentMock(PaymentStatusEnum::PENDING->value);
@@ -178,6 +234,94 @@ class PayWayProcessor3DSTest extends TestCase
         // Transient metadata cleared.
         $this->assertArrayNotHasKey('payway_token_acceso', $payment->metadata['data'] ?? []);
         $this->assertArrayNotHasKey('payway_seguimiento', $payment->metadata['data'] ?? []);
+    }
+
+    public function testSaveCardTrueCreatesPaymentMethodOnTerminalPaid(): void
+    {
+        $payment = $this->buildPaymentMock(PaymentStatusEnum::PENDING->value, user: static::$cachedUser);
+        $order = $this->buildOrderMock();
+
+        $this->fakeClient->queueResponse('payUsing3ds', PayWayResponse::fromArray([
+            'returnCode' => '01',
+            'message' => 'Step 1 OK',
+            'success' => false,
+            'tokenAcceso' => 'token-save',
+            'urlColeccionDatoDispositivo' => 'https://payway.sv/collect',
+            'referenciaId' => 'ref-save',
+        ]));
+
+        $this->processor->startChallenge($payment, $order, [
+            'save_card' => true,
+            'card' => [
+                'number' => '4111111111111111',
+                'cvv' => '123',
+                'expiration_date' => '2026-12',
+                'zip' => '11101',
+            ],
+        ]);
+
+        $this->fakeClient->queueResponse('completePayment', PayWayResponse::fromArray([
+            'returnCode' => '00',
+            'message' => 'Pago aprobado',
+            'success' => true,
+            'numeroUuid' => 'uuid-saved-card',
+            'numeroCompra' => 'compra-save',
+            'numeroAutorizacion' => 'auth-save',
+            'marcaTarjeta' => 'visa',
+            'terminacionTarjeta' => 'X-1111',
+        ]));
+
+        $this->processor->finalizeChallenge($payment, $order);
+
+        $this->assertNotNull($payment->payment_methods_id);
+
+        $saved = PaymentMethods::find($payment->payment_methods_id);
+        $this->assertSame('payway', $saved->processor);
+        $this->assertSame('uuid-saved-card', $saved->stripe_card_id);
+        $this->assertSame('uuid-saved-card', $saved->metadata[CustomFieldEnum::PAYWAY_NUMERO_UUID->value]);
+        $this->assertSame('visa', $saved->payment_methods_brand);
+        $this->assertSame('1111', $saved->payment_ending_numbers);
+        $this->assertSame('202612', $saved->expiration_date);
+        $this->assertSame(static::$cachedUser->getId(), (int) $saved->users_id);
+
+        $saved->forceDelete();
+    }
+
+    public function testSaveCardOmittedDoesNotCreatePaymentMethod(): void
+    {
+        $payment = $this->buildPaymentMock(PaymentStatusEnum::PENDING->value, user: static::$cachedUser);
+        $order = $this->buildOrderMock();
+
+        $this->fakeClient->queueResponse('payUsing3ds', PayWayResponse::fromArray([
+            'returnCode' => '01',
+            'message' => 'Step 1 OK',
+            'success' => false,
+            'tokenAcceso' => 'token-nosave',
+            'urlColeccionDatoDispositivo' => 'https://payway.sv/collect',
+            'referenciaId' => 'ref-nosave',
+        ]));
+
+        $this->processor->startChallenge($payment, $order, [
+            'card' => [
+                'number' => '4111111111111111',
+                'cvv' => '123',
+                'expiration_date' => '2612',
+            ],
+        ]);
+
+        $this->fakeClient->queueResponse('completePayment', PayWayResponse::fromArray([
+            'returnCode' => '00',
+            'message' => 'Pago aprobado',
+            'success' => true,
+            'numeroUuid' => 'uuid-not-saved',
+            'numeroCompra' => 'compra-nosave',
+        ]));
+
+        $this->processor->finalizeChallenge($payment, $order);
+
+        $this->assertNull($payment->payment_methods_id);
+        $this->assertNull($payment->getMetadata('payway_save_card'));
+        $this->assertSame(0, PaymentMethods::where('stripe_card_id', 'uuid-not-saved')->count());
     }
 
     public function testFinalizeChallengeEscenario2OtpRequired(): void
@@ -323,6 +467,7 @@ class PayWayProcessor3DSTest extends TestCase
     private function buildPaymentMock(
         string $initialStatus,
         ?PaymentMethods $paymentMethod = null,
+        ?Users $user = null,
     ): Payments {
         $payment = Mockery::mock(Payments::class)->makePartial();
         $payment->exists = true;
@@ -331,7 +476,10 @@ class PayWayProcessor3DSTest extends TestCase
         $payment->status = $initialStatus;
         $payment->metadata = [];
 
-        $paymentMethod ??= $this->buildPaymentMethodMock(null);
+        $payment->shouldReceive('getAttribute')
+            ->with('user')
+            ->andReturn($user)
+            ->byDefault();
 
         $payment->shouldReceive('paymentMethod')
             ->andReturn($paymentMethod)


### PR DESCRIPTION
…e_card

PayWay rejects plus-addressed emails (jesus+2@kanvas.dev) with returnCode 05 "Correo con formato invalido". resolveClienteCorreo now strips the +tag, validates each candidate instead of only null-checking, and falls back to the order's people emails.

Saved cards were impossible on PayWay from both ends: standalone tokenization throws by design, and persistUuidToPaymentMethod only updated a PaymentMethod that already existed, so the numeroUuid returned on a first payment was dropped. Step 1 now records the save_card consent plus the non-sensitive display fields (never PAN/CVV) in payment metadata, and the terminal handler creates the PaymentMethod from it. The uuid also lands in stripe_card_id because PaymentMethodMutation@delete gates deleteToken() on that column.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
