### PR TITLE
feat: recognize .xlsx/.xls/.csv when attaching a file to a bill

### DIFF
--- a/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaBillAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaBillAction.php
@@ -64,6 +64,9 @@ class AttachFileToAcumaticaBillAction
             'pdf' => 'application/pdf',
             'png' => 'image/png',
             'jpg', 'jpeg' => 'image/jpeg',
+            'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'xls' => 'application/vnd.ms-excel',
+            'csv' => 'text/csv',
             default => 'application/octet-stream',
         };
     }


### PR DESCRIPTION
Small follow-up to #10687 — attach_bill_file only recognized pdf/png/jpg before, everything else fell back to application/octet-stream. Adds xlsx/xls/csv content-type mapping, matching what attach_invoice_file already got in #10704. Verified the match resolves 'text/csv' correctly via reflection; no behavior change to the write path itself.