### PR TITLE
feat: add note and file attachment tools to Apex (AP agent)

### DIFF
--- a/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaBillAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaBillAction.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Acumatica\Actions;
+
+use Baka\Http\SafeUrlFetcher;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Acumatica\Client;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
+use Kanvas\Connectors\Acumatica\Support\AcumaticaPayload;
+use Kanvas\Connectors\Acumatica\Traits\HasAcumaticaWriter;
+use Kanvas\Scribe\Bills\Models\Bill;
+
+/** Attaches a file to an already-pushed AP bill in Acumatica via its own files:put link. */
+class AttachFileToAcumaticaBillAction
+{
+    use HasAcumaticaWriter;
+
+    /** The bill's own app — the tenant whose Acumatica config/credentials this push runs against. */
+    protected Apps $app;
+
+    public function __construct(
+        protected Bill $bill,
+        protected string $fileUrl,
+        protected string $fileName,
+        ?AcumaticaWriteService $writer = null,
+    ) {
+        $this->app = $bill->app;
+        $this->writer = $writer;
+    }
+
+    public function execute(): void
+    {
+        $billGuid = (string) $this->bill->get(CustomFieldEnum::BILL_ID->value, '');
+
+        if ($billGuid === '') {
+            throw new AcumaticaWriteException(
+                "Bill {$this->bill->getId()} has no Acumatica reference — it must be pushed before attaching a file."
+            );
+        }
+
+        $this->writer()->withSession(function (Client $client) use ($billGuid): void {
+            $template = AcumaticaPayload::filesPutHref($client->get('Bill/' . $billGuid));
+
+            if ($template === null) {
+                throw new AcumaticaWriteException(
+                    "Bill {$this->bill->getId()} has no files:put link in Acumatica — cannot attach a file."
+                );
+            }
+
+            $bytes = SafeUrlFetcher::fetch($this->fileUrl);
+            $url = str_ireplace('{filename}', rawurlencode($this->fileName), $template);
+
+            $client->putFile($url, $bytes, $this->contentType());
+        });
+    }
+
+    private function contentType(): string
+    {
+        return match (strtolower(pathinfo($this->fileName, PATHINFO_EXTENSION))) {
+            'pdf' => 'application/pdf',
+            'png' => 'image/png',
+            'jpg', 'jpeg' => 'image/jpeg',
+            default => 'application/octet-stream',
+        };
+    }
+}

--- a/src/Domains/Connectors/Acumatica/Actions/PushBillNoteToAcumaticaAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/PushBillNoteToAcumaticaAction.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Acumatica\Actions;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Acumatica\Client;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
+use Kanvas\Connectors\Acumatica\Support\AcumaticaPayload;
+use Kanvas\Connectors\Acumatica\Traits\HasAcumaticaWriter;
+use Kanvas\Scribe\Bills\Models\Bill;
+
+/** Appends a note to an already-pushed AP bill's Notes field in Acumatica. */
+class PushBillNoteToAcumaticaAction
+{
+    use HasAcumaticaWriter;
+
+    /** The bill's own app — the tenant whose Acumatica config/credentials this push runs against. */
+    protected Apps $app;
+
+    public function __construct(
+        protected Bill $bill,
+        ?AcumaticaWriteService $writer = null,
+    ) {
+        $this->app = $bill->app;
+        $this->writer = $writer;
+    }
+
+    /**
+     * @return string the full note text now stored in Acumatica
+     */
+    public function execute(string $note): string
+    {
+        $billGuid = (string) $this->bill->get(CustomFieldEnum::BILL_ID->value, '');
+
+        if ($billGuid === '') {
+            throw new AcumaticaWriteException(
+                "Bill {$this->bill->getId()} has no Acumatica reference — it must be pushed before adding a note."
+            );
+        }
+
+        return $this->writer()->withSession(
+            function (Client $client) use ($billGuid, $note): string {
+                $existing = (string) AcumaticaPayload::value($client->get('Bill/' . $billGuid), 'note', '');
+                $combined = $existing !== '' ? $existing . "\n" . $note : $note;
+
+                $client->put('Bill', ['id' => $billGuid, 'note' => ['value' => $combined]]);
+
+                return $combined;
+            }
+        );
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -14,7 +14,9 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ListOpenPurchaseOrdersToo
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\MatchBillsForPaymentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryApAgingTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryDataFreshnessTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AddBillNoteTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\ApplyApPaymentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AttachBillFileTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateApBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidApBillTool;
 use Override;
@@ -60,6 +62,8 @@ class AccountsPayableAgent extends SystemUserAgent
             new CreateApBillTool(),
             new VoidApBillTool(),
             new ApplyApPaymentTool(),
+            new AddBillNoteTool(),
+            new AttachBillFileTool(),
         ]));
     }
 
