### PR TITLE
feat: add AR credit memo creation, and note/file tools for invoices

### DIFF
--- a/database/migrations/Scribe/2026_08_06_000001_add_account_id_to_invoice_lines.php
+++ b/database/migrations/Scribe/2026_08_06_000001_add_account_id_to_invoice_lines.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Lets a credit-note line override the GL account it debits (e.g. a "Control Acct#" like Promotion
+ * Discount or MDF, from a back-end-rebate request form) instead of always hitting Service Revenue.
+ * Null on every existing/normal invoice line — behavior there is unchanged.
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        if (Schema::connection('accounting')->hasColumn('invoice_lines', 'account_id')) {
+            return;
+        }
+
+        Schema::connection('accounting')->table('invoice_lines', function (Blueprint $table): void {
+            $table->unsignedBigInteger('account_id')->nullable()->after('item_id');
+            $table->index(['account_id'], 'invoice_lines_account_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::connection('accounting')->hasColumn('invoice_lines', 'account_id')) {
+            return;
+        }
+
+        Schema::connection('accounting')->table('invoice_lines', function (Blueprint $table): void {
+            $table->dropIndex('invoice_lines_account_idx');
+            $table->dropColumn('account_id');
+        });
+    }
+};

--- a/src/Domains/Connectors/Acumatica/Actions/AbstractInvoiceAcumaticaDocumentAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/AbstractInvoiceAcumaticaDocumentAction.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Acumatica\Actions;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
+use Kanvas\Connectors\Acumatica\Traits\HasAcumaticaWriter;
+use Kanvas\Scribe\Invoices\Models\Invoice;
+
+/** Shared plumbing for actions that mutate an already-pushed AR invoice/credit memo in Acumatica. */
+abstract class AbstractInvoiceAcumaticaDocumentAction
+{
+    use HasAcumaticaWriter;
+
+    protected Apps $app;
+
+    public function __construct(
+        protected Invoice $invoice,
+        ?AcumaticaWriteService $writer = null,
+    ) {
+        $this->app = $invoice->app;
+        $this->writer = $writer;
+    }
+
+    /** The document must already have an Acumatica reference — resolves it or throws. */
+    protected function invoiceGuidOrFail(string $action): string
+    {
+        $guid = (string) $this->invoice->get(CustomFieldEnum::INVOICE_ID->value, '');
+
+        if ($guid === '') {
+            throw new AcumaticaWriteException(
+                "Invoice {$this->invoice->getId()} has no Acumatica reference — it must be pushed before {$action}."
+            );
+        }
+
+        return $guid;
+    }
+}

--- a/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaInvoiceAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaInvoiceAction.php
@@ -66,6 +66,7 @@ class AttachFileToAcumaticaInvoiceAction
             'jpg', 'jpeg' => 'image/jpeg',
             'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
             'xls' => 'application/vnd.ms-excel',
+            'csv' => 'text/csv',
             default => 'application/octet-stream',
         };
     }

--- a/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaInvoiceAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaInvoiceAction.php
@@ -5,42 +5,27 @@ declare(strict_types=1);
 namespace Kanvas\Connectors\Acumatica\Actions;
 
 use Baka\Http\SafeUrlFetcher;
-use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\Acumatica\Client;
-use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
 use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
 use Kanvas\Connectors\Acumatica\Support\AcumaticaPayload;
-use Kanvas\Connectors\Acumatica\Traits\HasAcumaticaWriter;
 use Kanvas\Scribe\Invoices\Models\Invoice;
 
 /** Attaches a file to an already-pushed AR invoice or credit memo in Acumatica via its own files:put link. */
