### PR TITLE
fix: create_ap_bill was losing the vendor's invoice number and could get the wrong subaccount

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
 
 use Illuminate\Support\Carbon;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\Acumatica\Actions\PushBillToAcumaticaAction;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;
 use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
@@ -17,6 +19,7 @@ use Kanvas\Scribe\Bills\Actions\SubmitBillForApprovalAction;
 use Kanvas\Scribe\Bills\DataTransferObject\Bill as BillData;
 use Kanvas\Scribe\Bills\DataTransferObject\BillLine as BillLineData;
 use Kanvas\Scribe\Ledger\Models\Account;
+use Kanvas\Scribe\Ledger\Models\Subaccount;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
@@ -73,6 +76,21 @@ class CreateApBillTool extends Tool
                 required: true,
             ),
             new ToolProperty(
+                name: 'invoice_number',
+                type: PropertyType::STRING,
+                description: 'The vendor\'s own invoice number (not a Kanvas-generated one) — becomes the '
+                    . 'Vendor Ref on the Acumatica document. Always required.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'subaccount',
+                type: PropertyType::STRING,
+                description: 'Acumatica subaccount code for the line, e.g. "BB-0G-M1", when the vendor or '
+                    . 'project requires a specific one. Optional — omit to let Acumatica derive a default from '
+                    . 'the GL account\'s history, which is not always correct for every vendor on that account.',
+                required: false,
+            ),
+            new ToolProperty(
                 name: 'currency',
                 type: PropertyType::STRING,
                 description: 'Currency code. Defaults to USD.',
@@ -89,6 +107,8 @@ class CreateApBillTool extends Tool
         float $amount,
         string $gl_account_number,
         string $memo,
+        string $invoice_number,
+        ?string $subaccount = null,
         ?string $currency = null,
     ): array {
         $app = $this->app;
@@ -99,6 +119,14 @@ class CreateApBillTool extends Tool
                 'created' => false,
                 'reason' => 'vendor_name_required',
                 'message' => 'A vendor_name is required — never pick an arbitrary vendor.',
+            ];
+        }
+
+        if (trim($invoice_number) === '') {
+            return [
+                'created' => false,
+                'reason' => 'invoice_number_required',
+                'message' => 'An invoice_number (the vendor\'s own invoice reference) is required.',
             ];
         }
 
@@ -134,6 +162,7 @@ class CreateApBillTool extends Tool
 
         $currency = $currency !== null && trim($currency) !== '' ? strtoupper(trim($currency)) : 'USD';
         $actingUser = $this->user;
+        $subaccountId = $this->resolveSubaccountId($subaccount, $app, $company);
 
         $bill = new CreateBillAction(
             new BillData(
@@ -146,10 +175,12 @@ class CreateApBillTool extends Tool
                         quantity: 1.0,
                         unit_price_native: $amount,
                         expense_account_id: $account->getId(),
+                        subaccount_id: $subaccountId,
                     ),
                 ]),
                 currency: $currency,
                 fx_rate_to_base: 1.0,
+                bill_number: $invoice_number,
                 bill_date: Carbon::today(),
                 notes: $memo,
             ),
@@ -189,10 +220,29 @@ class CreateApBillTool extends Tool
             'amount' => $amount,
             'currency' => $currency,
             'gl_account' => $gl_account_number,
+            'subaccount' => $subaccount,
             'memo' => $memo,
             'bill_ref' => $reference,
             'acumatica_bill_id' => (string) $bill->get(AcumaticaCustomFieldEnum::BILL_ID->value, ''),
             'next' => 'Pushed to Acumatica. bill_ref is the ERP reference.',
         ];
+    }
+
+    private function resolveSubaccountId(?string $subaccount, Apps $app, Companies $company): ?int
+    {
+        if ($subaccount === null || trim($subaccount) === '') {
+            return null;
+        }
+
+        $subaccountModel = Subaccount::firstOrCreate(
+            [
+                'apps_id' => $app->getId(),
+                'companies_id' => $company->getId(),
+                'sub_code' => trim($subaccount),
+            ],
+            ['source' => 'kanvas'],
+        );
+
+        return (int) $subaccountModel->getKey();
     }
 }

--- a/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
@@ -16,11 +16,14 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\MatchBillsForPaymentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryApAgingTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AddBillNoteTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AttachBillFileTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateApBillTool;
 use Kanvas\Scribe\Bills\Actions\CreateBillAction;
 use Kanvas\Scribe\Bills\Actions\ReceiveBillAction;
 use Kanvas\Scribe\Bills\DataTransferObject\Bill as BillData;
 use Kanvas\Scribe\Bills\DataTransferObject\BillLine as BillLineData;
+use Kanvas\Scribe\Bills\Models\Bill;
 use Kanvas\Scribe\Ledger\Enums\AccountSubTypeEnum;
+use Kanvas\Scribe\Ledger\Models\Account;
 use Kanvas\Scribe\Purchasing\Models\PurchaseOrder;
 use Kanvas\Scribe\Purchasing\Models\PurchaseOrderLine;
 use Spatie\LaravelData\DataCollection;
@@ -230,5 +233,54 @@ class AccountsPayableAgentToolsTest extends ScribeTestCase
 
         $this->assertFalse($result['file_attached']);
         $this->assertSame('bill_not_pushed', $result['reason']);
+    }
+
+    public function test_create_ap_bill_requires_an_invoice_number(): void
+    {
+        $this->seedTestOrganization('Windwalk Games Corp');
+        $accountCode = (string) Account::query()
+            ->where('id', $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS))
+            ->value('account_number');
+
+        $result = new CreateApBillTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(
+                vendor_name: 'Windwalk Games Corp',
+                amount: 2500.0,
+                gl_account_number: $accountCode,
+                memo: 'Community Building & Management Services',
+                invoice_number: '',
+            );
+
+        $this->assertFalse($result['created']);
+        $this->assertSame('invoice_number_required', $result['reason']);
+    }
+
+    public function test_create_ap_bill_uses_the_vendor_invoice_number_and_resolves_subaccount(): void
+    {
+        $this->seedTestOrganization('Windwalk Games Corp');
+        $accountId = $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS);
+        $accountCode = (string) Account::query()->where('id', $accountId)->value('account_number');
+
+        new CreateApBillTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(
+                vendor_name: 'Windwalk Games Corp',
+                amount: 2500.0,
+                gl_account_number: $accountCode,
+                memo: 'Community Building & Management Services',
+                invoice_number: '1498',
+                subaccount: 'BB-0G-M1',
+            );
+
+        /** @var Bill $bill */
+        $bill = Bill::query()
+            ->where('apps_id', $this->kanvasApp->getId())
+            ->where('companies_id', $this->company->getId())
+            ->latest('id')
+            ->first();
+
+        $this->assertSame('1498', $bill->bill_number);
+        $this->assertSame('BB-0G-M1', $bill->lines->first()->subaccount->sub_code);
     }
 }


### PR DESCRIPTION
Cherry-pick of #10698 to 1.x. Adds required invoice_number and optional subaccount params to create_ap_bill — fixes wrong Vendor Ref and wrong subaccount found live on a real invoice (Windwalk Games Corp #1498). Ran locally via Docker/phpunit — 12/12 pass, and live-verified against the real 2026R1 sandbox before pushing (throwaway test, deleted after).