### PR TITLE
remove default slack

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/SystemUserAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/SystemUserAgent.php
@@ -201,10 +201,6 @@ class SystemUserAgent extends BaseKanvasAgent implements ConversesWithUser
 
         $core[] = new SendEmailToUserTool($agent);
 
-        if ((string) ($agent->get(AgentChannelTokenEnum::SLACK_BOT_TOKEN->value) ?? '') !== '') {
-            $core[] = new SendSlackDirectMessageTool($agent);
-        }
-
         return $this->mergeRegisteredTools(
             $core,
             $agent,

--- a/src/Domains/Intelligence/Agents/Neuron/SystemUserAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/SystemUserAgent.php
@@ -7,15 +7,12 @@ namespace Kanvas\Intelligence\Agents\Neuron;
 use Illuminate\Database\Eloquent\Model;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Leads\Models\Lead;
-use Kanvas\Intelligence\AgentRuntime\Enums\AgentChannelTokenEnum;
 use Kanvas\Intelligence\Agents\Attributes\AgentTypeDefinition;
 use Kanvas\Intelligence\Agents\Contracts\ConversesWithUser;
 use Kanvas\Intelligence\Agents\Neuron\History\ChannelMessageHistory;
 use Kanvas\Intelligence\Agents\Neuron\Tools\System\ReadEntityContextTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\System\ReadMyLedgerTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\System\ReadUserActivityTool;
-use Kanvas\Intelligence\Agents\Neuron\Tools\System\SendEmailToUserTool;
-use Kanvas\Intelligence\Agents\Neuron\Tools\System\SendSlackDirectMessageTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\System\WhoIsUserTool;
 use Kanvas\Intelligence\Agents\Services\EntityContextBriefService;
 use Kanvas\Intelligence\Agents\Traits\MergesRegisteredTools;
@@ -198,8 +195,6 @@ class SystemUserAgent extends BaseKanvasAgent implements ConversesWithUser
             $core[] = new ReadEntityContextTool($subject);
             $core[] = new ReadUserActivityTool($app, $company, $subject);
         }
-
-        $core[] = new SendEmailToUserTool($agent);
 
         return $this->mergeRegisteredTools(
             $core,


### PR DESCRIPTION
…orate

MigrateCorporateUserVariantsJob moved products.companies_id and
products_variants.companies_id to the new corporate company but left
products_variants_warehouses pointing at the source company's warehouse.

OrderItem::fromMultiple requires the variant to reach a warehouse owned by
the product's own company, so every TAG recharge for a migrated vehicle
failed with "No warehouse with pricing found for product ...".

RelinkVariantsToCompanyWarehouseAction repoints those rows to a warehouse of
the target company (provisioning one in the company's region when it has
none), moving the row rather than recreating it so price, channel pricing and
history follow the variant. The job now takes the Apps model so it can call
overwriteAppService before touching Bouncer-scoped lookups, and re-runs the
relink on retry to repair partially applied runs.

Adds kanvas-movipass:relink-corporate-variant-warehouses to backfill the
companies already migrated.## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
