### PR TITLE
fix(acumatica): two-step PUT for AP payments + correct reference field

### DIFF
--- a/src/Domains/Connectors/Acumatica/Actions/PushPaymentToAcumaticaAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/PushPaymentToAcumaticaAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Connectors\Acumatica\Actions;
 
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Acumatica\Client;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
 use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
@@ -26,6 +27,13 @@ use Kanvas\Scribe\Payments\Models\Payment;
  * ACUMATICA_PAYMENT_ID; retry-safe via the PaymentRef find-query.
  *
  * AP applications go through the `Check` entity (Vendor field, Details array); AR through `Payment` (CustomerID field, DocumentsToApply array) — confirmed live, they are not interchangeable.
+ *
+ * AP is a two-step PUT (Dennis, 2026-07-29): sending PaymentAmount together with the Details application
+ * line on a single create makes the header amount land as 0 while the line still shows the real amount,
+ * and Hold=false on that same call forces balance validation immediately — so it fails as "out of
+ * balance" even though the application line itself is correct. Creating on Hold=true first (no
+ * PaymentAmount) skips validation and lands the line; a second PUT keyed on the returned ReferenceNbr
+ * then sets PaymentAmount and flips Hold to false, which both sticks the header amount and releases it.
  */
 class PushPaymentToAcumaticaAction
 {
@@ -71,13 +79,14 @@ class PushPaymentToAcumaticaAction
             );
         }
 
-        $record = $this->writer()->push(
-            $isAp ? 'Check' : 'Payment',
-            $this->buildPayload($isAp, $partyCode, $documents),
-            release: true,
-            findQuery: $this->existingPaymentQuery(),
-            releaseAction: $isAp ? 'ReleaseCheck' : 'Release',
-        );
+        $record = $isAp
+            ? $this->pushApCheck($partyCode, $documents)
+            : $this->writer()->push(
+                'Payment',
+                $this->buildArPayload($partyCode, $documents),
+                release: true,
+                findQuery: $this->existingPaymentQuery(),
+            );
 
         $id = AcumaticaPayload::recordId($record);
         $referenceNbr = (string) (AcumaticaPayload::value($record, 'ReferenceNbr') ?? $id ?? '');
@@ -119,7 +128,9 @@ class PushPaymentToAcumaticaAction
 
             $docs[] = AcumaticaPayload::wrap([
                 'DocType' => 'Bill',
-                'ReferenceNbr' => $bill->bill_number,
+                // The Acumatica ReferenceNbr set when the bill was pushed — not bill_number, which is
+                // Kanvas's own document number and won't resolve on Acumatica's side.
+                'ReferenceNbr' => (string) $bill->get(CustomFieldEnum::BILL_REF->value, ''),
                 'AmountPaid' => (float) $allocation->amount_native,
             ]);
         }
@@ -153,7 +164,9 @@ class PushPaymentToAcumaticaAction
 
             $docs[] = AcumaticaPayload::wrap([
                 'DocType' => 'INV',
-                'ReferenceNbr' => $invoice->invoice_number,
+                // The Acumatica ReferenceNbr set when the invoice was pushed — not invoice_number,
+                // which is Kanvas's own document number and won't resolve on Acumatica's side.
+                'ReferenceNbr' => (string) $invoice->get(CustomFieldEnum::INVOICE_REF->value, ''),
                 'AmountPaid' => (float) $allocation->amount_native,
             ]);
         }
@@ -166,11 +179,11 @@ class PushPaymentToAcumaticaAction
      *
      * @return array<string, mixed>
      */
