### PR TITLE
fix(intelligence): require an explicit customer/vendor name in create…

### DIFF
--- a/src/Domains/HumanResources/Employees/Models/Employee.php
+++ b/src/Domains/HumanResources/Employees/Models/Employee.php
@@ -46,6 +46,9 @@ use Override;
  * @property string      $employment_type
  * @property string|null $home_entity
  * @property string      $status
+ *
+ * @property-read Position|null   $position
+ * @property-read Department|null $department
  */
 #[ObservedBy([EmployeeObserver::class])]
 class Employee extends BaseModel
@@ -97,6 +100,21 @@ class Employee extends BaseModel
     public function getPathColumn(): string
     {
         return 'reporting_path';
+    }
+
+    /**
+     * A one-line summary — title, department, description — an orchestrator can match work against.
+     * Null when the record carries none of these, so callers fall back to matching by name.
+     */
+    public function describeForAssignment(): ?string
+    {
+        $parts = array_filter([
+            trim((string) $this->position?->title),
+            trim((string) $this->department?->name),
+            trim((string) $this->description),
+        ]);
+
+        return $parts === [] ? null : implode(' — ', $parts);
     }
 
     public function people(): BelongsTo

--- a/src/Domains/HumanResources/Employees/Services/EmployeeIdentityResolver.php
+++ b/src/Domains/HumanResources/Employees/Services/EmployeeIdentityResolver.php
@@ -7,6 +7,7 @@ namespace Kanvas\HumanResources\Employees\Services;
 use Baka\Contracts\AppInterface;
 use Baka\Contracts\CompanyInterface;
 use Baka\Users\Contracts\UserInterface;
