### PR TITLE
feat: support routing an AP bill to a specific Acumatica company

### DIFF
--- a/src/Domains/Connectors/Acumatica/Actions/PushBillToAcumaticaAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/PushBillToAcumaticaAction.php
@@ -71,7 +71,10 @@ class PushBillToAcumaticaAction
             return $existing;
         }
 
-        $vendorCode = $this->ensureVendorCode();
+        $targetCompany = (string) $this->bill->get(CustomFieldEnum::TARGET_COMPANY->value, '');
+        $targetCompany = $targetCompany !== '' ? $targetCompany : null;
+
+        $vendorCode = $this->ensureVendorCode($targetCompany);
 
         if ($vendorCode === '') {
             throw new AcumaticaWriteException(
@@ -79,7 +82,7 @@ class PushBillToAcumaticaAction
             );
         }
 
-        $record = $this->writer()->push(
+        $record = $this->writer($targetCompany)->push(
             'Bill',
             $this->buildPayload($vendorCode),
             release: true,
@@ -384,7 +387,7 @@ class PushBillToAcumaticaAction
      * Find-or-create the vendor in Acumatica (push path). Creates the ERP vendor lazily when the org
      * has no code yet — only reached on a real push, so a rejected bill never spawns a junk vendor.
      */
-    private function ensureVendorCode(): string
+    private function ensureVendorCode(?string $targetCompany = null): string
     {
         $vendor = $this->vendorOrg();
 
@@ -397,7 +400,7 @@ class PushBillToAcumaticaAction
             taxId: $this->bill->vendor_tax_id,
             name: $this->bill->vendor_display_name,
             email: $this->bill->vendor_email,
-            writer: $this->writer(),
+            writer: $this->writer($targetCompany),
         )->execute();
     }
 

--- a/src/Domains/Connectors/Acumatica/Client.php
+++ b/src/Domains/Connectors/Acumatica/Client.php
@@ -19,8 +19,10 @@ class Client
     protected array $config;
     protected string $entityBase;
 
-    public function __construct(protected AppInterface $app)
-    {
+    public function __construct(
+        protected AppInterface $app,
+        protected ?string $companyOverride = null,
+    ) {
         $config = $this->app->get(ConfigurationEnum::ACUMATICA_CONFIG->value);
 
         if (empty($config) || empty($config['baseUrl'])) {
@@ -46,9 +48,9 @@ class Client
         );
     }
 
-    public static function getInstance(AppInterface $app): self
+    public static function getInstance(AppInterface $app, ?string $companyOverride = null): self
     {
-        return new self($app);
+        return new self($app, $companyOverride);
     }
 
     public function login(): void
@@ -57,7 +59,7 @@ class Client
             'json' => [
                 'name' => $this->config['username'],
                 'password' => $this->config['password'],
-                'company' => $this->config['acumaticaCompany'],
+                'company' => $this->companyOverride ?? $this->config['acumaticaCompany'],
                 'branch' => $this->config['branch'] ?? '',
             ],
         ]);

--- a/src/Domains/Connectors/Acumatica/Enums/CustomFieldEnum.php
+++ b/src/Domains/Connectors/Acumatica/Enums/CustomFieldEnum.php
@@ -26,4 +26,7 @@ enum CustomFieldEnum: string
 
     /** Cached dominant subaccount for an expense Account, derived once from the replica's AP history. */
     case DERIVED_SUBACCOUNT = 'ACUMATICA_DERIVED_SUBACCOUNT';
+
+    /** The Acumatica CompanyID this specific document should push to, overriding the app's default tenant. */
+    case TARGET_COMPANY = 'ACUMATICA_TARGET_COMPANY';
 }

--- a/src/Domains/Connectors/Acumatica/Services/AcumaticaWriteService.php
+++ b/src/Domains/Connectors/Acumatica/Services/AcumaticaWriteService.php
@@ -28,6 +28,7 @@ class AcumaticaWriteService
     public function __construct(
         protected AppInterface $app,
         ?Client $client = null,
+        protected ?string $companyOverride = null,
     ) {
         $this->client = $client;
     }
@@ -191,7 +192,7 @@ class AcumaticaWriteService
 
     private function client(): Client
     {
-        return $this->client ??= Client::getInstance($this->app);
+        return $this->client ??= Client::getInstance($this->app, $this->companyOverride);
     }
 
     private function safeLogout(): void

