### PR TITLE
fix: surface Acumatica's nested per-field validation errors

### DIFF
--- a/src/Domains/Connectors/Acumatica/Exceptions/AcumaticaWriteException.php
+++ b/src/Domains/Connectors/Acumatica/Exceptions/AcumaticaWriteException.php
@@ -10,8 +10,14 @@ use Throwable;
 
 /**
  * Raised when a write-back to Acumatica fails or is not permitted. On transport failures it surfaces
- * Acumatica's own error body (`exceptionMessage` / `message`) rather than a bare HTTP status, so the
- * operator sees why the ERP rejected the document.
+ * Acumatica's own error body rather than a bare HTTP status, so the operator sees why the ERP
+ * rejected the document.
+ *
+ * A PUT validation failure on an entity puts its top-level `error` at "raised at least one error,
+ * please review the errors" — the actual cause sits nested per-field, e.g.
+ * `"PostPeriod": {"value": "082026", "error": "Error: The 08-2026 financial period is inactive..."}`.
+ * Those field-level errors (including inside `Details` line items) are what actually explain the
+ * rejection, so they take priority over the generic top-level message.
  */
 class AcumaticaWriteException extends RuntimeException
 {
@@ -37,8 +43,55 @@ class AcumaticaWriteException extends RuntimeException
             return null;
         }
 
-        $message = $decoded['exceptionMessage'] ?? $decoded['message'] ?? null;
+        $fieldErrors = self::collectFieldErrors($decoded);
 
-        return is_string($message) && $message !== '' ? $message : null;
+        if ($fieldErrors !== []) {
+            return implode('; ', $fieldErrors);
+        }
+
+        $message = $decoded['exceptionMessage'] ?? $decoded['message'] ?? $decoded['error'] ?? null;
+
+        if (is_string($message) && $message !== '') {
+            return $message;
+        }
+
+        // Per-row validation errors nest their own 'error' field, e.g. {"id":..., "error": "..."}.
+        if (isset($decoded[0]['error']) && is_string($decoded[0]['error']) && $decoded[0]['error'] !== '') {
+            return $decoded[0]['error'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Walks a decoded entity record (and its `Details` line items, one level deep) for
+     * `{"value": ..., "error": "..."}`-shaped fields — the specific validation failure(s) behind a
+     * generic top-level "raised at least one error" message.
+     *
+     * @param array<string, mixed> $record
+     *
+     * @return array<int, string>
+     */
+    private static function collectFieldErrors(array $record): array
+    {
+        $errors = [];
+
+        foreach ($record as $field => $value) {
+            if ($field === 'Details' && is_array($value)) {
+                foreach ($value as $line) {
+                    if (is_array($line)) {
+                        $errors = [...$errors, ...self::collectFieldErrors($line)];
+                    }
+                }
+
+                continue;
+            }
+
+            if (is_array($value) && isset($value['error']) && is_string($value['error']) && $value['error'] !== '') {
+                $errors[] = "{$field}: {$value['error']}";
+            }
+        }
+
+        return $errors;
     }
 }

--- a/src/Domains/Connectors/Acumatica/Exceptions/AcumaticaWriteException.php
+++ b/src/Domains/Connectors/Acumatica/Exceptions/AcumaticaWriteException.php
@@ -8,17 +8,7 @@ use GuzzleHttp\Exception\RequestException;
 use RuntimeException;
 use Throwable;
 
-/**
- * Raised when a write-back to Acumatica fails or is not permitted. On transport failures it surfaces
- * Acumatica's own error body rather than a bare HTTP status, so the operator sees why the ERP
- * rejected the document.
- *
- * A PUT validation failure on an entity puts its top-level `error` at "raised at least one error,
- * please review the errors" — the actual cause sits nested per-field, e.g.
- * `"PostPeriod": {"value": "082026", "error": "Error: The 08-2026 financial period is inactive..."}`.
- * Those field-level errors (including inside `Details` line items) are what actually explain the
- * rejection, so they take priority over the generic top-level message.
- */
+/** Raised when a write-back to Acumatica fails or is not permitted; surfaces nested per-field errors (e.g. PostPeriod) over the generic top-level validation message. */
 class AcumaticaWriteException extends RuntimeException
 {
     public static function fromThrowable(Throwable $e, string $context): self
@@ -64,10 +54,6 @@ class AcumaticaWriteException extends RuntimeException
     }
 
     /**
-     * Walks a decoded entity record (and its `Details` line items, one level deep) for
-     * `{"value": ..., "error": "..."}`-shaped fields — the specific validation failure(s) behind a
-     * generic top-level "raised at least one error" message.
-     *
      * @param array<string, mixed> $record
      *
      * @return array<int, string>

--- a/src/Domains/Connectors/Acumatica/Services/AcumaticaWriteService.php
+++ b/src/Domains/Connectors/Acumatica/Services/AcumaticaWriteService.php
@@ -71,6 +71,7 @@ class AcumaticaWriteService
         string $releaseAction = 'Release'
     ): array {
         $this->assertWriteEnabled();
+        $this->keepRunningPastClientDisconnect();
 
         $client = $this->client();
 
@@ -111,6 +112,7 @@ class AcumaticaWriteService
     public function withSession(callable $callback): mixed
     {
         $this->assertWriteEnabled();
+        $this->keepRunningPastClientDisconnect();
 
         $client = $this->client();
 
@@ -136,6 +138,7 @@ class AcumaticaWriteService
     public function findOrCreate(string $entity, array $query, array $createBody): array
     {
         $this->assertWriteEnabled();
+        $this->keepRunningPastClientDisconnect();
 
         $client = $this->client();
 
@@ -198,5 +201,17 @@ class AcumaticaWriteService
         } catch (Throwable) {
             // A failed logout must never mask the real write error.
         }
+    }
+
+    /**
+     * PHP aborts script execution the moment the client disconnects unless told otherwise — which
+     * skips straight past our finally-block logout, leaving the Acumatica session held open until it
+     * expires on its own (~20-30 min). A slow multi-step write (e.g. void's poll loops) is exactly
+     * when a client is most likely to give up and disconnect, so every write session opts out of that
+     * default: the logout always runs, whether or not anyone is still listening for the response.
+     */
+    private function keepRunningPastClientDisconnect(): void
+    {
+        ignore_user_abort(true);
     }
 }

