### PR TITLE
[1.x] fix: trigger first message after lead pull

### DIFF
--- a/src/Domains/Connectors/SalesAssist/Activities/PullLeadActivity.php
+++ b/src/Domains/Connectors/SalesAssist/Activities/PullLeadActivity.php
@@ -23,12 +23,14 @@ use Kanvas\Connectors\SalesAssist\Actions\CreateSocialChannelsAfterPullAction;
 use Kanvas\Connectors\VinSolution\Actions\PullLeadAction as ActionsPullLeadAction;
 use Kanvas\Connectors\VinSolution\Enums\CustomFieldEnum as EnumsCustomFieldEnum;
 use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
+use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadsConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Repositories\LeadsRepository;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Triggers\Actions\ApplyLeadClosingStatusAction;
 use Kanvas\Workflow\Attributes\WorkflowAction;
 use Kanvas\Workflow\Contracts\WorkflowActivityInterface;
+use Kanvas\Workflow\Enums\WorkflowEnum;
 use Kanvas\Workflow\KanvasActivity;
 use Override;
 use Throwable;
@@ -147,12 +149,29 @@ class PullLeadActivity extends KanvasActivity implements WorkflowActivityInterfa
                 )->execute();
 
                 new ApplyLeadClosingStatusAction($resolvedLead)->execute();
+                $this->triggerFirstMessageIfNeeded($resolvedLead, $app, $params);
             }
         } catch (Throwable $e) {
             report($e);
         }
 
         return $pullLead;
+    }
+
+    protected function triggerFirstMessageIfNeeded(Lead $lead, AppInterface $app, array $params): void
+    {
+        if (! empty($lead->get(LeadsConfigurationEnum::SENT_FIRST_MESSAGE_AT->value))) {
+            return;
+        }
+
+        $lead->fireWorkflow(
+            WorkflowEnum::FAKE_CONTEXT->value,
+            true,
+            array_merge($params, [
+                'app' => $app,
+                'company' => $lead->company,
+            ]),
+        );
     }
 
     private function findReynoldsLead(

--- a/tests/Connectors/Unit/SalesAssist/PullLeadActivityFirstMessageTest.php
+++ b/tests/Connectors/Unit/SalesAssist/PullLeadActivityFirstMessageTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Unit\SalesAssist;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\SalesAssist\Activities\PullLeadActivity;
+use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadsConfigurationEnum;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Workflow\Enums\WorkflowEnum;
+use Mockery;
+use ReflectionClass;
+use ReflectionMethod;
+use Tests\TestCaseUnit;
+
+final class PullLeadActivityFirstMessageTest extends TestCaseUnit
+{
+    public function testItTriggersFirstMessageWorkflowWhenNoMessageWasSent(): void
+    {
+        $app = Mockery::mock(Apps::class);
+        $company = Mockery::mock(Companies::class);
+        $lead = Mockery::mock(Lead::class);
+        $params = ['source' => 'manual-pull'];
+
+        $lead->shouldReceive('get')
+            ->once()
+            ->with(LeadsConfigurationEnum::SENT_FIRST_MESSAGE_AT->value)
+            ->andReturn(null);
+        $lead->shouldReceive('getAttribute')
+            ->once()
+            ->with('company')
+            ->andReturn($company);
+        $lead->shouldReceive('fireWorkflow')
+            ->once()
+            ->with(
+                WorkflowEnum::FAKE_CONTEXT->value,
+                true,
+                [
+                    'source' => 'manual-pull',
+                    'app' => $app,
+                    'company' => $company,
+                ],
+            )
+            ->andReturn(null);
+
+        $this->invokeTrigger($lead, $app, $params);
+    }
+
+    public function testItDoesNotTriggerFirstMessageWorkflowWhenMessageWasAlreadySent(): void
+    {
+        $app = Mockery::mock(Apps::class);
+        $lead = Mockery::mock(Lead::class);
+
+        $lead->shouldReceive('get')
+            ->once()
+            ->with(LeadsConfigurationEnum::SENT_FIRST_MESSAGE_AT->value)
+            ->andReturn('2026-08-06 10:00:00');
+        $lead->shouldNotReceive('fireWorkflow');
+
+        $this->invokeTrigger($lead, $app, []);
+    }
+
+    private function invokeTrigger(Lead $lead, Apps $app, array $params): void
+    {
+        $activity = new ReflectionClass(PullLeadActivity::class)->newInstanceWithoutConstructor();
+        $method = new ReflectionMethod(PullLeadActivity::class, 'triggerFirstMessageIfNeeded');
+        $method->invoke($activity, $lead, $app, $params);
+    }
+}


### PR DESCRIPTION
## Summary
- check the canonical first-message sent timestamp after resolving a pulled lead
- trigger the existing fake-context workflow when the first message has not been sent
- preserve the original pull parameters and pass the resolved app/company context
- add unit coverage for sent and unsent leads

## Validation
- PHP syntax checks pass
- git diff --check passes
- PHPUnit was not run because this isolated worktree has no vendor directory