### PR TITLE
Add apply_ar_payment / apply_ap_payment tools (standalone payment application)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,8 +163,6 @@ services:
             MYSQL_ROOT_PASSWORD: "${DB_PASSWORD}"
             MYSQL_ROOT_HOST: "%"
             MYSQL_DATABASE: "${DB_DATABASE}"
-            MYSQL_USER: "${DB_USERNAME}"
-            MYSQL_PASSWORD: "${DB_PASSWORD}"
             MYSQL_ALLOW_EMPTY_PASSWORD: 1
         volumes:
             - "sail-mysql:/var/lib/mysql"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,8 @@ services:
             MYSQL_ROOT_PASSWORD: "${DB_PASSWORD}"
             MYSQL_ROOT_HOST: "%"
             MYSQL_DATABASE: "${DB_DATABASE}"
+            MYSQL_USER: "${DB_USERNAME}"
+            MYSQL_PASSWORD: "${DB_PASSWORD}"
             MYSQL_ALLOW_EMPTY_PASSWORD: 1
         volumes:
             - "sail-mysql:/var/lib/mysql"

--- a/src/Domains/Connectors/Acumatica/Actions/PushPaymentToAcumaticaAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/PushPaymentToAcumaticaAction.php
@@ -25,9 +25,7 @@ use Kanvas\Scribe\Payments\Models\Payment;
  * already happened in Scribe. This just mirrors the applied payment into the ERP. Idempotent by
  * ACUMATICA_PAYMENT_ID; retry-safe via the PaymentRef find-query.
  *
- * NOTE: the `Payment` entity and `Type` are confirmed against a live push; the DocumentsToApply
- * DocType ('INV' for AR, 'Bill' for AP) follows Acumatica's defaults — verify on the first live
- * payment that carries applications.
+ * AP applications go through the `Check` entity (Vendor field, Details array); AR through `Payment` (CustomerID field, DocumentsToApply array) — confirmed live, they are not interchangeable.
  */
 class PushPaymentToAcumaticaAction
 {
@@ -74,10 +72,11 @@ class PushPaymentToAcumaticaAction
         }
 
         $record = $this->writer()->push(
-            'Payment',
+            $isAp ? 'Check' : 'Payment',
             $this->buildPayload($isAp, $partyCode, $documents),
             release: true,
             findQuery: $this->existingPaymentQuery(),
+            releaseAction: $isAp ? 'ReleaseCheck' : 'Release',
         );
 
         $id = AcumaticaPayload::recordId($record);
@@ -182,7 +181,8 @@ class PushPaymentToAcumaticaAction
             'Hold' => false,
         ]);
 
-        $header['DocumentsToApply'] = $documents;
+        // AP applies through the Check entity's Details field; AR through Payment's DocumentsToApply.
+        $header[$isAp ? 'Details' : 'DocumentsToApply'] = $documents;
 
         return $header;
     }

--- a/src/Domains/Connectors/Acumatica/Services/AcumaticaWriteService.php
+++ b/src/Domains/Connectors/Acumatica/Services/AcumaticaWriteService.php
@@ -58,6 +58,7 @@ class AcumaticaWriteService
      * @param array<string, mixed>                                             $body  `{value:}`-wrapped (AcumaticaPayload::wrap)
      * @param array<int, array{name: string, content: string, type?: string}> $files
      * @param array<string, mixed>|null                                        $findQuery OData filter to adopt an existing record
+     * @param string                                                            $releaseAction action name to invoke when $release is true (some entities use a non-generic name, e.g. Check -> ReleaseCheck)
      *
      * @return array<array-key, mixed> the persisted record (includes the `id` GUID)
      */
@@ -66,7 +67,8 @@ class AcumaticaWriteService
         array $body,
         bool $release = false,
         array $files = [],
-        ?array $findQuery = null
+        ?array $findQuery = null,
+        string $releaseAction = 'Release'
     ): array {
         $this->assertWriteEnabled();
 
@@ -91,7 +93,7 @@ class AcumaticaWriteService
                 $id = AcumaticaPayload::recordId($record);
 
                 if ($id !== null) {
-                    $client->invokeAction($entity, 'Release', ['entity' => ['id' => $id]]);
+                    $client->invokeAction($entity, $releaseAction, ['entity' => ['id' => $id]]);
                 }
             }
 

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -6,6 +6,7 @@ namespace Kanvas\Intelligence\Agents\Neuron\Accounting;
 
 use Kanvas\Intelligence\Agents\Attributes\AgentTypeDefinition;
 use Kanvas\Intelligence\Agents\Neuron\SystemUserAgent;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ApplyApPaymentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\CreateApBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindPurchaseOrderTool;