+use Illuminate\Database\Eloquent\Collection;
 use Kanvas\HumanResources\Employees\Models\Employee;
 
 /**
@@ -29,5 +30,29 @@ class EmployeeIdentityResolver
             ->first();
 
         return $employee;
+    }
+
+    /**
+     * Batch variant of fromUser: resolve many users to their Employee records in one query,
+     * keyed by users_id, with position + department eager-loaded for display.
+     *
+     * @param array<int, int> $userIds
+     *
+     * @return Collection<int, Employee>
+     */
+    public function fromUsers(array $userIds, CompanyInterface $company, AppInterface $app): Collection
+    {
+        if ($userIds === []) {
+            return new Collection();
+        }
+
+        return Employee::query()
+            ->fromApp($app)
+            ->fromCompany($company)
+            ->notDeleted()
+            ->whereIn('users_id', $userIds)
+            ->with(['position', 'department'])
+            ->get()
+            ->keyBy('users_id');
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -62,15 +62,15 @@ class CreateApBillTool extends Tool
             new ToolProperty(
                 name: 'memo',
                 type: PropertyType::STRING,
-                description: 'Description / memo for the bill and its single line, e.g. "TEST write-path".',
+                description: 'Description / memo for the bill and its single line.',
                 required: true,
             ),
             new ToolProperty(
                 name: 'vendor_name',
                 type: PropertyType::STRING,
-                description: 'Vendor name to match (substring). Omit to use any existing active vendor '
-                    . 'organization on this app/company — fine for a write-path smoke test.',
-                required: false,
+                description: 'Vendor name to match (substring). Always required — never guess or pick an '
+                    . 'arbitrary vendor; ask the user which one if it is not clear from context.',
+                required: true,
             ),
             new ToolProperty(
                 name: 'currency',
@@ -85,33 +85,35 @@ class CreateApBillTool extends Tool
      * @return array<string, mixed>
      */
     public function __invoke(
+        string $vendor_name,
         float $amount,
         string $gl_account_number,
         string $memo,
-        ?string $vendor_name = null,
         ?string $currency = null,
     ): array {
         $app = $this->app;
         $company = $this->company;
 
-        $vendorQuery = Organization::query()
-            ->where('apps_id', $app->getId())
-            ->where('companies_id', $company->getId())
-            ->where('is_deleted', false);
-
-        if ($vendor_name !== null && trim($vendor_name) !== '') {
-            $vendorQuery->where('name', 'like', '%' . trim($vendor_name) . '%');
+        if (trim($vendor_name) === '') {
+            return [
+                'created' => false,
+                'reason' => 'vendor_name_required',
+                'message' => 'A vendor_name is required — never pick an arbitrary vendor.',
+            ];
         }
 
-        $vendor = $vendorQuery->first();
+        $vendor = Organization::query()
+            ->where('apps_id', $app->getId())
+            ->where('companies_id', $company->getId())
+            ->where('is_deleted', false)
+            ->where('name', 'like', '%' . trim($vendor_name) . '%')
+            ->first();
 
         if ($vendor === null) {
             return [
                 'created' => false,
                 'reason' => 'vendor_not_found',
-                'message' => $vendor_name !== null
-                    ? "No vendor organization matching \"{$vendor_name}\" for this app/company."
-                    : 'No active vendor organization exists for this app/company yet.',
+                'message' => "No vendor organization matching \"{$vendor_name}\" for this app/company.",
             ];
         }
 

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
@@ -55,15 +55,15 @@ class CreateArInvoiceTool extends Tool
             new ToolProperty(
                 name: 'memo',
                 type: PropertyType::STRING,
-                description: 'Description / memo for the invoice and its single line, e.g. "TEST write-path".',
+                description: 'Description / memo for the invoice and its single line.',
                 required: true,
             ),
             new ToolProperty(
                 name: 'customer_name',
                 type: PropertyType::STRING,
-                description: 'Customer name to match (substring). Omit to use any existing active customer '
-                    . 'organization on this app/company — fine for a write-path smoke test.',
-                required: false,
+                description: 'Customer name to match (substring). Always required — never guess or pick an '
+                    . 'arbitrary customer; ask the user which one if it is not clear from context.',
+                required: true,
             ),
             new ToolProperty(
                 name: 'currency',
@@ -78,32 +78,34 @@ class CreateArInvoiceTool extends Tool
      * @return array<string, mixed>
      */
     public function __invoke(
+        string $customer_name,
         float $amount,
         string $memo,
-        ?string $customer_name = null,
         ?string $currency = null,
     ): array {
         $app = $this->app;
         $company = $this->company;
 
-        $customerQuery = Organization::query()
-            ->where('apps_id', $app->getId())
-            ->where('companies_id', $company->getId())
-            ->where('is_deleted', false);
-
-        if ($customer_name !== null && trim($customer_name) !== '') {
-            $customerQuery->where('name', 'like', '%' . trim($customer_name) . '%');
+        if (trim($customer_name) === '') {
+            return [
+                'created' => false,
+                'reason' => 'customer_name_required',
+                'message' => 'A customer_name is required — never pick an arbitrary customer.',
+            ];
         }
 
-        $customer = $customerQuery->first();
+        $customer = Organization::query()
+            ->where('apps_id', $app->getId())
+            ->where('companies_id', $company->getId())
+            ->where('is_deleted', false)
+            ->where('name', 'like', '%' . trim($customer_name) . '%')
+            ->first();
 
         if ($customer === null) {
             return [
                 'created' => false,
                 'reason' => 'customer_not_found',
-                'message' => $customer_name !== null
-                    ? "No customer organization matching \"{$customer_name}\" for this app/company."
-                    : 'No active customer organization exists for this app/company yet.',
+                'message' => "No customer organization matching \"{$customer_name}\" for this app/company.",
             ];
         }
 

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
@@ -15,6 +15,7 @@ use Kanvas\Scribe\Invoices\Actions\CreateInvoiceAction;
 use Kanvas\Scribe\Invoices\Actions\IssueInvoiceAction;
 use Kanvas\Scribe\Invoices\DataTransferObject\Invoice as InvoiceData;
 use Kanvas\Scribe\Invoices\DataTransferObject\InvoiceLine as InvoiceLineData;
+use Kanvas\Scribe\Invoices\Models\Invoice;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;

--- a/src/Domains/NervousSystem/Project/Services/ProjectContextService.php
+++ b/src/Domains/NervousSystem/Project/Services/ProjectContextService.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Kanvas\NervousSystem\Project\Services;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
+use Kanvas\HumanResources\Employees\Services\EmployeeIdentityResolver;
 use Kanvas\NervousSystem\Ledger\Models\Event;
 use Kanvas\NervousSystem\Plan\Models\Plan;
 use Kanvas\NervousSystem\Plan\Models\Task;
@@ -16,11 +18,6 @@ use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Users\Models\Users;
 use Throwable;
 
-/**
- * Assembles a project's full situational-awareness bundle — objective, members, open work, recent
- * narrative and structured trail — so an agent reads the whole story before it acts. Reads across
- * ALL of the project's channels for the narrative; the ledger for the structured trail.
- */
 class ProjectContextService
 {
     private const int RECENT_MESSAGE_CHAR_CAP = 1200;
@@ -75,28 +72,53 @@ class ProjectContextService
      */
     private function members(Project $project): array
     {
-        return $project->members()
-            ->with(['user', 'agent'])
-            ->get()
+        /** @var Collection<int, ProjectMember> $members */
+        $members = $project->members()->with(['user', 'agent'])->get();
+        $humanDescriptions = $this->humanCapabilityDescriptions($project, $members);
+
+        return $members
             ->toBase()
             ->map(fn (ProjectMember $member): array => [
                 'type' => $member->member_type,
                 'role' => $member->role,
                 'name' => $this->memberName($member),
-                // The exact @handle the mention parser resolves (app displayname). Null when the
-                // member has no resolvable handle — the PM can't notify them, so don't offer one.
                 'handle' => $this->memberHandle($project, $member),
-                // Every member is a Kanvas user — this is the id assign_plan/assign_task need to hand
-                // work to a HUMAN. Without it the PM can only ever assign to agents (agent_id below).
                 'users_id' => $member->users_id,
                 'agent_id' => $member->agent_id,
-                // What this agent is for — so the PM assigns by fit, not by name.
-                'description' => $member->agent?->description ?? $member->agent?->type?->description,
-                // Only agents that can actually own a plan / move the board. Never assign executable
-                // work (assign_plan/assign_task) to a member where this is false — they'll stall or fail.
+                'description' => $member->agent?->description
+                    ?? $member->agent?->type?->description
+                    ?? ($humanDescriptions[$member->users_id] ?? null),
                 'can_execute' => (bool) $member->agent?->canExecuteBoardWork(),
             ])
             ->all();
+    }
+
+    /**
+     * Map each HUMAN member's users_id to their HR capability string (agents describe themselves),
+     * so the PM routes by fit. One `hr` query for all of them — no N+1 across connections.
+     *
+     * @param Collection<int, ProjectMember> $members
+     *
+     * @return array<int, string> keyed by users_id
+     */
+    private function humanCapabilityDescriptions(Project $project, Collection $members): array
+    {
+        $userIds = $members
+            ->filter(fn (ProjectMember $member): bool => $member->agent_id === null)
+            ->pluck('users_id')
+            ->map(fn ($id): int => (int) $id)
+            ->values()
+            ->all();
+
+        $descriptions = [];
+        foreach (new EmployeeIdentityResolver()->fromUsers($userIds, $project->company, $project->app) as $employee) {
+            $description = $employee->describeForAssignment();
+            if ($description !== null) {
+                $descriptions[(int) $employee->users_id] = $description;
+            }
+        }
+
+        return $descriptions;
     }
 
     private function memberName(ProjectMember $member): string

--- a/src/Domains/NervousSystem/Project/Services/ProjectContextService.php
+++ b/src/Domains/NervousSystem/Project/Services/ProjectContextService.php
@@ -74,7 +74,7 @@ class ProjectContextService
     {
         /** @var Collection<int, ProjectMember> $members */
         $members = $project->members()->with(['user', 'agent'])->get();
-        $humanDescriptions = $this->humanCapabilityDescriptions($project, $members);
+        $memberDescriptions = $this->memberCapabilityDescriptions($project, $members);
 
         return $members
             ->toBase()
@@ -85,26 +85,28 @@ class ProjectContextService
                 'handle' => $this->memberHandle($project, $member),
                 'users_id' => $member->users_id,
                 'agent_id' => $member->agent_id,
+                // An agent's own description is its sharpest routing signal, so it wins for agents;
+                // otherwise use the HR org-chart role (which lists agents and humans alike). Humans
+                // have no self-description, so for them HR is the source; none in HR → null.
                 'description' => $member->agent?->description
-                    ?? $member->agent?->type?->description
-                    ?? ($humanDescriptions[$member->users_id] ?? null),
+                    ?? $memberDescriptions[$member->users_id]
+                    ?? $member->agent?->type?->description,
                 'can_execute' => (bool) $member->agent?->canExecuteBoardWork(),
             ])
             ->all();
     }
 
     /**
-     * Map each HUMAN member's users_id to their HR capability string (agents describe themselves),
-     * so the PM routes by fit. One `hr` query for all of them — no N+1 across connections.
+     * Map each member's users_id to their HR org-chart role — HR lists agents and humans alike, so
+     * this covers both. One `hr` query for all members; no N+1 across connections.
      *
      * @param Collection<int, ProjectMember> $members
      *
      * @return array<int, string> keyed by users_id
      */
-    private function humanCapabilityDescriptions(Project $project, Collection $members): array
+    private function memberCapabilityDescriptions(Project $project, Collection $members): array
     {
         $userIds = $members
-            ->filter(fn (ProjectMember $member): bool => $member->agent_id === null)
             ->pluck('users_id')
             ->map(fn ($id): int => (int) $id)
             ->values()

--- a/tests/Intelligence/NervousSystem/ProjectContextServiceTest.php
+++ b/tests/Intelligence/NervousSystem/ProjectContextServiceTest.php
@@ -21,7 +21,6 @@ use Kanvas\NervousSystem\Project\Actions\CreateProjectAction;
 use Kanvas\NervousSystem\Project\Actions\PostProjectMessageAction;
 use Kanvas\NervousSystem\Project\DataTransferObject\Project as ProjectData;
 use Kanvas\NervousSystem\Project\Enums\ProjectMemberRoleEnum;
-use Kanvas\NervousSystem\Project\Models\Project;
 use Kanvas\NervousSystem\Project\Services\ProjectContextService;
 use Kanvas\Users\Models\Users;
 use Tests\TestCase;
@@ -167,32 +166,7 @@ class ProjectContextServiceTest extends TestCase
             user: $user,
         )->execute();
 
-        $department = new CreateDepartmentAction(
-            new DepartmentData(app: $app, company: $company, user: $user, name: 'Platform'),
-        )->execute();
-
-        $position = new CreatePositionAction(
-            new PositionData(app: $app, company: $company, user: $user, title: 'Staff Engineer'),
-        )->execute();
-
-        $people = People::factory()->create([
-            'apps_id' => $app->getId(),
-            'companies_id' => $company->getId(),
-            'users_id' => $user->getId(),
-        ]);
-
-        new CreateEmployeeAction(
-            new EmployeeData(
-                app: $app,
-                company: $company,
-                loginUser: $user,
-                people: $people,
-                position: $position,
-                hiredAt: '2026-01-15',
-                department: $department,
-                description: 'Owns CI',
-            ),
-        )->execute();
+        $this->createEmployee($app, $company, $user, 'Staff Engineer', 'Platform', 'Owns CI');
 
         $bundle = new ProjectContextService()->buildContextBundle($project);
 
@@ -229,5 +203,76 @@ class ProjectContextServiceTest extends TestCase
         // adds signal without regressing members who aren't employees.
         $this->assertSame('user', $bundle->members[0]['type']);
         $this->assertNull($bundle->members[0]['description']);
+    }
+
+    public function testAgentMemberPrefersOwnDescriptionThenHrRole(): void
+    {
+        [$app, $company, $user] = $this->context();
+
+        $agent = Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create(['user_id' => $user->getId(), 'description' => 'Handles CRM chores']);
+
+        $project = new CreateProjectAction(
+            ProjectData::from($app, $user, $company, ['title' => 'Ops', 'agent_id' => $agent->id]),
+        )->execute();
+
+        new AddProjectMemberAction(
+            project: $project,
+            role: ProjectMemberRoleEnum::CONTRIBUTOR,
+            agent: $agent,
+        )->execute();
+
+        // The agent's user is in the HR org chart too, but an agent's own description is the sharper
+        // routing signal, so it wins over the HR role.
+        $this->createEmployee($app, $company, $user, 'Staff Engineer', 'Platform');
+
+        $bundle = new ProjectContextService()->buildContextBundle($project);
+        $this->assertSame('agent', $bundle->members[0]['type']);
+        $this->assertSame('Handles CRM chores', $bundle->members[0]['description']);
+
+        // Strip the self-description → the HR org-chart role takes over as the fallback.
+        $agent->description = null;
+        $agent->saveOrFail();
+
+        $bundle = new ProjectContextService()->buildContextBundle($project);
+        $this->assertSame('Staff Engineer — Platform', $bundle->members[0]['description']);
+    }
+
+    private function createEmployee(
+        Apps $app,
+        Companies $company,
+        Users $user,
+        string $title,
+        string $department,
+        ?string $description = null,
+    ): void {
+        $departmentModel = new CreateDepartmentAction(
+            new DepartmentData(app: $app, company: $company, user: $user, name: $department),
+        )->execute();
+
+        $position = new CreatePositionAction(
+            new PositionData(app: $app, company: $company, user: $user, title: $title),
+        )->execute();
+
+        $people = People::factory()->create([
+            'apps_id' => $app->getId(),
+            'companies_id' => $company->getId(),
+            'users_id' => $user->getId(),
+        ]);
+
+        new CreateEmployeeAction(
+            new EmployeeData(
+                app: $app,
+                company: $company,
+                loginUser: $user,
+                people: $people,
+                position: $position,
+                hiredAt: '2026-01-15',
+                department: $departmentModel,
+                description: $description,
+            ),
+        )->execute();
     }
 }

--- a/tests/Intelligence/NervousSystem/ProjectContextServiceTest.php
+++ b/tests/Intelligence/NervousSystem/ProjectContextServiceTest.php
@@ -4,8 +4,16 @@ declare(strict_types=1);
 
 namespace Tests\Intelligence\NervousSystem;
 
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\HumanResources\Departments\Actions\CreateDepartmentAction;
+use Kanvas\HumanResources\Departments\DataTransferObject\Department as DepartmentData;
+use Kanvas\HumanResources\Employees\Actions\CreateEmployeeAction;
+use Kanvas\HumanResources\Employees\DataTransferObject\Employee as EmployeeData;
+use Kanvas\HumanResources\Positions\Actions\CreatePositionAction;
+use Kanvas\HumanResources\Positions\DataTransferObject\Position as PositionData;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\NervousSystem\Plan\Models\Plan;
 use Kanvas\NervousSystem\Project\Actions\AddProjectMemberAction;
@@ -20,6 +28,10 @@ use Tests\TestCase;
 
 class ProjectContextServiceTest extends TestCase
 {
+    use DatabaseTransactions;
+
+    protected array $connectionsToTransact = ['mysql', 'crm', 'hr', 'intelligence', 'social'];
+
     /**
      * @return array{0: Apps, 1: Companies, 2: Users}
      */
@@ -134,5 +146,88 @@ class ProjectContextServiceTest extends TestCase
             $this->assertFalse(str_starts_with((string) $content, '[NS:'), 'scaffolding leaked into context');
             $this->assertLessThanOrEqual(1210, strlen((string) $content), 'message content not capped');
         }
+    }
+
+    public function testHumanMemberSurfacesHrCapabilityDescription(): void
+    {
+        [$app, $company, $user] = $this->context();
+
+        $agent = Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create(['user_id' => $user->getId()]);
+
+        $project = new CreateProjectAction(
+            ProjectData::from($app, $user, $company, ['title' => 'Launch', 'agent_id' => $agent->id]),
+        )->execute();
+
+        new AddProjectMemberAction(
+            project: $project,
+            role: ProjectMemberRoleEnum::CONTRIBUTOR,
+            user: $user,
+        )->execute();
+
+        $department = new CreateDepartmentAction(
+            new DepartmentData(app: $app, company: $company, user: $user, name: 'Platform'),
+        )->execute();
+
+        $position = new CreatePositionAction(
+            new PositionData(app: $app, company: $company, user: $user, title: 'Staff Engineer'),
+        )->execute();
+
+        $people = People::factory()->create([
+            'apps_id' => $app->getId(),
+            'companies_id' => $company->getId(),
+            'users_id' => $user->getId(),
+        ]);
+
+        new CreateEmployeeAction(
+            new EmployeeData(
+                app: $app,
+                company: $company,
+                loginUser: $user,
+                people: $people,
+                position: $position,
+                hiredAt: '2026-01-15',
+                department: $department,
+                description: 'Owns CI',
+            ),
+        )->execute();
+
+        $bundle = new ProjectContextService()->buildContextBundle($project);
+
+        // The human member is described by their HR record, so the PM can route work by fit —
+        // the same signal an agent's description carries.
+        $this->assertSame('user', $bundle->members[0]['type']);
+        $this->assertSame('Staff Engineer — Platform — Owns CI', $bundle->members[0]['description']);
+        // A human is never an auto-runner: the description carries the routing signal, not can_execute.
+        $this->assertFalse($bundle->members[0]['can_execute']);
+    }
+
+    public function testHumanMemberWithoutHrRecordHasNoDescription(): void
+    {
+        [$app, $company, $user] = $this->context();
+
+        $agent = Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create(['user_id' => $user->getId()]);
+
+        $project = new CreateProjectAction(
+            ProjectData::from($app, $user, $company, ['title' => 'NoHr', 'agent_id' => $agent->id]),
+        )->execute();
+
+        new AddProjectMemberAction(
+            project: $project,
+            role: ProjectMemberRoleEnum::CONTRIBUTOR,
+            user: $user,
+        )->execute();
+
+        $bundle = new ProjectContextService()->buildContextBundle($project);
+
+        // No HR record → no description, so the PM falls back to name matching. Proves the HR wiring
+        // adds signal without regressing members who aren't employees.
+        $this->assertSame('user', $bundle->members[0]['type']);
+        $this->assertNull($bundle->members[0]['description']);
     }
 }

--- a/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
@@ -160,6 +160,16 @@ class AccountsReceivableAgentToolsTest extends ScribeTestCase
         $this->assertSame('invoice_not_pushed', $result['reason']);
     }
 
+    public function test_create_ar_invoice_refuses_an_empty_customer_name(): void
+    {
+        $result = new CreateArInvoiceTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(customer_name: '', amount: 50.0, memo: 'test invoice');
+
+        $this->assertFalse($result['created']);
+        $this->assertSame('customer_name_required', $result['reason']);
+    }
+
     public function test_create_ar_invoice_leaves_it_open_with_no_auto_payment(): void
     {
         $customer = $this->seedTestOrganization('Open Invoice Customer');
@@ -167,7 +177,7 @@ class AccountsReceivableAgentToolsTest extends ScribeTestCase
 
         $result = new CreateArInvoiceTool()
             ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
-            ->__invoke(amount: 50.0, memo: 'test invoice', customer_name: 'Open Invoice Customer');
+            ->__invoke(customer_name: 'Open Invoice Customer', amount: 50.0, memo: 'test invoice');
 
         $this->assertTrue($result['created']);
         $this->assertArrayNotHasKey('payment_pushed', $result);


### PR DESCRIPTION
…_ar_invoice and create_ap_bill

Both tools silently fell back to "any active organization on this app/company" when the caller
omitted a name. Live testing just proved this is unsafe: with no customer named, the fallback
picked CaseKing GmbH — a real production customer — instead of a test account, and the invoice
was only stopped by Acumatica's own validation rejecting the write. Since this runs in production,
an agent must never guess which real customer/vendor to write a document against.

customer_name/vendor_name are now required parameters with no fallback; an empty value returns a
clear customer_name_required/vendor_name_required error instead of picking anything.

Also removes "smoke test" / "TEST write-path" wording from the tool property descriptions — the
model was echoing that language straight into real invoice/bill memos.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