--- a/src/Domains/Connectors/Acumatica/Services/AcumaticaWriteService.php
+++ b/src/Domains/Connectors/Acumatica/Services/AcumaticaWriteService.php
@@ -203,13 +203,7 @@ class AcumaticaWriteService
         }
     }
 
-    /**
-     * PHP aborts script execution the moment the client disconnects unless told otherwise — which
-     * skips straight past our finally-block logout, leaving the Acumatica session held open until it
-     * expires on its own (~20-30 min). A slow multi-step write (e.g. void's poll loops) is exactly
-     * when a client is most likely to give up and disconnect, so every write session opts out of that
-     * default: the logout always runs, whether or not anyone is still listening for the response.
-     */
+    /** A client disconnect mid-write would otherwise abort PHP before our finally-block logout runs, leaking the Acumatica session. */
     private function keepRunningPastClientDisconnect(): void
     {
         ignore_user_abort(true);

--- a/tests/Connectors/Acumatica/AcumaticaWriteFoundationTest.php
+++ b/tests/Connectors/Acumatica/AcumaticaWriteFoundationTest.php
@@ -235,4 +235,28 @@ class AcumaticaWriteFoundationTest extends TestCase
 
         new AcumaticaWriteService($this->app(), $client)->push('Bill', AcumaticaPayload::wrap(['Description' => 'x']));
     }
+
+    public function testPushSurfacesNestedFieldErrorOverGenericTopLevelMessage(): void
+    {
+        $this->enableWrites();
+        $body = [
+            'error' => "Inserting  'AP document' record raised at least one error. Please review the errors.",
+            'PostPeriod' => ['value' => '082026', 'error' => 'Error: The 08-2026 financial period is inactive in the NZXT US company.'],
+            'Details' => [
+                ['Account' => ['value' => '71610'], 'Subaccount' => []],
+            ],
+        ];
+        $response = new Response(422, [], (string) json_encode($body));
+        $request = new Request('PUT', 'entity/Default/24.200.001/Bill');
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('login')->once();
+        $client->shouldReceive('put')->once()->andThrow(new RequestException('Client error', $request, $response));
+        $client->shouldReceive('logout')->once();
+
+        $this->expectException(AcumaticaWriteException::class);
+        $this->expectExceptionMessage('PostPeriod: Error: The 08-2026 financial period is inactive in the NZXT US company.');
+
+        new AcumaticaWriteService($this->app(), $client)->push('Bill', AcumaticaPayload::wrap(['Description' => 'x']));
+    }
 }


### PR DESCRIPTION
Cherry-pick of #10671 to 1.x.

## Summary
- `AcumaticaWriteException` now surfaces Acumatica's nested per-field validation errors (e.g. `PostPeriod`) instead of the generic top-level "raised at least one error" message.
- `AcumaticaWriteService` now calls `ignore_user_abort(true)` before every write session, so a client disconnect mid-write doesn't skip the `finally`-block logout and leak the Acumatica session.
- Pure robustness/error-message improvement — no behavior change to the write/allocation logic itself.

## Test plan
- [x] Includes `testPushSurfacesNestedFieldErrorOverGenericTopLevelMessage`.
- [x] `php -l` syntax check on all changed files (clean).
- [ ] Full `phpunit` run — blocked locally by an unrelated `vendor/google/apiclient-services` Docker/Composer corruption.