### PR TITLE
fix: report engagement page failures to Sentry

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/CreateEngagementPageTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/CreateEngagementPageTool.php
@@ -16,7 +16,11 @@ use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
 use Override;
+use Sentry\State\Scope;
 use Throwable;
+
+use function Sentry\captureException;
+use function Sentry\withScope;
 
 #[AgentTool(name: 'Create Engagement Page', category: 'crm')]
 class CreateEngagementPageTool extends Tool
@@ -100,7 +104,7 @@ class CreateEngagementPageTool extends Tool
                 data: $data,
             ));
         } catch (Throwable $e) {
-            report($e);
+            $this->reportException($e, $lead_id, $action);
 
             return [
                 'status' => 'error',
@@ -136,5 +140,22 @@ class CreateEngagementPageTool extends Tool
     protected function createEngagement(EngagementData $data): Engagement
     {
         return new CreateEngagementAction($data)->execute();
+    }
+
+    protected function reportException(Throwable $exception, int $leadId, string $action): void
+    {
+        withScope(function (Scope $scope) use ($exception, $leadId, $action): void {
+            $scope->setTag('operation', 'create_engagement_page');
+            $scope->setTag('action_slug', $action);
+            $scope->setContext('create_engagement_page', [
+                'lead_id' => $leadId,
+                'action' => $action,
+                'app_id' => $this->app->getId(),
+                'company_id' => $this->company->getId(),
+                'user_id' => $this->user->getId(),
+            ]);
+
+            captureException($exception);
+        });
     }
 }

--- a/tests/Intelligence/Agents/Tools/CreateEngagementPageToolTest.php
+++ b/tests/Intelligence/Agents/Tools/CreateEngagementPageToolTest.php
@@ -12,6 +12,7 @@ use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\CreateEngagementPageTool;
 use Kanvas\Social\Messages\Models\Message;
 use Tests\TestCase;
+use Throwable;
 
 class CreateEngagementPageToolTest extends TestCase
 {
@@ -125,5 +126,48 @@ class CreateEngagementPageToolTest extends TestCase
 
         $this->assertSame('error', $result['status']);
         $this->assertSame(124, $result['engagement_id']);
+    }
+
+    public function testReportsEngagementCreationFailureWithSafeContext(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+        $lead = Lead::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create();
+        $exception = new \RuntimeException('Action Engine failed');
+
+        $tool = new class ($exception) extends CreateEngagementPageTool {
+            public ?Throwable $reportedException = null;
+            public ?int $reportedLeadId = null;
+            public ?string $reportedAction = null;
+
+            public function __construct(private readonly Throwable $exception)
+            {
+                parent::__construct();
+            }
+
+            protected function createEngagement(EngagementData $data): Engagement
+            {
+                throw $this->exception;
+            }
+
+            protected function reportException(Throwable $exception, int $leadId, string $action): void
+            {
+                $this->reportedException = $exception;
+                $this->reportedLeadId = $leadId;
+                $this->reportedAction = $action;
+            }
+        };
+        $tool->withContext($app, $company, $user);
+
+        $result = $tool->__invoke($lead->getId(), 'view-vehicle');
+
+        $this->assertSame('error', $result['status']);
+        $this->assertSame($exception, $tool->reportedException);
+        $this->assertSame($lead->getId(), $tool->reportedLeadId);
+        $this->assertSame('view-vehicle', $tool->reportedAction);
     }
 }


### PR DESCRIPTION
## Summary
- capture create_engagement_page failures explicitly in Sentry
- attach safe lead, action, app, company, and user context
- add regression coverage for the failure-reporting path

## Validation
- git diff --check
- PHP syntax checks passed for the tool and test
- PHPUnit not run: local PHP 8.4.10 does not satisfy the installed dependencies' PHP >= 8.5 requirement