### PR TITLE
feat(events): cap slot generation to a booking horizon and top up daily

### DIFF
--- a/app/Console/Commands/Event/GenerateUpcomingTimeSlotsCommand.php
+++ b/app/Console/Commands/Event/GenerateUpcomingTimeSlotsCommand.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Event;
+
+use Baka\Traits\KanvasJobsTrait;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Apps\Models\Settings;
+use Kanvas\Event\Events\Enums\ConfigurationEnum;
+use Kanvas\Event\Events\Jobs\GenerateTimeSlots;
+use Kanvas\Event\Events\Models\ScheduleRules;
+use Kanvas\Event\Events\Models\TimeSlots;
+
+class GenerateUpcomingTimeSlotsCommand extends Command
+{
+    use KanvasJobsTrait;
+
+    protected $signature = 'kanvas:events:generate-upcoming-time-slots {app_id?} {--prune}';
+
+    protected $description = 'Roll the time-slot window forward for active schedule rules and refresh price snapshots within each app booking horizon';
+
+    public function handle(): int
+    {
+        $appsId = $this->argument('app_id');
+
+        if ($appsId) {
+            $this->processApp((int) $appsId);
+
+            return self::SUCCESS;
+        }
+
+        $appsIds = Settings::where([
+            'name' => ConfigurationEnum::GENERATE_UPCOMING_TIME_SLOTS->value,
+            'value' => '1',
+        ])->select('apps_id')->get()->pluck('apps_id');
+
+        $this->info('Generating upcoming time slots for ' . $appsIds->count() . ' apps');
+
+        foreach ($appsIds as $id) {
+            $this->processApp((int) $id);
+        }
+
+        return self::SUCCESS;
+    }
+
+    protected function processApp(int $appsId): void
+    {
+        /** @var Apps $app */
+        $app = Apps::getById($appsId);
+        $this->overwriteAppService($app);
+
+        $horizonDays = GenerateTimeSlots::horizonDaysForApp($app);
+        $dispatched = 0;
+
+        ScheduleRules::query()
+            ->notDeleted()
+            ->fromApp($app)
+            ->where(
+                fn ($q) => $q->whereNull('end_at')->orWhere('end_at', '>=', Carbon::now())
+            )
+            ->orderBy('id')
+            ->chunk(
+                100,
+                function ($rules) use (&$dispatched, $horizonDays) {
+                    foreach ($rules as $rule) {
+                        [$windowFrom, $windowTo] = GenerateTimeSlots::resolveWindow(
+                            $rule->start_at,
+                            $rule->end_at,
+                            $horizonDays
+                        );
+
+                        if ($windowFrom->greaterThanOrEqualTo($windowTo)) {
+                            continue;
+                        }
+
+                        dispatch(new GenerateTimeSlots(
+                            $rule->resources_id,
+                            $rule->id,
+                            $windowFrom,
+                            $windowTo
+                        ));
+                        $dispatched++;
+                    }
+                }
+            );
+
+        $this->info("App {$appsId}: dispatched {$dispatched} time slot generation jobs.");
+
+        if ($this->option('prune')) {
+            $pruned = $this->prunePastUnbookedSlots($app);
+            $this->info("App {$appsId}: pruned {$pruned} past unbooked time slots.");
+        }
+    }
+
+    /**
+     * Rule-generated slots that ended in the past and were never booked are dead weight;
+     * booked ones stay as history. Batched so a first run over a large table doesn't
+     * hold one giant delete transaction.
+     */
+    protected function prunePastUnbookedSlots(Apps $app): int
+    {
+        $pruned = 0;
+
+        do {
+            $deleted = TimeSlots::query()
+                ->fromApp($app)
+                ->whereNotNull('schedule_rules_id')
+                ->where('end_at', '<', Carbon::now())
+                ->whereDoesntHave(
+                    'eventVersions',
+                    fn ($q) => $q->where('is_deleted', 0)
+                )
+                ->limit(1000)
+                ->forceDelete();
+
+            $pruned += $deleted;
+        } while ($deleted > 0);
+
+        return $pruned;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -9,6 +9,7 @@ use App\Console\Commands\Connectors\Movipass\CheckExpiringOrdersCommand;
 use App\Console\Commands\Connectors\Notifications\MailCaddieLabCommand;
 use App\Console\Commands\Connectors\OpenClaw\CollectAgentTelemetryCommand;
 use App\Console\Commands\Ecosystem\Users\DeleteUsersRequestedCommand;
+use App\Console\Commands\Event\GenerateUpcomingTimeSlotsCommand;
 use App\Console\Commands\ImportPromptsFromDocsCommand;
 use App\Console\Commands\Lead\Schedules\LeadFollowUpSchedule;
 use App\Console\Commands\NervousSystem\Schedules\NervousSystemSchedule;
@@ -49,6 +50,10 @@ class Kernel extends ConsoleKernel
         $schedule->command(CheckExpiringOrdersCommand::class)->everyMinute();
         $schedule->command(ChargeLateOrdersCommand::class)->hourly()->withoutOverlapping();
         $schedule->command(CancelStalePaymentsCommand::class)->everyFiveMinutes();
+
+        // Event — roll the booking window forward daily so active schedule rules always
+        // have slots up to their app's horizon, and refresh price snapshots on unsold ones.
+        $schedule->command(GenerateUpcomingTimeSlotsCommand::class, ['--prune'])->dailyAt('01:30')->withoutOverlapping();
 
         // Acumatica — incremental delta sync for every opted-in company (gated per company).
         //$schedule->command(ScheduledAcumaticaSyncCommand::class)->hourly()->withoutOverlapping()->onOneServer();

--- a/app/GraphQL/Event/Mutations/ScheduleRules/ScheduleRulesManagementMutation.php
+++ b/app/GraphQL/Event/Mutations/ScheduleRules/ScheduleRulesManagementMutation.php
@@ -35,7 +35,11 @@ class ScheduleRulesManagementMutation
             'metadata' => $req['input']['metadata'] ?? null,
         ]);
 
