### PR TITLE
Add pi.dev coding jobs note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,3 +459,4 @@ Note:
 - To install Swoole you can use the command ```pecl install swoole``` 
 - For production remove `--watch` from the command.
 - roles_kanvas_legacy will be deleted in the future
+Note: pi.dev coding jobs are supported.


### PR DESCRIPTION
Appends a single line to the end of README.md: "Note: pi.dev coding jobs are supported." No other content was modified.