### PR TITLE
fix: translate Insurance GraphQL query names/args to English

### DIFF
--- a/app/GraphQL/Connector/Insurance/Queries/InsuranceReferenceQuery.php
+++ b/app/GraphQL/Connector/Insurance/Queries/InsuranceReferenceQuery.php
@@ -13,30 +13,30 @@ class InsuranceReferenceQuery
     public function vehicleModels(mixed $rootValue, array $request): array
     {
         return $this->service()->getVehicleModels(
-            (string) ($request['marca'] ?? ''),
-            (string) ($request['modelo'] ?? '')
+            (string) ($request['brand'] ?? ''),
+            (string) ($request['model'] ?? '')
         );
     }
 
-    public function provincias(mixed $rootValue, array $request): array
+    public function provinces(mixed $rootValue, array $request): array
     {
         return $this->service()->getProvincias();
     }
 
-    public function municipios(mixed $rootValue, array $request): array
+    public function municipalities(mixed $rootValue, array $request): array
     {
-        return $this->service()->getMunicipios((string) $request['provincia']);
+        return $this->service()->getMunicipios((string) $request['province']);
     }
 
-    public function sectores(mixed $rootValue, array $request): array
+    public function sectors(mixed $rootValue, array $request): array
     {
         return $this->service()->getSectores(
-            (string) $request['provincia'],
-            (string) $request['municipio']
+            (string) $request['province'],
+            (string) $request['municipality']
         );
     }
 
-    public function aditamentos(mixed $rootValue, array $request): array
+    public function accessories(mixed $rootValue, array $request): array
     {
         return $this->service()->getAditamentos();
     }

--- a/graphql/schemas/Connector/insurance.graphql
+++ b/graphql/schemas/Connector/insurance.graphql
@@ -2,25 +2,25 @@
 # Setup is done via the generic createIntegrationCompany mutation
 # Reference catalogs are live-queryable; quote/pay/emit operate on a Souk Order.
 extend type Query @guard {
-    insuranceVehicleModels(marca: String = "", modelo: String = ""): Mixed
+    insuranceVehicleModels(brand: String = "", model: String = ""): Mixed
         @field(
             resolver: "App\\GraphQL\\Connector\\Insurance\\Queries\\InsuranceReferenceQuery@vehicleModels"
         )
-    insuranceProvincias: Mixed
+    insuranceProvinces: Mixed
         @field(
-            resolver: "App\\GraphQL\\Connector\\Insurance\\Queries\\InsuranceReferenceQuery@provincias"
+            resolver: "App\\GraphQL\\Connector\\Insurance\\Queries\\InsuranceReferenceQuery@provinces"
         )
-    insuranceMunicipios(provincia: String!): Mixed
+    insuranceMunicipalities(province: String!): Mixed
         @field(
-            resolver: "App\\GraphQL\\Connector\\Insurance\\Queries\\InsuranceReferenceQuery@municipios"
+            resolver: "App\\GraphQL\\Connector\\Insurance\\Queries\\InsuranceReferenceQuery@municipalities"
         )
-    insuranceSectores(provincia: String!, municipio: String!): Mixed
+    insuranceSectors(province: String!, municipality: String!): Mixed
         @field(
-            resolver: "App\\GraphQL\\Connector\\Insurance\\Queries\\InsuranceReferenceQuery@sectores"
+            resolver: "App\\GraphQL\\Connector\\Insurance\\Queries\\InsuranceReferenceQuery@sectors"
         )
-    insuranceAditamentos: Mixed
+    insuranceAccessories: Mixed
         @field(
-            resolver: "App\\GraphQL\\Connector\\Insurance\\Queries\\InsuranceReferenceQuery@aditamentos"
+            resolver: "App\\GraphQL\\Connector\\Insurance\\Queries\\InsuranceReferenceQuery@accessories"
         )
 }
 


### PR DESCRIPTION
## What
Follow-up on #10577. Translates the remaining Spanish-named GraphQL fields/arguments in the Insurance connector schema to English:

| Before | After |
| --- | --- |
| `insuranceProvincias` | `insuranceProvinces` |
| `insuranceMunicipios(provincia: String!)` | `insuranceMunicipalities(province: String!)` |
| `insuranceSectores(provincia: String!, municipio: String!)` | `insuranceSectors(province: String!, municipality: String!)` |
| `insuranceAditamentos` | `insuranceAccessories` |
| `insuranceVehicleModels(marca: String, modelo: String)` | `insuranceVehicleModels(brand: String, model: String)` |

`InsuranceReferenceQuery` resolver method names/argument keys were updated to match (`provincias` -> `provinces`, `municipios` -> `municipalities`, `sectores` -> `sectors`, `aditamentos` -> `accessories`).

## Why
#10577 made the Insurance GraphQL layer provider-agnostic, but several query/argument names were still in Spanish (leftover from the original `universalSeguros*` naming). Since this API is meant to be provider-agnostic and public-facing, the exposed schema should be consistent and in English.

## Notes
- Calls into `UniversalSegurosService` (`getProvincias`, `getMunicipios`, `getSectores`, `getAditamentos`, etc.) are left unchanged since that service wraps a third-party API whose endpoints/parameters are in Spanish - only the public GraphQL surface is translated.
- No mutation names/args needed changes; they were already in English.
- Base branch is `fix-insurance-mutations-agnostic` (the branch for #10577) since this PR builds directly on top of those renames.