### PR TITLE
fix: report Acumatica's real status on AP check payments

### DIFF
--- a/src/Domains/Connectors/Acumatica/Actions/PushPaymentToAcumaticaAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/PushPaymentToAcumaticaAction.php
@@ -28,12 +28,20 @@ class PushPaymentToAcumaticaAction
     /** The payment's own app — the tenant whose Acumatica config/credentials this push runs against. */
     protected Apps $app;
 
+    /** Acumatica's own Status on the record this call just pushed/released — null when the push was skipped (already pushed earlier). */
+    private ?string $lastPushedStatus = null;
+
     public function __construct(
         protected Payment $payment,
         ?AcumaticaWriteService $writer = null,
     ) {
         $this->app = $payment->app;
         $this->writer = $writer;
+    }
+
+    public function getLastPushedStatus(): ?string
+    {
+        return $this->lastPushedStatus;
     }
 
     public function execute(): string
@@ -76,6 +84,7 @@ class PushPaymentToAcumaticaAction
 
         $id = AcumaticaPayload::recordId($record);
         $referenceNbr = (string) (AcumaticaPayload::value($record, 'ReferenceNbr') ?? $id ?? '');
+        $this->lastPushedStatus = (string) (AcumaticaPayload::value($record, 'Status') ?? '') ?: null;
 
         if ($id !== null) {
             $this->payment->set(CustomFieldEnum::PAYMENT_ID->value, $id);

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AbstractApplyAcumaticaPaymentTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AbstractApplyAcumaticaPaymentTool.php
@@ -44,6 +44,17 @@ abstract class AbstractApplyAcumaticaPaymentTool extends Tool
     abstract protected function refreshedState(BaseModel $document): array;
 
     /**
+     * Extra response keys derived from Acumatica's own status on the just-pushed payment (e.g. a note when
+     * an AP Check lands in "Pending Print" rather than "Closed"). Empty by default.
+     *
+     * @return array<string, mixed>
+     */
+    protected function additionalContext(?string $acumaticaPaymentStatus): array
+    {
+        return [];
+    }
+
+    /**
      * @return array<int, ToolProperty>
      */
     #[Override]
@@ -111,8 +122,10 @@ abstract class AbstractApplyAcumaticaPaymentTool extends Tool
             ];
         }
 
+        $pushAction = new PushPaymentToAcumaticaAction($payment);
+
         try {
-            $paymentRef = new PushPaymentToAcumaticaAction($payment)->execute();
+            $paymentRef = $pushAction->execute();
         } catch (Throwable $e) {
             return [
                 'applied' => true,
@@ -123,6 +136,8 @@ abstract class AbstractApplyAcumaticaPaymentTool extends Tool
             ];
         }
 
+        $acumaticaStatus = $pushAction->getLastPushedStatus();
+
         return [
             'applied' => true,
             'pushed' => true,
@@ -130,7 +145,9 @@ abstract class AbstractApplyAcumaticaPaymentTool extends Tool
             $noun . '_ref' => $ref,
             'amount' => $amount,
             'payment_ref' => $paymentRef,
+            'acumatica_payment_status' => $acumaticaStatus,
             ...$this->refreshedState($document),
+            ...$this->additionalContext($acumaticaStatus),
         ];
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/ApplyApPaymentTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/ApplyApPaymentTool.php
@@ -86,4 +86,28 @@ class ApplyApPaymentTool extends AbstractApplyAcumaticaPaymentTool
             'document_status' => $fresh->document_status->value,
         ];
     }
+
+    /**
+     * A print-enabled Check payment method lands in Acumatica's "Pending Print" status on release — it
+     * doesn't post to GL or close the bill until someone runs Print/Release Checks (AP505000) there.
+     * Kanvas's own bookkeeping above already shows the bill as paid; this note keeps that from being
+     * mistaken for the bill being closed on the Acumatica side too.
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    protected function additionalContext(?string $acumaticaPaymentStatus): array
+    {
+        if ($acumaticaPaymentStatus === null || $acumaticaPaymentStatus === 'Closed') {
+            return [];
+        }
+
+        return [
+            'acumatica_note' => "The payment is in Acumatica status \"{$acumaticaPaymentStatus}\", not yet "
+                . 'Closed. This bill\'s cash account uses a Check payment method with printing enabled, so '
+                . 'Acumatica queues the check instead of posting it — the bill will not actually close there '
+                . 'until someone runs Print/Release Checks (screen AP505000). Kanvas shows this bill as paid '
+                . 'for internal tracking, but the ERP side is still pending that manual step.',
+        ];
+    }
 }

--- a/tests/Connectors/Acumatica/PushPaymentToAcumaticaActionTest.php
+++ b/tests/Connectors/Acumatica/PushPaymentToAcumaticaActionTest.php
@@ -106,7 +106,7 @@ class PushPaymentToAcumaticaActionTest extends ScribeTestCase
             function (string $entity, array $body) use (&$calls): array {
                 $calls[] = [$entity, $body];
 
-                return ['id' => 'PAY-1', 'ReferenceNbr' => ['value' => '000900']];
+                return ['id' => 'PAY-1', 'ReferenceNbr' => ['value' => '000900'], 'Status' => ['value' => 'Pending Print']];
             }
         );
 
@@ -115,10 +115,12 @@ class PushPaymentToAcumaticaActionTest extends ScribeTestCase
             fn (callable $callback) => $callback($client)
         );
 
-        $ref = new PushPaymentToAcumaticaAction($payment, $writer)->execute();
+        $action = new PushPaymentToAcumaticaAction($payment, $writer);
+        $ref = $action->execute();
 
         $this->assertSame('000900', $ref);
         $this->assertSame('PAY-1', $payment->get(CustomFieldEnum::PAYMENT_ID->value));
+        $this->assertSame('Pending Print', $action->getLastPushedStatus());
 
         [$step1Entity, $step1Body] = $calls[0];
         [$step2Entity, $step2Body] = $calls[1];


### PR DESCRIPTION
Cherry-pick of #10664 to 1.x.

## Summary
- `apply_ap_payment` previously reported a bill as paid using only Kanvas's own bookkeeping, even when the underlying Acumatica Check payment is left in "Pending Print" status (print-enabled Check payment methods don't post to GL or close the bill until someone runs Print/Release Checks, screen AP505000 — per Dennis).
- Now captures Acumatica's real `Status` after the push and surfaces it as `acumatica_payment_status`, plus an `acumatica_note` explaining the pending manual step when the status isn't `Closed`.
- No behavior change to the actual push/allocation flow — same two-step PUT as before. Safe to merge independent of the pending decision on which AP payment method (Check w/ printing vs ACH/Wire vs Check w/o printing) the AP team wants going forward.

## Test plan
- [x] Updated `PushPaymentToAcumaticaActionTest::test_ap_payment_pushes_a_check_via_two_step_put` to assert `getLastPushedStatus()` returns the mocked Acumatica status.
- [x] `php -l` syntax check on all 4 changed files (clean).
- [ ] Full `phpunit` run — blocked locally by an unrelated `vendor/google/apiclient-services` Docker/Composer corruption; not re-attempted here.