### PR TITLE
feat: recognize .xlsx/.xls/.csv when attaching a file to a bill

### DIFF
--- a/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaBillAction.php
+++ b/src/Domains/Connectors/Acumatica/Actions/AttachFileToAcumaticaBillAction.php
@@ -64,6 +64,9 @@ class AttachFileToAcumaticaBillAction
             'pdf' => 'application/pdf',
             'png' => 'image/png',
             'jpg', 'jpeg' => 'image/jpeg',
+            'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'xls' => 'application/vnd.ms-excel',
+            'csv' => 'text/csv',
             default => 'application/octet-stream',
         };
     }


### PR DESCRIPTION
Cherry-pick of #10705 to 1.x. Adds xlsx/xls/csv content-type mapping to attach_bill_file, matching attach_invoice_file. php -l clean; verified the match resolves correctly via reflection.