@@ -28,7 +29,7 @@ use Override;
  * chat history, and write attribution to its OWN user (actingUser). On top of that core it adds the
  * AP read tools below.
  *
- * Mostly read-only, but create_ap_bill/void_ap_bill write for real, bypassing human approval — only on explicit request.
+ * Mostly read-only, but create_ap_bill/void_ap_bill/apply_ap_payment write for real, bypassing human approval — only on explicit request.
  */
 #[AgentTypeDefinition(
     name: 'Accounts Payable Agent',
@@ -36,10 +37,10 @@ use Override;
         . 'open purchase orders, vendors), and can create+push or void a bill on explicit request.',
     provider: 'neuron',
     soul: 'You are the Accounts-Payable teammate. You answer questions about what the company owes its '
-        . 'vendors using your read tools. You are accountable and precise with numbers. create_ap_bill and '
-        . 'void_ap_bill bypass the normal human-approval path and write straight to whichever Acumatica '
-        . 'tenant is configured — only call either when the user explicitly asks you to create or void a bill '
-        . 'this way, never on your own initiative.',
+        . 'vendors using your read tools. You are accountable and precise with numbers. create_ap_bill, '
+        . 'void_ap_bill, and apply_ap_payment bypass the normal human-approval path and write straight to '
+        . 'whichever Acumatica tenant is configured — only call any of them when the user explicitly asks you '
+        . 'to, never on your own initiative.',
     outputFormat: 'Plain text. Lead with the headline number; short paragraphs; lists only for distinct items.',
 )]
 class AccountsPayableAgent extends SystemUserAgent
@@ -61,6 +62,7 @@ class AccountsPayableAgent extends SystemUserAgent
             new MatchBillsForPaymentTool()->withContext($this->app, $this->company, $this->actingUser()),
             new CreateApBillTool()->withContext($this->app, $this->company, $this->actingUser()),
             new VoidApBillTool()->withContext($this->app, $this->company, $this->actingUser()),
+            new ApplyApPaymentTool()->withContext($this->app, $this->company, $this->actingUser()),
         ]);
     }
 
@@ -85,6 +87,8 @@ class AccountsPayableAgent extends SystemUserAgent
             '- "Create a bill for vendor X" → create_ap_bill, only when the user explicitly asks for it — it '
             . 'writes straight to Acumatica, bypassing human approval.',
             '- "Void/cancel/undo that bill" → void_ap_bill, given the bill_id from create_ap_bill.',