-class AttachFileToAcumaticaInvoiceAction
+class AttachFileToAcumaticaInvoiceAction extends AbstractInvoiceAcumaticaDocumentAction
 {
-    use HasAcumaticaWriter;
-
-    /** The invoice's own app — the tenant whose Acumatica config/credentials this push runs against. */
-    protected Apps $app;
-
     public function __construct(
-        protected Invoice $invoice,
+        Invoice $invoice,
         protected string $fileUrl,
         protected string $fileName,
         ?AcumaticaWriteService $writer = null,
     ) {
-        $this->app = $invoice->app;
-        $this->writer = $writer;
+        parent::__construct($invoice, $writer);
     }
 
     public function execute(): void
     {
-        $invoiceGuid = (string) $this->invoice->get(CustomFieldEnum::INVOICE_ID->value, '');
-
-        if ($invoiceGuid === '') {
-            throw new AcumaticaWriteException(
-                "Invoice {$this->invoice->getId()} has no Acumatica reference — it must be pushed before attaching a file."
-            );
-        }
+        $invoiceGuid = $this->invoiceGuidOrFail('attaching a file');
 
         $this->writer()->withSession(function (Client $client) use ($invoiceGuid): void {
             $template = AcumaticaPayload::filesPutHref($client->get('Invoice/' . $invoiceGuid));

--- a/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaInvoiceAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaInvoiceAction.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Acumatica\Actions;
+
+use Baka\Http\SafeUrlFetcher;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Acumatica\Client;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
+use Kanvas\Connectors\Acumatica\Support\AcumaticaPayload;
+use Kanvas\Connectors\Acumatica\Traits\HasAcumaticaWriter;
+use Kanvas\Scribe\Invoices\Models\Invoice;
+
+/** Attaches a file to an already-pushed AR invoice or credit memo in Acumatica via its own files:put link. */
+class AttachFileToAcumaticaInvoiceAction
+{
+    use HasAcumaticaWriter;
+
+    /** The invoice's own app — the tenant whose Acumatica config/credentials this push runs against. */
+    protected Apps $app;
+
+    public function __construct(
+        protected Invoice $invoice,
+        protected string $fileUrl,
+        protected string $fileName,
+        ?AcumaticaWriteService $writer = null,
+    ) {
+        $this->app = $invoice->app;
+        $this->writer = $writer;
+    }
+
+    public function execute(): void
+    {
+        $invoiceGuid = (string) $this->invoice->get(CustomFieldEnum::INVOICE_ID->value, '');
+
+        if ($invoiceGuid === '') {
+            throw new AcumaticaWriteException(
+                "Invoice {$this->invoice->getId()} has no Acumatica reference — it must be pushed before attaching a file."
+            );
+        }
+
+        $this->writer()->withSession(function (Client $client) use ($invoiceGuid): void {
+            $template = AcumaticaPayload::filesPutHref($client->get('Invoice/' . $invoiceGuid));
+
+            if ($template === null) {
+                throw new AcumaticaWriteException(
+                    "Invoice {$this->invoice->getId()} has no files:put link in Acumatica — cannot attach a file."
+                );
+            }
+
+            $bytes = SafeUrlFetcher::fetch($this->fileUrl);
+            $url = str_ireplace('{filename}', rawurlencode($this->fileName), $template);
+
+            $client->putFile($url, $bytes, $this->contentType());
+        });
+    }
+
+    private function contentType(): string
+    {
+        return match (strtolower(pathinfo($this->fileName, PATHINFO_EXTENSION))) {
+            'pdf' => 'application/pdf',
+            'png' => 'image/png',
+            'jpg', 'jpeg' => 'image/jpeg',
+            'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'xls' => 'application/vnd.ms-excel',
+            default => 'application/octet-stream',
+        };
+    }
+}

--- a/src/Domains/Connectors/Acumatica/Actions/PushInvoiceNoteToAcumaticaAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/PushInvoiceNoteToAcumaticaAction.php
@@ -4,43 +4,18 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\Acumatica\Actions;
 
-use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\Acumatica\Client;
-use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
-use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
-use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
 use Kanvas\Connectors\Acumatica\Support\AcumaticaPayload;
-use Kanvas\Connectors\Acumatica\Traits\HasAcumaticaWriter;
-use Kanvas\Scribe\Invoices\Models\Invoice;
 
 /** Appends a note to an already-pushed AR invoice or credit memo's Notes field in Acumatica. */
-class PushInvoiceNoteToAcumaticaAction
+class PushInvoiceNoteToAcumaticaAction extends AbstractInvoiceAcumaticaDocumentAction
 {
-    use HasAcumaticaWriter;
-
-    /** The invoice's own app — the tenant whose Acumatica config/credentials this push runs against. */
-    protected Apps $app;
-
-    public function __construct(
-        protected Invoice $invoice,
-        ?AcumaticaWriteService $writer = null,
-    ) {
-        $this->app = $invoice->app;
-        $this->writer = $writer;
-    }
-
     /**
      * @return string the full note text now stored in Acumatica
      */
     public function execute(string $note): string
     {
-        $invoiceGuid = (string) $this->invoice->get(CustomFieldEnum::INVOICE_ID->value, '');
-
-        if ($invoiceGuid === '') {
-            throw new AcumaticaWriteException(
-                "Invoice {$this->invoice->getId()} has no Acumatica reference — it must be pushed before adding a note."
-            );
-        }
+        $invoiceGuid = $this->invoiceGuidOrFail('adding a note');
 
         return $this->writer()->withSession(
             function (Client $client) use ($invoiceGuid, $note): string {

--- a/src/Domains/Connectors/Acumatica/Actions/PushInvoiceNoteToAcumaticaAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/PushInvoiceNoteToAcumaticaAction.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Acumatica\Actions;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Acumatica\Client;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
+use Kanvas\Connectors\Acumatica\Support\AcumaticaPayload;
+use Kanvas\Connectors\Acumatica\Traits\HasAcumaticaWriter;
+use Kanvas\Scribe\Invoices\Models\Invoice;
+
+/** Appends a note to an already-pushed AR invoice or credit memo's Notes field in Acumatica. */
+class PushInvoiceNoteToAcumaticaAction
+{
+    use HasAcumaticaWriter;
+
+    /** The invoice's own app — the tenant whose Acumatica config/credentials this push runs against. */
+    protected Apps $app;
+
+    public function __construct(
+        protected Invoice $invoice,
+        ?AcumaticaWriteService $writer = null,
+    ) {
+        $this->app = $invoice->app;
+        $this->writer = $writer;
+    }
+
+    /**
+     * @return string the full note text now stored in Acumatica
+     */
+    public function execute(string $note): string
+    {
+        $invoiceGuid = (string) $this->invoice->get(CustomFieldEnum::INVOICE_ID->value, '');
+
+        if ($invoiceGuid === '') {
+            throw new AcumaticaWriteException(
+                "Invoice {$this->invoice->getId()} has no Acumatica reference — it must be pushed before adding a note."
+            );
+        }
+
+        return $this->writer()->withSession(
+            function (Client $client) use ($invoiceGuid, $note): string {
+                $existing = (string) AcumaticaPayload::value($client->get('Invoice/' . $invoiceGuid), 'note', '');
+                $combined = $existing !== '' ? $existing . "\n" . $note : $note;
+
+                $client->put('Invoice', ['id' => $invoiceGuid, 'note' => ['value' => $combined]]);
+
+                return $combined;
+            }
+        );
+    }
+}

--- a/src/Domains/Connectors/Acumatica/Actions/PushInvoiceToAcumaticaAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/PushInvoiceToAcumaticaAction.php
@@ -14,6 +14,7 @@ use Kanvas\Connectors\Acumatica\Traits\HasAcumaticaWriter;
 use Kanvas\Guild\Organizations\Models\Organization;
 use Kanvas\Scribe\Invoices\Models\Invoice;
 use Kanvas\Scribe\Invoices\Models\InvoiceLine;
+use Kanvas\Scribe\Ledger\Models\Account;
 use Kanvas\Workflow\Enums\IntegrationsEnum;
 
 /** Pushes a Kanvas invoice to Acumatica as an AR Invoice (create + Release), the AR mirror of PushBillToAcumaticaAction. */
@@ -103,11 +104,30 @@ class PushInvoiceToAcumaticaAction
             'Hold' => false,
             // Intermittently flags brand-new customers into Credit Hold regardless of CreditLimit.
             'CreditHold' => false,
+            // Header-level hint; the line-level TaxCategory in buildLines() is what actually drives the calc.
+            'TaxZone' => $this->taxExemptCode(),
         ]);
 
         $header['Details'] = $this->buildLines();
 
         return $header;
+    }
+
+    /**
+     * Only exempts when Kanvas itself computed zero tax — a normal taxable document is untouched.
+     * The same configured code is used for both the header TaxZone and each line's TaxCategory:
+     * Acumatica computes tax off the line's TaxCategory (which otherwise defaults from the GL
+     * account), not the header TaxZone alone — setting only the header leaves VAT applied per line.
+     */
+    private function taxExemptCode(): ?string
+    {
+        if ((float) $this->invoice->tax_native !== 0.0) {
+            return null;
+        }
+
+        $code = (string) $this->app->get(ConfigurationEnum::ACUMATICA_TAX_EXEMPT_ZONE->value);
+
+        return $code !== '' ? $code : null;
     }
 
     /**
@@ -117,18 +137,33 @@ class PushInvoiceToAcumaticaAction
     {
         $lines = [];
         $defaultSubaccount = (string) $this->app->get(ConfigurationEnum::ACUMATICA_DEFAULT_SUBACCOUNT->value);
+        $taxExemptCode = $this->taxExemptCode();
 
         foreach ($this->invoice->lines as $line) {
             /** @var InvoiceLine $line */
+            $accountCode = $this->lineAccountCode($line->account_id);
+
             $lines[] = AcumaticaPayload::wrap([
                 'Description' => $line->description,
                 'Qty' => (float) $line->quantity,
                 'UnitPrice' => (float) $line->unit_price_native,
+                'Account' => $accountCode,
                 'Subaccount' => $defaultSubaccount !== '' ? $defaultSubaccount : null,
+                'TaxCategory' => $taxExemptCode,
             ]);
         }
 
         return $lines;
+    }
+
+    /** Resolves a line's own GL account (e.g. a rebate's Control Acct#) to the Acumatica account code; null lets Acumatica derive its default. */
+    private function lineAccountCode(?int $accountId): ?string
+    {
+        if ($accountId === null) {
+            return null;
+        }
+
+        return Account::query()->where('id', $accountId)->value('account_number');
     }
 
     /** Find-or-create the customer in Acumatica, mirroring EnsureAcumaticaVendorAction for the AP side. */

--- a/src/Domains/Connectors/Acumatica/Actions/PushInvoiceToAcumaticaAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/PushInvoiceToAcumaticaAction.php
@@ -90,7 +90,7 @@ class PushInvoiceToAcumaticaAction
     private function buildPayload(string $customerCode): array
     {
         $header = AcumaticaPayload::wrap([
-            'Type' => 'Invoice',
+            'Type' => $this->invoice->isCreditNote() ? 'Credit Memo' : 'Invoice',
             'Customer' => $customerCode,
             'CustomerRef' => $this->invoice->invoice_number,
             'Description' => $this->invoice->notes ?? ('Kanvas invoice ' . $this->invoice->invoice_number),

--- a/src/Domains/Connectors/Acumatica/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/Acumatica/Enums/ConfigurationEnum.php
@@ -18,6 +18,13 @@ enum ConfigurationEnum: string
     case ACUMATICA_DEFAULT_SUBACCOUNT = 'ACUMATICA_DEFAULT_SUBACCOUNT';
 
     /**
+     * TaxZone code to send on an AR Invoice/Credit Memo push when the Kanvas document has zero tax
+     * (e.g. Germany's "NONTAX" zone). Without this, Acumatica falls back to the tenant's default tax
+     * zone and silently adds VAT on top of a document Kanvas computed as tax-exempt.
+     */
+    case ACUMATICA_TAX_EXEMPT_ZONE = 'ACUMATICA_TAX_EXEMPT_ZONE';
+
+    /**
      * Per-tenant required custom fields injected into a SalesOrder push, so a tenant's Acumatica
      * customizations (e.g. required Usr* order-date fields) are satisfied without hardcoding them in
      * the connector. Map of Acumatica field name → spec; a spec is `{days:int}` (order date + N days,

--- a/src/Domains/Connectors/Acumatica/Traits/HasAcumaticaWriter.php
+++ b/src/Domains/Connectors/Acumatica/Traits/HasAcumaticaWriter.php
@@ -15,7 +15,7 @@ trait HasAcumaticaWriter
 {
     protected ?AcumaticaWriteService $writer = null;
 
-    private function writer(): AcumaticaWriteService
+    protected function writer(): AcumaticaWriteService
     {
         return $this->writer ??= new AcumaticaWriteService($this->app);
     }

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -13,7 +13,10 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\MatchInvoicesForPaymentTo
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryArAgingTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryDataFreshnessTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\TopLatePayersTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AddInvoiceNoteTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\ApplyArPaymentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AttachInvoiceFileTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArCreditMemoTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Sales\CreateSampleOrderTool;
@@ -71,6 +74,9 @@ class AccountsReceivableAgent extends SystemUserAgent
             new CreateArInvoiceTool(),
             new VoidArInvoiceTool(),
             new ApplyArPaymentTool(),
+            new CreateArCreditMemoTool(),
+            new AddInvoiceNoteTool(),
+            new AttachInvoiceFileTool(),
         ]));
     }
 
@@ -100,6 +106,10 @@ class AccountsReceivableAgent extends SystemUserAgent
             '- "Void/cancel/undo that invoice" → void_ar_invoice, given the invoice_id from create_ar_invoice.',
             '- "Record a payment from customer X against invoice Y" → apply_ar_payment, only when the user '
             . 'explicitly asks to record a real payment. Needs the invoice_id, amount, and a payment reference.',
+            '- "Issue a credit/allowance against invoice X" → create_ar_credit_memo, only on explicit request. '
+            . 'Needs the original invoice_number, credit amount, and a reason.',
+            '- "Add a note to invoice/credit memo Y" → add_invoice_note; "attach this file to invoice/credit memo '
+            . 'Y" → attach_invoice_file. Both require the document to already be pushed to Acumatica.',
             '- Lead with the headline, then the top 3-5 items. Be honest about freshness.',
         ]);
     }

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -106,8 +106,10 @@ class AccountsReceivableAgent extends SystemUserAgent
             '- "Void/cancel/undo that invoice" → void_ar_invoice, given the invoice_id from create_ar_invoice.',
             '- "Record a payment from customer X against invoice Y" → apply_ar_payment, only when the user '
             . 'explicitly asks to record a real payment. Needs the invoice_id, amount, and a payment reference.',
-            '- "Issue a credit/allowance against invoice X" → create_ar_credit_memo, only on explicit request. '
-            . 'Needs the original invoice_number, credit amount, and a reason.',
+            '- "Issue a standalone credit memo for customer X" (e.g. a back-end rebate) → create_ar_credit_memo, '
+            . 'only on explicit request. Not tied to any invoice — needs the customer name, a reference (e.g. '
+            . 'the Credit Request Form\'s Request Reference No), and one or more lines with a Control Acct# and '
+            . 'amount each.',
             '- "Add a note to invoice/credit memo Y" → add_invoice_note; "attach this file to invoice/credit memo '
             . 'Y" → attach_invoice_file. Both require the document to already be pushed to Acumatica.',
             '- Lead with the headline, then the top 3-5 items. Be honest about freshness.',

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AddInvoiceNoteTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AddInvoiceNoteTool.php
@@ -10,7 +10,7 @@ use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnu
 use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
-use Kanvas\Scribe\Invoices\Models\Invoice;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\ResolvesPushedInvoiceForTool;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
@@ -22,6 +22,7 @@ use Throwable;
 class AddInvoiceNoteTool extends Tool
 {
     use HasKanvasContext;
+    use ResolvesPushedInvoiceForTool;
 
     public function __construct()
     {
@@ -60,28 +61,10 @@ class AddInvoiceNoteTool extends Tool
      */
     public function __invoke(int $invoice_id, string $note): array
     {
-        $invoice = Invoice::query()
-            ->where('id', $invoice_id)
-            ->where('apps_id', $this->app->getId())
-            ->where('companies_id', $this->company->getId())
-            ->first();
+        $invoice = $this->resolvePushedInvoice($invoice_id);
 
-        if ($invoice === null) {
-            return [
-                'note_added' => false,
-                'reason' => 'invoice_not_found',
-                'message' => "No invoice with id {$invoice_id} for this app/company.",
-            ];
-        }
-
-        $ref = (string) $invoice->get(AcumaticaCustomFieldEnum::INVOICE_REF->value, '');
-
-        if ($ref === '') {
-            return [
-                'note_added' => false,
-                'reason' => 'invoice_not_pushed',
-                'message' => "Invoice {$invoice_id} hasn't been pushed to Acumatica yet — push it before adding a note.",
-            ];
+        if (is_array($invoice)) {
+            return ['note_added' => false, ...$invoice];
         }
 
         $stamped = '[' . Carbon::now()->toDateTimeString() . '] ' . $note;
@@ -106,7 +89,7 @@ class AddInvoiceNoteTool extends Tool
             'note_added' => true,
             'pushed' => true,
             'invoice_id' => $invoice->getId(),
-            'invoice_ref' => $ref,
+            'invoice_ref' => (string) $invoice->get(AcumaticaCustomFieldEnum::INVOICE_REF->value, ''),
             'note' => $stamped,
         ];
     }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AddInvoiceNoteTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AddInvoiceNoteTool.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
+
+use Illuminate\Support\Carbon;
+use Kanvas\Connectors\Acumatica\Actions\PushInvoiceNoteToAcumaticaAction;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Scribe\Invoices\Models\Invoice;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+/** Appends a note to an already-pushed AR invoice or credit memo, in Kanvas and in Acumatica. */
+#[AgentTool(name: 'Add Invoice Note', category: 'accounting')]
+class AddInvoiceNoteTool extends Tool
+{
+    use HasKanvasContext;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'add_invoice_note',
+            description: 'Appends a note to an AR invoice or credit memo that has already been pushed to '
+                . 'Acumatica — records it both in Kanvas and on the Acumatica document\'s Notes field.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'invoice_id',
+                type: PropertyType::INTEGER,
+                description: 'The Kanvas invoice/credit memo id to add the note to (returned as invoice_id by '
+                    . 'create_ar_invoice, or credit_memo_id by create_ar_credit_memo).',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'note',
+                type: PropertyType::STRING,
+                description: 'The note text to append.',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(int $invoice_id, string $note): array
+    {
+        $invoice = Invoice::query()
+            ->where('id', $invoice_id)
+            ->where('apps_id', $this->app->getId())
+            ->where('companies_id', $this->company->getId())
+            ->first();
+
+        if ($invoice === null) {
+            return [
+                'note_added' => false,
+                'reason' => 'invoice_not_found',
+                'message' => "No invoice with id {$invoice_id} for this app/company.",
+            ];
+        }
+
+        $ref = (string) $invoice->get(AcumaticaCustomFieldEnum::INVOICE_REF->value, '');
+
+        if ($ref === '') {
+            return [
+                'note_added' => false,
+                'reason' => 'invoice_not_pushed',
+                'message' => "Invoice {$invoice_id} hasn't been pushed to Acumatica yet — push it before adding a note.",
+            ];
+        }
+
+        $stamped = '[' . Carbon::now()->toDateTimeString() . '] ' . $note;
+        $invoice->internal_notes = $invoice->internal_notes !== null && $invoice->internal_notes !== ''
+            ? $invoice->internal_notes . "\n" . $stamped
+            : $stamped;
+        $invoice->saveOrFail();
+
+        try {
+            new PushInvoiceNoteToAcumaticaAction($invoice)->execute($stamped);
+        } catch (AcumaticaWriteException|Throwable $e) {
+            return [
+                'note_added' => true,
+                'pushed' => false,
+                'invoice_id' => $invoice->getId(),
+                'reason' => 'push_failed',
+                'message' => 'Note saved in Kanvas but the push to Acumatica failed: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'note_added' => true,
+            'pushed' => true,
+            'invoice_id' => $invoice->getId(),
+            'invoice_ref' => $ref,
+            'note' => $stamped,
+        ];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AttachInvoiceFileTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AttachInvoiceFileTool.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
+
+use Kanvas\Connectors\Acumatica\Actions\AttachFileToAcumaticaInvoiceAction;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Scribe\Invoices\Models\Invoice;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+/** Attaches a file to an already-pushed AR invoice or credit memo, in Kanvas and in Acumatica. */
+#[AgentTool(name: 'Attach Invoice File', category: 'accounting')]
+class AttachInvoiceFileTool extends Tool
+{
+    use HasKanvasContext;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'attach_invoice_file',
+            description: 'Attaches a file (by URL) to an AR invoice or credit memo that has already been pushed '
+                . 'to Acumatica — stores it in Kanvas and uploads it to the Acumatica document too.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'invoice_id',
+                type: PropertyType::INTEGER,
+                description: 'The Kanvas invoice/credit memo id to attach the file to (returned as invoice_id by '
+                    . 'create_ar_invoice, or credit_memo_id by create_ar_credit_memo).',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'file_url',
+                type: PropertyType::STRING,
+                description: 'A URL the file can be downloaded from.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'file_name',
+                type: PropertyType::STRING,
+                description: 'File name to store it under, including extension. Defaults to the URL\'s own file name.',
+                required: false,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(int $invoice_id, string $file_url, ?string $file_name = null): array
+    {
+        $invoice = Invoice::query()
+            ->where('id', $invoice_id)
+            ->where('apps_id', $this->app->getId())
+            ->where('companies_id', $this->company->getId())
+            ->first();
+
+        if ($invoice === null) {
+            return [
+                'file_attached' => false,
+                'reason' => 'invoice_not_found',
+                'message' => "No invoice with id {$invoice_id} for this app/company.",
+            ];
+        }
+
+        $ref = (string) $invoice->get(AcumaticaCustomFieldEnum::INVOICE_REF->value, '');
+
+        if ($ref === '') {
+            return [
+                'file_attached' => false,
+                'reason' => 'invoice_not_pushed',
+                'message' => "Invoice {$invoice_id} hasn't been pushed to Acumatica yet — push it before attaching a file.",
+            ];
+        }
+
+        $name = $file_name !== null && $file_name !== '' ? $file_name : basename(parse_url($file_url, PHP_URL_PATH) ?: 'file');
+
+        $invoice->addFileFromUrl($file_url, $name);
+
+        try {
+            new AttachFileToAcumaticaInvoiceAction($invoice, $file_url, $name)->execute();
+        } catch (AcumaticaWriteException|Throwable $e) {
+            return [
+                'file_attached' => true,
+                'pushed' => false,
+                'invoice_id' => $invoice->getId(),
+                'file_name' => $name,
+                'reason' => 'push_failed',
+                'message' => 'File saved in Kanvas but the push to Acumatica failed: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'file_attached' => true,
+            'pushed' => true,
+            'invoice_id' => $invoice->getId(),
+            'invoice_ref' => $ref,
+            'file_name' => $name,
+        ];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AttachInvoiceFileTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/AttachInvoiceFileTool.php
@@ -9,7 +9,7 @@ use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnu
 use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
-use Kanvas\Scribe\Invoices\Models\Invoice;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\ResolvesPushedInvoiceForTool;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
@@ -21,6 +21,7 @@ use Throwable;
 class AttachInvoiceFileTool extends Tool
 {
     use HasKanvasContext;
+    use ResolvesPushedInvoiceForTool;
 
     public function __construct()
     {
@@ -65,28 +66,10 @@ class AttachInvoiceFileTool extends Tool
      */
     public function __invoke(int $invoice_id, string $file_url, ?string $file_name = null): array
     {
-        $invoice = Invoice::query()
-            ->where('id', $invoice_id)
-            ->where('apps_id', $this->app->getId())
-            ->where('companies_id', $this->company->getId())
-            ->first();
+        $invoice = $this->resolvePushedInvoice($invoice_id);
 
-        if ($invoice === null) {
-            return [
-                'file_attached' => false,
-                'reason' => 'invoice_not_found',
-                'message' => "No invoice with id {$invoice_id} for this app/company.",
-            ];
-        }
-
-        $ref = (string) $invoice->get(AcumaticaCustomFieldEnum::INVOICE_REF->value, '');
-
-        if ($ref === '') {
-            return [
-                'file_attached' => false,
-                'reason' => 'invoice_not_pushed',
-                'message' => "Invoice {$invoice_id} hasn't been pushed to Acumatica yet — push it before attaching a file.",
-            ];
+        if (is_array($invoice)) {
+            return ['file_attached' => false, ...$invoice];
         }
 
         $name = $file_name !== null && $file_name !== '' ? $file_name : basename(parse_url($file_url, PHP_URL_PATH) ?: 'file');
@@ -110,7 +93,7 @@ class AttachInvoiceFileTool extends Tool
             'file_attached' => true,
             'pushed' => true,
             'invoice_id' => $invoice->getId(),
-            'invoice_ref' => $ref,
+            'invoice_ref' => (string) $invoice->get(AcumaticaCustomFieldEnum::INVOICE_REF->value, ''),
             'file_name' => $name,
         ];
     }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArCreditMemoTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArCreditMemoTool.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
 
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\Acumatica\Actions\PushInvoiceToAcumaticaAction;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;
 use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Guild\Organizations\Models\Organization;
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use Kanvas\Scribe\Invoices\Actions\IssueCreditNoteAction;
 use Kanvas\Scribe\Invoices\DataTransferObject\Invoice as InvoiceData;
 use Kanvas\Scribe\Invoices\DataTransferObject\InvoiceLine as InvoiceLineData;
-use Kanvas\Scribe\Invoices\Enums\DocumentTypeEnum;
-use Kanvas\Scribe\Invoices\Enums\InvoiceDocumentStatusEnum;
-use Kanvas\Scribe\Invoices\Models\Invoice;
+use Kanvas\Scribe\Ledger\Models\Account;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
@@ -22,7 +23,7 @@ use Override;
 use Spatie\LaravelData\DataCollection;
 use Throwable;
 
-/** Issues an AR credit memo against an already-issued invoice, and pushes it to Acumatica. */
+/** Issues a standalone AR credit memo (e.g. a back-end rebate) not tied to any specific invoice, and pushes it to Acumatica. */
 #[AgentTool(name: 'Create AR Credit Memo', category: 'accounting')]
 class CreateArCreditMemoTool extends Tool
 {
@@ -32,9 +33,10 @@ class CreateArCreditMemoTool extends Tool
     {
         parent::__construct(
             name: 'create_ar_credit_memo',
-            description: 'Issues a credit memo against an already-issued invoice — for a credit/allowance the '
-                . 'sales team has approved — and pushes it to Acumatica as a Credit Memo. Only call when the '
-                . 'user explicitly asks to issue a credit, never on a whim.',
+            description: 'Issues a standalone AR credit memo for a customer — e.g. a back-end rebate/sell-out '
+                . 'allowance from a Credit Request Form — and pushes it to Acumatica as a Credit Memo. It is not '
+                . 'tied to any specific invoice. Only call when the user explicitly asks to issue a credit, never '
+                . 'on a whim.',
         );
     }
 
@@ -46,93 +48,138 @@ class CreateArCreditMemoTool extends Tool
     {
         return [
             new ToolProperty(
+                name: 'customer_name',
+                type: PropertyType::STRING,
+                description: 'Customer name to match (substring), e.g. "Proshop". Always required — never '
+                    . 'guess or pick an arbitrary customer; ask the user if it is not clear from context.',
+                required: true,
+            ),
+            new ToolProperty(
                 name: 'invoice_number',
                 type: PropertyType::STRING,
-                description: 'The original invoice number this credit memo is against. Always required — never '
-                    . 'guess which invoice; ask the user if it is not clear from context.',
+                description: 'The Request Reference No. from the Credit Request Form (e.g. "Proshop Superdays '
+                    . 'Sell-Out (22/05-07/06)") — used as this credit memo\'s own document number, never a lookup '
+                    . 'into an existing invoice. Always required.',
                 required: true,
             ),
             new ToolProperty(
-                name: 'amount',
-                type: PropertyType::NUMBER,
-                description: 'The credit amount. Must not exceed the original invoice\'s total.',
+                name: 'lines',
+                type: PropertyType::ARRAY,
+                description: 'Array of line objects, one per row on the Credit Request Form: '
+                    . '{control_account_number: string (the "Control Acct#", e.g. "41045"), amount: number, '
+                    . 'description: string (e.g. product name)}. At least one line is required.',
                 required: true,
             ),
             new ToolProperty(
-                name: 'memo',
+                name: 'currency',
                 type: PropertyType::STRING,
-                description: 'Reason for the credit/allowance — becomes the credit memo\'s description.',
-                required: true,
+                description: 'Currency code. Defaults to USD.',
+                required: false,
             ),
         ];
     }
 
     /**
+     * @param array<int, array{control_account_number?: string, amount?: float|int|string, description?: string}> $lines
+     *
      * @return array<string, mixed>
      */
-    public function __invoke(string $invoice_number, float $amount, string $memo): array
-    {
+    public function __invoke(
+        string $customer_name,
+        string $invoice_number,
+        array $lines,
+        ?string $currency = null,
+    ): array {
         $app = $this->app;
         $company = $this->company;
+
+        if (trim($customer_name) === '') {
+            return [
+                'created' => false,
+                'reason' => 'customer_name_required',
+                'message' => 'A customer_name is required — never pick an arbitrary customer.',
+            ];
+        }
 
         if (trim($invoice_number) === '') {
             return [
                 'created' => false,
                 'reason' => 'invoice_number_required',
-                'message' => 'An invoice_number is required — never guess which invoice to credit.',
+                'message' => 'An invoice_number (the Credit Request Form\'s Request Reference No.) is required.',
             ];
         }
 
-        $parentInvoice = Invoice::query()
+        if ($lines === []) {
+            return [
+                'created' => false,
+                'reason' => 'lines_required',
+                'message' => 'At least one line (control_account_number + amount) is required.',
+            ];
+        }
+
+        /** @var Organization|null $customer */
+        $customer = Organization::query()
             ->where('apps_id', $app->getId())
             ->where('companies_id', $company->getId())
-            ->where('invoice_number', trim($invoice_number))
-            ->where('document_type', DocumentTypeEnum::INVOICE->value)
+            ->where('is_deleted', false)
+            ->where('name', 'like', '%' . trim($customer_name) . '%')
             ->first();
 
-        if ($parentInvoice === null) {
+        if ($customer === null) {
             return [
                 'created' => false,
-                'reason' => 'invoice_not_found',
-                'message' => "No invoice numbered \"{$invoice_number}\" for this app/company.",
+                'reason' => 'customer_not_found',
+                'message' => "No customer organization matching \"{$customer_name}\" for this app/company.",
             ];
         }
 
-        $validParentStatuses = [
-            InvoiceDocumentStatusEnum::ISSUED,
-            InvoiceDocumentStatusEnum::SENT,
-            InvoiceDocumentStatusEnum::PAID,
-        ];
+        $lineData = [];
+        foreach ($lines as $line) {
+            $accountNumber = trim((string) ($line['control_account_number'] ?? ''));
 
-        if (! in_array($parentInvoice->document_status, $validParentStatuses, true)) {
-            return [
-                'created' => false,
-                'reason' => 'invoice_not_creditable',
-                'message' => "Invoice {$invoice_number} is '{$parentInvoice->document_status->value}' — it must "
-                    . 'be issued, sent, or paid before it can be credited.',
-            ];
+            if ($accountNumber === '') {
+                return [
+                    'created' => false,
+                    'reason' => 'control_account_number_required',
+                    'message' => 'Every line requires a control_account_number.',
+                ];
+            }
+
+            $account = $this->resolveAccount($accountNumber, $app, $company);
+
+            if ($account === null) {
+                return [
+                    'created' => false,
+                    'reason' => 'account_not_found',
+                    'message' => "No active GL account with number \"{$accountNumber}\" for this app/company.",
+                ];
+            }
+
+            $lineData[] = new InvoiceLineData(
+                description: (string) ($line['description'] ?? $accountNumber),
+                quantity: 1.0,
+                unit_price_native: (float) ($line['amount'] ?? 0),
+                account_id: $account->getId(),
+            );
         }
 
+        $currency = $currency !== null && trim($currency) !== '' ? strtoupper(trim($currency)) : 'USD';
         $actingUser = $this->user;
 
         try {
             $creditNote = new IssueCreditNoteAction(
-                parentInvoice: $parentInvoice,
+                parentInvoice: null,
                 data: new InvoiceData(
                     app: $app,
                     company: $company,
-                    billable: null,
-                    lines: new DataCollection(InvoiceLineData::class, [
-                        new InvoiceLineData(
-                            description: $memo,
-                            quantity: 1.0,
-                            unit_price_native: $amount,
-                        ),
-                    ]),
-                    currency: $parentInvoice->currency,
-                    fx_rate_to_base: (float) $parentInvoice->fx_rate_to_base,
-                    notes: $memo,
+                    billable: $customer,
+                    lines: new DataCollection(InvoiceLineData::class, $lineData),
+                    currency: $currency,
+                    fx_rate_to_base: 1.0,
+                    invoice_number: trim($invoice_number),
+                    notes: "Credit Request Form reference: {$invoice_number}",
                 ),
+                billable: $customer,
                 user: $actingUser,
             )->execute();
         } catch (Throwable $e) {
@@ -151,7 +198,7 @@ class CreateArCreditMemoTool extends Tool
                 'pushed' => false,
                 'credit_memo_id' => $creditNote->getId(),
                 'credit_memo_number' => $creditNote->invoice_number,
-                'parent_invoice_number' => $parentInvoice->invoice_number,
+                'customer' => $customer->name,
                 'reason' => 'push_failed',
                 'message' => 'Credit memo was issued in Kanvas but the push to Acumatica failed: '
                     . $e->getMessage() . '. It needs manual attention — it will not auto-retry.',
@@ -163,14 +210,23 @@ class CreateArCreditMemoTool extends Tool
             'pushed' => true,
             'credit_memo_id' => $creditNote->getId(),
             'credit_memo_number' => $creditNote->invoice_number,
-            'parent_invoice_number' => $parentInvoice->invoice_number,
-            'amount' => $amount,
-            'currency' => $creditNote->currency,
-            'memo' => $memo,
+            'customer' => $customer->name,
+            'amount' => (float) $creditNote->total_native,
+            'currency' => $currency,
             'credit_memo_ref' => $reference,
             'acumatica_invoice_id' => (string) $creditNote->get(AcumaticaCustomFieldEnum::INVOICE_ID->value, ''),
             'next' => 'Pushed to Acumatica as a Credit Memo. credit_memo_ref is the ERP reference. Use '
-                . 'add_bill_note-style tools if you need to attach the approval email or add a note.',
+                . 'add_invoice_note / attach_invoice_file if you need to attach the request form or manager approval.',
         ];
+    }
+
+    private function resolveAccount(string $accountNumber, Apps $app, Companies $company): ?Account
+    {
+        return Account::query()
+            ->where('apps_id', $app->getId())
+            ->where('companies_id', $company->getId())
+            ->where('account_number', $accountNumber)
+            ->where('is_active', true)
+            ->first();
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArCreditMemoTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArCreditMemoTool.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
+
+use Kanvas\Connectors\Acumatica\Actions\PushInvoiceToAcumaticaAction;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Scribe\Invoices\Actions\IssueCreditNoteAction;
+use Kanvas\Scribe\Invoices\DataTransferObject\Invoice as InvoiceData;
+use Kanvas\Scribe\Invoices\DataTransferObject\InvoiceLine as InvoiceLineData;
+use Kanvas\Scribe\Invoices\Enums\DocumentTypeEnum;
+use Kanvas\Scribe\Invoices\Enums\InvoiceDocumentStatusEnum;
+use Kanvas\Scribe\Invoices\Models\Invoice;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Spatie\LaravelData\DataCollection;
+use Throwable;
+
+/** Issues an AR credit memo against an already-issued invoice, and pushes it to Acumatica. */
+#[AgentTool(name: 'Create AR Credit Memo', category: 'accounting')]
+class CreateArCreditMemoTool extends Tool
+{
+    use HasKanvasContext;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'create_ar_credit_memo',
+            description: 'Issues a credit memo against an already-issued invoice — for a credit/allowance the '
+                . 'sales team has approved — and pushes it to Acumatica as a Credit Memo. Only call when the '
+                . 'user explicitly asks to issue a credit, never on a whim.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'invoice_number',
+                type: PropertyType::STRING,
+                description: 'The original invoice number this credit memo is against. Always required — never '
+                    . 'guess which invoice; ask the user if it is not clear from context.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'amount',
+                type: PropertyType::NUMBER,
+                description: 'The credit amount. Must not exceed the original invoice\'s total.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'memo',
+                type: PropertyType::STRING,
+                description: 'Reason for the credit/allowance — becomes the credit memo\'s description.',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(string $invoice_number, float $amount, string $memo): array
+    {
+        $app = $this->app;
+        $company = $this->company;
+
+        if (trim($invoice_number) === '') {
+            return [
+                'created' => false,
+                'reason' => 'invoice_number_required',
+                'message' => 'An invoice_number is required — never guess which invoice to credit.',
+            ];
+        }
+
+        $parentInvoice = Invoice::query()
+            ->where('apps_id', $app->getId())
+            ->where('companies_id', $company->getId())
+            ->where('invoice_number', trim($invoice_number))
+            ->where('document_type', DocumentTypeEnum::INVOICE->value)
+            ->first();
+
+        if ($parentInvoice === null) {
+            return [
+                'created' => false,
+                'reason' => 'invoice_not_found',
+                'message' => "No invoice numbered \"{$invoice_number}\" for this app/company.",
+            ];
+        }
+
+        $validParentStatuses = [
+            InvoiceDocumentStatusEnum::ISSUED,
+            InvoiceDocumentStatusEnum::SENT,
+            InvoiceDocumentStatusEnum::PAID,
+        ];
+
+        if (! in_array($parentInvoice->document_status, $validParentStatuses, true)) {
+            return [
+                'created' => false,
+                'reason' => 'invoice_not_creditable',
+                'message' => "Invoice {$invoice_number} is '{$parentInvoice->document_status->value}' — it must "
+                    . 'be issued, sent, or paid before it can be credited.',
+            ];
+        }
+
+        $actingUser = $this->user;
+
+        try {
+            $creditNote = new IssueCreditNoteAction(
+                parentInvoice: $parentInvoice,
+                data: new InvoiceData(
+                    app: $app,
+                    company: $company,
+                    billable: null,
+                    lines: new DataCollection(InvoiceLineData::class, [
+                        new InvoiceLineData(
+                            description: $memo,
+                            quantity: 1.0,
+                            unit_price_native: $amount,
+                        ),
+                    ]),
+                    currency: $parentInvoice->currency,
+                    fx_rate_to_base: (float) $parentInvoice->fx_rate_to_base,
+                    notes: $memo,
+                ),
+                user: $actingUser,
+            )->execute();
+        } catch (Throwable $e) {
+            return [
+                'created' => false,
+                'reason' => 'issue_failed',
+                'message' => 'Could not issue the credit memo: ' . $e->getMessage(),
+            ];
+        }
+
+        try {
+            $reference = new PushInvoiceToAcumaticaAction($creditNote)->execute();
+        } catch (AcumaticaWriteException|Throwable $e) {
+            return [
+                'created' => true,
+                'pushed' => false,
+                'credit_memo_id' => $creditNote->getId(),
+                'credit_memo_number' => $creditNote->invoice_number,
+                'parent_invoice_number' => $parentInvoice->invoice_number,
+                'reason' => 'push_failed',
+                'message' => 'Credit memo was issued in Kanvas but the push to Acumatica failed: '
+                    . $e->getMessage() . '. It needs manual attention — it will not auto-retry.',
+            ];
+        }
+
+        return [
+            'created' => true,
+            'pushed' => true,
+            'credit_memo_id' => $creditNote->getId(),
+            'credit_memo_number' => $creditNote->invoice_number,
+            'parent_invoice_number' => $parentInvoice->invoice_number,
+            'amount' => $amount,
+            'currency' => $creditNote->currency,
+            'memo' => $memo,
+            'credit_memo_ref' => $reference,
+            'acumatica_invoice_id' => (string) $creditNote->get(AcumaticaCustomFieldEnum::INVOICE_ID->value, ''),
+            'next' => 'Pushed to Acumatica as a Credit Memo. credit_memo_ref is the ERP reference. Use '
+                . 'add_bill_note-style tools if you need to attach the approval email or add a note.',
+        ];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Traits/ResolvesPushedInvoiceForTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Traits/ResolvesPushedInvoiceForTool.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Traits;
+
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum as AcumaticaCustomFieldEnum;
+use Kanvas\Scribe\Invoices\Models\Invoice;
+
+/**
+ * Resolves an AR invoice/credit memo that must already be pushed to Acumatica for a tool. Requires
+ * HasKanvasContext ($app, $company). Returns the Invoice, or an LLM-facing error array the caller
+ * merges into its own response shape (e.g. `['note_added' => false, ...$invoice]`).
+ */
+trait ResolvesPushedInvoiceForTool
+{
+    /**
+     * @return Invoice|array{reason: string, message: string}
+     */
+    protected function resolvePushedInvoice(int $invoiceId): Invoice|array
+    {
+        $invoice = Invoice::query()
+            ->where('id', $invoiceId)
+            ->where('apps_id', $this->app->getId())
+            ->where('companies_id', $this->company->getId())
+            ->first();
+
+        if ($invoice === null) {
+            return [
+                'reason' => 'invoice_not_found',
+                'message' => "No invoice with id {$invoiceId} for this app/company.",
+            ];
+        }
+
+        if ((string) $invoice->get(AcumaticaCustomFieldEnum::INVOICE_REF->value, '') === '') {
+            return [
+                'reason' => 'invoice_not_pushed',
+                'message' => "Invoice {$invoiceId} hasn't been pushed to Acumatica yet — push it before continuing.",
+            ];
+        }
+
+        return $invoice;
+    }
+}

--- a/src/Domains/Scribe/Invoices/Actions/IssueCreditNoteAction.php
+++ b/src/Domains/Scribe/Invoices/Actions/IssueCreditNoteAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Scribe\Invoices\Actions;
 
+use Baka\Contracts\BillableInterface;
 use Baka\Users\Contracts\UserInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -25,30 +26,32 @@ use Kanvas\Scribe\Invoices\Services\InvoiceJournalEntryComposerService;
 use Kanvas\Scribe\Ledger\Actions\PostJournalEntryAction;
 
 /**
- * Issues a credit note against a parent Invoice.
+ * Issues a credit note, either against a parent Invoice or standalone (e.g. a period/campaign-based
+ * back-end rebate that never referenced a specific invoice).
  *
  * A credit note is a new row in `accounting.invoices` with:
  *   - `document_type = 'credit_note'`
- *   - `parent_invoice_id = <parent>`
+ *   - `parent_invoice_id = <parent>` when there is one, else null
  *   - `document_status = 'issued'` (credit notes skip the DRAFT stage — they're issued instantly with a JE)
  *   - amounts stored POSITIVE (the document_type discriminator + JE direction carry the credit sign)
  *
  * Side effects (all atomic in one accounting-DB transaction):
- *   1. Validate parent invoice state (must be ISSUED / SENT / PAID — not draft, not voided, not already-credit-note)
- *   2. Validate credit_amount ≤ parent.total_native (can't credit more than billed)
+ *   1. Validate parent invoice state when there is one (must be ISSUED / SENT / PAID)
+ *   2. Validate credit_amount > 0, and ≤ parent.total_native when there is a parent
  *   3. Create credit-note Invoice row + lines + tax_lines
- *   4. Allocate credit-note number via DocumentNumberAllocatorService (CREDIT_NOTE document_type)
- *   5. Post the credit-note JE via composeCreditNote (DR Revenue + DR Tax Payable / CR AR)
- *   6. Insert InvoicePaymentAllocation row on parent with source_type='credit_note'
- *   7. Re-run MarkInvoicePaidAction on the parent — recomputes balance_due, flips to PAID if balance hit zero
+ *   4. Allocate credit-note number via DocumentNumberAllocatorService, unless the caller supplied one
+ *   5. Post the credit-note JE via composeCreditNote (DR Revenue or per-line account + DR Tax Payable / CR AR)
+ *   6. When there is a parent: insert InvoicePaymentAllocation with source_type='credit_note' and
+ *      re-run MarkInvoicePaidAction — recomputes balance_due, flips to PAID if balance hit zero
  *
  * @see plan §7.3 — credit notes as document_type discriminator
  */
 class IssueCreditNoteAction
 {
     public function __construct(
-        public readonly Invoice $parentInvoice,
+        public readonly ?Invoice $parentInvoice,
         public readonly InvoiceData $data,
+        public readonly ?BillableInterface $billable = null,
         public readonly ?UserInterface $user = null,
         protected readonly InvoiceJournalEntryComposerService $composer = new InvoiceJournalEntryComposerService(),
         protected readonly ?DocumentNumberAllocatorService $allocator = null,
@@ -58,6 +61,12 @@ class IssueCreditNoteAction
     public function execute(): Invoice
     {
         $this->validateParentState();
+
+        if ($this->parentInvoice === null && $this->billable === null) {
+            throw new InvalidInvoiceTransitionException(
+                'A standalone credit note (no parent invoice) requires a billable customer.'
+            );
+        }
 
         return DB::connection('accounting')->transaction(function (): Invoice {
             $parent = $this->parentInvoice;
@@ -70,15 +79,15 @@ class IssueCreditNoteAction
                 );
             }
 
-            if ($totals['total'] > (float) $parent->total_native + 0.0001) {
+            if ($parent !== null && $totals['total'] > (float) $parent->total_native + 0.0001) {
                 throw new InvalidInvoiceTransitionException(
                     "Credit note total ({$totals['total']}) exceeds parent invoice total ({$parent->total_native})."
                 );
             }
 
             $creditNote = new Invoice();
-            $creditNote->apps_id = $parent->apps_id;
-            $creditNote->companies_id = $parent->companies_id;
+            $creditNote->apps_id = $this->data->app->getId();
+            $creditNote->companies_id = $this->data->company->getId();
             $creditNote->document_type = DocumentTypeEnum::CREDIT_NOTE;
             $creditNote->document_status = InvoiceDocumentStatusEnum::ISSUED;
             $creditNote->collection_state = null;
@@ -107,7 +116,8 @@ class IssueCreditNoteAction
             $creditNote->notes = $this->data->notes;
             $creditNote->internal_notes = $this->data->internal_notes;
             $creditNote->terms = $this->data->terms;
-            $creditNote->parent_invoice_id = $parent->id;
+            $creditNote->parent_invoice_id = $parent?->id;
+            $creditNote->invoice_number = $this->data->invoice_number;
             $creditNote->source = $this->data->source;
             $creditNote->external_id = $this->data->external_id;
             $creditNote->external_url = $this->data->external_url;
@@ -115,14 +125,7 @@ class IssueCreditNoteAction
             $creditNote->metadata = $this->data->metadata;
             $creditNote->users_id = $this->user?->getId();
 
-            // Inherit billable snapshot from parent (frozen — same customer the credit goes to)
-            $creditNote->customer_organization_id = $parent->customer_organization_id;
-            $creditNote->billable_display_name = $parent->billable_display_name;
-            $creditNote->billable_legal_name = $parent->billable_legal_name;
-            $creditNote->billable_tax_id = $parent->billable_tax_id;
-            $creditNote->billable_email = $parent->billable_email;
-            $creditNote->billing_address_snapshot = $parent->billing_address_snapshot;
-            $creditNote->shipping_address_snapshot = $parent->shipping_address_snapshot;
+            $this->hydrateBillableSnapshot($creditNote, $parent);
 
             $creditNote->save();
 
@@ -141,19 +144,21 @@ class IssueCreditNoteAction
                 postedByUser: $this->user,
             )->execute();
 
-            $this->writeAllocationOnParent($parent, $creditNote);
+            if ($parent !== null) {
+                $this->writeAllocationOnParent($parent, $creditNote);
 
-            new MarkInvoicePaidAction(
-                invoice: $parent,
-                user: $this->user,
-            )->execute();
+                new MarkInvoicePaidAction(
+                    invoice: $parent,
+                    user: $this->user,
+                )->execute();
+            }
 
             $creditNote->emitLedgerEvent(
                 eventType: 'scribe.credit_note.issued',
                 payload: [
                     'credit_note_number' => $creditNote->invoice_number,
-                    'parent_invoice_id' => $parent->id,
-                    'parent_invoice_number' => $parent->invoice_number,
+                    'parent_invoice_id' => $parent?->id,
+                    'parent_invoice_number' => $parent?->invoice_number,
                     'currency' => $creditNote->currency,
                     'total_native' => (float) $creditNote->total_native,
                     'total_base' => (float) $creditNote->total_base,
@@ -167,6 +172,10 @@ class IssueCreditNoteAction
     private function validateParentState(): void
     {
         $parent = $this->parentInvoice;
+
+        if ($parent === null) {
+            return;
+        }
 
         if ($parent->document_type === DocumentTypeEnum::CREDIT_NOTE) {
             throw new InvalidInvoiceTransitionException(
@@ -188,6 +197,31 @@ class IssueCreditNoteAction
         }
     }
 
+    /** Inherits the frozen snapshot from the parent when there is one, else freezes it from the standalone billable. */
+    private function hydrateBillableSnapshot(Invoice $creditNote, ?Invoice $parent): void
+    {
+        if ($parent !== null) {
+            $creditNote->customer_organization_id = $parent->customer_organization_id;
+            $creditNote->billable_display_name = $parent->billable_display_name;
+            $creditNote->billable_legal_name = $parent->billable_legal_name;
+            $creditNote->billable_tax_id = $parent->billable_tax_id;
+            $creditNote->billable_email = $parent->billable_email;
+            $creditNote->billing_address_snapshot = $parent->billing_address_snapshot;
+            $creditNote->shipping_address_snapshot = $parent->shipping_address_snapshot;
+
+            return;
+        }
+
+        /** @var BillableInterface $billable */
+        $billable = $this->billable;
+        $creditNote->customer_organization_id = $billable->getBillableId();
+        $creditNote->billable_display_name = $billable->getBillableDisplayName();
+        $creditNote->billable_legal_name = $billable->getBillableLegalName();
+        $creditNote->billable_tax_id = $billable->getBillableTaxId();
+        $creditNote->billable_email = $billable->getBillingEmail();
+        $creditNote->billing_address_snapshot = $billable->getBillingAddressArray();
+    }
+
     private function persistLines(Invoice $creditNote, float $fxRate): void
     {
         $sortOrder = 0;
@@ -197,6 +231,7 @@ class IssueCreditNoteAction
             $line->invoice_id = $creditNote->id;
             $line->sort_order = $lineData->sort_order ?? $sortOrder++;
             $line->item_id = $lineData->item_id;
+            $line->account_id = $lineData->account_id;
             $line->sku = $lineData->sku;
             $line->description = $lineData->description;
             $line->quantity = $lineData->quantity;

--- a/src/Domains/Scribe/Invoices/DataTransferObject/InvoiceLine.php
+++ b/src/Domains/Scribe/Invoices/DataTransferObject/InvoiceLine.php
@@ -18,6 +18,8 @@ class InvoiceLine extends Data
         public readonly ?int $item_id = null,
         public readonly ?string $sku = null,
         public readonly ?int $sort_order = null,
+        /** Overrides the account this line's JE debit/credit hits (e.g. a rebate's Control Acct#); null falls back to the document default. */
+        public readonly ?int $account_id = null,
         public readonly ?float $discount_rate = null,
         public readonly float $discount_amount_native = 0.0,
         public readonly ?float $tax_rate = null,

--- a/src/Domains/Scribe/Invoices/Models/InvoiceLine.php
+++ b/src/Domains/Scribe/Invoices/Models/InvoiceLine.php
@@ -8,6 +8,7 @@ use Baka\Casts\Json;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Kanvas\Scribe\Items\Models\Item;
+use Kanvas\Scribe\Ledger\Models\Account;
 
 /**
  * Invoice line. Immutable post-issue (caller responsibility — observer enforcement comes later).
@@ -16,6 +17,7 @@ use Kanvas\Scribe\Items\Models\Item;
  * @property int $invoice_id
  * @property int $sort_order
  * @property int|null $item_id
+ * @property int|null $account_id
  * @property string|null $sku
  * @property string|null $description
  * @property float $quantity
@@ -67,5 +69,10 @@ class InvoiceLine extends EloquentModel
     public function item(): BelongsTo
     {
         return $this->belongsTo(Item::class, 'item_id', 'id');
+    }
+
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(Account::class, 'account_id', 'id');
     }
 }

--- a/src/Domains/Scribe/Invoices/Services/InvoiceJournalEntryComposerService.php
+++ b/src/Domains/Scribe/Invoices/Services/InvoiceJournalEntryComposerService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Scribe\Invoices\Services;
 
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Kanvas\Scribe\Invoices\Models\Invoice;
 use Kanvas\Scribe\Invoices\Models\InvoicePaymentAllocation;
 use Kanvas\Scribe\Ledger\DataTransferObject\JournalEntry as JournalEntryData;
@@ -210,6 +211,10 @@ class InvoiceJournalEntryComposerService
      *   DR Sales Tax Payable      {tax}                   (reverses the tax liability)
      *     CR Accounts Receivable   {total}                (reduces customer balance)
      *
+     * When a line carries its own account_id (e.g. a back-end-rebate's Control Acct#), that line debits
+     * its own account instead of Service Revenue — one JE line per distinct account, lines sharing an
+     * account are summed together. Falls back to the single Service-Revenue line when no line overrides it.
+     *
      * The credit_note Invoice row carries POSITIVE amounts; the JE direction is what makes it a credit.
      */
     public function composeCreditNote(Invoice $creditNote): JournalEntryData
@@ -220,10 +225,7 @@ class InvoiceJournalEntryComposerService
         $billableId = $creditNote->customer_organization_id;
 
         $arAccount = $this->accountResolver->bySubType($app, $company, AccountSubTypeEnum::ACCOUNTS_RECEIVABLE);
-        $revenueAccount = $this->accountResolver->bySubType($app, $company, AccountSubTypeEnum::SERVICE_REVENUE);
 
-        $netRevenueNative = (float) $creditNote->subtotal_native - (float) $creditNote->discount_native;
-        $netRevenueBase = (float) $creditNote->subtotal_base - (float) $creditNote->discount_base;
         $totalNative = (float) $creditNote->total_native;
         $totalBase = (float) $creditNote->total_base;
         $taxNative = (float) $creditNote->tax_native;
@@ -231,22 +233,39 @@ class InvoiceJournalEntryComposerService
         $currency = $creditNote->currency;
         $fxRate = (float) $creditNote->fx_rate_to_base;
 
-        $lines = [
-            // DR Revenue
-            new JournalEntryLineData(
-                account_id: $revenueAccount->id,
-                debit_native: $netRevenueNative,
-                credit_native: 0.0,
-                debit_base: $netRevenueBase,
-                credit_base: 0.0,
-                currency: $currency,
-                fx_rate_to_base: $fxRate,
-                sort_order: 0,
-                customer_billable_type: $billableType,
-                customer_billable_id: $billableId,
-                memo: "Credit Note {$creditNote->invoice_number} — Revenue reversal",
-            ),
-        ];
+        $codedLines = $creditNote->lines->whereNotNull('account_id');
+
+        if ($codedLines->isNotEmpty()) {
+            $lines = $this->composeCreditNoteDebitLinesByAccount(
+                $creditNote,
+                $codedLines,
+                $billableType,
+                $billableId,
+                $currency,
+                $fxRate,
+            );
+        } else {
+            $revenueAccount = $this->accountResolver->bySubType($app, $company, AccountSubTypeEnum::SERVICE_REVENUE);
+            $netRevenueNative = (float) $creditNote->subtotal_native - (float) $creditNote->discount_native;
+            $netRevenueBase = (float) $creditNote->subtotal_base - (float) $creditNote->discount_base;
+
+            $lines = [
+                // DR Revenue
+                new JournalEntryLineData(
+                    account_id: $revenueAccount->id,
+                    debit_native: $netRevenueNative,
+                    credit_native: 0.0,
+                    debit_base: $netRevenueBase,
+                    credit_base: 0.0,
+                    currency: $currency,
+                    fx_rate_to_base: $fxRate,
+                    sort_order: 0,
+                    customer_billable_type: $billableType,
+                    customer_billable_id: $billableId,
+                    memo: "Credit Note {$creditNote->invoice_number} — Revenue reversal",
+                ),
+            ];
+        }
 
         if ($taxNative > 0) {
             $taxLines = $creditNote->taxLines;
@@ -309,6 +328,43 @@ class InvoiceJournalEntryComposerService
             externalId: $creditNote->external_id,
             origin: $creditNote->origin,
         );
+    }
+
+    /**
+     * One DR JE line per distinct account_id among the coded lines (lines sharing an account are summed).
+     *
+     * @return array<int, JournalEntryLineData>
+     */
+    private function composeCreditNoteDebitLinesByAccount(
+        Invoice $creditNote,
+        Collection $codedLines,
+        string $billableType,
+        ?int $billableId,
+        string $currency,
+        float $fxRate,
+    ): array {
+        $lines = [];
+        $sortOrder = 0;
+
+        foreach ($codedLines->groupBy('account_id') as $accountId => $groupLines) {
+            $account = Account::query()->where('id', $accountId)->firstOrFail();
+
+            $lines[] = new JournalEntryLineData(
+                account_id: $account->id,
+                debit_native: (float) $groupLines->sum('line_total_native'),
+                credit_native: 0.0,
+                debit_base: (float) $groupLines->sum('line_total_base'),
+                credit_base: 0.0,
+                currency: $currency,
+                fx_rate_to_base: $fxRate,
+                sort_order: $sortOrder++,
+                customer_billable_type: $billableType,
+                customer_billable_id: $billableId,
+                memo: "Credit Note {$creditNote->invoice_number} — {$account->name}",
+            );
+        }
+
+        return $lines;
     }
 
     /**

--- a/src/Domains/Scribe/Invoices/Services/InvoiceJournalEntryComposerService.php
+++ b/src/Domains/Scribe/Invoices/Services/InvoiceJournalEntryComposerService.php
@@ -59,8 +59,6 @@ class InvoiceJournalEntryComposerService
         $netRevenueBase = (float) $invoice->subtotal_base - (float) $invoice->discount_base;
         $totalNative = (float) $invoice->total_native;
         $totalBase = (float) $invoice->total_base;
-        $taxNative = (float) $invoice->tax_native;
-        $taxBase = (float) $invoice->tax_base;
         $currency = $invoice->currency;
         $fxRate = (float) $invoice->fx_rate_to_base;
 
@@ -95,41 +93,7 @@ class InvoiceJournalEntryComposerService
             ),
         ];
 
-        // CR Sales Tax Payable — one line per tax jurisdiction when tax_lines are populated;
-        // single fallback line when only the header tax_native is set.
-        if ($taxNative > 0) {
-            $taxLines = $invoice->taxLines;
-            if ($taxLines->isNotEmpty()) {
-                $sortOrder = 2;
-                foreach ($taxLines as $taxLine) {
-                    $taxAccount = $this->resolveTaxAccount($invoice, $taxLine->jurisdiction);
-                    $lines[] = new JournalEntryLineData(
-                        account_id: $taxAccount->id,
-                        debit_native: 0.0,
-                        credit_native: (float) $taxLine->tax_amount_native,
-                        debit_base: 0.0,
-                        credit_base: (float) $taxLine->tax_amount_base,
-                        currency: $currency,
-                        fx_rate_to_base: $fxRate,
-                        sort_order: $sortOrder++,
-                        memo: "Invoice {$invoice->invoice_number} — {$taxLine->name}",
-                    );
-                }
-            } else {
-                $taxAccount = $this->accountResolver->bySubType($app, $company, AccountSubTypeEnum::SALES_TAX_PAYABLE);
-                $lines[] = new JournalEntryLineData(
-                    account_id: $taxAccount->id,
-                    debit_native: 0.0,
-                    credit_native: $taxNative,
-                    debit_base: 0.0,
-                    credit_base: $taxBase,
-                    currency: $currency,
-                    fx_rate_to_base: $fxRate,
-                    sort_order: 2,
-                    memo: "Invoice {$invoice->invoice_number} — Sales Tax",
-                );
-            }
-        }
+        array_push($lines, ...$this->buildTaxLines($invoice, credit: true, memoSuffix: '', startSortOrder: 2));
 
         return new JournalEntryData(
             app: $app,
@@ -228,8 +192,6 @@ class InvoiceJournalEntryComposerService
 
         $totalNative = (float) $creditNote->total_native;
         $totalBase = (float) $creditNote->total_base;
-        $taxNative = (float) $creditNote->tax_native;
-        $taxBase = (float) $creditNote->tax_base;
         $currency = $creditNote->currency;
         $fxRate = (float) $creditNote->fx_rate_to_base;
 
@@ -267,39 +229,7 @@ class InvoiceJournalEntryComposerService
             ];
         }
 
-        if ($taxNative > 0) {
-            $taxLines = $creditNote->taxLines;
-            if ($taxLines->isNotEmpty()) {
-                $sortOrder = 1;
-                foreach ($taxLines as $taxLine) {
-                    $taxAccount = $this->resolveTaxAccount($creditNote, $taxLine->jurisdiction);
-                    $lines[] = new JournalEntryLineData(
-                        account_id: $taxAccount->id,
-                        debit_native: (float) $taxLine->tax_amount_native,
-                        credit_native: 0.0,
-                        debit_base: (float) $taxLine->tax_amount_base,
-                        credit_base: 0.0,
-                        currency: $currency,
-                        fx_rate_to_base: $fxRate,
-                        sort_order: $sortOrder++,
-                        memo: "Credit Note {$creditNote->invoice_number} — {$taxLine->name} reversal",
-                    );
-                }
-            } else {
-                $taxAccount = $this->accountResolver->bySubType($app, $company, AccountSubTypeEnum::SALES_TAX_PAYABLE);
-                $lines[] = new JournalEntryLineData(
-                    account_id: $taxAccount->id,
-                    debit_native: $taxNative,
-                    credit_native: 0.0,
-                    debit_base: $taxBase,
-                    credit_base: 0.0,
-                    currency: $currency,
-                    fx_rate_to_base: $fxRate,
-                    sort_order: 1,
-                    memo: "Credit Note {$creditNote->invoice_number} — Sales Tax reversal",
-                );
-            }
-        }
+        array_push($lines, ...$this->buildTaxLines($creditNote, credit: false, memoSuffix: ' reversal', startSortOrder: 1));
 
         // CR Accounts Receivable
         $lines[] = new JournalEntryLineData(
@@ -361,6 +291,64 @@ class InvoiceJournalEntryComposerService
                 customer_billable_type: $billableType,
                 customer_billable_id: $billableId,
                 memo: "Credit Note {$creditNote->invoice_number} — {$account->name}",
+            );
+        }
+
+        return $lines;
+    }
+
+    /**
+     * Shared by composeIssue (credit: true) and composeCreditNote (credit: false, " reversal" suffix):
+     * one tax-payable line per jurisdiction when tax_lines are populated, else a single fallback line
+     * off the header tax_native/tax_base. Empty array when there's no tax to book.
+     *
+     * @return array<int, JournalEntryLineData>
+     */
+    private function buildTaxLines(Invoice $invoice, bool $credit, string $memoSuffix, int $startSortOrder): array
+    {
+        $taxNative = (float) $invoice->tax_native;
+
+        if ($taxNative <= 0) {
+            return [];
+        }
+
+        $label = $invoice->isCreditNote() ? 'Credit Note' : 'Invoice';
+        $currency = $invoice->currency;
+        $fxRate = (float) $invoice->fx_rate_to_base;
+        $taxLines = $invoice->taxLines;
+
+        if ($taxLines->isEmpty()) {
+            $taxAccount = $this->accountResolver->bySubType($invoice->app, $invoice->company, AccountSubTypeEnum::SALES_TAX_PAYABLE);
+
+            return [
+                new JournalEntryLineData(
+                    account_id: $taxAccount->id,
+                    debit_native: $credit ? 0.0 : $taxNative,
+                    credit_native: $credit ? $taxNative : 0.0,
+                    debit_base: $credit ? 0.0 : (float) $invoice->tax_base,
+                    credit_base: $credit ? (float) $invoice->tax_base : 0.0,
+                    currency: $currency,
+                    fx_rate_to_base: $fxRate,
+                    sort_order: $startSortOrder,
+                    memo: "{$label} {$invoice->invoice_number} — Sales Tax{$memoSuffix}",
+                ),
+            ];
+        }
+
+        $lines = [];
+        $sortOrder = $startSortOrder;
+        foreach ($taxLines as $taxLine) {
+            $taxAccount = $this->resolveTaxAccount($invoice, $taxLine->jurisdiction);
+            $lines[] = new JournalEntryLineData(
+                account_id: $taxAccount->id,
+                debit_native: $credit ? 0.0 : (float) $taxLine->tax_amount_native,
+                credit_native: $credit ? (float) $taxLine->tax_amount_native : 0.0,
+                debit_base: $credit ? 0.0 : (float) $taxLine->tax_amount_base,
+                credit_base: $credit ? (float) $taxLine->tax_amount_base : 0.0,
+                currency: $currency,
+                fx_rate_to_base: $fxRate,
+                sort_order: $sortOrder++,
+                memo: "{$label} {$invoice->invoice_number} — {$taxLine->name}{$memoSuffix}",
             );
         }
 

--- a/tests/Connectors/Acumatica/AttachFileToAcumaticaInvoiceActionTest.php
+++ b/tests/Connectors/Acumatica/AttachFileToAcumaticaInvoiceActionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Acumatica;
+
+use Illuminate\Support\Carbon;
+use Kanvas\Connectors\Acumatica\Actions\AttachFileToAcumaticaInvoiceAction;
+use Kanvas\Connectors\Acumatica\Client;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
+use Kanvas\Scribe\Invoices\Enums\InvoiceDocumentStatusEnum;
+use Kanvas\Scribe\Invoices\Models\Invoice;
+use Mockery;
+use Tests\Scribe\ScribeTestCase;
+
+class AttachFileToAcumaticaInvoiceActionTest extends ScribeTestCase
+{
+    private function invoiceWithoutPush(): Invoice
+    {
+        $customer = $this->seedTestOrganization('Acme Corporation');
+
+        return Invoice::create([
+            'apps_id' => $this->kanvasApp->getId(),
+            'companies_id' => $this->company->getId(),
+            'document_type' => 'invoice',
+            'invoice_number' => 'INV-1',
+            'customer_organization_id' => $customer->getId(),
+            'billable_display_name' => 'Acme Corporation',
+            'document_status' => InvoiceDocumentStatusEnum::ISSUED->value,
+            'currency' => 'USD',
+            'fx_rate_to_base' => 1.0,
+            'subtotal_native' => 100.0, 'total_native' => 100.0, 'paid_native' => 0.0, 'balance_due_native' => 100.0,
+            'subtotal_base' => 100.0, 'total_base' => 100.0, 'paid_base' => 0.0, 'balance_due_base' => 100.0,
+            'issued_date' => Carbon::parse('2026-06-01'),
+            'source' => 'kanvas',
+        ]);
+    }
+
+    public function test_refuses_an_invoice_that_was_never_pushed(): void
+    {
+        $invoice = $this->invoiceWithoutPush();
+
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldNotReceive('withSession');
+
+        $this->expectException(AcumaticaWriteException::class);
+
+        new AttachFileToAcumaticaInvoiceAction($invoice, 'https://example.test/credit.xlsx', 'credit.xlsx', $writer)->execute();
+    }
+
+    public function test_throws_when_the_invoice_has_no_files_put_link(): void
+    {
+        $invoice = $this->invoiceWithoutPush();
+        $invoice->set(CustomFieldEnum::INVOICE_ID->value, 'INV-GUID');
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('get')->once()->with('Invoice/INV-GUID')->andReturn(['id' => 'INV-GUID']);
+
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldReceive('withSession')->once()->andReturnUsing(fn (callable $cb) => $cb($client));
+
+        $this->expectException(AcumaticaWriteException::class);
+        $this->expectExceptionMessage('no files:put link');
+
+        new AttachFileToAcumaticaInvoiceAction($invoice, 'https://example.test/credit.xlsx', 'credit.xlsx', $writer)->execute();
+    }
+}

--- a/tests/Connectors/Acumatica/PushInvoiceNoteToAcumaticaActionTest.php
+++ b/tests/Connectors/Acumatica/PushInvoiceNoteToAcumaticaActionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Acumatica;
+
+use Illuminate\Support\Carbon;
+use Kanvas\Connectors\Acumatica\Actions\PushInvoiceNoteToAcumaticaAction;
+use Kanvas\Connectors\Acumatica\Client;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Exceptions\AcumaticaWriteException;
+use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
+use Kanvas\Scribe\Invoices\Enums\InvoiceDocumentStatusEnum;
+use Kanvas\Scribe\Invoices\Models\Invoice;
+use Mockery;
+use Tests\Scribe\ScribeTestCase;
+
+class PushInvoiceNoteToAcumaticaActionTest extends ScribeTestCase
+{
+    private function pushedInvoice(): Invoice
+    {
+        $customer = $this->seedTestOrganization('Acme Corporation');
+        $customer->set(CustomFieldEnum::CUSTOMER_ID->value, 'C0000123');
+
+        $invoice = Invoice::create([
+            'apps_id' => $this->kanvasApp->getId(),
+            'companies_id' => $this->company->getId(),
+            'document_type' => 'invoice',
+            'invoice_number' => 'INV-1',
+            'customer_organization_id' => $customer->getId(),
+            'billable_display_name' => 'Acme Corporation',
+            'document_status' => InvoiceDocumentStatusEnum::ISSUED->value,
+            'currency' => 'USD',
+            'fx_rate_to_base' => 1.0,
+            'subtotal_native' => 100.0, 'total_native' => 100.0, 'paid_native' => 0.0, 'balance_due_native' => 100.0,
+            'subtotal_base' => 100.0, 'total_base' => 100.0, 'paid_base' => 0.0, 'balance_due_base' => 100.0,
+            'issued_date' => Carbon::parse('2026-06-01'),
+            'source' => 'kanvas',
+        ]);
+        $invoice->set(CustomFieldEnum::INVOICE_ID->value, 'INV-GUID');
+        $invoice->set(CustomFieldEnum::INVOICE_REF->value, '6300164923');
+
+        return $invoice;
+    }
+
+    public function test_appends_to_an_existing_note(): void
+    {
+        $invoice = $this->pushedInvoice();
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('get')->once()->with('Invoice/INV-GUID')
+            ->andReturn(['note' => ['value' => 'Called customer about delivery.']]);
+        $client->shouldReceive('put')->once()
+            ->with('Invoice', ['id' => 'INV-GUID', 'note' => ['value' => "Called customer about delivery.\nApproved by manager."]])
+            ->andReturn([]);
+
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldReceive('withSession')->once()->andReturnUsing(fn (callable $cb) => $cb($client));
+
+        $result = new PushInvoiceNoteToAcumaticaAction($invoice, $writer)->execute('Approved by manager.');
+
+        $this->assertSame("Called customer about delivery.\nApproved by manager.", $result);
+    }
+
+    public function test_refuses_an_invoice_that_was_never_pushed(): void
+    {
+        $customer = $this->seedTestOrganization('Acme Corporation');
+        $invoice = Invoice::create([
+            'apps_id' => $this->kanvasApp->getId(),
+            'companies_id' => $this->company->getId(),
+            'document_type' => 'invoice',
+            'invoice_number' => 'INV-2',
+            'customer_organization_id' => $customer->getId(),
+            'billable_display_name' => 'Acme Corporation',
+            'document_status' => InvoiceDocumentStatusEnum::ISSUED->value,
+            'currency' => 'USD',
+            'fx_rate_to_base' => 1.0,
+            'subtotal_native' => 100.0, 'total_native' => 100.0, 'paid_native' => 0.0, 'balance_due_native' => 100.0,
+            'subtotal_base' => 100.0, 'total_base' => 100.0, 'paid_base' => 0.0, 'balance_due_base' => 100.0,
+            'issued_date' => Carbon::parse('2026-06-01'),
+            'source' => 'kanvas',
+        ]);
+
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldNotReceive('withSession');
+
+        $this->expectException(AcumaticaWriteException::class);
+
+        new PushInvoiceNoteToAcumaticaAction($invoice, $writer)->execute('Note.');
+    }
+}

--- a/tests/Connectors/Acumatica/PushInvoiceToAcumaticaActionTest.php
+++ b/tests/Connectors/Acumatica/PushInvoiceToAcumaticaActionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Acumatica;
+
+use Illuminate\Support\Carbon;
+use Kanvas\Connectors\Acumatica\Actions\PushInvoiceToAcumaticaAction;
+use Kanvas\Connectors\Acumatica\Client;
+use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
+use Kanvas\Scribe\Invoices\Enums\DocumentTypeEnum;
+use Kanvas\Scribe\Invoices\Enums\InvoiceDocumentStatusEnum;
+use Kanvas\Scribe\Invoices\Models\Invoice;
+use Mockery;
+use Tests\Scribe\ScribeTestCase;
+
+class PushInvoiceToAcumaticaActionTest extends ScribeTestCase
+{
+    private function invoice(DocumentTypeEnum $documentType, ?int $parentInvoiceId = null): Invoice
+    {
+        $customer = $this->seedTestOrganization('Acme Corporation');
+        $customer->set(CustomFieldEnum::CUSTOMER_ID->value, 'C0000123');
+
+        return Invoice::create([
+            'apps_id' => $this->kanvasApp->getId(),
+            'companies_id' => $this->company->getId(),
+            'document_type' => $documentType->value,
+            'parent_invoice_id' => $parentInvoiceId,
+            'invoice_number' => $documentType === DocumentTypeEnum::CREDIT_NOTE ? 'CRN-1' : 'INV-1',
+            'customer_organization_id' => $customer->getId(),
+            'billable_display_name' => 'Acme Corporation',
+            'document_status' => InvoiceDocumentStatusEnum::ISSUED->value,
+            'currency' => 'USD',
+            'fx_rate_to_base' => 1.0,
+            'subtotal_native' => 100.0, 'total_native' => 100.0, 'paid_native' => 0.0, 'balance_due_native' => 100.0,
+            'subtotal_base' => 100.0, 'total_base' => 100.0, 'paid_base' => 0.0, 'balance_due_base' => 100.0,
+            'issued_date' => Carbon::parse('2026-06-01'),
+            'source' => 'kanvas',
+        ]);
+    }
+
+    public function test_pushes_a_regular_invoice_with_type_invoice(): void
+    {
+        $invoice = $this->invoice(DocumentTypeEnum::INVOICE);
+
+        $captured = null;
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldReceive('push')->once()->andReturnUsing(
+            function (string $entity, array $body) use (&$captured): array {
+                $captured = $body;
+
+                return ['id' => 'GUID-1', 'ReferenceNbr' => ['value' => '000111']];
+            }
+        );
+
+        $ref = new PushInvoiceToAcumaticaAction($invoice, $writer)->execute();
+
+        $this->assertSame('000111', $ref);
+        $this->assertSame(['value' => 'Invoice'], $captured['Type']);
+    }
+
+    public function test_pushes_a_credit_note_with_type_credit_memo(): void
+    {
+        $parent = $this->invoice(DocumentTypeEnum::INVOICE);
+        $creditNote = $this->invoice(DocumentTypeEnum::CREDIT_NOTE, $parent->getId());
+
+        $captured = null;
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldReceive('push')->once()->andReturnUsing(
+            function (string $entity, array $body) use (&$captured): array {
+                $captured = $body;
+
+                return ['id' => 'GUID-2', 'ReferenceNbr' => ['value' => '000222']];
+            }
+        );
+
+        $ref = new PushInvoiceToAcumaticaAction($creditNote, $writer)->execute();
+
+        $this->assertSame('000222', $ref);
+        $this->assertSame(['value' => 'Credit Memo'], $captured['Type']);
+    }
+}

--- a/tests/Connectors/Acumatica/PushInvoiceToAcumaticaActionTest.php
+++ b/tests/Connectors/Acumatica/PushInvoiceToAcumaticaActionTest.php
@@ -7,11 +7,15 @@ namespace Tests\Connectors\Acumatica;
 use Illuminate\Support\Carbon;
 use Kanvas\Connectors\Acumatica\Actions\PushInvoiceToAcumaticaAction;
 use Kanvas\Connectors\Acumatica\Client;
+use Kanvas\Connectors\Acumatica\Enums\ConfigurationEnum;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;
 use Kanvas\Scribe\Invoices\Enums\DocumentTypeEnum;
 use Kanvas\Scribe\Invoices\Enums\InvoiceDocumentStatusEnum;
 use Kanvas\Scribe\Invoices\Models\Invoice;
+use Kanvas\Scribe\Invoices\Models\InvoiceLine;
+use Kanvas\Scribe\Ledger\Enums\AccountSubTypeEnum;
+use Kanvas\Scribe\Ledger\Models\Account;
 use Mockery;
 use Tests\Scribe\ScribeTestCase;
 
@@ -79,5 +83,106 @@ class PushInvoiceToAcumaticaActionTest extends ScribeTestCase
 
         $this->assertSame('000222', $ref);
         $this->assertSame(['value' => 'Credit Memo'], $captured['Type']);
+    }
+
+    public function test_a_line_level_account_override_is_sent_as_the_acumatica_detail_account(): void
+    {
+        $controlAccountId = $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS);
+        $controlAccountCode = (string) Account::query()->where('id', $controlAccountId)->value('account_number');
+
+        $creditNote = $this->invoice(DocumentTypeEnum::CREDIT_NOTE);
+        InvoiceLine::create([
+            'invoice_id' => $creditNote->id,
+            'sort_order' => 0,
+            'account_id' => $controlAccountId,
+            'description' => 'Promotion Discount',
+            'quantity' => 1,
+            'unit_price_native' => 100.0,
+            'line_total_native' => 100.0,
+        ]);
+        $creditNote->refresh();
+        $creditNote->load('lines');
+
+        $captured = null;
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldReceive('push')->once()->andReturnUsing(
+            function (string $entity, array $body) use (&$captured): array {
+                $captured = $body;
+
+                return ['id' => 'GUID-3', 'ReferenceNbr' => ['value' => '000333']];
+            }
+        );
+
+        new PushInvoiceToAcumaticaAction($creditNote, $writer)->execute();
+
+        $this->assertSame($controlAccountCode, $captured['Details'][0]['Account']['value']);
+    }
+
+    public function test_zero_tax_document_gets_the_configured_exempt_tax_zone_on_header_and_lines(): void
+    {
+        $this->kanvasApp->set(ConfigurationEnum::ACUMATICA_TAX_EXEMPT_ZONE->value, 'NONTAX');
+        $creditNote = $this->invoice(DocumentTypeEnum::CREDIT_NOTE);
+        InvoiceLine::create([
+            'invoice_id' => $creditNote->id,
+            'sort_order' => 0,
+            'description' => 'Promotion Discount',
+            'quantity' => 1,
+            'unit_price_native' => 100.0,
+            'line_total_native' => 100.0,
+        ]);
+        $creditNote->refresh();
+        $creditNote->load('lines');
+
+        $captured = null;
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldReceive('push')->once()->andReturnUsing(
+            function (string $entity, array $body) use (&$captured): array {
+                $captured = $body;
+
+                return ['id' => 'GUID-4', 'ReferenceNbr' => ['value' => '000444']];
+            }
+        );
+
+        new PushInvoiceToAcumaticaAction($creditNote, $writer)->execute();
+
+        $this->assertSame('NONTAX', $captured['TaxZone']['value']);
+        $this->assertSame('NONTAX', $captured['Details'][0]['TaxCategory']['value']);
+    }
+
+    public function test_a_taxable_document_is_not_marked_exempt_even_when_a_zone_is_configured(): void
+    {
+        $this->kanvasApp->set(ConfigurationEnum::ACUMATICA_TAX_EXEMPT_ZONE->value, 'NONTAX');
+        $customer = $this->seedTestOrganization('Acme Corporation');
+        $customer->set(CustomFieldEnum::CUSTOMER_ID->value, 'C0000123');
+
+        $invoice = Invoice::create([
+            'apps_id' => $this->kanvasApp->getId(),
+            'companies_id' => $this->company->getId(),
+            'document_type' => DocumentTypeEnum::INVOICE->value,
+            'invoice_number' => 'INV-TAXED-1',
+            'customer_organization_id' => $customer->getId(),
+            'billable_display_name' => 'Acme Corporation',
+            'document_status' => InvoiceDocumentStatusEnum::ISSUED->value,
+            'currency' => 'USD',
+            'fx_rate_to_base' => 1.0,
+            'subtotal_native' => 100.0, 'tax_native' => 19.0, 'total_native' => 119.0, 'paid_native' => 0.0, 'balance_due_native' => 119.0,
+            'subtotal_base' => 100.0, 'tax_base' => 19.0, 'total_base' => 119.0, 'paid_base' => 0.0, 'balance_due_base' => 119.0,
+            'issued_date' => Carbon::parse('2026-06-01'),
+            'source' => 'kanvas',
+        ]);
+
+        $captured = null;
+        $writer = Mockery::mock(AcumaticaWriteService::class);
+        $writer->shouldReceive('push')->once()->andReturnUsing(
+            function (string $entity, array $body) use (&$captured): array {
+                $captured = $body;
+
+                return ['id' => 'GUID-5', 'ReferenceNbr' => ['value' => '000555']];
+            }
+        );
+
+        new PushInvoiceToAcumaticaAction($invoice, $writer)->execute();
+
+        $this->assertArrayNotHasKey('TaxZone', $captured);
     }
 }

--- a/tests/Connectors/Acumatica/PushInvoiceToAcumaticaActionTest.php
+++ b/tests/Connectors/Acumatica/PushInvoiceToAcumaticaActionTest.php
@@ -6,7 +6,6 @@ namespace Tests\Connectors\Acumatica;
 
 use Illuminate\Support\Carbon;
 use Kanvas\Connectors\Acumatica\Actions\PushInvoiceToAcumaticaAction;
-use Kanvas\Connectors\Acumatica\Client;
 use Kanvas\Connectors\Acumatica\Enums\ConfigurationEnum;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Acumatica\Services\AcumaticaWriteService;

--- a/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
@@ -10,7 +10,10 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindCustomerTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ListOverdueInvoicesTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\MatchInvoicesForPaymentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AddInvoiceNoteTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\ApplyArPaymentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AttachInvoiceFileTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArCreditMemoTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArInvoiceTool;
 use Kanvas\Scribe\Invoices\Enums\DocumentTypeEnum;
 use Kanvas\Scribe\Invoices\Enums\InvoiceDocumentStatusEnum;
@@ -215,5 +218,79 @@ class AccountsReceivableAgentToolsTest extends ScribeTestCase
 
         $this->assertNotEmpty($result['open_invoices']);
         $this->assertSame('INV-9001', $result['exact_match']);
+    }
+
+    public function test_create_ar_credit_memo_requires_an_invoice_number(): void
+    {
+        $result = new CreateArCreditMemoTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(invoice_number: '', amount: 50.0, memo: 'Damaged goods');
+
+        $this->assertFalse($result['created']);
+        $this->assertSame('invoice_number_required', $result['reason']);
+    }
+
+    public function test_create_ar_credit_memo_reports_not_found_for_unknown_invoice(): void
+    {
+        $result = new CreateArCreditMemoTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(invoice_number: 'DOES-NOT-EXIST', amount: 50.0, memo: 'Damaged goods');
+
+        $this->assertFalse($result['created']);
+        $this->assertSame('invoice_not_found', $result['reason']);
+    }
+
+    public function test_create_ar_credit_memo_issues_against_the_parent_invoice(): void
+    {
+        $customer = $this->seedTestOrganization('Acme Corporation');
+
+        $parent = Invoice::create([
+            'apps_id' => $this->kanvasApp->getId(),
+            'companies_id' => $this->company->getId(),
+            'document_type' => DocumentTypeEnum::INVOICE,
+            'invoice_number' => 'INV-CREDIT-1',
+            'customer_organization_id' => $customer->getId(),
+            'billable_display_name' => 'Acme Corporation',
+            'document_status' => InvoiceDocumentStatusEnum::ISSUED->value,
+            'currency' => 'USD',
+            'fx_rate_to_base' => 1.0,
+            'subtotal_native' => 500.0, 'total_native' => 500.0, 'paid_native' => 0.0, 'balance_due_native' => 500.0,
+            'subtotal_base' => 500.0, 'total_base' => 500.0, 'paid_base' => 0.0, 'balance_due_base' => 500.0,
+            'issued_date' => Carbon::parse('2026-06-01'),
+            'source' => 'kanvas',
+        ]);
+
+        $result = new CreateArCreditMemoTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(invoice_number: 'INV-CREDIT-1', amount: 100.0, memo: 'Damaged goods allowance');
+
+        $this->assertTrue($result['created']);
+        $this->assertSame('INV-CREDIT-1', $result['parent_invoice_number']);
+
+        /** @var Invoice $creditNote */
+        $creditNote = Invoice::query()->where('id', $result['credit_memo_id'])->firstOrFail();
+        $this->assertSame(DocumentTypeEnum::CREDIT_NOTE, $creditNote->document_type);
+        $this->assertSame($parent->getId(), $creditNote->parent_invoice_id);
+        $this->assertSame(100.0, (float) $creditNote->total_native);
+    }
+
+    public function test_add_invoice_note_reports_not_found_for_unknown_invoice(): void
+    {
+        $result = new AddInvoiceNoteTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(invoice_id: 999999999, note: 'Called customer.');
+
+        $this->assertFalse($result['note_added']);
+        $this->assertSame('invoice_not_found', $result['reason']);
+    }
+
+    public function test_attach_invoice_file_reports_not_found_for_unknown_invoice(): void
+    {
+        $result = new AttachInvoiceFileTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(invoice_id: 999999999, file_url: 'https://example.test/credit.xlsx');
+
+        $this->assertFalse($result['file_attached']);
+        $this->assertSame('invoice_not_found', $result['reason']);
     }
 }

--- a/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
@@ -20,6 +20,8 @@ use Kanvas\Scribe\Invoices\Enums\InvoiceDocumentStatusEnum;
 use Kanvas\Scribe\Invoices\Models\Invoice;
 use Kanvas\Scribe\Invoices\Models\InvoiceLine;
 use Kanvas\Scribe\Invoices\Models\InvoicePaymentAllocation;
+use Kanvas\Scribe\Ledger\Enums\AccountSubTypeEnum;
+use Kanvas\Scribe\Ledger\Models\Account;
 use Tests\Scribe\ScribeTestCase;
 
 class AccountsReceivableAgentToolsTest extends ScribeTestCase
@@ -220,58 +222,82 @@ class AccountsReceivableAgentToolsTest extends ScribeTestCase
         $this->assertSame('INV-9001', $result['exact_match']);
     }
 
-    public function test_create_ar_credit_memo_requires_an_invoice_number(): void
+    public function test_create_ar_credit_memo_requires_a_customer_name(): void
     {
         $result = new CreateArCreditMemoTool()
             ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
-            ->__invoke(invoice_number: '', amount: 50.0, memo: 'Damaged goods');
+            ->__invoke(customer_name: '', invoice_number: 'REF-1', lines: [['control_account_number' => '71610', 'amount' => 50.0]]);
+
+        $this->assertFalse($result['created']);
+        $this->assertSame('customer_name_required', $result['reason']);
+    }
+
+    public function test_create_ar_credit_memo_requires_an_invoice_number(): void
+    {
+        $customer = $this->seedTestOrganization('Proshop');
+
+        $result = new CreateArCreditMemoTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(customer_name: 'Proshop', invoice_number: '', lines: [['control_account_number' => '71610', 'amount' => 50.0]]);
 
         $this->assertFalse($result['created']);
         $this->assertSame('invoice_number_required', $result['reason']);
     }
 
-    public function test_create_ar_credit_memo_reports_not_found_for_unknown_invoice(): void
+    public function test_create_ar_credit_memo_reports_not_found_for_unknown_customer(): void
     {
         $result = new CreateArCreditMemoTool()
             ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
-            ->__invoke(invoice_number: 'DOES-NOT-EXIST', amount: 50.0, memo: 'Damaged goods');
+            ->__invoke(customer_name: 'Does Not Exist Inc', invoice_number: 'REF-1', lines: [['control_account_number' => '71610', 'amount' => 50.0]]);
 
         $this->assertFalse($result['created']);
-        $this->assertSame('invoice_not_found', $result['reason']);
+        $this->assertSame('customer_not_found', $result['reason']);
     }
 
-    public function test_create_ar_credit_memo_issues_against_the_parent_invoice(): void
+    public function test_create_ar_credit_memo_reports_not_found_for_unknown_control_account(): void
     {
-        $customer = $this->seedTestOrganization('Acme Corporation');
-
-        $parent = Invoice::create([
-            'apps_id' => $this->kanvasApp->getId(),
-            'companies_id' => $this->company->getId(),
-            'document_type' => DocumentTypeEnum::INVOICE,
-            'invoice_number' => 'INV-CREDIT-1',
-            'customer_organization_id' => $customer->getId(),
-            'billable_display_name' => 'Acme Corporation',
-            'document_status' => InvoiceDocumentStatusEnum::ISSUED->value,
-            'currency' => 'USD',
-            'fx_rate_to_base' => 1.0,
-            'subtotal_native' => 500.0, 'total_native' => 500.0, 'paid_native' => 0.0, 'balance_due_native' => 500.0,
-            'subtotal_base' => 500.0, 'total_base' => 500.0, 'paid_base' => 0.0, 'balance_due_base' => 500.0,
-            'issued_date' => Carbon::parse('2026-06-01'),
-            'source' => 'kanvas',
-        ]);
+        $this->seedTestOrganization('Proshop');
 
         $result = new CreateArCreditMemoTool()
             ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
-            ->__invoke(invoice_number: 'INV-CREDIT-1', amount: 100.0, memo: 'Damaged goods allowance');
+            ->__invoke(customer_name: 'Proshop', invoice_number: 'REF-1', lines: [['control_account_number' => 'DOES-NOT-EXIST', 'amount' => 50.0]]);
+
+        $this->assertFalse($result['created']);
+        $this->assertSame('account_not_found', $result['reason']);
+    }
+
+    public function test_create_ar_credit_memo_issues_a_standalone_credit_note(): void
+    {
+        $customer = $this->seedTestOrganization('Proshop Rebate QA Customer');
+        $controlAccount = Account::query()
+            ->where('apps_id', $this->kanvasApp->getId())
+            ->where('companies_id', $this->company->getId())
+            ->where('account_sub_type', AccountSubTypeEnum::TRAVEL_AND_MEALS->value)
+            ->firstOrFail();
+
+        $result = new CreateArCreditMemoTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(
+                customer_name: 'Proshop Rebate QA Customer',
+                invoice_number: 'Proshop Superdays Sell-Out (22/05-07/06)',
+                lines: [
+                    ['control_account_number' => $controlAccount->account_number, 'amount' => 250.0, 'description' => 'Promotion Discount'],
+                ],
+            );
 
         $this->assertTrue($result['created']);
-        $this->assertSame('INV-CREDIT-1', $result['parent_invoice_number']);
+        $this->assertSame('Proshop Rebate QA Customer', $result['customer']);
 
         /** @var Invoice $creditNote */
         $creditNote = Invoice::query()->where('id', $result['credit_memo_id'])->firstOrFail();
         $this->assertSame(DocumentTypeEnum::CREDIT_NOTE, $creditNote->document_type);
-        $this->assertSame($parent->getId(), $creditNote->parent_invoice_id);
-        $this->assertSame(100.0, (float) $creditNote->total_native);
+        $this->assertNull($creditNote->parent_invoice_id);
+        $this->assertSame('Proshop Superdays Sell-Out (22/05-07/06)', $creditNote->invoice_number);
+        $this->assertSame($customer->getId(), $creditNote->customer_organization_id);
+        $this->assertSame(250.0, (float) $creditNote->total_native);
+
+        $line = $creditNote->lines->first();
+        $this->assertSame($controlAccount->getId(), $line->account_id);
     }
 
     public function test_add_invoice_note_reports_not_found_for_unknown_invoice(): void

--- a/tests/Scribe/ScribeFollowUpActionsTest.php
+++ b/tests/Scribe/ScribeFollowUpActionsTest.php
@@ -224,6 +224,53 @@ class ScribeFollowUpActionsTest extends TestCase
         $this->assertEquals(0.0, (float) $parent->balance_due_native);
     }
 
+    public function test_issue_standalone_credit_note_with_no_parent_debits_the_lines_own_accounts(): void
+    {
+        $billable = $this->seedOrganization('Proshop');
+        $controlAccountId = $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS);
+
+        $creditNote = new IssueCreditNoteAction(
+            parentInvoice: null,
+            data: new InvoiceData(
+                app: $this->kanvasApp,
+                company: $this->company,
+                billable: $billable,
+                lines: new DataCollection(InvoiceLineData::class, [
+                    new InvoiceLineData(
+                        description: 'Promotion Discount',
+                        quantity: 1,
+                        unit_price_native: 300.0,
+                        account_id: $controlAccountId,
+                    ),
+                ]),
+                currency: 'USD',
+                fx_rate_to_base: 1.0,
+                invoice_number: 'Proshop Superdays Sell-Out (22/05-07/06)',
+                issued_date: Carbon::parse('2026-06-20'),
+            ),
+            billable: $billable,
+            user: static::$cachedUser,
+        )->execute();
+
+        $this->assertSame(DocumentTypeEnum::CREDIT_NOTE, $creditNote->document_type);
+        $this->assertNull($creditNote->parent_invoice_id);
+        $this->assertSame('Proshop Superdays Sell-Out (22/05-07/06)', $creditNote->invoice_number);
+        $this->assertSame($billable->getId(), $creditNote->customer_organization_id);
+        $this->assertEquals(300.0, (float) $creditNote->total_native);
+
+        $creditJe = JournalEntry::query()
+            ->where('source_type', 'credit_note')
+            ->where('source_id', $creditNote->id)
+            ->first();
+        $this->assertNotNull($creditJe);
+        $creditJe->load('lines');
+        $this->assertEquals($creditJe->lines->sum('debit_base'), $creditJe->lines->sum('credit_base'));
+
+        $debitLine = $creditJe->lines->firstWhere('account_id', $controlAccountId);
+        $this->assertNotNull($debitLine, 'Expected the credit note JE to debit the line-level control account.');
+        $this->assertEquals(300.0, (float) $debitLine->debit_native);
+    }
+
     public function test_issue_credit_note_rejects_amount_exceeding_parent_total(): void
     {
         $billable = $this->seedOrganization();


### PR DESCRIPTION
Cherry-pick of #10704 to 1.x. Adds create_ar_credit_memo, add_invoice_note, attach_invoice_file, plus a fix so PushInvoiceToAcumaticaAction sends Type: 'Credit Memo' for credit notes instead of always 'Invoice'. Ran locally via Docker/phpunit — 130/130 pass, and live-verified against the real 2026R1 sandbox before pushing (throwaway tests, deleted after) — including a real .csv file attachment.