### PR TITLE
fix: create engagement pages as agent user

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/CreateEngagementPageTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/CreateEngagementPageTool.php
@@ -11,6 +11,7 @@ use Kanvas\ActionEngine\Engagements\Models\Engagement;
 use Kanvas\ActionEngine\Enums\ActionStatusEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
@@ -27,7 +28,7 @@ class CreateEngagementPageTool extends Tool
 {
     use HasKanvasContext;
 
-    public function __construct()
+    public function __construct(private readonly Agent $agent)
     {
         parent::__construct(
             name: 'create_engagement_page',
@@ -90,10 +91,18 @@ class CreateEngagementPageTool extends Tool
         }
 
         try {
+            $agentUser = $this->agent->user;
+            if ($agentUser === null) {
+                return [
+                    'status' => 'error',
+                    'message' => 'The agent must have an acting user configured to create an engagement page.',
+                ];
+            }
+
             $engagement = $this->createEngagement(new EngagementData(
                 app: $this->app,
                 company: $this->company,
-                user: $this->user,
+                user: $agentUser,
                 lead: $lead,
                 action: $action,
                 requestId: (string) Str::uuid(),
@@ -152,7 +161,7 @@ class CreateEngagementPageTool extends Tool
                 'action' => $action,
                 'app_id' => $this->app->getId(),
                 'company_id' => $this->company->getId(),
-                'user_id' => $this->user->getId(),
+                'user_id' => $this->agent->user_id,
             ]);
 
             captureException($exception);

--- a/tests/Intelligence/Agents/Tools/CreateEngagementPageToolTest.php
+++ b/tests/Intelligence/Agents/Tools/CreateEngagementPageToolTest.php
@@ -9,8 +9,10 @@ use Kanvas\ActionEngine\Engagements\Models\Engagement;
 use Kanvas\ActionEngine\Enums\ActionStatusEnum;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\CreateEngagementPageTool;
 use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Users\Models\Users;
 use Tests\TestCase;
 use Throwable;
 
@@ -19,8 +21,13 @@ class CreateEngagementPageToolTest extends TestCase
     public function testCreatesEngagementPageAndReturnsUnsentActionLink(): void
     {
         $app = app(Apps::class);
-        $user = auth()->user();
-        $company = $user->getCurrentCompany();
+        $requestingUser = auth()->user();
+        $company = $requestingUser->getCurrentCompany();
+        $agentUser = Users::factory()->create();
+        $agent = Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create(['user_id' => $agentUser->getId()]);
         $lead = Lead::factory()
             ->withAppId($app->getId())
             ->withCompanyId($company->getId())
@@ -38,12 +45,12 @@ class CreateEngagementPageToolTest extends TestCase
         $engagement->id = 123;
         $engagement->setRelation('message', $message);
 
-        $tool = new class ($engagement) extends CreateEngagementPageTool {
+        $tool = new class ($agent, $engagement) extends CreateEngagementPageTool {
             public ?EngagementData $receivedData = null;
 
-            public function __construct(private readonly Engagement $engagementResult)
+            public function __construct(Agent $agent, private readonly Engagement $engagementResult)
             {
-                parent::__construct();
+                parent::__construct($agent);
             }
 
             protected function createEngagement(EngagementData $data): Engagement
@@ -53,7 +60,7 @@ class CreateEngagementPageToolTest extends TestCase
                 return $this->engagementResult;
             }
         };
-        $tool->withContext($app, $company, $user);
+        $tool->withContext($app, $company, $requestingUser);
 
         $result = $tool->__invoke(
             lead_id: $lead->getId(),
@@ -75,6 +82,8 @@ class CreateEngagementPageToolTest extends TestCase
         $this->assertSame(ActionStatusEnum::SENT, $tool->receivedData?->status);
         $this->assertSame('agent', $tool->receivedData?->source);
         $this->assertSame('agent', $tool->receivedData?->via);
+        $this->assertSame($agentUser->getId(), $tool->receivedData?->user->getId());
+        $this->assertNotSame($requestingUser->getId(), $tool->receivedData?->user->getId());
         $this->assertTrue($tool->receivedData?->data['products'][0]['interested']);
     }
 
@@ -83,7 +92,11 @@ class CreateEngagementPageToolTest extends TestCase
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
-        $tool = new CreateEngagementPageTool();
+        $agent = Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create(['user_id' => $user->getId()]);
+        $tool = new CreateEngagementPageTool($agent);
         $tool->withContext($app, $company, $user);
 
         $missingAction = $tool->__invoke(1, '   ');
@@ -98,6 +111,10 @@ class CreateEngagementPageToolTest extends TestCase
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
+        $agent = Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create(['user_id' => $user->getId()]);
         $lead = Lead::factory()
             ->withAppId($app->getId())
             ->withCompanyId($company->getId())
@@ -109,10 +126,10 @@ class CreateEngagementPageToolTest extends TestCase
         $engagement->id = 124;
         $engagement->setRelation('message', new Message(['message' => []]));
 
-        $tool = new class ($engagement) extends CreateEngagementPageTool {
-            public function __construct(private readonly Engagement $engagementResult)
+        $tool = new class ($agent, $engagement) extends CreateEngagementPageTool {
+            public function __construct(Agent $agent, private readonly Engagement $engagementResult)
             {
-                parent::__construct();
+                parent::__construct($agent);
             }
 
             protected function createEngagement(EngagementData $data): Engagement
@@ -133,20 +150,24 @@ class CreateEngagementPageToolTest extends TestCase
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
+        $agent = Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create(['user_id' => $user->getId()]);
         $lead = Lead::factory()
             ->withAppId($app->getId())
             ->withCompanyId($company->getId())
             ->create();
         $exception = new \RuntimeException('Action Engine failed');
 
-        $tool = new class ($exception) extends CreateEngagementPageTool {
+        $tool = new class ($agent, $exception) extends CreateEngagementPageTool {
             public ?Throwable $reportedException = null;
             public ?int $reportedLeadId = null;
             public ?string $reportedAction = null;
 
-            public function __construct(private readonly Throwable $exception)
+            public function __construct(Agent $agent, private readonly Throwable $exception)
             {
-                parent::__construct();
+                parent::__construct($agent);
             }
 
             protected function createEngagement(EngagementData $data): Engagement


### PR DESCRIPTION
## Summary
- resolve the engagement actor from the configured Agent user
- never fall back to the human requesting the chat
- return a clear error when the agent has no acting user
- add regression coverage with distinct requester and agent identities

## Validation
- PHP syntax checks passed for the tool and focused test
- git diff --check passed
- PHPUnit was not run because vendor/bin/phpunit is unavailable in this worktree