### PR TITLE
Dedup duplicate best-seller listings + one variant per product in bundles

### DIFF
--- a/app/Console/Commands/Connectors/ScrapingDog/ScrapeScrapingDogBestSellersCommand.php
+++ b/app/Console/Commands/Connectors/ScrapingDog/ScrapeScrapingDogBestSellersCommand.php
@@ -92,6 +92,7 @@ class ScrapeScrapingDogBestSellersCommand extends Command
 
         $imported = 0;
         $updated = 0;
+        $duplicates = 0;
         $failed = 0;
 
         foreach ($categories as $category) {
@@ -102,10 +103,24 @@ class ScrapeScrapingDogBestSellersCommand extends Command
 
             $this->info(sprintf('Category "%s" (%s): %d product(s)', $category['name'], $category['slug'], count($items)));
 
+            // Amazon lists the same product under different ASINs — keep only the first per
+            // normalized name in a department so the homepage/bundle don't show duplicates.
+            $seenNames = [];
+
             foreach ($items as $item) {
                 $asin = (string) ($item['sku'] ?? $item['asin'] ?? '');
                 if ($asin === '') {
                     continue;
+                }
+
+                $nameKey = Str::slug((string) ($item['name'] ?? $item['product'] ?? ''));
+                if ($nameKey !== '' && isset($seenNames[$nameKey])) {
+                    $duplicates++;
+
+                    continue;
+                }
+                if ($nameKey !== '') {
+                    $seenNames[$nameKey] = true;
                 }
 
                 $price = (float) ($item['price'] ?? 0);
@@ -194,6 +209,7 @@ class ScrapeScrapingDogBestSellersCommand extends Command
         $this->info('Categories: ' . count($categories));
         $this->info('New imported: ' . $imported);
         $this->info('Existing updated: ' . $updated);
+        $this->info('Duplicates skipped: ' . $duplicates);
         $this->info('Failed: ' . $failed);
         $this->info('======================');
 
@@ -442,10 +458,15 @@ class ScrapeScrapingDogBestSellersCommand extends Command
             return [];
         }
 
+        // One variant per product so a multi-variant product doesn't flood the bundle.
         return Variants::query()
             ->whereIn('products_id', $productIds)
             ->where('is_deleted', 0)
-            ->pluck('id')
+            ->orderBy('id')
+            ->get()
+            ->groupBy('products_id')
+            ->map(fn ($group) => $group->first()->getKey())
+            ->values()
             ->all();
     }
 

--- a/app/Console/Commands/Connectors/ScrapperApi/ScrapeAmazonBestSellersCommand.php
+++ b/app/Console/Commands/Connectors/ScrapperApi/ScrapeAmazonBestSellersCommand.php
@@ -92,6 +92,7 @@ class ScrapeAmazonBestSellersCommand extends Command
         $this->clearHomepageTag($app, $tag);
 
         $success = 0;
+        $duplicates = 0;
         $failed = 0;
 
         foreach ($categories as $category) {
@@ -102,7 +103,21 @@ class ScrapeAmazonBestSellersCommand extends Command
 
             $this->info(sprintf('Category "%s" (%s): %d product(s)', $category['name'], $category['slug'], count($products)));
 
+            // Amazon lists the same product under different ASINs — keep only the first per
+            // normalized name in a department so the homepage/bundle don't show duplicates.
+            $seenNames = [];
+
             foreach ($products as $item) {
+                $nameKey = Str::slug((string) ($item['name'] ?? ''));
+                if ($nameKey !== '' && isset($seenNames[$nameKey])) {
+                    $duplicates++;
+
+                    continue;
+                }
+                if ($nameKey !== '') {
+                    $seenNames[$nameKey] = true;
+                }
+
                 try {
                     // Un-delete a previously removed product so the importer reuses it instead of leaving it hidden.
                     Products::withTrashed()->where('slug', Str::slug($item['asin']))->update(['is_deleted' => 0]);
@@ -163,6 +178,7 @@ class ScrapeAmazonBestSellersCommand extends Command
         $this->info('=== Import Summary ===');
         $this->info('Categories: ' . count($categories));
         $this->info('Imported: ' . $success);
+        $this->info('Duplicates skipped: ' . $duplicates);
         $this->info('Failed: ' . $failed);
         $this->info('======================');
 
@@ -268,10 +284,15 @@ class ScrapeAmazonBestSellersCommand extends Command
             return [];
         }
 
+        // One variant per product so a multi-variant product doesn't flood the bundle.
         return Variants::query()
             ->whereIn('products_id', $productIds)
             ->where('is_deleted', 0)
-            ->pluck('id')
+            ->orderBy('id')
+            ->get()
+            ->groupBy('products_id')
+            ->map(fn ($group) => $group->first()->getKey())
+            ->values()
             ->all();
     }
 


### PR DESCRIPTION
Follow-up on the merged best-sellers PRs.

## Change
Amazon lists the same product under different ASINs, so the homepage grid and bundles showed visual duplicates (e.g. two identical AirTags).

- **Dedup by normalized name per department** — skip a best seller whose `Str::slug(name)` was already taken in that department, so only one is imported/tagged Homepage.
- **One variant per product in bundles** — `categoryVariantIds` now groups by product and takes a single variant, so a multi-variant product doesn't flood the bundle.

Applied to both the ScraperAPI and ScrapingDog best-seller commands. Summary now reports `Duplicates skipped`.