### PR TITLE
feat(souk): exclude configurable states from order turnover

### DIFF
--- a/app/GraphQL/Souk/Queries/OrderStatsQuery.php
+++ b/app/GraphQL/Souk/Queries/OrderStatsQuery.php
@@ -13,6 +13,7 @@ use Kanvas\Souk\Orders\Actions\GetOrderCommissionStatsAction;
 use Kanvas\Souk\Orders\Actions\GetOrderPaymentStatsAction;
 use Kanvas\Souk\Orders\Actions\GetOrderStatsAction;
 use Kanvas\Souk\Orders\DataTransferObject\CommissionStats;
+use Kanvas\Souk\Orders\Enums\OrderStatsExcludeModeEnum;
 use Kanvas\Users\Models\Users;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
@@ -38,6 +39,8 @@ class OrderStatsQuery
         $providerCompanyIds = array_map('intval', $input['provider_company_id'] ?? []);
         $providers = $input['providers'] ?? [];
         $userEmail = $input['user_email'] ?? null;
+        $excludeStates = $input['excludeStates'] ?? [];
+        $excludeMode = OrderStatsExcludeModeEnum::from(strtolower($input['excludeMode'] ?? 'current'));
 
         $orderStats = new GetOrderStatsAction(
             $app,
@@ -49,7 +52,9 @@ class OrderStatsQuery
             $productId,
             $providerCompanyIds,
             $providers,
-            $userEmail
+            $userEmail,
+            $excludeStates,
+            $excludeMode
         )->execute(
             $date,
             $startDate,

--- a/graphql/schemas/Souk/orderStats.graphql
+++ b/graphql/schemas/Souk/orderStats.graphql
@@ -11,6 +11,11 @@ enum PeriodType {
     YEAR
 }
 
+enum OrderStatsExcludeMode {
+    IN_RANGE # exclude an order from turnover only if it hit an excluded state within the queried period
+    CURRENT # exclude an order whenever its current status is excluded (live snapshot)
+}
+
 type OrderPaymentBreakdownItem {
     label: String!
     total_transactions: Int!
@@ -153,6 +158,8 @@ input OrderStatsInput {
     provider_company_id: [ID!] # DB-level filter: only orders linked to these provider companies via order_providers
     providers: [ProviderInput!] # Email-pattern byProvider breakdown (same as OrderPaymentStatsInput)
     user_email: String # Filter by order user email
+    excludeStates: [String!] # States that neutralize an order in turnover — counts as neither entry nor exit (e.g. ["cancelled"]); empty = no exclusion
+    excludeMode: OrderStatsExcludeMode # How excludeStates is applied: CURRENT (default, live) or IN_RANGE (within period)
 }
 
 input ProviderInput {

--- a/src/Domains/Souk/Orders/Actions/GetOrderStatsAction.php
+++ b/src/Domains/Souk/Orders/Actions/GetOrderStatsAction.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Souk\Orders\Enums\DateGroupByEnum;
+use Kanvas\Souk\Orders\Enums\OrderStatsExcludeModeEnum;
 use Kanvas\Souk\Orders\Helpers\DateGroupingHelper;
 use Kanvas\Souk\Orders\Helpers\DateHelper;
 use Kanvas\Souk\Orders\Models\Order;
@@ -29,6 +30,8 @@ class GetOrderStatsAction
         protected array $providerCompanyIds = [],
         protected array $providers = [],
         protected ?string $userEmail = null,
+        protected array $excludeStates = [],
+        protected OrderStatsExcludeModeEnum $excludeMode = OrderStatsExcludeModeEnum::CURRENT,
     ) {
         if ($this->productId) {
             $this->productVariantIds = DB::connection('inventory')
@@ -330,7 +333,10 @@ class GetOrderStatsAction
 
     private function getDailyTurnover($start, $end, string $timezone = 'UTC'): array
     {
+        $applyExclusion = $this->turnoverExclusionCallback($start, $end);
+
         $entries = OrderTransitionHistory::query()
+            ->when(! empty($this->excludeStates), $applyExclusion)
             ->selectRaw("COUNT(DISTINCT order_id) as count, DATE(CONVERT_TZ(changed_at, 'UTC', ?)) as date", [$timezone])
             ->whereBetween('changed_at', [$start, $end])
             ->groupBy('date')
@@ -365,6 +371,7 @@ class GetOrderStatsAction
             ->keyBy('date');
 
         $exits = OrderTransitionHistory::query()
+            ->when(! empty($this->excludeStates), $applyExclusion)
             ->selectRaw("COUNT(DISTINCT order_id) as count, DATE(CONVERT_TZ(changed_at, 'UTC', ?)) as date", [$timezone])
             ->whereBetween('changed_at', [$start, $end])
             ->groupBy('date')
@@ -433,6 +440,33 @@ class GetOrderStatsAction
             ],
             'data' => $byDates,
         ];
+    }
+
+    /**
+     * Build the exclusion clause applied to both entries and exits so an order in an excluded
+     * state (e.g. cancelled) counts as neither. CURRENT drops it whenever its current status is
+     * excluded; IN_RANGE only when it hit an excluded state inside the queried period.
+     */
+    private function turnoverExclusionCallback(Carbon $start, Carbon $end): callable
+    {
+        if ($this->excludeMode === OrderStatsExcludeModeEnum::CURRENT) {
+            return function ($query) {
+                $query->whereDoesntHave(
+                    'order',
+                    fn ($q) => $q->whereHas('orderStatus', fn ($sq) => $sq->whereIn('slug', $this->excludeStates))
+                );
+            };
+        }
+
+        $excludedOrderIds = OrderTransitionHistory::query()
+            ->where('apps_id', $this->app->id)
+            ->whereBetween('changed_at', [$start, $end])
+            ->whereHas('toStatus', fn ($q) => $q->whereIn('slug', $this->excludeStates))
+            ->distinct()
+            ->pluck('order_id')
+            ->all();
+
+        return fn ($query) => $query->whereNotIn('order_id', $excludedOrderIds);
     }
 
     private function getByProvider(Carbon $start, Carbon $end): array

--- a/src/Domains/Souk/Orders/Enums/OrderStatsExcludeModeEnum.php
+++ b/src/Domains/Souk/Orders/Enums/OrderStatsExcludeModeEnum.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Souk\Orders\Enums;
+
+enum OrderStatsExcludeModeEnum: string
+{
+    // Neutralize an order only when its excluded transition falls inside the queried period
+    // (historically-correct turnover: an entry + same-period cancel net to zero).
+    case IN_RANGE = 'in_range';
+
+    // Neutralize an order whenever its current status is excluded, regardless of when it changed
+    // (live snapshot: cancelled orders never show up in turnover, even retroactively).
+    case CURRENT = 'current';
+}

--- a/tests/GraphQL/Souk/OrderStatsExclusionTest.php
+++ b/tests/GraphQL/Souk/OrderStatsExclusionTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\GraphQL\Souk;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Souk\Orders\Actions\GetOrderStatsAction;
+use Kanvas\Souk\Orders\Enums\OrderStatsExcludeModeEnum;
+use Kanvas\Souk\Orders\Models\Order;
+use Kanvas\Souk\Orders\Models\OrderStatus;
+use Kanvas\Souk\Orders\Models\OrderTransitionHistory;
+use Kanvas\Souk\Orders\Models\OrderTypes;
+
+class OrderStatsExclusionTest extends OrderBase
+{
+    protected string $orderTypeName = 'reservation';
+
+    /** @var array<string, int> slug => order_status_id */
+    private array $statusIds = [];
+
+    private string $variantId;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $orderType = OrderTypes::firstOrCreate([
+            'name' => $this->orderTypeName,
+            'apps_id' => $this->apps->id,
+        ]);
+
+        $this->statusIds = $this->createStatuses($this->apps, $orderType, [
+            ['slug' => 'draft', 'name' => 'Draft', 'is_default' => true, 'is_final' => false],
+            ['slug' => 'in_transit', 'name' => 'In Transit', 'is_default' => false, 'is_final' => false],
+            ['slug' => 'released_from_lot', 'name' => 'Released', 'is_default' => false, 'is_final' => true],
+            ['slug' => 'cancelled', 'name' => 'Cancelled', 'is_default' => false, 'is_final' => true],
+        ]);
+
+        $productResponse = $this->createProduct(attributes: [
+            ['name' => 'slots', 'value' => 100],
+        ])->json()['data']['createProduct'];
+
+        $variantResponse = $this->createVariant(
+            productId: $productResponse['id'],
+            warehouseData: ['id' => $this->warehouseResponse['id']],
+            attributes: [['name' => 'timezone', 'value' => 'UTC']]
+        )->json()['data']['createVariant'];
+
+        $this->addVariantToChannel(
+            variantId: $variantResponse['id'],
+            channelId: $this->channelResponse['id'],
+            warehouseData: ['id' => $this->warehouseResponse['id']]
+        );
+
+        $this->addVariantToWarehouse(
+            variantId: $variantResponse['id'],
+            warehouseId: $this->warehouseResponse['id'],
+            amount: 100
+        );
+
+        $this->variantId = $variantResponse['id'];
+    }
+
+    private function createStatuses(Apps $app, OrderTypes $orderType, array $statuses): array
+    {
+        $ids = [];
+        foreach ($statuses as $status) {
+            $ids[$status['slug']] = OrderStatus::firstOrCreate([
+                'order_types_id' => $orderType->id,
+                'apps_id' => $app->id,
+                'slug' => $status['slug'],
+                'name' => $status['name'],
+                'is_default' => $status['is_default'],
+                'is_final' => $status['is_final'],
+            ])->id;
+        }
+
+        return $ids;
+    }
+
+    private function seedOrder(string $entryAt, string $exitSlug, string $exitAt, string $currentSlug): Order
+    {
+        $order = $this->createOrderFromCart(
+            metadata: ['data' => []],
+            variantId: $this->variantId,
+            orderType: $this->orderTypeName,
+        );
+
+        $this->addTransition($order, 'in_transit', $entryAt);
+        $this->addTransition($order, $exitSlug, $exitAt);
+
+        $order->order_status_id = $this->statusIds[$currentSlug];
+        $order->saveQuietly();
+
+        return $order;
+    }
+
+    private function addTransition(Order $order, string $slug, string $changedAt): void
+    {
+        OrderTransitionHistory::create([
+            'apps_id' => $order->apps_id,
+            'companies_id' => $order->companies_id,
+            'order_id' => $order->id,
+            'from_status_id' => null,
+            'to_status_id' => $this->statusIds[$slug],
+            'changed_at' => $changedAt,
+            'is_current' => false,
+            'is_deleted' => 0,
+        ]);
+    }
+
+    private function turnover(array $excludeStates, OrderStatsExcludeModeEnum $mode): array
+    {
+        return new GetOrderStatsAction(
+            app: $this->apps,
+            initialStates: ['in_transit'],
+            finalStates: ['released_from_lot'],
+            currentCountStates: ['in_transit'],
+            excludeStates: $excludeStates,
+            excludeMode: $mode,
+        )->execute(
+            startDate: '2026-06-01',
+            endDate: '2026-06-30',
+            timezone: 'UTC',
+        )['dailyTurnover'];
+    }
+
+    public function testCancelledCountsAsEntryWithoutExclusion(): void
+    {
+        $this->seedOrder('2026-06-05 12:00:00', 'released_from_lot', '2026-06-06 12:00:00', 'released_from_lot');
+        $this->seedOrder('2026-06-05 12:00:00', 'cancelled', '2026-06-06 12:00:00', 'cancelled');
+
+        $turnover = $this->turnover([], OrderStatsExcludeModeEnum::CURRENT);
+
+        // Both orders entered in_transit; only the released one is a final exit.
+        $this->assertEquals(2, $turnover['totalEntries']);
+        $this->assertEquals(1, $turnover['totalExits']);
+    }
+
+    public function testCurrentModeExcludesCancelledFromEntriesAndExits(): void
+    {
+        $this->seedOrder('2026-06-05 12:00:00', 'released_from_lot', '2026-06-06 12:00:00', 'released_from_lot');
+        $this->seedOrder('2026-06-05 12:00:00', 'cancelled', '2026-06-06 12:00:00', 'cancelled');
+
+        $turnover = $this->turnover(['cancelled'], OrderStatsExcludeModeEnum::CURRENT);
+
+        // The cancelled order is dropped entirely: it counts as neither entry nor exit.
+        $this->assertEquals(1, $turnover['totalEntries']);
+        $this->assertEquals(1, $turnover['totalExits']);
+    }
+
+    public function testInRangeModeExcludesCancelWithinPeriod(): void
+    {
+        $this->seedOrder('2026-06-05 12:00:00', 'released_from_lot', '2026-06-06 12:00:00', 'released_from_lot');
+        $this->seedOrder('2026-06-05 12:00:00', 'cancelled', '2026-06-06 12:00:00', 'cancelled');
+
+        $turnover = $this->turnover(['cancelled'], OrderStatsExcludeModeEnum::IN_RANGE);
+
+        $this->assertEquals(1, $turnover['totalEntries']);
+        $this->assertEquals(1, $turnover['totalExits']);
+    }
+
+    public function testInRangeKeepsEntryWhenCancelIsOutsidePeriod(): void
+    {
+        $this->seedOrder('2026-06-05 12:00:00', 'released_from_lot', '2026-06-06 12:00:00', 'released_from_lot');
+        // Entered in June but cancelled in July (outside the queried window).
+        $this->seedOrder('2026-06-05 12:00:00', 'cancelled', '2026-07-06 12:00:00', 'cancelled');
+
+        $inRange = $this->turnover(['cancelled'], OrderStatsExcludeModeEnum::IN_RANGE);
+        // No cancel transition inside June → the June entry still counts.
+        $this->assertEquals(2, $inRange['totalEntries']);
+
+        $current = $this->turnover(['cancelled'], OrderStatsExcludeModeEnum::CURRENT);
+        // Current status is cancelled → dropped regardless of when it happened.
+        $this->assertEquals(1, $current['totalEntries']);
+    }
+}


### PR DESCRIPTION
orderStats.dailyTurnover double-counted cancelled orders — as an entry (on the in_transit transition) and as an exit (when cancelled was in finalStates). Add caller-supplied excludeStates + excludeMode so an order in an excluded state counts as neither entry nor exit.

- OrderStatsExcludeModeEnum: CURRENT (live, by current status) | IN_RANGE (only if the excluded transition falls inside the queried period)
- GetOrderStatsAction: turnoverExclusionCallback applied to both entries and exits in getDailyTurnover; empty excludeStates = unchanged behavior
- Schema: OrderStatsExcludeMode enum + excludeStates/excludeMode on OrderStatsInput; resolver wires them through
- Tests: OrderStatsExclusionTest covering baseline, CURRENT, and IN_RANGE in/out of window

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