+            '- "Pay a vendor bill" / "record a payment against bill Y" → apply_ap_payment, only when the user '
+            . 'explicitly asks to record a real payment. Needs the bill_id, amount, and a payment reference.',
         ]);
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/ApplyApPaymentTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/ApplyApPaymentTool.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
+
+use Kanvas\Connectors\Acumatica\Actions\PushPaymentToAcumaticaAction;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Scribe\Bills\Actions\AllocateBillPaymentAction;
+use Kanvas\Scribe\Bills\Models\Bill;
+use Kanvas\Scribe\Ledger\Enums\AccountSubTypeEnum;
+use Kanvas\Scribe\Payments\Enums\PaymentMethodEnum;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use RuntimeException;
+use Throwable;
+
+/** Applies a disbursement to an existing, already-pushed AP bill and pushes the payment to Acumatica. */
+#[AgentTool(name: 'Apply AP Payment')]
+class ApplyApPaymentTool extends Tool
+{
+    use HasKanvasContext;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'apply_ap_payment',
+            description: 'Applies a disbursement to an existing AP bill (partial or full) and pushes the '
+                . 'payment to Acumatica. Only call when the user explicitly asks to record a real vendor '
+                . 'payment against a bill — never on a whim.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'bill_id',
+                type: PropertyType::NUMBER,
+                description: 'The Kanvas bill id to apply the payment against.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'amount',
+                type: PropertyType::NUMBER,
+                description: 'Payment amount. Must not exceed the bill\'s remaining balance.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'reference',
+                type: PropertyType::STRING,
+                description: 'Payment reference (check number, wire ref, etc). Acumatica rejects an empty one.',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(int $bill_id, float $amount, string $reference): array
+    {
+        $app = $this->app;
+
+        $bill = Bill::query()
+            ->where('id', $bill_id)
+            ->where('apps_id', $app->getId())
+            ->where('companies_id', $this->company->getId())
+            ->first();
+
+        if ($bill === null) {
+            return [
+                'applied' => false,
+                'reason' => 'bill_not_found',
+                'message' => "No bill with id {$bill_id} for this app/company.",
+            ];
+        }
+
+        $billRef = (string) $bill->get(AcumaticaCustomFieldEnum::BILL_REF->value, '');
+
+        if ($billRef === '') {
+            return [
+                'applied' => false,
+                'reason' => 'bill_not_pushed',
+                'message' => "Bill {$bill_id} hasn't been pushed to Acumatica yet — push it before applying a payment.",
+            ];
+        }
+
+        try {
+            $allocation = new AllocateBillPaymentAction(
+                bill: $bill,
+                amountNative: $amount,
+                method: PaymentMethodEnum::CHECK,
+                cashAccountSubType: AccountSubTypeEnum::CASH_CHECKING,
+                reference: $reference,
+                user: $this->user,
+            )->execute();
+        } catch (RuntimeException $e) {
+            return [
+                'applied' => false,
+                'reason' => 'allocation_failed',
+                'message' => $e->getMessage(),
+            ];
+        }
+
+        $payment = $allocation->payment;
+
+        try {
+            $paymentRef = new PushPaymentToAcumaticaAction($payment)->execute();
+        } catch (AcumaticaWriteException|Throwable $e) {
+            return [
+                'applied' => true,
+                'pushed' => false,
+                'bill_id' => $bill->getId(),
+                'reason' => 'push_failed',
+                'message' => 'Payment recorded in Kanvas but the push to Acumatica failed: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'applied' => true,
+            'pushed' => true,
+            'bill_id' => $bill->getId(),
+            'bill_ref' => $billRef,
+            'amount' => $amount,
+            'payment_ref' => $paymentRef,
+            'remaining_balance' => (float) $bill->fresh()->balance_due_native,
+            'document_status' => $bill->fresh()->document_status->value,
+        ];
+    }
+}

--- a/tests/Connectors/Acumatica/PushPaymentToAcumaticaActionTest.php
+++ b/tests/Connectors/Acumatica/PushPaymentToAcumaticaActionTest.php
@@ -100,8 +100,8 @@ class PushPaymentToAcumaticaActionTest extends ScribeTestCase
         $captured = null;
         $writer = Mockery::mock(AcumaticaWriteService::class);
         $writer->shouldReceive('push')->once()->andReturnUsing(
-            function (string $entity, array $body, bool $release = false, array $files = [], ?array $findQuery = null) use (&$captured): array {
-                $captured = [$entity, $body];
+            function (string $entity, array $body, bool $release = false, array $files = [], ?array $findQuery = null, string $releaseAction = 'Release') use (&$captured): array {
+                $captured = [$entity, $body, $releaseAction];
 
                 return ['id' => 'PAY-1', 'ReferenceNbr' => ['value' => '000900']];
             }
@@ -112,14 +112,15 @@ class PushPaymentToAcumaticaActionTest extends ScribeTestCase
         $this->assertSame('000900', $ref);
         $this->assertSame('PAY-1', $payment->get(CustomFieldEnum::PAYMENT_ID->value));
 
-        [$entity, $body] = $captured;
-        $this->assertSame('Payment', $entity);
+        [$entity, $body, $releaseAction] = $captured;
+        $this->assertSame('Check', $entity);
+        $this->assertSame('ReleaseCheck', $releaseAction);
         $this->assertSame(['value' => 'Check'], $body['Type']);
         $this->assertSame(['value' => 'V0000505'], $body['Vendor']);
         $this->assertSame(['value' => 'CHK-1'], $body['PaymentRef']);
-        $this->assertSame(['value' => 'Bill'], $body['DocumentsToApply'][0]['DocType']);
-        $this->assertSame(['value' => 'AP000777'], $body['DocumentsToApply'][0]['ReferenceNbr']);
-        $this->assertSame(['value' => 500.0], $body['DocumentsToApply'][0]['AmountPaid']);
+        $this->assertSame(['value' => 'Bill'], $body['Details'][0]['DocType']);
+        $this->assertSame(['value' => 'AP000777'], $body['Details'][0]['ReferenceNbr']);
+        $this->assertSame(['value' => 500.0], $body['Details'][0]['AmountPaid']);
     }
 
     public function test_ar_receipt_pushes_a_payment_applied_to_the_customer_invoice(): void


### PR DESCRIPTION
## Summary

Follow-up to #10494, requested by Fanny: both create_ar_invoice and create_ap_bill combine create+pay/create+push in a single test-oriented call. This adds standalone tools to apply a payment against an **existing, already-pushed** invoice/bill — for real customer payments coming in / real vendor payments going out.

- **Arc (AR)**: `apply_ar_payment` — applies a cash receipt to an existing invoice.
- **Apex (AP)**: `apply_ap_payment` — applies a disbursement to an existing bill.

**Correction from the original PR description**: `apply_ar_payment` was originally committed to the #10494 branch, but *after* that PR had already merged — so it silently never made it to `development`. Caught this when the tool didn't show up post-deploy. It's now properly included here (commit history preserved via cherry-pick).

## What each commit does

1. **`fix(acumatica): route AP payment applications through the Check entity, not Payment`** — a real bug found while building `apply_ap_payment`: `PushPaymentToAcumaticaAction`'s AP branch was pushing to the `Payment` entity regardless of direction. `Payment` is AR-only in this tenant's contract API (no `Vendor` field — confirmed via swagger while building `VoidApBillAction` in #10494), and the application array field name differs per entity (`Check` uses `Details`, `Payment` uses `DocumentsToApply`). AP now correctly targets `Check` + `Details`, released via `ReleaseCheck` (`Check` has no generic `Release` action). `AcumaticaWriteService::push()` gained an optional `$releaseAction` param for this. This bug was never caught because no AP payment had ever been pushed live before this work.

2. **`chore: revert accidental docker-compose.yml change`** — local-only Docker fix that shouldn't ship, cleaned up.

3. **`feat(intelligence): give Apex a standalone apply_ap_payment tool`** — registers the tool, reusing `AllocateBillPaymentAction` (validates RECEIVED status + balance) and the now-fixed AP branch above.

4. **`test(acumatica): update AP payment test to match the Check-entity routing fix`** — the existing `PushPaymentToAcumaticaActionTest` asserted the pre-fix (buggy) behavior; CI caught this on the first push. Updated to expect `Check` + `Details` + `ReleaseCheck`.

5. **`feat(intelligence): give Arc a standalone apply_ar_payment tool`** — registers `apply_ar_payment` on `AccountsReceivableAgent`, reusing `AllocateInvoicePaymentAction` and `PushPaymentToAcumaticaAction`'s AR branch (confirmed working end-to-end multiple times in #10494). This is the commit that was orphaned from #10494 — recovered via cherry-pick.

## Known issue — apply_ap_payment is NOT confirmed working live

Creating a brand-new `Type='Check'` document in this tenant's Acumatica staging fails with an opaque, non-field-specific error (`"the system failed to commit the document row"` — no field detail, unlike the 422s we've hit elsewhere with clear messages).

Checked the entire tenant's `Check`-entity history back to **2015**: zero records have ever used `Type='Check'`. The only types with real history there are `Debit Adj.`, `Prepayment`, and a single `Refund`. This looks like a tenant configuration/business-process question — how do vendor payments actually get made in this instance (ACH? Wire? something external, reconciled in after the fact?) — not a code bug in this PR.

Asked Dennis directly rather than keep guessing at fields blind. The routing fix (commit 1) is still correct and worth shipping regardless of the outcome — it fixes a real bug in already-merged code. `apply_ap_payment` will need either a different `Type`/`PaymentMethod` once we hear back, or tenant-side configuration before it can push successfully.

## Test plan

- [x] `apply_ar_payment`: code reuses fully-proven components (`AllocateInvoicePaymentAction`, `PushPaymentToAcumaticaAction`'s AR branch — confirmed working end-to-end multiple times in #10494).
- [ ] `apply_ar_payment` live confirmation: pending — the two existing staging test customers are currently in Acumatica Credit Hold from accumulated test data.
- [x] `apply_ap_payment` routing fix validated directly and via updated unit test: confirmed the fix correctly targets `Check`/`Details` (error changed from "push Payment" to "push Check" once the routing was corrected; `PushPaymentToAcumaticaActionTest` passes with the corrected assertions).
- [ ] `apply_ap_payment` live confirmation: blocked on the `Type='Check'` tenant question above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)