### PR TITLE
fix(intelligence): dedupe agent tools by name + list_overdue_invoices customer filter

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -89,6 +89,8 @@ class AccountsReceivableAgent extends SystemUserAgent
             '## How to handle Accounts-Receivable / sales-order questions',
             '- Call query_data_freshness first; if the sync is more than 2 days stale, say so before quoting numbers.',
             '- "Who owes us" / "AR aging" / "biggest late payers" → query_ar_aging, list_overdue_invoices, top_late_payers.',
+            '- "What invoices are overdue for customer X" → list_overdue_invoices with the customer parameter set — '
+            . 'not list_open_sales_orders, which is for purchase/sales orders, not invoices.',
             '- "Look up invoice #X" / "status of invoice X" → find_invoice (one specific invoice by number).',
             '- "Who is customer X" / resolve a customer name to its ERP code → find_customer.',
             '- "Look up sales order #X" → find_sales_order (a sales order is a CUSTOMER order, not a purchase order).',

--- a/src/Domains/Intelligence/Agents/Neuron/BaseKanvasAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/BaseKanvasAgent.php
@@ -135,7 +135,27 @@ class BaseKanvasAgent extends NeuronAIAgent implements ProvidesToolDependencies
             }
         }
 
-        return $tools;
+        // A registry-granted tool (e.g. toggled on in the admin UI) can share its name with one
+        // a subclass hardcodes in tools() — the registry merge in MergesRegisteredTools can't see
+        // that hardcoded addition since it happens after parent::tools() returns. Keeping the LAST
+        // occurrence favors the hardcoded instance, which is always appended after the registry
+        // merge in this codebase's array_merge(parent::tools(), [...]) convention.
+        return $this->dedupeByName($tools);
+    }
+
+    /**
+     * @param array<int, object> $tools
+     * @return list<object>
+     */
+    private function dedupeByName(array $tools): array
+    {
+        $byName = [];
+        foreach ($tools as $tool) {
+            $key = $tool instanceof ToolInterface ? $tool->getName() : spl_object_id($tool);
+            $byName[$key] = $tool;
+        }
+
+        return array_values($byName);
     }
 
     /**

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/ListOverdueInvoicesTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/ListOverdueInvoicesTool.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
 
 use Illuminate\Support\Carbon;
+use Kanvas\Guild\Organizations\Models\Organization;
+use Kanvas\Guild\Organizations\Services\OrganizationNameNormalizerService;
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use Kanvas\Scribe\Invoices\Enums\AgingBucketEnum;
@@ -28,7 +30,7 @@ class ListOverdueInvoicesTool extends Tool
             description: 'Lists individual overdue invoices (issued/sent, balance_due > 0, due_date in the past). '
                 . 'Returns invoice_number, customer name, total, balance due, days overdue, aging bucket. '
                 . 'Use this when the user asks "which invoices are overdue", wants a hit list to chase, or asks '
-                . 'about a specific customer\'s late invoices.',
+                . 'about a specific customer\'s late invoices — pass customer to filter to one.',
         );
     }
 
@@ -36,6 +38,12 @@ class ListOverdueInvoicesTool extends Tool
     protected function properties(): array
     {
         return [
+            new ToolProperty(
+                name: 'customer',
+                type: PropertyType::STRING,
+                description: 'Filter to one customer by (partial) organization name. Omit for all customers.',
+                required: false,
+            ),
             new ToolProperty(
                 name: 'limit',
                 type: PropertyType::INTEGER,
@@ -51,13 +59,25 @@ class ListOverdueInvoicesTool extends Tool
         ];
     }
 
-    public function __invoke(?int $limit = null, ?int $min_days_overdue = null): array
+    public function __invoke(?string $customer = null, ?int $limit = null, ?int $min_days_overdue = null): array
     {
         $app = $this->app;
         $company = $this->company;
         $limit = max(1, min(100, $limit ?? 25));
         $minDays = max(1, $min_days_overdue ?? 1);
         $today = Carbon::today();
+
+        $orgIds = null;
+        if ($customer !== null && $customer !== '') {
+            $term = OrganizationNameNormalizerService::normalize($customer) ?: $customer;
+
+            $orgIds = Organization::query()
+                ->where('apps_id', $app->getId())
+                ->where('companies_id', $company->getId())
+                ->where('is_deleted', false)
+                ->where('name', 'like', '%' . $term . '%')
+                ->pluck('id');
+        }
 
         $invoices = Invoice::query()
             ->where('apps_id', $app->getId())
@@ -70,6 +90,7 @@ class ListOverdueInvoicesTool extends Tool
             ->where('balance_due_base', '>', 0.005)
             ->whereDate('due_date', '<=', $today->copy()->subDays($minDays))
             ->where('is_deleted', false)
+            ->when($orgIds !== null, fn ($q) => $q->whereIn('customer_organization_id', $orgIds))
             ->orderBy('due_date')
             ->limit($limit)
             ->get();

--- a/tests/Intelligence/Agents/UniversalAgentToolsTest.php
+++ b/tests/Intelligence/Agents/UniversalAgentToolsTest.php
@@ -11,9 +11,11 @@ use Kanvas\Intelligence\Agents\Laravel\KanvasGenericLaravelAgent;
 use Kanvas\Intelligence\Agents\Laravel\Tools\Common\CurrentTimeTool as LaravelCurrentTimeTool;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Models\AgentType;
+use Kanvas\Intelligence\Agents\Neuron\Accounting\AccountsReceivableAgent;
 use Kanvas\Intelligence\Agents\Neuron\Accounting\CFOAgent;
 use Kanvas\Intelligence\Agents\Neuron\KanvasGenericNeuronAgent;
 use Kanvas\Intelligence\Agents\Neuron\SystemUserAgent;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Common\CurrentTimeTool as NeuronCurrentTimeTool;
 use Kanvas\NervousSystem\Capability\Actions\CreateToolAction;
 use Kanvas\NervousSystem\Capability\Actions\GrantToolToAgentAction;
@@ -78,6 +80,38 @@ final class UniversalAgentToolsTest extends TestCase
         $this->assertSame(
             1,
             count(array_filter($names, fn (string $name): bool => $name === 'get_current_time')),
+        );
+    }
+
+    /**
+     * Reproduces the Gemini "Duplicate function declaration found: create_ar_invoice" crash: an
+     * operator toggles create_ar_invoice on for an AR agent in the admin UI (a registry grant),
+     * which collides with the same tool AccountsReceivableAgent already hardcodes in tools(). The
+     * registry merge inside SystemUserAgent::tools() runs before the subclass appends its hardcoded
+     * tools, so it can't see the collision coming — getTools()'s final dedupe pass must catch it.
+     */
+    public function testGrantingAHardcodedAgentToolNameDoesNotRegisterItTwice(): void
+    {
+        $agent = $this->makeAgent('neuron');
+
+        $tool = new CreateToolAction(new ToolData(
+            app: app(Apps::class),
+            name: 'create-ar-invoice-' . uniqid(),
+            frameworks: ['neuron'],
+            toolType: ToolTypeEnum::CUSTOM,
+            handler: CreateArInvoiceTool::class,
+        ))->execute();
+
+        new GrantToolToAgentAction($agent, $tool)->execute();
+
+        $handler = new AccountsReceivableAgent();
+        $handler->setConfiguration($agent, user: auth()->user());
+
+        $names = $this->neuronToolNames($handler->getTools());
+
+        $this->assertSame(
+            1,
+            count(array_filter($names, fn (string $name): bool => $name === 'create_ar_invoice')),
         );
     }
 

