### PR TITLE
[dev] feat(intelligence): add engagement page tool

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/CreateEngagementPageTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/CreateEngagementPageTool.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\CRM;
+
+use Illuminate\Support\Str;
+use Kanvas\ActionEngine\Engagements\Actions\CreateEngagementAction;
+use Kanvas\ActionEngine\Engagements\DataTransferObject\Engagement as EngagementData;
+use Kanvas\ActionEngine\Engagements\Models\Engagement;
+use Kanvas\ActionEngine\Enums\ActionStatusEnum;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+#[AgentTool(name: 'Create Engagement Page', category: 'crm')]
+class CreateEngagementPageTool extends Tool
+{
+    use HasKanvasContext;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'create_engagement_page',
+            description: 'Create one tracked Action Engine page for a lead and return its action URL. '
+                . 'Use an action slug such as view-vehicle, get-docs, credit-app or add-trade. '
+                . 'This tool does not contact the customer; pass the returned action_link to send_sms or send_email.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'lead_id',
+                type: PropertyType::INTEGER,
+                description: 'The ID of the lead that will own the engagement page.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'action',
+                type: PropertyType::STRING,
+                description: 'Action slug for the page, for example view-vehicle, get-docs, credit-app or add-trade.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'data',
+                type: PropertyType::OBJECT,
+                description: 'Action-specific page payload. For view-vehicle, provide a products array and mark the selected vehicle with interested=true.',
+                required: false,
+            ),
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    public function __invoke(int $lead_id, string $action, array $data = []): array
+    {
+        $action = trim($action);
+        if ($action === '') {
+            return [
+                'status' => 'error',
+                'message' => 'The action slug is required.',
+            ];
+        }
+
+        try {
+            $lead = Lead::getByIdFromCompanyApp($lead_id, $this->company, $this->app);
+        } catch (Throwable) {
+            return [
+                'status' => 'error',
+                'message' => "Lead {$lead_id} does not exist in the current app and company.",
+            ];
+        }
+
+        try {
+            $engagement = $this->createEngagement(new EngagementData(
+                app: $this->app,
+                company: $this->company,
+                user: $this->user,
+                lead: $lead,
+                action: $action,
+                requestId: (string) Str::uuid(),
+                source: 'agent',
+                status: ActionStatusEnum::SENT,
+                people: $lead->people,
+                via: 'agent',
+                data: $data,
+            ));
+        } catch (Throwable $e) {
+            report($e);
+
+            return [
+                'status' => 'error',
+                'message' => 'The engagement page could not be created. Verify the action and company configuration.',
+            ];
+        }
+
+        $message = $engagement->message;
+        $messageData = is_array($message?->message) ? $message->message : [];
+        $actionLink = $messageData['action_link'] ?? null;
+
+        if (! is_string($actionLink) || $actionLink === '') {
+            return [
+                'status' => 'error',
+                'message' => 'The engagement was created but no action URL was generated.',
+                'engagement_id' => $engagement->getId(),
+                'engagement_uuid' => (string) $engagement->uuid,
+            ];
+        }
+
+        return [
+            'status' => 'success',
+            'lead_id' => $lead->getId(),
+            'action' => $action,
+            'engagement_id' => $engagement->getId(),
+            'engagement_uuid' => (string) $engagement->uuid,
+            'message_id' => $message?->getId(),
+            'action_link' => $actionLink,
+            'delivery' => 'not_sent',
+        ];
+    }
+
+    protected function createEngagement(EngagementData $data): Engagement
+    {
+        return new CreateEngagementAction($data)->execute();
+    }
+}

