### PR TITLE
Add apply_ar_payment tool + move Acumatica write tools into their own namespace

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -6,8 +6,6 @@ namespace Kanvas\Intelligence\Agents\Neuron\Accounting;
 
 use Kanvas\Intelligence\Agents\Attributes\AgentTypeDefinition;
 use Kanvas\Intelligence\Agents\Neuron\SystemUserAgent;
-use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ApplyApPaymentTool;
-use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\CreateApBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindPurchaseOrderTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindVendorTool;
@@ -16,7 +14,9 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ListOpenPurchaseOrdersToo
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\MatchBillsForPaymentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryApAgingTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryDataFreshnessTool;
-use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\VoidApBillTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\ApplyApPaymentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateApBillTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidApBillTool;
 use Override;
 
 /**

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -6,8 +6,6 @@ namespace Kanvas\Intelligence\Agents\Neuron\Accounting;
 
 use Kanvas\Intelligence\Agents\Attributes\AgentTypeDefinition;
 use Kanvas\Intelligence\Agents\Neuron\SystemUserAgent;
-use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ApplyArPaymentTool;
-use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\CreateArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindCustomerTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ListOverdueInvoicesTool;
@@ -15,7 +13,9 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\MatchInvoicesForPaymentTo
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryArAgingTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryDataFreshnessTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\TopLatePayersTool;
-use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\VoidArInvoiceTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\ApplyArPaymentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArInvoiceTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Sales\CreateSampleOrderTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Sales\FindProductTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Sales\FindSalesOrderTool;

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -6,6 +6,7 @@ namespace Kanvas\Intelligence\Agents\Neuron\Accounting;
 
 use Kanvas\Intelligence\Agents\Attributes\AgentTypeDefinition;
 use Kanvas\Intelligence\Agents\Neuron\SystemUserAgent;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ApplyArPaymentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\CreateArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindCustomerTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindInvoiceTool;
@@ -30,7 +31,7 @@ use Override;
  * order #X" over receivables (Scribe invoices) + customer orders (Souk).
  *
  * Extends SystemUserAgent (internal teammate: it IS a Kanvas user, has identity + ledger memory).
- * Mostly read-only, but create_ar_invoice/void_ar_invoice write for real, bypassing human approval — only on explicit request.
+ * Mostly read-only, but create_ar_invoice/void_ar_invoice/apply_ar_payment write for real, bypassing human approval — only on explicit request.
  *
  * Scope split (deliberate): this agent owns SALES orders (customer orders) + receivables; the AP
  * agent owns PURCHASE orders + payables. A sales order is a CUSTOMER order (revenue side), never an
@@ -42,9 +43,9 @@ use Override;
         . '(Souk) + invoices, and can create+push or void an invoice+cash receipt on explicit request.',
     provider: 'neuron',
     soul: 'You are the Accounts-Receivable teammate. You answer questions about money customers owe us and about '
-        . 'customer sales orders, using your read tools. You are precise with numbers. create_ar_invoice and '
-        . 'void_ar_invoice write straight to whichever Acumatica tenant is configured — only call either when '
-        . 'the user explicitly asks you to create or void an invoice this way, never on your own initiative.',
+        . 'customer sales orders, using your read tools. You are precise with numbers. create_ar_invoice, '
+        . 'void_ar_invoice, and apply_ar_payment write straight to whichever Acumatica tenant is configured — '
+        . 'only call any of them when the user explicitly asks you to, never on your own initiative.',
     outputFormat: 'Plain text. Lead with the headline number; short paragraphs; lists only for distinct items.',
 )]
 class AccountsReceivableAgent extends SystemUserAgent
@@ -72,6 +73,7 @@ class AccountsReceivableAgent extends SystemUserAgent
             new MatchInvoicesForPaymentTool()->withContext($this->app, $this->company, $this->actingUser()),
             new CreateArInvoiceTool()->withContext($this->app, $this->company, $this->actingUser()),
             new VoidArInvoiceTool()->withContext($this->app, $this->company, $this->actingUser()),
+            new ApplyArPaymentTool()->withContext($this->app, $this->company, $this->actingUser()),
         ]);
     }
 
@@ -97,6 +99,8 @@ class AccountsReceivableAgent extends SystemUserAgent
             '- "Create an invoice for customer X" → create_ar_invoice, only when the user explicitly asks for it '
             . '— it writes straight to Acumatica, bypassing human approval.',
             '- "Void/cancel/undo that invoice" → void_ar_invoice, given the invoice_id from create_ar_invoice.',
+            '- "Record a payment from customer X against invoice Y" → apply_ar_payment, only when the user '
+            . 'explicitly asks to record a real payment. Needs the invoice_id, amount, and a payment reference.',
             '- Lead with the headline, then the top 3-5 items. Be honest about freshness.',
         ]);
     }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/ApplyArPaymentTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/ApplyArPaymentTool.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
+
+use Kanvas\Connectors\Acumatica\Actions\PushPaymentToAcumaticaAction;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Scribe\Invoices\Actions\AllocateInvoicePaymentAction;
+use Kanvas\Scribe\Invoices\Models\Invoice;
+use Kanvas\Scribe\Ledger\Enums\AccountSubTypeEnum;
+use Kanvas\Scribe\Payments\Enums\PaymentMethodEnum;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use RuntimeException;
+use Throwable;
+
+/** Applies a cash receipt to an existing, already-pushed AR invoice and pushes the payment to Acumatica. */
+#[AgentTool(name: 'Apply AR Payment')]
+class ApplyArPaymentTool extends Tool
+{
+    use HasKanvasContext;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'apply_ar_payment',
+            description: 'Applies a cash receipt to an existing AR invoice (partial or full) and pushes the '
+                . 'payment to Acumatica. Only call when the user explicitly asks to record a real customer '
+                . 'payment against an invoice — never on a whim.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'invoice_id',
+                type: PropertyType::NUMBER,
+                description: 'The Kanvas invoice id to apply the payment against.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'amount',
+                type: PropertyType::NUMBER,
+                description: 'Payment amount. Must not exceed the invoice\'s remaining balance.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'reference',
+                type: PropertyType::STRING,
+                description: 'Payment reference (check number, wire ref, etc). Acumatica rejects an empty one.',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(int $invoice_id, float $amount, string $reference): array
+    {
+        $app = $this->app;
+
+        $invoice = Invoice::query()
+            ->where('id', $invoice_id)
+            ->where('apps_id', $app->getId())
+            ->where('companies_id', $this->company->getId())
+            ->first();
+
+        if ($invoice === null) {
+            return [
+                'applied' => false,
+                'reason' => 'invoice_not_found',
+                'message' => "No invoice with id {$invoice_id} for this app/company.",
+            ];
+        }
+
+        $invoiceRef = (string) $invoice->get(AcumaticaCustomFieldEnum::INVOICE_REF->value, '');
+
+        if ($invoiceRef === '') {
+            return [
+                'applied' => false,
+                'reason' => 'invoice_not_pushed',
+                'message' => "Invoice {$invoice_id} hasn't been pushed to Acumatica yet — push it before applying a payment.",
+            ];
+        }
+
+        try {
+            $allocation = new AllocateInvoicePaymentAction(
+                invoice: $invoice,
+                amountNative: $amount,
+                method: PaymentMethodEnum::CHECK,
+                cashAccountSubType: AccountSubTypeEnum::CASH_CHECKING,
+                reference: $reference,
+                user: $this->user,
+            )->execute();
+        } catch (RuntimeException $e) {
+            return [
+                'applied' => false,
+                'reason' => 'allocation_failed',
+                'message' => $e->getMessage(),
+            ];
+        }
+
+        $payment = $allocation->payment;
+
+        try {
+            $paymentRef = new PushPaymentToAcumaticaAction($payment)->execute();
+        } catch (AcumaticaWriteException|Throwable $e) {
+            return [
+                'applied' => true,
+                'pushed' => false,
+                'invoice_id' => $invoice->getId(),
+                'reason' => 'push_failed',
+                'message' => 'Payment recorded in Kanvas but the push to Acumatica failed: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'applied' => true,
+            'pushed' => true,
+            'invoice_id' => $invoice->getId(),
+            'invoice_ref' => $invoiceRef,
+            'amount' => $amount,
+            'payment_ref' => $paymentRef,
+            'remaining_balance' => (float) $invoice->fresh()->balance_due_native,
+            'document_status' => $invoice->fresh()->document_status->value,
+        ];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/ApplyApPaymentTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/ApplyApPaymentTool.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
 
 use Kanvas\Connectors\Acumatica\Actions\PushPaymentToAcumaticaAction;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/ApplyArPaymentTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/ApplyArPaymentTool.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
 
 use Kanvas\Connectors\Acumatica\Actions\PushPaymentToAcumaticaAction;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
 
 use Illuminate\Support\Carbon;
 use Kanvas\Connectors\Acumatica\Actions\PushBillToAcumaticaAction;

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
 
 use Illuminate\Support\Carbon;
 use Kanvas\Connectors\Acumatica\Actions\PushInvoiceToAcumaticaAction;

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/VoidApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/VoidApBillTool.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
 
 use Kanvas\Connectors\Acumatica\Actions\VoidApBillAction;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/VoidArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/VoidArInvoiceTool.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
 
 use Kanvas\Connectors\Acumatica\Actions\VoidArInvoiceAction;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;


### PR DESCRIPTION
## Summary

\`apply_ar_payment\` (Arc/AR standalone payment-application tool) was committed twice now to branches that got merged *before* the commit was pushed — so it's been silently missing from \`development\` despite two prior PRs (#10494, #10544) claiming to include it. This PR recovers it via cherry-pick, on its own branch, verified via \`git merge-base --is-ancestor\` that it wasn't already in \`origin/development\` before opening.

**Also**, per kaioken: Acumatica-specific write tools were mixed into the generic \`Tools/Accounting/\` folder alongside plain read-only Scribe queries — moved them into their own \`Tools/Acumatica/\` namespace, mirroring the existing \`Tools/FinancialModelingPrep/\` pattern in this codebase, to keep ERP-write tools clearly separated from generic reads.

## What's in this PR

1. **\`feat(intelligence): give Arc a standalone apply_ar_payment tool\`** — recovered via cherry-pick. Applies a cash receipt to an existing, already-pushed AR invoice. Reuses \`AllocateInvoicePaymentAction\` + \`PushPaymentToAcumaticaAction\`'s AR branch (both proven working in #10494).

2. **\`refactor(intelligence): move Acumatica write tools into their own Tools/Acumatica namespace\`** — namespace-only move (git-tracked renames, no behavior change): \`CreateApBillTool\`, \`VoidApBillTool\`, \`ApplyApPaymentTool\`, \`CreateArInvoiceTool\`, \`VoidArInvoiceTool\`, \`ApplyArPaymentTool\` now live in \`Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\`. \`Tools/Accounting/\` now holds only generic Find*/List*/Query*/Match*/TopLatePayersTool.

## Test plan

- [x] All moved files + both agent files pass \`php -l\`.
- [x] Confirmed no remaining references to the old \`Tools\Accounting\` namespace for these 6 classes anywhere in the repo.
- [ ] Live confirmation of \`apply_ar_payment\` still pending — the staging test customers are in Acumatica Credit Hold from accumulated test data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)