### PR TITLE
Fix: don't leak company from a different app when resolving current company

### DIFF
--- a/src/Kanvas/Users/Models/Users.php
+++ b/src/Kanvas/Users/Models/Users.php
@@ -599,7 +599,22 @@ class Users extends Authenticatable implements UserInterface, ContractsAuthentic
             }
         }
 
-        $companyId = (int) ($this->get(Companies::cacheKey()) ?? $this->default_company);
+        $cachedCompanyId = (int) ($this->get(Companies::cacheKey()) ?? 0);
+        $companyId = $cachedCompanyId > 0 ? $cachedCompanyId : (int) $this->default_company;
+
+        /**
+         * `default_company` is a plain column on the `users` row, shared across the whole
+         * ecosystem, it is NOT scoped per app. A user that belongs to more than one app can
+         * carry a `default_company` (or a stale cached hint) that belongs to a *different*
+         * app/tenant. If we trust it blindly, a new resource created on an app that has no
+         * company of its own can end up scoped to a completely unrelated company.
+         *
+         * Only trust a non zero value here if it's actually a company the user is
+         * associated with on the *current* app, otherwise force a fresh resolution below.
+         */
+        if ($companyId > 0 && ! $this->companies()->where('companies.id', $companyId)->exists()) {
+            $companyId = 0;
+        }
 
         if ($companyId === 0) {
             $company = $this->companies()->first();
@@ -609,6 +624,7 @@ class Users extends Authenticatable implements UserInterface, ContractsAuthentic
                 $this->default_company = $companyId;
                 $this->default_company_branch = (int) ($company->branches()->first()?->getId() ?? 0);
                 $this->saveQuietly();
+                $this->set(Companies::cacheKey(), $companyId);
             }
         }
 

--- a/tests/Ecosystem/Integration/Users/CurrentCompanyIdAppScopingTest.php
+++ b/tests/Ecosystem/Integration/Users/CurrentCompanyIdAppScopingTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Ecosystem\Integration\Users;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Auth;
+use Kanvas\Apps\Actions\CreateAppsAction;
+use Kanvas\Apps\DataTransferObject\AppInput;
+use Kanvas\Apps\Models\Apps;
+use Tests\TestCase;
+
+/**
+ * Regression for https://github.com/bakaphp/kanvas-ecosystem-api/issues/10500
+ *
+ * `Users::default_company` is a plain, global column on the `users` row (it is not
+ * scoped per app). A single physical user can be an owner/member of several apps in
+ * the ecosystem, each with their own set of companies. When a *new* app is created
+ * that has no company of its own yet, `currentCompanyId()` must not fall back to a
+ * `default_company` (or cached hint) that actually belongs to a *different* app -
+ * doing so silently scopes new resources to an unrelated tenant's company.
+ */
+final class CurrentCompanyIdAppScopingTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function testNewAppWithoutCompanyDoesNotInheritCompanyFromAnotherApp(): void
+    {
+        $user = Auth::user();
+
+        // Sanity check: on the "original" app this user already has a real company.
+        $originalCompanyId = $user->getCurrentCompany()->getId();
+        $this->assertGreaterThan(0, $originalCompanyId);
+
+        // Simulate "create a new app" - the owner is associated to the new app with
+        // no company of its own (see CreateAppsAction::execute() / associateUser()).
+        $newAppData = AppInput::from([
+            'name' => 'Brand new tenant app',
+            'url' => 'brand-new-tenant.test',
+            'description' => 'App with no company associated to it',
+            'domain' => 'brand-new-tenant.test',
+            'is_actived' => 1,
+            'ecosystem_auth' => 1,
+            'payments_active' => 0,
+            'is_public' => 1,
+            'domain_based' => 0,
+        ]);
+
+        $newApp = new CreateAppsAction($newAppData, $user)->execute();
+
+        // Switch the resolved "current app" to the freshly created one, the same
+        // way the app container is bound per-request based on the incoming app key.
+        app()->instance(Apps::class, $newApp);
+
+        // The user has no company at all in the new app's scope, so resolving the
+        // current company id must NOT leak the other app's company id.
+        $this->assertNotSame($originalCompanyId, $user->currentCompanyId());
+        $this->assertSame(0, $user->currentCompanyId());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #10500.

`Users::default_company` is a plain column on the `users` row, shared across the whole ecosystem — it is **not** scoped per app. A single physical user can be a member/owner of several apps in the ecosystem, each with its own set of companies.

`Users::currentCompanyId()` had this fallback chain:

```php
$companyId = (int) ($this->get(Companies::cacheKey()) ?? $this->default_company);

if ($companyId === 0) {
    $company = $this->companies()->first();
    ...
}
```

`Companies::cacheKey()` is correctly app-scoped, but when that per-app cache is empty it falls back to the *global* `default_company` column without checking whether that company actually has anything to do with the app currently in scope. If the user already had a `default_company` set from a **different** app (e.g. they created/joined an earlier app and later create a brand-new app that has no company of its own yet), `currentCompanyId()` would happily return that unrelated company's id, since it's non-zero it never falls through to the (already app-scoped) `companies()` relation lookup.

That unrelated company id then gets used to scope newly created resources (`companies_id`), which is exactly the cross-tenant leak described in the issue: *"A random company — one that belongs to a different app/tenant — is set on the new resource."*

## Fix

`currentCompanyId()` now only trusts a resolved (cached or `default_company`) company id if it's actually one of the companies the user is associated with **in the current app** (validated via the existing, already app-scoped `companies()` relation). If it isn't, the id is treated as unresolved, and we fall back to freshly resolving (or defaulting to `0`, matching the reasonable fallback proposed in the issue) — while also priming the app-scoped Redis cache once a valid company is found, to avoid the extra lookup on future calls.

With this fix:
- A new app with no company associated to it resolves `currentCompanyId()` to `0` (instead of leaking a company from a different app).
- Consumers that require a company (e.g. `getCurrentCompany()`) now correctly raise their existing "no default company configured" error instead of silently operating under the wrong tenant.

## Test

Added `tests/Ecosystem/Integration/Users/CurrentCompanyIdAppScopingTest.php`, which:
1. Confirms the current test user has a real company on the "original" app.
2. Creates a brand-new app for that same user (mirroring `CreateAppsAction`, which associates the owner to the new app with no company, exactly like the issue's repro steps).
3. Switches the resolved "current app" to the new app.
4. Asserts `currentCompanyId()` returns `0` for the new app, and specifically does **not** return the original app's company id.

## Note

I wasn't able to run the test suite in this sandbox (no PHP runtime / vendor dependencies available), so please run CI on this PR to confirm.