@@ -86,6 +90,8 @@ class AccountsPayableAgent extends SystemUserAgent
             '- "Void/cancel/undo that bill" → void_ap_bill, given the bill_id from create_ap_bill.',
             '- "Pay a vendor bill" / "record a payment against bill Y" → apply_ap_payment, only when the user '
             . 'explicitly asks to record a real payment. Needs the bill_id, amount, and a payment reference.',
+            '- "Add a note to bill Y" → add_bill_note; "attach this file to bill Y" → attach_bill_file. Both '
+            . 'require the bill to already be pushed to Acumatica.',
         ]);
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AddBillNoteTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AddBillNoteTool.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
+
+use Illuminate\Support\Carbon;
+use Kanvas\Connectors\Acumatica\Actions\PushBillNoteToAcumaticaAction;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Scribe\Bills\Models\Bill;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+/** Appends a note to an already-pushed AP bill, in Kanvas and in Acumatica. */
+#[AgentTool(name: 'Add Bill Note', category: 'accounting')]
+class AddBillNoteTool extends Tool
+{
+    use HasKanvasContext;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'add_bill_note',
+            description: 'Appends a note to an AP bill that has already been pushed to Acumatica — records it '
+                . 'both in Kanvas and on the Acumatica document\'s Notes field.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'bill_id',
+                type: PropertyType::INTEGER,
+                description: 'The Kanvas bill id to add the note to (returned as bill_id by create_ap_bill).',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'note',
+                type: PropertyType::STRING,
+                description: 'The note text to append.',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(int $bill_id, string $note): array
+    {
+        $bill = Bill::query()
+            ->where('id', $bill_id)
+            ->where('apps_id', $this->app->getId())
+            ->where('companies_id', $this->company->getId())
+            ->first();
+
+        if ($bill === null) {
+            return [
+                'note_added' => false,
+                'reason' => 'bill_not_found',
+                'message' => "No bill with id {$bill_id} for this app/company.",
+            ];
+        }
+
+        $ref = (string) $bill->get(AcumaticaCustomFieldEnum::BILL_REF->value, '');
+
+        if ($ref === '') {
+            return [
+                'note_added' => false,
+                'reason' => 'bill_not_pushed',
+                'message' => "Bill {$bill_id} hasn't been pushed to Acumatica yet — push it before adding a note.",
+            ];
+        }
+
+        $stamped = '[' . Carbon::now()->toDateTimeString() . '] ' . $note;
+        $bill->internal_notes = $bill->internal_notes !== null && $bill->internal_notes !== ''
+            ? $bill->internal_notes . "\n" . $stamped
+            : $stamped;
+        $bill->saveOrFail();
+
+        try {
+            new PushBillNoteToAcumaticaAction($bill)->execute($stamped);
+        } catch (AcumaticaWriteException|Throwable $e) {
+            return [
+                'note_added' => true,
+                'pushed' => false,
+                'bill_id' => $bill->getId(),
+                'reason' => 'push_failed',
+                'message' => 'Note saved in Kanvas but the push to Acumatica failed: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'note_added' => true,
+            'pushed' => true,
+            'bill_id' => $bill->getId(),
+            'bill_ref' => $ref,
+            'note' => $stamped,
+        ];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AttachBillFileTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AttachBillFileTool.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
+
+use Kanvas\Connectors\Acumatica\Actions\AttachFileToAcumaticaBillAction;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Scribe\Bills\Models\Bill;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+/** Attaches a file to an already-pushed AP bill, in Kanvas and in Acumatica. */
+#[AgentTool(name: 'Attach Bill File', category: 'accounting')]
+class AttachBillFileTool extends Tool
+{
+    use HasKanvasContext;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'attach_bill_file',
+            description: 'Attaches a file (by URL) to an AP bill that has already been pushed to Acumatica — '
+                . 'stores it in Kanvas and uploads it to the Acumatica document too.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'bill_id',
+                type: PropertyType::INTEGER,
+                description: 'The Kanvas bill id to attach the file to (returned as bill_id by create_ap_bill).',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'file_url',
+                type: PropertyType::STRING,
+                description: 'A URL the file can be downloaded from.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'file_name',
+                type: PropertyType::STRING,
+                description: 'File name to store it under, including extension. Defaults to the URL\'s own file name.',
+                required: false,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(int $bill_id, string $file_url, ?string $file_name = null): array
+    {
+        $bill = Bill::query()
+            ->where('id', $bill_id)
+            ->where('apps_id', $this->app->getId())
+            ->where('companies_id', $this->company->getId())
+            ->first();
+
+        if ($bill === null) {
+            return [
+                'file_attached' => false,
+                'reason' => 'bill_not_found',
+                'message' => "No bill with id {$bill_id} for this app/company.",
+            ];
+        }
+
+        $ref = (string) $bill->get(AcumaticaCustomFieldEnum::BILL_REF->value, '');
+
+        if ($ref === '') {
+            return [
+                'file_attached' => false,
+                'reason' => 'bill_not_pushed',
+                'message' => "Bill {$bill_id} hasn't been pushed to Acumatica yet — push it before attaching a file.",
+            ];
+        }
+
+        $name = $file_name !== null && $file_name !== '' ? $file_name : basename(parse_url($file_url, PHP_URL_PATH) ?: 'file');
+
+        $bill->addFileFromUrl($file_url, $name);
+
+        try {
+            new AttachFileToAcumaticaBillAction($bill, $file_url, $name)->execute();
+        } catch (AcumaticaWriteException|Throwable $e) {
+            return [
+                'file_attached' => true,
+                'pushed' => false,
+                'bill_id' => $bill->getId(),
+                'file_name' => $name,
+                'reason' => 'push_failed',
+                'message' => 'File saved in Kanvas but the push to Acumatica failed: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'file_attached' => true,
+            'pushed' => true,
+            'bill_id' => $bill->getId(),
+            'bill_ref' => $ref,
+            'file_name' => $name,
+        ];
+    }
+}

--- a/tests/Connectors/Acumatica/AttachFileToAcumaticaBillActionTest.php
+++ b/tests/Connectors/Acumatica/AttachFileToAcumaticaBillActionTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Acumatica;
+
+use Illuminate\Support\Carbon;
+use Kanvas\Connectors\Acumatica\Actions\AttachFileToAcumaticaBillAction;
+use Kanvas\Connectors\Acumatica\Client;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
+use Kanvas\Scribe\Bills\Actions\CreateBillAction;
+use Kanvas\Scribe\Bills\DataTransferObject\Bill as BillData;
+use Kanvas\Scribe\Bills\DataTransferObject\BillLine as BillLineData;
+use Kanvas\Scribe\Bills\Models\Bill;
+use Kanvas\Scribe\Ledger\Enums\AccountSubTypeEnum;
+use Mockery;
+use Spatie\LaravelData\DataCollection;
+use Tests\Scribe\ScribeTestCase;
+
+class AttachFileToAcumaticaBillActionTest extends ScribeTestCase
+{
+    private function billWithLines(): Bill
+    {
+        $vendor = $this->seedTestOrganization('Globex Supply');
+
+        return new CreateBillAction(
+            new BillData(
+                app: $this->kanvasApp,
+                company: $this->company,
+                vendor: $vendor,
+                lines: new DataCollection(BillLineData::class, [
+                    new BillLineData(
+                        description: 'Materials',
+                        quantity: 1,
+                        unit_price_native: 50.0,
+                        expense_account_id: $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS),
+                    ),
+                ]),
+                currency: 'USD',
+                fx_rate_to_base: 1.0,
+                bill_date: Carbon::parse('2026-06-01'),
+            ),
+            static::$cachedUser,
+        )->execute();
+    }
+
+    public function test_refuses_a_bill_that_was_never_pushed(): void
+    {
+        $bill = $this->billWithLines();
+
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldNotReceive('withSession');
+
+        $this->expectException(AcumaticaWriteException::class);
+
+        new AttachFileToAcumaticaBillAction($bill, 'https://example.test/invoice.pdf', 'invoice.pdf', $writer)->execute();
+    }
+
+    public function test_throws_when_the_bill_has_no_files_put_link(): void
+    {
+        $bill = $this->billWithLines();
+        $bill->set(CustomFieldEnum::BILL_ID->value, 'BILL-GUID');
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('get')->once()->with('Bill/BILL-GUID')->andReturn(['id' => 'BILL-GUID']);
+
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldReceive('withSession')->once()->andReturnUsing(fn (callable $cb) => $cb($client));
+
+        $this->expectException(AcumaticaWriteException::class);
+        $this->expectExceptionMessage('no files:put link');
+
+        new AttachFileToAcumaticaBillAction($bill, 'https://example.test/invoice.pdf', 'invoice.pdf', $writer)->execute();
+    }
+}

--- a/tests/Connectors/Acumatica/PushBillNoteToAcumaticaActionTest.php
+++ b/tests/Connectors/Acumatica/PushBillNoteToAcumaticaActionTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Acumatica;
+
+use Illuminate\Support\Carbon;
+use Kanvas\Connectors\Acumatica\Actions\PushBillNoteToAcumaticaAction;
+use Kanvas\Connectors\Acumatica\Client;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
+use Kanvas\Scribe\Bills\Actions\CreateBillAction;
+use Kanvas\Scribe\Bills\DataTransferObject\Bill as BillData;
+use Kanvas\Scribe\Bills\DataTransferObject\BillLine as BillLineData;
+use Kanvas\Scribe\Bills\Models\Bill;
+use Kanvas\Scribe\Ledger\Enums\AccountSubTypeEnum;
+use Mockery;
+use Spatie\LaravelData\DataCollection;
+use Tests\Scribe\ScribeTestCase;
+
+class PushBillNoteToAcumaticaActionTest extends ScribeTestCase
+{
+    private function pushedBill(): Bill
+    {
+        $vendor = $this->seedTestOrganization('Globex Supply');
+        $bill = new CreateBillAction(
+            new BillData(
+                app: $this->kanvasApp,
+                company: $this->company,
+                vendor: $vendor,
+                lines: new DataCollection(BillLineData::class, [
+                    new BillLineData(
+                        description: 'Materials',
+                        quantity: 1,
+                        unit_price_native: 50.0,
+                        expense_account_id: $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS),
+                    ),
+                ]),
+                currency: 'USD',
+                fx_rate_to_base: 1.0,
+                bill_date: Carbon::parse('2026-06-01'),
+            ),
+            static::$cachedUser,
+        )->execute();
+        $bill->set(CustomFieldEnum::BILL_ID->value, 'BILL-GUID');
+        $bill->set(CustomFieldEnum::BILL_REF->value, '66102685');
+
+        return $bill;
+    }
+
+    public function test_appends_to_an_existing_note(): void
+    {
+        $bill = $this->pushedBill();
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('get')->once()->with('Bill/BILL-GUID')
+            ->andReturn(['note' => ['value' => 'Called vendor about delivery.']]);
+        $client->shouldReceive('put')->once()
+            ->with('Bill', ['id' => 'BILL-GUID', 'note' => ['value' => "Called vendor about delivery.\nPaid via check."]])
+            ->andReturn([]);
+
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldReceive('withSession')->once()->andReturnUsing(fn (callable $cb) => $cb($client));
+
+        $result = new PushBillNoteToAcumaticaAction($bill, $writer)->execute('Paid via check.');
+
+        $this->assertSame("Called vendor about delivery.\nPaid via check.", $result);
+    }
+
+    public function test_sets_the_note_when_acumatica_has_none_yet(): void
+    {
+        $bill = $this->pushedBill();
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('get')->once()->with('Bill/BILL-GUID')->andReturn(['note' => []]);
+        $client->shouldReceive('put')->once()
+            ->with('Bill', ['id' => 'BILL-GUID', 'note' => ['value' => 'First note.']])
+            ->andReturn([]);
+
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldReceive('withSession')->once()->andReturnUsing(fn (callable $cb) => $cb($client));
+
+        $result = new PushBillNoteToAcumaticaAction($bill, $writer)->execute('First note.');
+
+        $this->assertSame('First note.', $result);
+    }
+
+    public function test_refuses_a_bill_that_was_never_pushed(): void
+    {
+        $vendor = $this->seedTestOrganization('Globex Supply');
+        $bill = new CreateBillAction(
+            new BillData(
+                app: $this->kanvasApp,
+                company: $this->company,
+                vendor: $vendor,
+                lines: new DataCollection(BillLineData::class, [
+                    new BillLineData(
+                        description: 'Materials',
+                        quantity: 1,
+                        unit_price_native: 50.0,
+                        expense_account_id: $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS),
+                    ),
+                ]),
+                currency: 'USD',
+                fx_rate_to_base: 1.0,
+                bill_date: Carbon::parse('2026-06-01'),
+            ),
+            static::$cachedUser,
+        )->execute();
+
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldNotReceive('withSession');
+
+        $this->expectException(AcumaticaWriteException::class);
+
+        new PushBillNoteToAcumaticaAction($bill, $writer)->execute('Note.');
+    }
+}

--- a/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
@@ -14,6 +14,8 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ListOpenBillsTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ListOpenPurchaseOrdersTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\MatchBillsForPaymentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryApAgingTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AddBillNoteTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AttachBillFileTool;
 use Kanvas\Scribe\Bills\Actions\CreateBillAction;
 use Kanvas\Scribe\Bills\Actions\ReceiveBillAction;
 use Kanvas\Scribe\Bills\DataTransferObject\Bill as BillData;
@@ -170,5 +172,63 @@ class AccountsPayableAgentToolsTest extends ScribeTestCase
         $this->assertSame('received', $result['document_status']);
         $this->assertSame(640.0, (float) $result['balance_due_native']);
         $this->assertNotEmpty($result['lines']);
+    }
+
+    public function test_add_bill_note_reports_not_found_for_unknown_bill(): void
+    {
+        $result = new AddBillNoteTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(bill_id: 999999999, note: 'Called vendor.');
+
+        $this->assertFalse($result['note_added']);
+        $this->assertSame('bill_not_found', $result['reason']);
+    }
+
+    public function test_add_bill_note_reports_not_pushed_when_bill_has_no_acumatica_ref(): void
+    {
+        $vendor = $this->seedTestOrganization('Globex Supply');
+        $this->receiveOpenBill($vendor, 300.0, '2026-06-20');
+
+        $bill = \Kanvas\Scribe\Bills\Models\Bill::query()
+            ->where('apps_id', $this->kanvasApp->getId())
+            ->where('companies_id', $this->company->getId())
+            ->latest('id')
+            ->first();
+
+        $result = new AddBillNoteTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(bill_id: (int) $bill->id, note: 'Called vendor.');
+
+        $this->assertFalse($result['note_added']);
+        $this->assertSame('bill_not_pushed', $result['reason']);
+    }
+
+    public function test_attach_bill_file_reports_not_found_for_unknown_bill(): void
+    {
+        $result = new AttachBillFileTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(bill_id: 999999999, file_url: 'https://example.test/invoice.pdf');
+
+        $this->assertFalse($result['file_attached']);
+        $this->assertSame('bill_not_found', $result['reason']);
+    }
+
+    public function test_attach_bill_file_reports_not_pushed_when_bill_has_no_acumatica_ref(): void
+    {
+        $vendor = $this->seedTestOrganization('Globex Supply');
+        $this->receiveOpenBill($vendor, 300.0, '2026-06-20');
+
+        $bill = \Kanvas\Scribe\Bills\Models\Bill::query()
+            ->where('apps_id', $this->kanvasApp->getId())
+            ->where('companies_id', $this->company->getId())
+            ->latest('id')
+            ->first();
+
+        $result = new AttachBillFileTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(bill_id: (int) $bill->id, file_url: 'https://example.test/invoice.pdf');
+
+        $this->assertFalse($result['file_attached']);
+        $this->assertSame('bill_not_pushed', $result['reason']);
     }
 }


### PR DESCRIPTION
Cherry-pick of #10687 to 1.x. Adds add_bill_note and attach_bill_file tools to Apex — both require the bill to already be pushed to Acumatica. Ran locally via Docker/phpunit — 15/15 pass (60 assertions).