### PR TITLE
style: trim comments to one line per house style

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AbstractApplyAcumaticaPaymentTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AbstractApplyAcumaticaPaymentTool.php
@@ -44,8 +44,7 @@ abstract class AbstractApplyAcumaticaPaymentTool extends Tool
     abstract protected function refreshedState(BaseModel $document): array;
 
     /**
-     * Extra response keys derived from Acumatica's own status on the just-pushed payment (e.g. a note when
-     * an AP Check lands in "Pending Print" rather than "Closed"). Empty by default.
+     * Extra response keys derived from Acumatica's own status on the just-pushed payment. Empty by default.
      *
      * @return array<string, mixed>
      */

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/ApplyApPaymentTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/ApplyApPaymentTool.php
@@ -88,10 +88,7 @@ class ApplyApPaymentTool extends AbstractApplyAcumaticaPaymentTool
     }
 
     /**
-     * A print-enabled Check payment method lands in Acumatica's "Pending Print" status on release — it
-     * doesn't post to GL or close the bill until someone runs Print/Release Checks (AP505000) there.
-     * Kanvas's own bookkeeping above already shows the bill as paid; this note keeps that from being
-     * mistaken for the bill being closed on the Acumatica side too.
+     * A print-enabled Check method leaves the payment "Pending Print" — not posted to GL/closed — until someone runs Print/Release Checks (AP505000).
      *
      * @return array<string, mixed>
      */


### PR DESCRIPTION
Cherry-pick of #10680 to 1.x — trims two multi-line comment blocks down to one line each, per house style. No behavior change.