--- a/tests/Intelligence/Agents/Tools/CreateEngagementPageToolTest.php
+++ b/tests/Intelligence/Agents/Tools/CreateEngagementPageToolTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Intelligence\Agents\Tools;
+
+use Kanvas\ActionEngine\Engagements\DataTransferObject\Engagement as EngagementData;
+use Kanvas\ActionEngine\Engagements\Models\Engagement;
+use Kanvas\ActionEngine\Enums\ActionStatusEnum;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\CreateEngagementPageTool;
+use Kanvas\Social\Messages\Models\Message;
+use Tests\TestCase;
+
+class CreateEngagementPageToolTest extends TestCase
+{
+    public function testCreatesEngagementPageAndReturnsUnsentActionLink(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+        $lead = Lead::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create();
+        $message = new Message([
+            'message' => [
+                'action_link' => 'https://short.example/vehicle-page',
+            ],
+        ]);
+        $message->id = 456;
+        $engagement = new Engagement([
+            'uuid' => '019c166e-c115-7000-8000-000000000001',
+            'slug' => 'view-vehicle',
+        ]);
+        $engagement->id = 123;
+        $engagement->setRelation('message', $message);
+
+        $tool = new class ($engagement) extends CreateEngagementPageTool {
+            public ?EngagementData $receivedData = null;
+
+            public function __construct(private readonly Engagement $engagementResult)
+            {
+                parent::__construct();
+            }
+
+            protected function createEngagement(EngagementData $data): Engagement
+            {
+                $this->receivedData = $data;
+
+                return $this->engagementResult;
+            }
+        };
+        $tool->withContext($app, $company, $user);
+
+        $result = $tool->__invoke(
+            lead_id: $lead->getId(),
+            action: 'view-vehicle',
+            data: [
+                'products' => [
+                    ['id' => 'vehicle-1', 'interested' => true],
+                ],
+            ],
+        );
+
+        $this->assertSame('success', $result['status']);
+        $this->assertSame('https://short.example/vehicle-page', $result['action_link']);
+        $this->assertSame('not_sent', $result['delivery']);
+        $this->assertSame(123, $result['engagement_id']);
+        $this->assertSame(456, $result['message_id']);
+        $this->assertSame($lead->getId(), $tool->receivedData?->lead->getId());
+        $this->assertSame('view-vehicle', $tool->receivedData?->action);
+        $this->assertSame(ActionStatusEnum::SENT, $tool->receivedData?->status);
+        $this->assertSame('agent', $tool->receivedData?->source);
+        $this->assertSame('agent', $tool->receivedData?->via);
+        $this->assertTrue($tool->receivedData?->data['products'][0]['interested']);
+    }
+
+    public function testRejectsMissingActionAndUnknownTenantLead(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+        $tool = new CreateEngagementPageTool();
+        $tool->withContext($app, $company, $user);
+
+        $missingAction = $tool->__invoke(1, '   ');
+        $missingLead = $tool->__invoke(PHP_INT_MAX, 'view-vehicle');
+
+        $this->assertSame('error', $missingAction['status']);
+        $this->assertSame('error', $missingLead['status']);
+    }
+
+    public function testReportsMissingGeneratedActionLink(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+        $lead = Lead::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create();
+        $engagement = new Engagement([
+            'uuid' => '019c166e-c115-7000-8000-000000000002',
+            'slug' => 'view-vehicle',
+        ]);
+        $engagement->id = 124;
+        $engagement->setRelation('message', new Message(['message' => []]));
+
+        $tool = new class ($engagement) extends CreateEngagementPageTool {
+            public function __construct(private readonly Engagement $engagementResult)
+            {
+                parent::__construct();
+            }
+
+            protected function createEngagement(EngagementData $data): Engagement
+            {
+                return $this->engagementResult;
+            }
+        };
+        $tool->withContext($app, $company, $user);
+
+        $result = $tool->__invoke($lead->getId(), 'view-vehicle');
+
+        $this->assertSame('error', $result['status']);
+        $this->assertSame(124, $result['engagement_id']);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Neuron tool that creates tracked Action Engine engagement pages
- return the generated action link without contacting the customer
- scope lead resolution to the injected app and company context
- cover successful URL generation and error paths

## Validation
- 3 tests passed (15 assertions)
- PHPStan: no errors
- PHP syntax and git diff checks passed