-        [$windowFrom, $windowTo] = GenerateTimeSlots::resolveWindow($scheduleRule->start_at, $scheduleRule->end_at);
+        [$windowFrom, $windowTo] = GenerateTimeSlots::resolveWindow(
+            $scheduleRule->start_at,
+            $scheduleRule->end_at,
+            GenerateTimeSlots::horizonDaysForApp($app)
+        );
 
         dispatch(new GenerateTimeSlots(
             $entity->id,
@@ -71,7 +75,11 @@ class ScheduleRulesManagementMutation
             'metadata' => $req['input']['metadata'] ?? $scheduleRule->metadata,
         ]);
 
-        [$windowFrom, $windowTo] = GenerateTimeSlots::resolveWindow($scheduleRule->start_at, $scheduleRule->end_at);
+        [$windowFrom, $windowTo] = GenerateTimeSlots::resolveWindow(
+            $scheduleRule->start_at,
+            $scheduleRule->end_at,
+            GenerateTimeSlots::horizonDaysForApp($app)
+        );
 
         dispatch(new GenerateTimeSlots(
             $scheduleRule->resources_id,

--- a/src/Domains/Connectors/TeeTime/Workflows/Activities/ExpandProductSlotsActivity.php
+++ b/src/Domains/Connectors/TeeTime/Workflows/Activities/ExpandProductSlotsActivity.php
@@ -44,6 +44,7 @@ class ExpandProductSlotsActivity extends KanvasActivity implements WorkflowActiv
                         $capacityOverride = $params['capacity_override'] ?? null;
                         $leadTimeMin = $params['lead_time_min'] ?? 0;
                         $cutoffTimeMin = $params['cutoff_time_min'] ?? 0;
+                        $horizonDays = isset($params['booking_horizon_days']) ? (int) $params['booking_horizon_days'] : null;
 
                         if (! $variant) {
                             return [
@@ -65,7 +66,8 @@ class ExpandProductSlotsActivity extends KanvasActivity implements WorkflowActiv
                             slotDurationMinutes: $slotDurationMinutes,
                             capacityOverride: $capacityOverride,
                             leadTimeMin: $leadTimeMin,
-                            cutoffTimeMin: $cutoffTimeMin
+                            cutoffTimeMin: $cutoffTimeMin,
+                            horizonDays: $horizonDays
                         );
 
                         // Create schedule rules (existing rules are automatically cleared during execution)

--- a/src/Domains/Event/Events/Actions/CreateScheduleRulesFromOperationDaysAction.php
+++ b/src/Domains/Event/Events/Actions/CreateScheduleRulesFromOperationDaysAction.php
@@ -38,6 +38,7 @@ class CreateScheduleRulesFromOperationDaysAction
         protected bool $generateSlots = true,
         protected ?Carbon $startAt = null,
         protected ?Carbon $endAt = null,
+        protected ?int $horizonDays = null,
     ) {
     }
 
@@ -183,7 +184,11 @@ class CreateScheduleRulesFromOperationDaysAction
 
     protected function dispatchTimeSlotGeneration(ScheduleRules $scheduleRule): void
     {
-        [$windowFrom, $windowTo] = GenerateTimeSlots::resolveWindow($scheduleRule->start_at, $scheduleRule->end_at);
+        [$windowFrom, $windowTo] = GenerateTimeSlots::resolveWindow(
+            $scheduleRule->start_at,
+            $scheduleRule->end_at,
+            $this->horizonDays ?? GenerateTimeSlots::horizonDaysForApp($this->app)
+        );
 
         dispatch(new GenerateTimeSlots(
             $this->resource->getId(),

--- a/src/Domains/Event/Events/Enums/ConfigurationEnum.php
+++ b/src/Domains/Event/Events/Enums/ConfigurationEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Event\Events\Enums;
+
+enum ConfigurationEnum: string
+{
+    case BOOKING_HORIZON_DAYS = 'event_booking_horizon_days';
+    case GENERATE_UPCOMING_TIME_SLOTS = 'event_generate_upcoming_time_slots';
+}

--- a/src/Domains/Event/Events/Jobs/GenerateTimeSlots.php
+++ b/src/Domains/Event/Events/Jobs/GenerateTimeSlots.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Kanvas\Event\Events\Jobs;
 
+use Baka\Contracts\AppInterface;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Carbon;
+use Kanvas\Event\Events\Enums\ConfigurationEnum;
 use Kanvas\Event\Events\Models\ScheduleException;
 use Kanvas\Event\Events\Models\ScheduleRules;
 use Kanvas\Event\Events\Models\TimeSlots;
@@ -13,6 +15,8 @@ use RRule\RRule;
 
 class GenerateTimeSlots implements ShouldQueue
 {
+    public const DEFAULT_HORIZON_DAYS = 60;
+
     public function __construct(
         public int $resourceId,
         public int $ruleId,
@@ -22,20 +26,30 @@ class GenerateTimeSlots implements ShouldQueue
     }
 
     /**
-     * Resolve the [from, to] generation window for a rule: never backfill the past, and bound
-     * the upper end by end_at when set (otherwise a year out). Shared by both schedule mutations
-     * so they behave identically.
+     * Resolve the [from, to] generation window for a rule: never backfill the past, and cap
+     * the upper end at the booking horizon (never a year of mostly-unsold slots). The daily
+     * top-up command keeps rolling the window forward, so a short horizon doesn't starve
+     * long-lived rules — and re-upserting inside the horizon refreshes price snapshots.
+     * Shared by both schedule mutations so they behave identically.
      *
      * @return array{0: Carbon, 1: Carbon}
      */
-    public static function resolveWindow(?Carbon $startAt, ?Carbon $endAt): array
+    public static function resolveWindow(?Carbon $startAt, ?Carbon $endAt, ?int $horizonDays = null): array
     {
         $now = Carbon::now();
 
         $windowFrom = $startAt && $startAt->greaterThan($now) ? $startAt->clone() : $now;
-        $windowTo = $endAt?->clone() ?? $now->clone()->addYear();
+        $horizonEnd = $now->clone()->addDays($horizonDays ?? self::DEFAULT_HORIZON_DAYS);
+        $windowTo = $endAt && $endAt->lessThan($horizonEnd) ? $endAt->clone() : $horizonEnd;
 
         return [$windowFrom, $windowTo];
+    }
+
+    public static function horizonDaysForApp(AppInterface $app): int
+    {
+        $configured = (int) $app->get(ConfigurationEnum::BOOKING_HORIZON_DAYS->value);
+
+        return $configured > 0 ? $configured : self::DEFAULT_HORIZON_DAYS;
     }
 
     public function handle()
@@ -132,8 +146,10 @@ class GenerateTimeSlots implements ShouldQueue
             return;
         }
 
-        // Compute capacity & price
-        $capacity = $rule->capacity_override ?? $resource->default_capacity;
+        // Compute capacity & price. Variants have no default_capacity column, so a rule
+        // without capacity_override must still land on a non-null value — the column is
+        // NOT NULL and a null here fails the whole generation job.
+        $capacity = $rule->capacity_override ?? $resource->default_capacity ?? 1;
         $price = $resource?->getPriceInfoFromDefaultChannel()?->price;
 
         TimeSlots::upsert([[

--- a/src/Domains/Event/Events/Jobs/GenerateTimeSlots.php
+++ b/src/Domains/Event/Events/Jobs/GenerateTimeSlots.php
@@ -34,8 +34,11 @@ class GenerateTimeSlots implements ShouldQueue
      *
      * @return array{0: Carbon, 1: Carbon}
      */
-    public static function resolveWindow(?Carbon $startAt, ?Carbon $endAt, ?int $horizonDays = null): array
-    {
+    public static function resolveWindow(
+        ?Carbon $startAt,
+        ?Carbon $endAt,
+        ?int $horizonDays = null,
+    ): array {
         $now = Carbon::now();
 
         $windowFrom = $startAt && $startAt->greaterThan($now) ? $startAt->clone() : $now;
@@ -58,22 +61,18 @@ class GenerateTimeSlots implements ShouldQueue
         $resource   = $rule->resource;
         $tz         = $resource->tz ?? $resource->company->timezone  ?? "America/Santo_Domingo";
 
-        // 1) Expand RRULE in venue TZ to get the days
         $rrule = RRule::createFromRfcString($rule->rrule, $rule->start_at->setTimezone($tz));
         if ($rule->end_at) {
             $rrule->getOccurrencesBefore($rule->end_at->setTimezone($tz));
         }
         $occurrences = $rrule->getOccurrencesBetween($this->windowFrom->clone()->tz($tz), $this->windowTo->clone()->tz($tz));
 
-        // 2) For each day occurrence, generate time slots based on day_rrule
         foreach ($occurrences as $dayOccurrence) {
             $dayOccurrence = Carbon::instance($dayOccurrence);
 
-            // If day_rrule exists, use it to generate slots within this day
             if ($rule->day_rrule) {
                 $this->generateSlotsForDayWithRRule($rule, $resource, $dayOccurrence, $tz);
             } else {
-                // Fallback to old behavior: single slot per occurrence
                 $localStart = $dayOccurrence;
                 $localEnd = $localStart->copy()->addMinutes($rule->slot_duration_min);
 
@@ -82,9 +81,6 @@ class GenerateTimeSlots implements ShouldQueue
         }
     }
 
-    /**
-     * Generate time slots for a specific day using day_rrule.
-     */
     protected function generateSlotsForDayWithRRule(
         ScheduleRules $rule,
         $resource,
@@ -107,7 +103,6 @@ class GenerateTimeSlots implements ShouldQueue
             ? $base->copy()->setTime((int) $um[2], (int) $um[3], (int) $um[4])
             : $base->copy()->endOfDay();
 
-        // Slot cadence comes from INTERVAL, falling back to the slot length.
         preg_match('/INTERVAL=(\d+)/', $rule->day_rrule, $im);
         $stepMinutes = isset($im[1]) ? max(1, (int) $im[1]) : max(1, $rule->slot_duration_min);
 
@@ -131,9 +126,6 @@ class GenerateTimeSlots implements ShouldQueue
         }
     }
 
-    /**
-     * Create a single time slot.
-     */
     protected function createTimeSlot(
         ScheduleRules $rule,
         $resource,
@@ -141,14 +133,13 @@ class GenerateTimeSlots implements ShouldQueue
         Carbon $localEnd,
         string $tz
     ): void {
-        // Skip if blacked out
         if ($this->isBlackedOut($resource->id, $localStart, $localEnd, $tz)) {
             return;
         }
 
-        // Compute capacity & price. Variants have no default_capacity column, so a rule
-        // without capacity_override must still land on a non-null value — the column is
-        // NOT NULL and a null here fails the whole generation job.
+        // Variants have no default_capacity column, so a rule without capacity_override must
+        // still land on a non-null value — the column is NOT NULL and a null here fails the
+        // whole generation job.
         $capacity = $rule->capacity_override ?? $resource->default_capacity ?? 1;
         $price = $resource?->getPriceInfoFromDefaultChannel()?->price;
 

--- a/tests/Event/Integration/GenerateTimeSlotsJobTest.php
+++ b/tests/Event/Integration/GenerateTimeSlotsJobTest.php
@@ -308,6 +308,48 @@ class GenerateTimeSlotsJobTest extends TestCase
         }
     }
 
+    public function testGenerateTimeSlotsDefaultsCapacityWhenRuleHasNoOverride(): void
+    {
+        $startDate = Carbon::now()->addDay()->setTime(8, 0, 0);
+        $endDate = $startDate->copy()->endOfDay();
+        $dayCode = strtoupper(substr($startDate->format('D'), 0, 2));
+        $dtstart = $startDate->format('Ymd\THis');
+
+        // Mirrors what CreateScheduleRulesFromOperationDaysAction produces for a rule
+        // with no capacity_override — the variant has no default_capacity column, so
+        // the job must fall back instead of inserting a null capacity.
+        $scheduleRule = ScheduleRules::create([
+            'apps_id' => $this->apps->getId(),
+            'companies_id' => $this->company->getId(),
+            'resources_id' => $this->variantId,
+            'resources_type' => 'Kanvas\Inventory\Variants\Models\Variants',
+            'start_at' => $startDate,
+            'end_at' => $endDate,
+            'rrule' => "DTSTART:{$dtstart}\nRRULE:FREQ=WEEKLY;BYDAY={$dayCode}",
+            'day_rrule' => "DTSTART:{$dtstart}\nRRULE:FREQ=MINUTELY;INTERVAL=15;BYHOUR=8,9;BYMINUTE=0,15,30,45",
+            'slot_duration_min' => 15,
+            'lead_time_min' => 0,
+            'cutoff_time_min' => 0,
+            'capacity_override' => null,
+        ]);
+
+        $job = new GenerateTimeSlots(
+            $this->variantId,
+            $scheduleRule->id,
+            $startDate,
+            $endDate
+        );
+        $job->handle();
+
+        $slots = TimeSlots::where('schedule_rules_id', $scheduleRule->id)->get();
+
+        $this->assertGreaterThan(0, $slots->count());
+
+        foreach ($slots as $slot) {
+            $this->assertEquals(1, $slot->initial_capacity);
+        }
+    }
+
     public function testGenerateTimeSlotsWithMultipleHourSlots(): void
     {
         $startDate = Carbon::now()->addDay()->setTime(9, 0, 0);

--- a/tests/Event/Integration/GenerateUpcomingTimeSlotsCommandTest.php
+++ b/tests/Event/Integration/GenerateUpcomingTimeSlotsCommandTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Event\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Bus;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Event\Events\Enums\ConfigurationEnum;
+use Kanvas\Event\Events\Jobs\GenerateTimeSlots;
+use Kanvas\Event\Events\Models\ScheduleRules;
+use Kanvas\Event\Events\Models\TimeSlots;
+use Tests\TestCase;
+
+class GenerateUpcomingTimeSlotsCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected Apps $apps;
+    protected $company;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->apps = app(Apps::class);
+        $this->company = auth()->user()->getCurrentCompany();
+    }
+
+    public function tearDown(): void
+    {
+        Carbon::setTestNow();
+        // Settings are cached outside the test transaction; leaving these set leaks a
+        // shortened horizon / an opted-in app into every other test in the shared DB.
+        $this->apps->del(ConfigurationEnum::BOOKING_HORIZON_DAYS->value);
+        $this->apps->del(ConfigurationEnum::GENERATE_UPCOMING_TIME_SLOTS->value);
+
+        parent::tearDown();
+    }
+
+    public function testResolveWindowCapsAtDefaultHorizon(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-07-16 10:00:00'));
+
+        [$windowFrom, $windowTo] = GenerateTimeSlots::resolveWindow(null, null);
+
+        $this->assertTrue($windowFrom->equalTo(Carbon::now()));
+        $this->assertTrue(
+            $windowTo->equalTo(Carbon::now()->addDays(GenerateTimeSlots::DEFAULT_HORIZON_DAYS))
+        );
+    }
+
+    public function testResolveWindowUsesEndAtWhenSoonerThanHorizon(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-07-16 10:00:00'));
+
+        $endAt = Carbon::now()->addDays(5);
+
+        [, $windowTo] = GenerateTimeSlots::resolveWindow(null, $endAt);
+
+        $this->assertTrue($windowTo->equalTo($endAt));
+    }
+
+    public function testResolveWindowCapsEndAtBeyondHorizon(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-07-16 10:00:00'));
+
+        $endAt = Carbon::now()->addYears(3);
+
+        [, $windowTo] = GenerateTimeSlots::resolveWindow(null, $endAt, 30);
+
+        $this->assertTrue($windowTo->equalTo(Carbon::now()->addDays(30)));
+    }
+
+    public function testHorizonDaysForAppReadsAppSetting(): void
+    {
+        $this->apps->set(ConfigurationEnum::BOOKING_HORIZON_DAYS->value, 14);
+
+        $this->assertEquals(14, GenerateTimeSlots::horizonDaysForApp($this->apps));
+
+        $this->apps->set(ConfigurationEnum::BOOKING_HORIZON_DAYS->value, 0);
+
+        $this->assertEquals(
+            GenerateTimeSlots::DEFAULT_HORIZON_DAYS,
+            GenerateTimeSlots::horizonDaysForApp($this->apps)
+        );
+    }
+
+    public function testCommandDispatchesForActiveRulesAndSkipsExpired(): void
+    {
+        Bus::fake([GenerateTimeSlots::class]);
+
+        $activeRule = $this->createScheduleRule(['end_at' => null]);
+        $expiredRule = $this->createScheduleRule(['end_at' => Carbon::now()->subDay()]);
+
+        $this->artisan('kanvas:events:generate-upcoming-time-slots', [
+            'app_id' => $this->apps->getId(),
+        ])->assertExitCode(0);
+
+        Bus::assertDispatched(
+            GenerateTimeSlots::class,
+            fn (GenerateTimeSlots $job) => $job->ruleId === $activeRule->id
+        );
+
+        Bus::assertNotDispatched(
+            GenerateTimeSlots::class,
+            fn (GenerateTimeSlots $job) => $job->ruleId === $expiredRule->id
+        );
+    }
+
+    public function testCommandWindowRespectsAppHorizonSetting(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-07-16 10:00:00'));
+        Bus::fake([GenerateTimeSlots::class]);
+
+        $this->apps->set(ConfigurationEnum::BOOKING_HORIZON_DAYS->value, 10);
+
+        $rule = $this->createScheduleRule(['end_at' => null]);
+
+        $this->artisan('kanvas:events:generate-upcoming-time-slots', [
+            'app_id' => $this->apps->getId(),
+        ])->assertExitCode(0);
+
+        Bus::assertDispatched(
+            GenerateTimeSlots::class,
+            fn (GenerateTimeSlots $job) => $job->ruleId === $rule->id
+                && $job->windowTo->equalTo(Carbon::now()->addDays(10))
+        );
+    }
+
+    public function testCommandWithoutAppIdOnlyRunsOptedInApps(): void
+    {
+        Bus::fake([GenerateTimeSlots::class]);
+
+        $rule = $this->createScheduleRule(['end_at' => null]);
+
+        $this->artisan('kanvas:events:generate-upcoming-time-slots')->assertExitCode(0);
+
+        Bus::assertNotDispatched(
+            GenerateTimeSlots::class,
+            fn (GenerateTimeSlots $job) => $job->ruleId === $rule->id
+        );
+
+        $this->apps->set(ConfigurationEnum::GENERATE_UPCOMING_TIME_SLOTS->value, '1');
+
+        $this->artisan('kanvas:events:generate-upcoming-time-slots')->assertExitCode(0);
+
+        Bus::assertDispatched(
+            GenerateTimeSlots::class,
+            fn (GenerateTimeSlots $job) => $job->ruleId === $rule->id
+        );
+    }
+
+    public function testPruneDeletesPastUnbookedSlotsAndKeepsFutureOnes(): void
+    {
+        Bus::fake([GenerateTimeSlots::class]);
+
+        $rule = $this->createScheduleRule(['end_at' => null]);
+
+        $pastSlot = $this->createTimeSlot($rule, Carbon::now()->subDays(2));
+        $futureSlot = $this->createTimeSlot($rule, Carbon::now()->addDays(2));
+
+        $this->artisan('kanvas:events:generate-upcoming-time-slots', [
+            'app_id' => $this->apps->getId(),
+            '--prune' => true,
+        ])->assertExitCode(0);
+
+        $this->assertDatabaseMissing('time_slots', ['id' => $pastSlot->id], 'event');
+        $this->assertDatabaseHas('time_slots', ['id' => $futureSlot->id], 'event');
+    }
+
+    protected function createScheduleRule(array $overrides = []): ScheduleRules
+    {
+        return ScheduleRules::create(array_merge([
+            'apps_id' => $this->apps->getId(),
+            'companies_id' => $this->company->getId(),
+            'resources_id' => 999999,
+            'resources_type' => 'Kanvas\Inventory\Variants\Models\Variants',
+            'start_at' => Carbon::now()->subDay(),
+            'end_at' => null,
+            'rrule' => 'RRULE:FREQ=DAILY',
+            'slot_duration_min' => 15,
+            'lead_time_min' => 0,
+            'cutoff_time_min' => 0,
+            'capacity_override' => 4,
+        ], $overrides));
+    }
+
+    protected function createTimeSlot(ScheduleRules $rule, Carbon $startAt): TimeSlots
+    {
+        return TimeSlots::create([
+            'apps_id' => $this->apps->getId(),
+            'companies_id' => $this->company->getId(),
+            'resources_id' => $rule->resources_id,
+            'resources_type' => $rule->resources_type,
+            'schedule_rules_id' => $rule->id,
+            'start_at' => $startAt,
+            'end_at' => $startAt->clone()->addMinutes(15),
+            'initial_capacity' => 4,
+        ]);
+    }
+}


### PR DESCRIPTION
- resolveWindow now caps windowTo at a configurable booking horizon (event_booking_horizon_days app setting, default 60d) instead of generating a full year of mostly-unsold slots
- new kanvas:events:generate-upcoming-time-slots command (opt-in per app via event_generate_upcoming_time_slots setting) rolls the window forward daily, refreshes price snapshots and prunes past unbooked slots
- TeeTime ExpandProductSlotsActivity accepts booking_horizon_days param
- fix: default time slot capacity to 1 when the rule has no capacity_override and the resource has no default_capacity (variants do not have that column, insert failed with initial_capacity null)

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
