### PR TITLE
Fix Sentry noise for empty input validation in ImportMutation

### DIFF
--- a/app/GraphQL/Inventory/Mutations/Products/ImportMutation.php
+++ b/app/GraphQL/Inventory/Mutations/Products/ImportMutation.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\GraphQL\Inventory\Mutations\Products;
 
 use Baka\Support\Str;
-use InvalidArgumentException;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Companies\Repositories\CompaniesRepository;
+use Kanvas\Exceptions\ValidationException;
 use Kanvas\Imports\Actions\WriteImporterArrayToJsonlFileAction;
 use Kanvas\Inventory\Importer\DataTransferObjects\ProductImporter;
 use Kanvas\Inventory\Importer\Jobs\ProductImporterJob as ImporterJob;
@@ -36,7 +36,11 @@ class ImportMutation
         $region = ! isset($req['regionId']) ? Regions::getDefault($company) : RegionRepository::getById($req['regionId'], $company);
 
         if (empty($req['input']) || ! is_array($req['input'])) {
-            throw new InvalidArgumentException('Input array cannot be empty.');
+            // Use ValidationException (client-safe / ClientAware) instead of a plain
+            // InvalidArgumentException so the GraphQL error handler treats this as
+            // client input misuse: the caller still gets the error message, but it
+            // is not forwarded to Sentry as noise.
+            throw new ValidationException('Input array cannot be empty.');
         }
 
         //verify it has the correct format


### PR DESCRIPTION
## What
`ImportMutation::product()` threw a plain `InvalidArgumentException` when the
`input` array supplied to the GraphQL mutation was empty/not an array. This is
expected client-side misuse (empty payload), but it was being reported to
Sentry as an unhandled error, creating noise.

## Why this happens
Lighthouse's `ReportingErrorHandler` forwards any GraphQL error to Laravel's
exception handler (`->report()`) unless the underlying exception is considered
"client safe" (`GraphQL\Error\ClientAware::isClientSafe()`). Our app's
`Handler::register()` reports every such exception straight to Sentry via
`Integration::captureUnhandledException()`.

## Fix
Replace the plain `InvalidArgumentException` with
`Kanvas\Exceptions\ValidationException`, which already exists in this codebase
specifically for this scenario (it extends `Baka\Exceptions\LightHouseCustomException`,
which implements `ClientAware` and marks errors as client-safe). This is the
same pattern already used throughout the app for client-facing validation
errors (e.g. `PipelineManagementMutation`, `FilesystemMapperMutation`).

Effects:
- The validation check itself is unchanged — an empty/non-array `input` still
  throws an exception.
- The client still receives the same error message in the GraphQL response.
- Because the exception is now client-safe, Lighthouse's
  `ReportingErrorHandler` skips calling the exception handler's `report()`
  entirely for it, so Sentry no longer receives this expected validation
  error. No other exception types or handling paths are affected.

## Files changed
- `app/GraphQL/Inventory/Mutations/Products/ImportMutation.php`