--- a/src/Domains/Connectors/Acumatica/Traits/HasAcumaticaWriter.php
+++ b/src/Domains/Connectors/Acumatica/Traits/HasAcumaticaWriter.php
@@ -15,8 +15,9 @@ trait HasAcumaticaWriter
 {
     protected ?AcumaticaWriteService $writer = null;
 
-    private function writer(): AcumaticaWriteService
+    /** $companyOverride only takes effect the first call — the writer is memoized after that. */
+    private function writer(?string $companyOverride = null): AcumaticaWriteService
     {
-        return $this->writer ??= new AcumaticaWriteService($this->app);
+        return $this->writer ??= new AcumaticaWriteService($this->app, companyOverride: $companyOverride);
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -96,6 +96,17 @@ class CreateApBillTool extends Tool
                 description: 'Currency code. Defaults to USD.',
                 required: false,
             ),
+            new ToolProperty(
+                name: 'acumatica_company',
+                type: PropertyType::STRING,
+                description: 'The Acumatica CompanyID this bill belongs to, when it is not the tenant\'s default. '
+                    . 'Infer it from the invoice\'s "Bill to" entity — match it by reasoning (name, country, legal '
+                    . 'suffix like GmbH/Ltd/Inc), not exact spelling, against the active companies: NZXT (US), '
+                    . '"NZXT Germany - USD", "NZXT Europe GmbH - Germany", "NZXT China", "NZXT AU", "NZXT UK LTD", '
+                    . '"NZXT UK", "NZXT TAIWAN", "NZXT TAIWAN CO LTD". If none is a reasonably confident match, '
+                    . 'omit this and ask the user instead of guessing — never invent a CompanyID.',
+                required: false,
+            ),
         ];
     }
 
@@ -110,6 +121,7 @@ class CreateApBillTool extends Tool
         string $invoice_number,
         ?string $subaccount = null,
         ?string $currency = null,
+        ?string $acumatica_company = null,
     ): array {
         $app = $this->app;
         $company = $this->company;
@@ -187,6 +199,10 @@ class CreateApBillTool extends Tool
             $actingUser,
         )->execute();
 
+        if ($acumatica_company !== null && trim($acumatica_company) !== '') {
+            $bill->set(AcumaticaCustomFieldEnum::TARGET_COMPANY->value, trim($acumatica_company));
+        }
+
         new SubmitBillForApprovalAction($bill, $actingUser)->execute();
 
         /** @var Organization $approvalVendor */
@@ -203,6 +219,7 @@ class CreateApBillTool extends Tool
                 'bill_id' => $bill->getId(),
                 'bill_number' => $bill->bill_number,
                 'document_status' => $bill->document_status->value,
+                'acumatica_company' => $acumatica_company,
                 'reason' => 'push_failed',
                 'message' => 'Bill was created and approved in Kanvas (status: received) but the push to '
                     . 'Acumatica failed: ' . $e->getMessage() . '. It needs manual attention — it will not '
@@ -221,6 +238,7 @@ class CreateApBillTool extends Tool
             'currency' => $currency,
             'gl_account' => $gl_account_number,
             'subaccount' => $subaccount,
+            'acumatica_company' => $acumatica_company,
             'memo' => $memo,
             'bill_ref' => $reference,
             'acumatica_bill_id' => (string) $bill->get(AcumaticaCustomFieldEnum::BILL_ID->value, ''),

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -103,8 +103,13 @@ class CreateApBillTool extends Tool
                     . 'Infer it from the invoice\'s "Bill to" entity — match it by reasoning (name, country, legal '
                     . 'suffix like GmbH/Ltd/Inc), not exact spelling, against the active companies: NZXT (US), '
                     . '"NZXT Germany - USD", "NZXT Europe GmbH - Germany", "NZXT China", "NZXT AU", "NZXT UK LTD", '
-                    . '"NZXT UK", "NZXT TAIWAN", "NZXT TAIWAN CO LTD". If none is a reasonably confident match, '
-                    . 'omit this and ask the user instead of guessing — never invent a CompanyID.',
+                    . '"NZXT UK", "NZXT TAIWAN", "NZXT TAIWAN CO LTD". Some countries have two companies sharing '
+                    . 'the exact same legal name on the Bill to — for Germany, "NZXT Europe GmbH" maps to either '
+                    . '"NZXT Germany - USD" or "NZXT Europe GmbH - Germany" depending ONLY on the invoice\'s own '
+                    . 'currency: USD invoices go to "NZXT Germany - USD", any other currency (e.g. EUR) goes to '
+                    . '"NZXT Europe GmbH - Germany". Apply the same currency-based rule if another country turns '
+                    . 'out to have this same split. If none is a reasonably confident match, omit this and ask '
+                    . 'the user instead of guessing — never invent a CompanyID.',
                 required: false,
             ),
         ];

