### PR TITLE
Fix ScrapingDog sale price mapping

### DIFF
--- a/src/Domains/Connectors/ScrapingDog/Services/ProductService.php
+++ b/src/Domains/Connectors/ScrapingDog/Services/ProductService.php
@@ -232,7 +232,7 @@ class ProductService
     public function calcDiscountPrice(array $product): array
     {
         $discount = 0;
-        $amazonPrice = $this->extractPrice($product);
+        $amazonPrice = $this->extractPrices($product)['discountPrice'];
         $weight = $this->calcWeight($product) / 453.592;
         $deliveryCostMile = 2.50;
         $courierCost = $weight * 1.3;

--- a/src/Domains/Connectors/ScrapingDog/Services/ProductService.php
+++ b/src/Domains/Connectors/ScrapingDog/Services/ProductService.php
@@ -23,21 +23,16 @@ class ProductService
     public function mapProduct(array $product): array
     {
         $weight = $this->calcWeight($product);
-        $amazonPrice = $this->extractPrice($product);
+        $prices = $this->extractPrices($product);
+        $amazonPrice = $prices['price'];
         $name = Str::limit($product['title'] ?? '', 255);
-        $listPrice = $this->extractListPrice($product);
-        if ($amazonPrice <= 0 && $listPrice > 0) {
-            $amazonPrice = $listPrice;
-        }
-        if ($listPrice == 0 && $amazonPrice > 0) {
-            $listPrice = $amazonPrice;
-        }
+        $discountPrice = $prices['discountPrice'];
         $asin = $this->getProductAsin($product);
         $mappedProduct = [
             'name' => $name,
             'description' => $this->getDescription($product),
             'price' => $amazonPrice,
-            'discountPrice' => $listPrice,
+            'discountPrice' => $discountPrice,
             'slug' => Str::slug($asin),
             'sku' => $asin,
             'source' => 'amazon',
@@ -284,24 +279,51 @@ class ProductService
         return '';
     }
 
-    protected function extractPrice(array $product): float
+    /**
+     * @return array{price: float, discountPrice: float}
+     */
+    protected function extractPrices(array $product): array
     {
-        if (isset($product['price']) && ! empty($product['price'])) {
-            if (preg_match('/\$?([\d,]+\.?\d*)\s+with\s+(\d+)\s+percent\s+savings/i', $product['price'], $matches)) {
-                $discountedPrice = (float) str_replace(',', '', $matches[1]);
-                $discountPercent = (int) $matches[2];
-                $originalPrice = ($discountedPrice * 100) / (100 - $discountPercent);
+        $currentPrice = $this->extractCurrentPrice($product);
+        $listPrice = $this->extractListPrice($product);
 
-                return $originalPrice;
-            }
-
-            preg_match('/\$?([\d,]+\.?\d*)/', $product['price'], $matches);
-            if (isset($matches[1])) {
-                return (float) str_replace(',', '', $matches[1]);
-            }
+        if ($listPrice <= 0) {
+            $listPrice = $this->extractOriginalPriceFromSavings($product);
         }
 
-        return 0.0;
+        $regularPrice = $listPrice > 0 ? $listPrice : $currentPrice;
+        $discountPrice = $currentPrice > 0 ? $currentPrice : $regularPrice;
+
+        return [
+            'price' => $regularPrice,
+            'discountPrice' => $discountPrice,
+        ];
+    }
+
+    protected function extractCurrentPrice(array $product): float
+    {
+        preg_match('/\$?([\d,]+\.?\d*)/', (string) ($product['price'] ?? ''), $matches);
+
+        return isset($matches[1])
+            ? (float) str_replace(',', '', $matches[1])
+            : 0.0;
+    }
+
+    protected function extractOriginalPriceFromSavings(array $product): float
+    {
+        $price = (string) ($product['price'] ?? '');
+        if (! preg_match('/\$?([\d,]+\.?\d*)\s+with\s+(\d+)\s+percent\s+savings/i', $price, $matches)) {
+            return 0.0;
+        }
+
+        $discountedPrice = (float) str_replace(',', '', $matches[1]);
+        $discountPercent = (int) $matches[2];
+
+        if ($discountPercent <= 0 || $discountPercent >= 100) {
+            return 0.0;
+        }
+
+        return round(($discountedPrice * 100) / (100 - $discountPercent), 2);
     }
 
     protected function extractListPrice(array $product): float

--- a/tests/Unit/Connectors/ScrapingDog/ProductServiceTest.php
+++ b/tests/Unit/Connectors/ScrapingDog/ProductServiceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Connectors\ScrapingDog;
+
+use Kanvas\Connectors\ScrapingDog\Services\ProductService;
+use PHPUnit\Framework\TestCase;
+
+final class ProductServiceTest extends TestCase
+{
+    public function testItMapsListAndSalePricesFromDedicatedFields(): void
+    {
+        $prices = $this->service()->prices([
+            'price' => '$129.99',
+            'list_price' => '$199.99',
+        ]);
+
+        $this->assertSame(199.99, $prices['price']);
+        $this->assertSame(129.99, $prices['discountPrice']);
+    }
+
+    public function testItPreservesSalePriceWhenOriginalPriceIsDerivedFromSavings(): void
+    {
+        $prices = $this->service()->prices([
+            'price' => '$129.99 with 35 percent savings',
+        ]);
+
+        $this->assertSame(199.98, $prices['price']);
+        $this->assertSame(129.99, $prices['discountPrice']);
+    }
+
+    public function testItUsesCurrentPriceForBothFieldsWhenProductIsNotOnSale(): void
+    {
+        $prices = $this->service()->prices([
+            'price' => '$129.99',
+        ]);
+
+        $this->assertSame(129.99, $prices['price']);
+        $this->assertSame(129.99, $prices['discountPrice']);
+    }
+
+    private function service(): ProductServicePriceTestHarness
+    {
+        return new ProductServicePriceTestHarness();
+    }
+}
+
+final class ProductServicePriceTestHarness extends ProductService
+{
+    public function __construct()
+    {
+    }
+
+    /**
+     * @return array{price: float, discountPrice: float}
+     */
+    public function prices(array $product): array
+    {
+        return $this->extractPrices($product);
+    }
+}

--- a/tests/Unit/Connectors/ScrapingDog/ProductServiceTest.php
+++ b/tests/Unit/Connectors/ScrapingDog/ProductServiceTest.php
@@ -40,6 +40,17 @@ final class ProductServiceTest extends TestCase
         $this->assertSame(129.99, $prices['discountPrice']);
     }
 
+    public function testItCalculatesCostsFromTheEffectiveSalePrice(): void
+    {
+        $result = $this->service()->calcDiscountPrice([
+            'price' => '$129.99',
+            'list_price' => '$199.99',
+        ]);
+
+        $this->assertGreaterThan(129.99, $result['total']);
+        $this->assertLessThan(129.99, $result['discount']);
+    }
+
     private function service(): ProductServicePriceTestHarness
     {
         return new ProductServicePriceTestHarness();


### PR DESCRIPTION
## Summary
- preserve ScrapingDog current price as `discounted_price`
- map `list_price` as the regular channel price
- derive the regular price from percentage savings when `list_price` is absent
- add unit coverage for dedicated list price, percentage savings, and no-sale responses

## Production case
For `B0G2BWG3HK`, ScrapingDog returned a value equivalent to `$129.99 with 35 percent savings`. The old parser stored the reconstructed `$199.98` in both fields. This change maps regular price to `$199.98` and discounted price to `$129.99`.

## Validation
- `php -l` passes for both changed PHP files
- `git diff --check` passes
- PHPUnit could not run locally because installed Composer dependencies require PHP >= 8.5 while the host is PHP 8.4.10; the documented `phpkanvas-ecosystem` container is not running