--- a/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
@@ -8,7 +8,9 @@ use Illuminate\Support\Carbon;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindCustomerTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindInvoiceTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ListOverdueInvoicesTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\MatchInvoicesForPaymentTool;
+use Kanvas\Scribe\Invoices\Enums\DocumentTypeEnum;
 use Kanvas\Scribe\Invoices\Enums\InvoiceDocumentStatusEnum;
 use Kanvas\Scribe\Invoices\Models\Invoice;
 use Kanvas\Scribe\Invoices\Models\InvoiceLine;
@@ -69,6 +71,55 @@ class AccountsReceivableAgentToolsTest extends ScribeTestCase
 
         $missing = new FindInvoiceTool()->withContext($this->kanvasApp, $this->company, static::$cachedUser)->__invoke(invoice_number: 'DOES-NOT-EXIST');
         $this->assertFalse($missing['found']);
+    }
+
+    public function test_list_overdue_invoices_filters_by_customer(): void
+    {
+        $target = $this->seedTestOrganization('Overdue Target Inc');
+        $other = $this->seedTestOrganization('Someone Else Inc');
+
+        $overdueForTarget = Invoice::create([
+            'apps_id' => $this->kanvasApp->getId(),
+            'companies_id' => $this->company->getId(),
+            'document_type' => DocumentTypeEnum::INVOICE,
+            'invoice_number' => 'INV-OVERDUE-TARGET',
+            'customer_organization_id' => $target->getId(),
+            'billable_display_name' => 'Overdue Target Inc',
+            'document_status' => InvoiceDocumentStatusEnum::ISSUED->value,
+            'currency' => 'USD',
+            'fx_rate_to_base' => 1.0,
+            'subtotal_native' => 500.0, 'total_native' => 500.0, 'paid_native' => 0.0, 'balance_due_native' => 500.0,
+            'subtotal_base' => 500.0, 'total_base' => 500.0, 'paid_base' => 0.0, 'balance_due_base' => 500.0,
+            'issued_date' => Carbon::today()->subDays(30),
+            'due_date' => Carbon::today()->subDays(10),
+            'source' => 'kanvas',
+        ]);
+
+        Invoice::create([
+            'apps_id' => $this->kanvasApp->getId(),
+            'companies_id' => $this->company->getId(),
+            'document_type' => DocumentTypeEnum::INVOICE,
+            'invoice_number' => 'INV-OVERDUE-OTHER',
+            'customer_organization_id' => $other->getId(),
+            'billable_display_name' => 'Someone Else Inc',
+            'document_status' => InvoiceDocumentStatusEnum::ISSUED->value,
+            'currency' => 'USD',
+            'fx_rate_to_base' => 1.0,
+            'subtotal_native' => 700.0, 'total_native' => 700.0, 'paid_native' => 0.0, 'balance_due_native' => 700.0,
+            'subtotal_base' => 700.0, 'total_base' => 700.0, 'paid_base' => 0.0, 'balance_due_base' => 700.0,
+            'issued_date' => Carbon::today()->subDays(30),
+            'due_date' => Carbon::today()->subDays(10),
+            'source' => 'kanvas',
+        ]);
+
+        $result = new ListOverdueInvoicesTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(customer: 'Overdue Target');
+
+        $numbers = array_column($result['invoices'], 'invoice_number');
+        $this->assertContains('INV-OVERDUE-TARGET', $numbers);
+        $this->assertNotContains('INV-OVERDUE-OTHER', $numbers);
+        $this->assertSame($overdueForTarget->invoice_number, $numbers[0]);
     }
 
     public function test_match_invoices_for_payment_flags_the_exact_invoice(): void


### PR DESCRIPTION
## Summary
- Fixes a live crash: `Duplicate function declaration found: create_ar_invoice` / `create_lead` (reproduced in Apex/Arc chat) — when a tool an agent already hardcodes in `tools()` is also granted via the admin Tools registry for that agent, the registry merge (inside `SystemUserAgent::tools()`) runs before the subclass appends its hardcoded tools, so it can't see the collision. `BaseKanvasAgent::getTools()` now does a final dedupe pass by tool name.
- Adds a `customer` filter to `list_overdue_invoices` — without it, "overdue invoices for customer X" had no invoice-specific tool that accepted a customer name, so the model fell back to `list_open_sales_orders` (wrong domain, plus a separate cross-connection bug there).

## Test plan
- [x] `UniversalAgentToolsTest::testGrantingAHardcodedAgentToolNameDoesNotRegisterItTwice` (new) + existing suite passing
- [x] `AccountsReceivableAgentToolsTest::test_list_overdue_invoices_filters_by_customer` (new) passing
- [x] Confirmed live in Arc chat: "Duplicate function declaration" crash stopped after this fix

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>