### PR TITLE
fix: store created follow-up message model

### DIFF
--- a/src/Domains/Intelligence/PipelinesStages/Actions/CreateMessageFollowUpAction.php
+++ b/src/Domains/Intelligence/PipelinesStages/Actions/CreateMessageFollowUpAction.php
@@ -154,7 +154,7 @@ class CreateMessageFollowUpAction
             ),
             $this->lead->getId(),
         )->execute();
-        $this->createdMessage = $message;
+        $this->createdMessage = $created;
 
         $this->session->channel->addMessage($created);
         $created->addTag('followup');


### PR DESCRIPTION
## Summary
- store the persisted Social Message model in CreateMessageFollowUpAction
- prevent TypeError when follow-up actions retrieve the created message to store the provider SID
- fixes the failing FollowUpEngagement V1/V2 and Manly Honda follow-up test paths

## Validation
- PHP syntax check passed
- git diff --check passed
- PHPUnit could not run locally because dependencies require PHP >= 8.5 while the local runtime is PHP 8.4.10