### PR TITLE
feat(events): sync appointments to Google Calendar

### DIFF
--- a/src/Domains/Connectors/Google/Actions/CreateGoogleCalendarMeetingAction.php
+++ b/src/Domains/Connectors/Google/Actions/CreateGoogleCalendarMeetingAction.php
@@ -9,6 +9,7 @@ use Carbon\CarbonInterface;
 use Kanvas\Connectors\Google\Enums\ConfigurationEnum;
 use Kanvas\Exceptions\ValidationException;
 use Spatie\GoogleCalendar\Event as GoogleCalendarEvent;
+use Throwable;
 
 class CreateGoogleCalendarMeetingAction
 {
@@ -20,12 +21,28 @@ class CreateGoogleCalendarMeetingAction
         protected CarbonInterface $endDateTime,
         protected ?string $description = null,
         protected bool $withMeetLink = true,
+        protected ?string $externalEventId = null,
     ) {
     }
 
     public function execute(): array
     {
         $this->applyCompanyCalendarConfig();
+
+        if ($this->externalEventId !== null) {
+            try {
+                $existing = GoogleCalendarEvent::find($this->externalEventId);
+                if ($existing !== null) {
+                    return $this->formatResult($existing);
+                }
+            } catch (Throwable $e) {
+                if ((int) $e->getCode() !== 404) {
+                    throw $e;
+                }
+
+                // Missing is expected on the first execution or after external deletion.
+            }
+        }
 
         $emails = array_values(array_unique(array_filter(
             $this->attendeeEmails,
@@ -38,6 +55,10 @@ class CreateGoogleCalendarMeetingAction
         $event->startDateTime = $this->startDateTime;
         $event->endDateTime = $this->endDateTime;
 
+        if ($this->externalEventId !== null) {
+            $event->googleEvent->setId($this->externalEventId);
+        }
+
         foreach ($emails as $email) {
             $event->addAttendee(['email' => $email]);
         }
@@ -46,8 +67,13 @@ class CreateGoogleCalendarMeetingAction
             $event->addMeetLink();
         }
 
-        $saved = $event->save();
+        $saved = $event->save($this->externalEventId !== null ? 'insertEvent' : null);
 
+        return $this->formatResult($saved, $emails);
+    }
+
+    protected function formatResult(GoogleCalendarEvent $saved, ?array $emails = null): array
+    {
         return [
             'id' => $saved->id,
             'calendar_id' => $saved->getCalendarId(),
@@ -57,7 +83,7 @@ class CreateGoogleCalendarMeetingAction
             'end' => $this->endDateTime->toIso8601String(),
             'meet_link' => $saved->googleEvent->getHangoutLink(),
             'html_link' => $saved->googleEvent->getHtmlLink(),
-            'attendees' => $emails,
+            'attendees' => $emails ?? $this->attendeeEmails,
         ];
     }
 

--- a/src/Domains/Connectors/Google/Actions/SyncEventToGoogleCalendarAction.php
+++ b/src/Domains/Connectors/Google/Actions/SyncEventToGoogleCalendarAction.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Google\Actions;
+
+use Carbon\Carbon;
+use Kanvas\Connectors\Google\Enums\CustomFieldEnum;
+use Kanvas\Event\Events\Models\Event;
+use Kanvas\Exceptions\ValidationException;
+
+class SyncEventToGoogleCalendarAction
+{
+    public function __construct(protected Event $event)
+    {
+    }
+
+    public function execute(): array
+    {
+        $externalId = $this->event->get(CustomFieldEnum::GOOGLE_CALENDAR_EVENT_ID->value);
+
+        $version = $this->event->versions()->with('dates')->latest('version')->first();
+        if ($version === null || $version->dates->isEmpty()) {
+            throw new ValidationException('Event has no dated version to synchronize.');
+        }
+
+        $dates = $version->dates->sortBy('event_date');
+        $first = $dates->first();
+        $last = $dates->last();
+        $timezone = $this->event->company->timezone ?: 'UTC';
+        $start = Carbon::createFromFormat('Y-m-d H:i:s', $first->event_date->format('Y-m-d') . ' ' . $first->start_time, $timezone);
+        $end = Carbon::createFromFormat('Y-m-d H:i:s', $last->event_date->format('Y-m-d') . ' ' . $last->end_time, $timezone);
+        $googleEventId = is_string($externalId) && $externalId !== ''
+            ? $externalId
+            : hash('sha256', 'kanvas-event-' . $this->event->uuid);
+        $result = $this->createMeeting($start, $end, $googleEventId);
+
+        $this->event->set(CustomFieldEnum::GOOGLE_CALENDAR_EVENT_ID->value, $result['id']);
+        if (! empty($result['html_link'])) {
+            $this->event->set(CustomFieldEnum::GOOGLE_CALENDAR_HTML_LINK->value, $result['html_link']);
+        }
+        if (! empty($result['meet_link'])) {
+            $this->event->set(CustomFieldEnum::GOOGLE_CALENDAR_MEET_LINK->value, $result['meet_link']);
+            $this->event->meeting_link = $result['meet_link'];
+            $this->event->saveQuietly();
+        }
+
+        return ['status' => 'success', 'event_id' => $this->event->getId(), 'google_event' => $result];
+    }
+
+    protected function createMeeting(Carbon $start, Carbon $end, string $externalEventId): array
+    {
+        return new CreateGoogleCalendarMeetingAction(
+            company: $this->event->company,
+            name: $this->event->name,
+            attendeeEmails: $this->resolveAttendeeEmails(),
+            startDateTime: $start,
+            endDateTime: $end,
+            description: $this->event->description,
+            withMeetLink: true,
+            externalEventId: $externalEventId,
+        )->execute();
+    }
+
+    protected function resolveAttendeeEmails(): array
+    {
+        $version = $this->event->versions()->latest('version')->first();
+        $configuredEmails = $version?->metadata['google_calendar']['attendee_emails'] ?? [];
+        if (is_array($configuredEmails) && $configuredEmails !== []) {
+            $validConfiguredEmails = collect($configuredEmails)
+                ->filter(fn (mixed $email): bool => is_string($email) && filter_var($email, FILTER_VALIDATE_EMAIL) !== false)
+                ->unique()->values()->all();
+
+            if ($validConfiguredEmails !== []) {
+                return $validConfiguredEmails;
+            }
+        }
+
+        $people = $this->event->resource?->people;
+        if ($people === null) {
+            return [];
+        }
+
+        return $people->contacts()
+            ->whereIn('contacts_types_id', [1, 9, 10])
+            ->where('is_opt_out', 0)
+            ->pluck('value')
+            ->filter(fn (mixed $email): bool => is_string($email) && filter_var($email, FILTER_VALIDATE_EMAIL) !== false)
+            ->unique()->values()->all();
+    }
+}

--- a/src/Domains/Connectors/Google/Activities/CreateGoogleCalendarEventActivity.php
+++ b/src/Domains/Connectors/Google/Activities/CreateGoogleCalendarEventActivity.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Google\Activities;
+
+use Baka\Contracts\AppInterface;
+use Illuminate\Database\Eloquent\Model;
+use Kanvas\Connectors\Google\Actions\SyncEventToGoogleCalendarAction;
+use Kanvas\Event\Events\Models\Event;
+use Kanvas\Workflow\Attributes\WorkflowAction;
+use Kanvas\Workflow\Contracts\WorkflowActivityInterface;
+use Kanvas\Workflow\KanvasActivity;
+use Override;
+
+#[WorkflowAction]
+class CreateGoogleCalendarEventActivity extends KanvasActivity implements WorkflowActivityInterface
+{
+    #[Override]
+    public function execute(Model $entity, AppInterface $app, array $params): array
+    {
+        $this->overwriteAppService($app);
+
+        if (! $entity instanceof Event) {
+            return $this->failWorkflow(['status' => 'error', 'message' => 'This activity only supports Event entities.']);
+        }
+
+        $event = $entity;
+        if ($event->apps_id !== $app->getId()) {
+            return $this->failWorkflow(['status' => 'error', 'message' => 'Event does not belong to the workflow app.']);
+        }
+
+        return new SyncEventToGoogleCalendarAction($event)->execute();
+    }
+}

--- a/src/Domains/Connectors/Google/Enums/CustomFieldEnum.php
+++ b/src/Domains/Connectors/Google/Enums/CustomFieldEnum.php
@@ -7,4 +7,7 @@ namespace Kanvas\Connectors\Google\Enums;
 enum CustomFieldEnum: string
 {
     case GOOGLE_INTERACTION_NAME = 'google-interaction-name';
+    case GOOGLE_CALENDAR_EVENT_ID = 'google-calendar-event-id';
+    case GOOGLE_CALENDAR_HTML_LINK = 'google-calendar-html-link';
+    case GOOGLE_CALENDAR_MEET_LINK = 'google-calendar-meet-link';
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/CalendarEventTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/CalendarEventTool.php
@@ -10,6 +10,7 @@ use Kanvas\Event\Events\DataTransferObject\Event as EventData;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\ResolvesLeadForTool;
+use Kanvas\Workflow\Enums\WorkflowEnum;
 use NeuronAI\Tools\ArrayProperty;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
@@ -133,6 +134,13 @@ class CalendarEventTool extends Tool
             ];
         }
 
+        if (! $start->isSameDay($end)) {
+            return [
+                'status' => 'error',
+                'message' => 'Appointments must start and end on the same local calendar date.',
+            ];
+        }
+
         $attendeeBlock = $attendee_emails === [] ? '' : "\nAttendees: " . implode(', ', $attendee_emails);
         $fullDescription = trim(($description ?? '') . $attendeeBlock);
 
@@ -161,10 +169,19 @@ class CalendarEventTool extends Tool
                 ]
             );
 
-            $event = new CreateEventAction($eventData)->disableWorkflow()->execute();
+            $event = new CreateEventAction($eventData, [
+                'google_calendar' => [
+                    'attendee_emails' => array_values(array_unique($attendee_emails)),
+                ],
+            ])->disableWorkflow()->execute();
             $event->resources_id = $lead->getId();
             $event->resources_type = Lead::class;
             $event->saveQuietly();
+            $event->fireWorkflow(
+                WorkflowEnum::CREATED->value,
+                true,
+                ['app' => $lead->app, 'company' => $company],
+            );
         } catch (Throwable $e) {
             return [
                 'status' => 'error',


### PR DESCRIPTION
## Summary
- create Guild events from scheduled appointments and dispatch the created workflow
- add a workflow activity that syncs Event records to Google Calendar
- persist Google Calendar event, Meet, and HTML link metadata with idempotent retries

## Validation
- PHP syntax checks passed for all five changed files
- git diff --check passed

## Notes
- workflow rule must target Event created and CreateGoogleCalendarEventActivity
- no production access performed