--- a/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
@@ -283,4 +283,59 @@ class AccountsPayableAgentToolsTest extends ScribeTestCase
         $this->assertSame('1498', $bill->bill_number);
         $this->assertSame('BB-0G-M1', $bill->lines->first()->subaccount->sub_code);
     }
+
+    public function test_create_ap_bill_stores_the_target_company_when_given(): void
+    {
+        $this->seedTestOrganization('Windwalk Games Corp');
+        $accountCode = (string) Account::query()
+            ->where('id', $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS))
+            ->value('account_number');
+
+        new CreateApBillTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(
+                vendor_name: 'Windwalk Games Corp',
+                amount: 2500.0,
+                gl_account_number: $accountCode,
+                memo: 'Community Building & Management Services',
+                invoice_number: '1498-DE',
+                acumatica_company: 'NZXT Germany - USD',
+            );
+
+        /** @var Bill $bill */
+        $bill = Bill::query()
+            ->where('apps_id', $this->kanvasApp->getId())
+            ->where('companies_id', $this->company->getId())
+            ->latest('id')
+            ->first();
+
+        $this->assertSame('NZXT Germany - USD', $bill->get(CustomFieldEnum::TARGET_COMPANY->value));
+    }
+
+    public function test_create_ap_bill_leaves_target_company_unset_by_default(): void
+    {
+        $this->seedTestOrganization('Windwalk Games Corp');
+        $accountCode = (string) Account::query()
+            ->where('id', $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS))
+            ->value('account_number');
+
+        new CreateApBillTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(
+                vendor_name: 'Windwalk Games Corp',
+                amount: 2500.0,
+                gl_account_number: $accountCode,
+                memo: 'Community Building & Management Services',
+                invoice_number: '1498-US',
+            );
+
+        /** @var Bill $bill */
+        $bill = Bill::query()
+            ->where('apps_id', $this->kanvasApp->getId())
+            ->where('companies_id', $this->company->getId())
+            ->latest('id')
+            ->first();
+
+        $this->assertSame('', (string) $bill->get(CustomFieldEnum::TARGET_COMPANY->value, ''));
+    }
 }


### PR DESCRIPTION
## Summary
This tenant's Acumatica account has multiple companies under one login (NZXT US, NZXT Germany, NZXT Taiwan, NZXT China, NZXT UK, etc.), confirmed via the tenant list in the admin screen. The connector previously assumed a single fixed company per Kanvas app, with no way to route a specific document elsewhere.

- Adds an optional company override threaded through `Client` → `AcumaticaWriteService` → `HasAcumaticaWriter` → the push action. Defaults to `null` everywhere, preserving today's single-company behavior when not used.
- Stores the override per-bill via a new `ACUMATICA_TARGET_COMPANY` custom field, so it survives the create → submit → approve → push chain and is auditable after the fact.
- `create_ap_bill` gets an optional `acumatica_company` param. The tool description tells the agent to infer it from the invoice's "Bill to" entity by reasoning (name/country/legal suffix) against the list of active companies — not exact-string matching a lookup table — and to never guess when there's no confident match.
- Fixed a related bug found while building this: `ensureVendorCode()`'s internal `writer()` call ran before the company override was computed, so the memoized writer from `HasAcumaticaWriter` would silently ignore the override on the first vendor-lookup call. Now the override is computed once at the top of `execute()` and passed to both calls.

## Test plan
- [x] Added `test_create_ap_bill_stores_the_target_company_when_given` / `..._leaves_target_company_unset_by_default`.
- [x] Ran the full Acumatica connector suite + `AccountsPayableAgentToolsTest` locally — 105/105 then 14/14 pass (regression-free).
- [x] **Live-verified against the real 2026R1 sandbox** (throwaway test, deleted after):
  - A bill with `acumatica_company: 'NZXT Germany - USD'` failed with `Vendor 'V0002181' cannot be found in the system` (+ different required-field errors) — proving it authenticated against the **German** company, not the default, since that vendor code is US-specific.
  - The same call with no override still pushed successfully to the default company (Bill Ref `66110511`), confirming no regression to existing behavior.