### PR TITLE
fix: ignore empty-input validation errors from ImportMutation in Sentry

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -52,6 +52,16 @@ return [
 
     'traces_sample_rate' => (float)(env('SENTRY_TRACES_SAMPLE_RATE', 0.0)),
 
+    'before_send' => function (\Sentry\Event $event, ?\Sentry\EventHint $hint): ?\Sentry\Event {
+        $exception = $hint?->exception;
+
+        if ($exception instanceof \InvalidArgumentException && $exception->getMessage() === 'Input array cannot be empty.') {
+            return null;
+        }
+
+        return $event;
+    },
+
     'controllers_base_namespace' => env('SENTRY_CONTROLLERS_BASE_NAMESPACE', 'App\\Http\\Controllers'),
 
     // Sentry Structured Logs — sends Log:: calls to Sentry's Logs product


### PR DESCRIPTION
`ImportMutation::product()` already throws `InvalidArgumentException('Input array cannot be empty.')` when the `input` array is empty or not an array.

This exception is expected client-side misuse and was being forwarded to Sentry as noise via `Handler::register()` -> `Integration::captureUnhandledException()`.

This PR adds a `before_send` hook to `config/sentry.php` (passed through to the Sentry PHP SDK by sentry-laravel) that drops the event when the underlying exception is an `InvalidArgumentException` with the message `Input array cannot be empty.`, before it is sent to Sentry. All other exceptions are unaffected.

No behavior change for the GraphQL client — the exception is still thrown and the error message is still returned as before.

## Files changed
- `config/sentry.php`