### PR TITLE
feat(souk): make the order correction final-status guard toggleable p…

### DIFF
--- a/src/Domains/Souk/Enums/ConfigurationEnum.php
+++ b/src/Domains/Souk/Enums/ConfigurationEnum.php
@@ -24,4 +24,5 @@ enum ConfigurationEnum: string
     case STALE_PAYMENT_TTL_MINUTES = 'souk_stale_payment_ttl_minutes';
     case DEFAULT_COMMISSION_RATE = 'default_commission_rate';
     case DISABLE_ORDER_ITEM_STOCK_VALIDATION = 'souk_disable_order_item_stock_validation';
+    case ALLOW_ORDER_CORRECTION_ON_FINAL_STATUS = 'souk_allow_order_correction_on_final_status';
 }

--- a/src/Domains/Souk/Orders/Actions/Corrections/BaseOrderCorrectionAction.php
+++ b/src/Domains/Souk/Orders/Actions/Corrections/BaseOrderCorrectionAction.php
@@ -7,6 +7,7 @@ namespace Kanvas\Souk\Orders\Actions\Corrections;
 use Closure;
 use Illuminate\Support\Facades\DB;
 use Kanvas\Exceptions\ValidationException;
+use Kanvas\Souk\Enums\ConfigurationEnum;
 use Kanvas\Souk\Orders\Models\Order;
 use Kanvas\Users\Models\Users;
 
@@ -35,6 +36,10 @@ abstract class BaseOrderCorrectionAction
 
     protected function guardNotFinalStatus(): void
     {
+        if ((bool) $this->order->app->get(ConfigurationEnum::ALLOW_ORDER_CORRECTION_ON_FINAL_STATUS->value)) {
+            return;
+        }
+
         if ($this->order->orderStatus?->is_final) {
             $slug = $this->order->orderStatus->slug;
 

--- a/tests/Connectors/Integration/Movipass/CorrectVehiclePlateActionTest.php
+++ b/tests/Connectors/Integration/Movipass/CorrectVehiclePlateActionTest.php
@@ -13,6 +13,7 @@ use Kanvas\Connectors\Movipass\Enums\MovipassOrderStatusEnum;
 use Kanvas\Exceptions\ValidationException;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Regions\Models\Regions;
+use Kanvas\Souk\Enums\ConfigurationEnum;
 use Kanvas\Souk\Orders\Models\Order;
 use Kanvas\Souk\Orders\Models\OrderStatus;
 use Kanvas\Souk\Orders\Models\OrderTypes;
@@ -119,11 +120,8 @@ final class CorrectVehiclePlateActionTest extends TestCase
         $this->assertCount(3, $images);
     }
 
-    public function testItBlocksCorrectionOnFinalStatus(): void
+    private function resolveReleasedStatus(Apps $app): OrderStatus
     {
-        $app = app(Apps::class);
-        $user = Auth::user();
-
         $orderType = OrderTypes::where('name', 'impound_lot')->fromApp($app)->first();
 
         if (! $orderType) {
@@ -138,6 +136,16 @@ final class CorrectVehiclePlateActionTest extends TestCase
             $this->markTestSkipped('released_from_lot status not found — run movipass:setup-impound-lot first');
         }
 
+        return $releasedStatus;
+    }
+
+    public function testItBlocksCorrectionOnFinalStatus(): void
+    {
+        $app = app(Apps::class);
+        $user = Auth::user();
+
+        $releasedStatus = $this->resolveReleasedStatus($app);
+
         $order = $this->createTestOrder($app, $user, [
             'order_number' => 12347,
             'order_status_id' => $releasedStatus->id,
@@ -150,5 +158,33 @@ final class CorrectVehiclePlateActionTest extends TestCase
         Order::withoutSyncingToSearch(
             fn () => new CorrectVehiclePlateAction($order, $user, 'FIN999', 'should fail')->execute()
         );
+    }
+
+    public function testItAllowsCorrectionOnFinalStatusWhenAppFlagIsEnabled(): void
+    {
+        $app = app(Apps::class);
+        $user = Auth::user();
+
+        $releasedStatus = $this->resolveReleasedStatus($app);
+
+        $order = $this->createTestOrder($app, $user, [
+            'order_number' => 12348,
+            'order_status_id' => $releasedStatus->id,
+            'metadata' => ['data' => ['vehiclePlate' => 'FLG001', 'vehicleBrand' => 'Nissan']],
+            'reference' => 'Nissan / FLG001 - #12348',
+        ]);
+
+        $app->set(ConfigurationEnum::ALLOW_ORDER_CORRECTION_ON_FINAL_STATUS->value, 1);
+
+        try {
+            $result = Order::withoutSyncingToSearch(
+                fn () => new CorrectVehiclePlateAction($order, $user, 'FLG999', 'late correction authorized by app flag')->execute()
+            );
+
+            $this->assertEquals('FLG999', $result->metadata['data']['vehiclePlate']);
+            $this->assertEquals('Nissan / FLG999 - #12348', $result->reference);
+        } finally {
+            $app->del(ConfigurationEnum::ALLOW_ORDER_CORRECTION_ON_FINAL_STATUS->value);
+        }
     }
 }


### PR DESCRIPTION
…er app

Corrections on orders in a final status (completed, cancelled, released_from_lot, service_completed) were always rejected, which blocks legitimate late fixes — parking sessions auto-complete on the sync workflow while an operator is still filling the correction form.

Add the souk_allow_order_correction_on_final_status app setting. When it is enabled the guard returns early; unset or 0 keeps the current behavior. The app is derived from the order itself, so the rule is always evaluated against the order's own tenant. Every correction keeps writing its audit trail either way.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