-    private function buildPayload(bool $isAp, string $partyCode, array $documents): array
+    private function buildArPayload(string $partyCode, array $documents): array
     {
         $header = AcumaticaPayload::wrap([
-            'Type' => $isAp ? 'Check' : 'Payment',
-            $isAp ? 'Vendor' : 'CustomerID' => $partyCode,
+            'Type' => 'Payment',
+            'CustomerID' => $partyCode,
             'CashAccount' => $this->cashAccountCode(),
             'PaymentAmount' => (float) $this->payment->amount_native,
             'PaymentMethod' => strtoupper($this->payment->method->value),
@@ -181,10 +194,61 @@ class PushPaymentToAcumaticaAction
             'Hold' => false,
         ]);
 
-        // AP applies through the Check entity's Details field; AR through Payment's DocumentsToApply.
-        $header[$isAp ? 'Details' : 'DocumentsToApply'] = $documents;
+        $header['DocumentsToApply'] = $documents;
 
         return $header;
+    }
+
+    /**
+     * @param array<int, array<string, array{value: mixed}>> $documents
+     *
+     * @return array<string, mixed> the released Check record
+     */
+    private function pushApCheck(string $vendorCode, array $documents): array
+    {
+        return $this->writer()->withSession(function (Client $client) use ($vendorCode, $documents): array {
+            $findQuery = $this->existingPaymentQuery();
+
+            if ($findQuery !== null) {
+                $found = $client->get('Check', $findQuery);
+
+                if (isset($found[0]) && is_array($found[0])) {
+                    return $found[0];
+                }
+            }
+
+            // Step 1: create on hold with the application line, no header amount yet — sending
+            // PaymentAmount alongside Details on the same call makes it land as 0 on the header.
+            $created = AcumaticaPayload::wrap([
+                'Type' => 'Payment',
+                'Vendor' => $vendorCode,
+                'CashAccount' => $this->cashAccountCode(),
+                'PaymentMethod' => strtoupper($this->payment->method->value),
+                'PaymentRef' => $this->payment->reference,
+                'ApplicationDate' => $this->payment->payment_date->toDateString(),
+                'CurrencyID' => $this->payment->currency,
+                'Hold' => true,
+            ]);
+            $created['Details'] = $documents;
+
+            $record = $client->put('Check', $created);
+            $referenceNbr = (string) (AcumaticaPayload::value($record, 'ReferenceNbr') ?? '');
+
+            if ($referenceNbr === '') {
+                throw new AcumaticaWriteException(
+                    "Payment {$this->payment->getId()}: AP Check creation did not return a usable ReferenceNbr."
+                );
+            }
+
+            // Step 2: the application line now exists, so the header amount sticks — set it and
+            // release by flipping Hold to false.
+            return $client->put('Check', AcumaticaPayload::wrap([
+                'Type' => 'Payment',
+                'ReferenceNbr' => $referenceNbr,
+                'PaymentAmount' => (float) $this->payment->amount_native,
+                'Hold' => false,
+            ]));
+        });
     }
 
     /**

--- a/tests/Connectors/Acumatica/PushPaymentToAcumaticaActionTest.php
+++ b/tests/Connectors/Acumatica/PushPaymentToAcumaticaActionTest.php
@@ -6,6 +6,7 @@ namespace Tests\Connectors\Acumatica;
 
 use Illuminate\Support\Carbon;
 use Kanvas\Connectors\Acumatica\Actions\PushPaymentToAcumaticaAction;
+use Kanvas\Connectors\Acumatica\Client;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
 use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
@@ -72,11 +73,12 @@ class PushPaymentToAcumaticaActionTest extends ScribeTestCase
         )->execute();
         $bill->bill_number = 'AP000777';
         $bill->save();
+        $bill->set(CustomFieldEnum::BILL_REF->value, 'AP000777');
 
         return $bill;
     }
 
-    public function test_ap_payment_pushes_a_check_applied_to_the_vendor_bill(): void
+    public function test_ap_payment_pushes_a_check_via_two_step_put(): void
     {
         $vendor = $this->seedTestOrganization('Globex Supply');
         $vendor->set(CustomFieldEnum::VENDOR_ID->value, 'V0000505');
@@ -97,14 +99,20 @@ class PushPaymentToAcumaticaActionTest extends ScribeTestCase
             'allocated_at' => Carbon::parse('2026-07-01'),
         ]);
 
-        $captured = null;
-        $writer = Mockery::mock(AcumaticaWriteService::class);
-        $writer->shouldReceive('push')->once()->andReturnUsing(
-            function (string $entity, array $body, bool $release = false, array $files = [], ?array $findQuery = null, string $releaseAction = 'Release') use (&$captured): array {
-                $captured = [$entity, $body, $releaseAction];
+        $calls = [];
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('get')->once()->with('Check', Mockery::type('array'))->andReturn([]);
+        $client->shouldReceive('put')->twice()->andReturnUsing(
+            function (string $entity, array $body) use (&$calls): array {
+                $calls[] = [$entity, $body];
 
                 return ['id' => 'PAY-1', 'ReferenceNbr' => ['value' => '000900']];
             }
+        );
+
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldReceive('withSession')->once()->andReturnUsing(
+            fn (callable $callback) => $callback($client)
         );
 
         $ref = new PushPaymentToAcumaticaAction($payment, $writer)->execute();
@@ -112,15 +120,24 @@ class PushPaymentToAcumaticaActionTest extends ScribeTestCase
         $this->assertSame('000900', $ref);
         $this->assertSame('PAY-1', $payment->get(CustomFieldEnum::PAYMENT_ID->value));
 
-        [$entity, $body, $releaseAction] = $captured;
-        $this->assertSame('Check', $entity);
-        $this->assertSame('ReleaseCheck', $releaseAction);
-        $this->assertSame(['value' => 'Check'], $body['Type']);
-        $this->assertSame(['value' => 'V0000505'], $body['Vendor']);
-        $this->assertSame(['value' => 'CHK-1'], $body['PaymentRef']);
-        $this->assertSame(['value' => 'Bill'], $body['Details'][0]['DocType']);
-        $this->assertSame(['value' => 'AP000777'], $body['Details'][0]['ReferenceNbr']);
-        $this->assertSame(['value' => 500.0], $body['Details'][0]['AmountPaid']);
+        [$step1Entity, $step1Body] = $calls[0];
+        [$step2Entity, $step2Body] = $calls[1];
+
+        $this->assertSame('Check', $step1Entity);
+        $this->assertSame(['value' => 'Payment'], $step1Body['Type']);
+        $this->assertSame(['value' => 'V0000505'], $step1Body['Vendor']);
+        $this->assertSame(['value' => 'CHK-1'], $step1Body['PaymentRef']);
+        $this->assertSame(['value' => true], $step1Body['Hold']);
+        $this->assertArrayNotHasKey('PaymentAmount', $step1Body);
+        $this->assertSame(['value' => 'Bill'], $step1Body['Details'][0]['DocType']);
+        $this->assertSame(['value' => 'AP000777'], $step1Body['Details'][0]['ReferenceNbr']);
+        $this->assertSame(['value' => 500.0], $step1Body['Details'][0]['AmountPaid']);
+
+        $this->assertSame('Check', $step2Entity);
+        $this->assertSame(['value' => 'Payment'], $step2Body['Type']);
+        $this->assertSame(['value' => '000900'], $step2Body['ReferenceNbr']);
+        $this->assertSame(['value' => 500.0], $step2Body['PaymentAmount']);
+        $this->assertSame(['value' => false], $step2Body['Hold']);
     }
 
     public function test_ar_receipt_pushes_a_payment_applied_to_the_customer_invoice(): void
@@ -143,6 +160,7 @@ class PushPaymentToAcumaticaActionTest extends ScribeTestCase
             'issued_date' => Carbon::parse('2026-06-01'),
             'source' => 'kanvas',
         ]);
+        $invoice->set(CustomFieldEnum::INVOICE_REF->value, 'AR000123');
 
         $payment = $this->payment('inbound', ['reference' => 'ACH-77']);
         InvoicePaymentAllocation::create([


### PR DESCRIPTION
## Summary
- Fixes the "the document is out of the balance" error on `apply_ap_payment`: a single-call PUT (Type=Payment + PaymentAmount + Details + Hold=false) made the header PaymentAmount land as 0 while the application line kept the real amount, and `Hold=false` forced immediate balance validation. Per Dennis's diagnosis, AP now does a two-step PUT — create on Hold=true with the Details line (no header amount), then a second PUT keyed on the returned ReferenceNbr sets PaymentAmount and flips Hold to false.
- Fixes `apApplications()`/`arApplications()` sending the bill's/invoice's own Kanvas document number as the Acumatica `ReferenceNbr` instead of the `ACUMATICA_BILL_REF`/`ACUMATICA_INVOICE_REF` custom field — confirmed live against staging ("Reference Nbr ... cannot be found in the system").
- AR is unaffected — its single-call push already worked correctly.

## Test plan
- [x] `PushPaymentToAcumaticaActionTest` updated to assert the two-step AP flow (create-on-hold body, then amount+release body) and passing (4 tests, 30 assertions)
- [ ] Live confirmation via Apex chat: `create_ap_bill` → `apply_ap_payment` against the fresh bill (old test bill 66102675 no longer resolves in staging)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>