### PR TITLE
fix(intelligence): require explicit customer/vendor (prod safety)

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -62,15 +62,15 @@ class CreateApBillTool extends Tool
             new ToolProperty(
                 name: 'memo',
                 type: PropertyType::STRING,
-                description: 'Description / memo for the bill and its single line, e.g. "TEST write-path".',
+                description: 'Description / memo for the bill and its single line.',
                 required: true,
             ),
             new ToolProperty(
                 name: 'vendor_name',
                 type: PropertyType::STRING,
-                description: 'Vendor name to match (substring). Omit to use any existing active vendor '
-                    . 'organization on this app/company — fine for a write-path smoke test.',
-                required: false,
+                description: 'Vendor name to match (substring). Always required — never guess or pick an '
+                    . 'arbitrary vendor; ask the user which one if it is not clear from context.',
+                required: true,
             ),
             new ToolProperty(
                 name: 'currency',
@@ -85,33 +85,35 @@ class CreateApBillTool extends Tool
      * @return array<string, mixed>
      */
     public function __invoke(
+        string $vendor_name,
         float $amount,
         string $gl_account_number,
         string $memo,
-        ?string $vendor_name = null,
         ?string $currency = null,
     ): array {
         $app = $this->app;
         $company = $this->company;
 
-        $vendorQuery = Organization::query()
-            ->where('apps_id', $app->getId())
-            ->where('companies_id', $company->getId())
-            ->where('is_deleted', false);
-
-        if ($vendor_name !== null && trim($vendor_name) !== '') {
-            $vendorQuery->where('name', 'like', '%' . trim($vendor_name) . '%');
+        if (trim($vendor_name) === '') {
+            return [
+                'created' => false,
+                'reason' => 'vendor_name_required',
+                'message' => 'A vendor_name is required — never pick an arbitrary vendor.',
+            ];
         }
 
-        $vendor = $vendorQuery->first();
+        $vendor = Organization::query()
+            ->where('apps_id', $app->getId())
+            ->where('companies_id', $company->getId())
+            ->where('is_deleted', false)
+            ->where('name', 'like', '%' . trim($vendor_name) . '%')
+            ->first();
 
         if ($vendor === null) {
             return [
                 'created' => false,
                 'reason' => 'vendor_not_found',
-                'message' => $vendor_name !== null
-                    ? "No vendor organization matching \"{$vendor_name}\" for this app/company."
-                    : 'No active vendor organization exists for this app/company yet.',
+                'message' => "No vendor organization matching \"{$vendor_name}\" for this app/company.",
             ];
         }
 

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
@@ -55,15 +55,15 @@ class CreateArInvoiceTool extends Tool
             new ToolProperty(
                 name: 'memo',
                 type: PropertyType::STRING,
-                description: 'Description / memo for the invoice and its single line, e.g. "TEST write-path".',
+                description: 'Description / memo for the invoice and its single line.',
                 required: true,
             ),
             new ToolProperty(
                 name: 'customer_name',
                 type: PropertyType::STRING,
-                description: 'Customer name to match (substring). Omit to use any existing active customer '
-                    . 'organization on this app/company — fine for a write-path smoke test.',
-                required: false,
+                description: 'Customer name to match (substring). Always required — never guess or pick an '
+                    . 'arbitrary customer; ask the user which one if it is not clear from context.',
+                required: true,
             ),
             new ToolProperty(
                 name: 'currency',
@@ -78,32 +78,34 @@ class CreateArInvoiceTool extends Tool
      * @return array<string, mixed>
      */
     public function __invoke(
+        string $customer_name,
         float $amount,
         string $memo,
-        ?string $customer_name = null,
         ?string $currency = null,
     ): array {
         $app = $this->app;
         $company = $this->company;
 
-        $customerQuery = Organization::query()
-            ->where('apps_id', $app->getId())
-            ->where('companies_id', $company->getId())
-            ->where('is_deleted', false);
-
-        if ($customer_name !== null && trim($customer_name) !== '') {
-            $customerQuery->where('name', 'like', '%' . trim($customer_name) . '%');
+        if (trim($customer_name) === '') {
+            return [
+                'created' => false,
+                'reason' => 'customer_name_required',
+                'message' => 'A customer_name is required — never pick an arbitrary customer.',
+            ];
         }
 
-        $customer = $customerQuery->first();
+        $customer = Organization::query()
+            ->where('apps_id', $app->getId())
+            ->where('companies_id', $company->getId())
+            ->where('is_deleted', false)
+            ->where('name', 'like', '%' . trim($customer_name) . '%')
+            ->first();
 
         if ($customer === null) {
             return [
                 'created' => false,
                 'reason' => 'customer_not_found',
-                'message' => $customer_name !== null
-                    ? "No customer organization matching \"{$customer_name}\" for this app/company."
-                    : 'No active customer organization exists for this app/company yet.',
+                'message' => "No customer organization matching \"{$customer_name}\" for this app/company.",
             ];
         }
 

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
@@ -15,6 +15,7 @@ use Kanvas\Scribe\Invoices\Actions\CreateInvoiceAction;
 use Kanvas\Scribe\Invoices\Actions\IssueInvoiceAction;
 use Kanvas\Scribe\Invoices\DataTransferObject\Invoice as InvoiceData;
 use Kanvas\Scribe\Invoices\DataTransferObject\InvoiceLine as InvoiceLineData;
+use Kanvas\Scribe\Invoices\Models\Invoice;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;

--- a/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
@@ -160,6 +160,16 @@ class AccountsReceivableAgentToolsTest extends ScribeTestCase
         $this->assertSame('invoice_not_pushed', $result['reason']);
     }
 
+    public function test_create_ar_invoice_refuses_an_empty_customer_name(): void
+    {
+        $result = new CreateArInvoiceTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(customer_name: '', amount: 50.0, memo: 'test invoice');
+
+        $this->assertFalse($result['created']);
+        $this->assertSame('customer_name_required', $result['reason']);
+    }
+
     public function test_create_ar_invoice_leaves_it_open_with_no_auto_payment(): void
     {
         $customer = $this->seedTestOrganization('Open Invoice Customer');
@@ -167,7 +177,7 @@ class AccountsReceivableAgentToolsTest extends ScribeTestCase
 
         $result = new CreateArInvoiceTool()
             ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
-            ->__invoke(amount: 50.0, memo: 'test invoice', customer_name: 'Open Invoice Customer');
+            ->__invoke(customer_name: 'Open Invoice Customer', amount: 50.0, memo: 'test invoice');
 
         $this->assertTrue($result['created']);
         $this->assertArrayNotHasKey('payment_pushed', $result);


### PR DESCRIPTION
## Summary
Cherry-pick of #10660 onto `1.x` — **production safety fix**. `create_ar_invoice`/`create_ap_bill` fell back to "any active organization" when no name was given; this just landed on a real customer (CaseKing GmbH) in live testing, only blocked by Acumatica's own validation rejecting the write against a live account. `customer_name`/`vendor_name` are now required, no fallback.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>