### PR TITLE
fix: never leak raw exception detail into an agent's channel-facing reply

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
@@ -6,6 +6,7 @@ namespace Kanvas\Intelligence\Agents\Actions\Chat;
 
 use Baka\Http\SafeUrlFetcher;
 use finfo;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Guild\Customers\Services\PeopleChannelService;
 use Kanvas\Guild\Leads\Models\Lead;
@@ -105,17 +106,10 @@ class RunNeuronChatAction
         } catch (Throwable $e) {
             report($e);
 
-            // User-facing fallback stays friendly for channel responders.
-            // The trailing `[provider_error: ...]` marker is parseable by
-            // structured callers (e.g. FollowUpLeadAction) so they don't have
-            // to correlate two Sentry events to debug a provider failure.
-            $fallback = sprintf(
-                'I ran into a hiccup processing that. Could you try rephrasing, '
-                . "or let me know if you want me to hand off to a human?\n"
-                . '[provider_error: %s: %s]',
-                $e::class,
-                substr($e->getMessage(), 0, 500),
-            );
+            // Never leak exception class/message/SQL/hostnames to the channel — that's
+            // internal detail, logged below via `usage` (Sentry + KanvasConversationStore)
+            // for ops, not shown to the person on the other end of the chat.
+            $fallback = $this->humanizedFallback($e);
 
             if (! $selfRecords) {
                 new KanvasConversationStore()->logTurn(
@@ -159,6 +153,29 @@ class RunNeuronChatAction
         $this->backfillChannelMessagesToLead();
 
         return $content;
+    }
+
+    /** A duplicate-key violation is a recoverable, explainable case — everything else stays generic. */
+    private function humanizedFallback(Throwable $e): string
+    {
+        if ($this->isDuplicateEntryError($e)) {
+            return "It looks like that already exists — I didn't create a duplicate. Let me know if you'd "
+                . 'like me to look into it or handle it a different way.';
+        }
+
+        return 'I ran into a hiccup processing that. Could you try rephrasing, '
+            . 'or let me know if you want me to hand off to a human?';
+    }
+
+    private function isDuplicateEntryError(Throwable $e): bool
+    {
+        for ($current = $e; $current !== null; $current = $current->getPrevious()) {
+            if ($current instanceof UniqueConstraintViolationException) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function backfillChannelMessagesToLead(): void

--- a/tests/Intelligence/Agents/Chat/RunNeuronChatErrorHandlingTest.php
+++ b/tests/Intelligence/Agents/Chat/RunNeuronChatErrorHandlingTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Intelligence\Agents\Chat;
+
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Intelligence\Agents\Actions\Chat\RunNeuronChatAction;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Models\AgentType;
+use PDOException;
+use RuntimeException;
+use Tests\Stubs\Intelligence\ThrowingNeuronHandlerStub;
+use Tests\TestCase;
+use Throwable;
+
+/**
+ * A tool/provider failure must never leak internal detail (exception class, raw message, SQL,
+ * DB host) into the channel-facing reply — only a humanized fallback, with the real detail going
+ * to Sentry/KanvasConversationStore's usage field instead. See PR discussion: a duplicate-bill
+ * insert once surfaced a raw `Illuminate\Database\UniqueConstraintViolationException` with the
+ * production RDS hostname directly in a Slack message.
+ */
+class RunNeuronChatErrorHandlingTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function testDuplicateEntryErrorGetsAHumanizedExplanationInsteadOfRawSql(): void
+    {
+        $response = $this->runChatWithThrowingHandler($this->uniqueConstraintViolation());
+
+        $this->assertStringContainsString("It looks like that already exists", $response);
+        $this->assertStringNotContainsString('UniqueConstraintViolationException', $response);
+        $this->assertStringNotContainsString('rds.amazonaws.com', $response);
+        $this->assertStringNotContainsString('bills_vendor_number_uq', $response);
+    }
+
+    public function testGenericErrorGetsAHumanizedFallbackNotTheRawException(): void
+    {
+        $response = $this->runChatWithThrowingHandler(new RuntimeException('Gemini returned STOP with no parts'));
+
+        $this->assertStringContainsString('I ran into a hiccup processing that', $response);
+        $this->assertStringNotContainsString('RuntimeException', $response);
+        $this->assertStringNotContainsString('Gemini returned STOP', $response);
+    }
+
+    private function runChatWithThrowingHandler(Throwable $exception): string
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        $agentType = AgentType::factory()
+            ->withAppId($app->getId())
+            ->create(['provider' => 'neuron', 'handler' => ThrowingNeuronHandlerStub::class]);
+
+        $agent = Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create(['agent_type_id' => $agentType->getId()]);
+
+        return new RunNeuronChatAction(
+            agent: $agent,
+            session: null,
+            message: 'process this invoice',
+            app: $app,
+            user: $user,
+            handler: new ThrowingNeuronHandlerStub($exception),
+        )->execute();
+    }
+
+    private function uniqueConstraintViolation(): UniqueConstraintViolationException
+    {
+        return new UniqueConstraintViolationException(
+            'accounting',
+            "insert into bills (bill_number, apps_id, companies_id) values ('1498', 31, 9659)",
+            [],
+            new PDOException(
+                "SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry "
+                . "'31-9659-148291-1498-MDF' for key 'bills.bills_vendor_number_uq' "
+                . '(Connection: accounting, Host: prod-kanvas-niche-cluster-cvyag02o4s55.us-east-1.rds.amazonaws.com, Port: 3306)'
+            ),
+        );
+    }
+}

--- a/tests/Intelligence/FollowUp/Actions/FollowUpLeadActionTest.php
+++ b/tests/Intelligence/FollowUp/Actions/FollowUpLeadActionTest.php
@@ -1204,12 +1204,12 @@ class FollowUpLeadActionTest extends TestCase
         );
     }
 
-    public function testProviderErrorMarkerSurfacedInOutcomeReasonViaFallback(): void
+    public function testProviderErrorFallbackReachesOutcomeReasonWithoutLeakingRawException(): void
     {
-        // Force the provider to throw so RunNeuronChatAction's catch block
-        // fires and returns its `[provider_error: ...]`-tagged fallback.
-        // The follow-up action's invalid-JSON catch should bubble that marker
-        // into the outcome.reason so debugging needs ONE Sentry event, not two.
+        // Force the provider to throw so RunNeuronChatAction's catch block fires and returns its
+        // humanized fallback. The follow-up action's invalid-JSON catch bubbles that fallback into
+        // outcome.reason — but the raw exception class/message must never appear in it, since that
+        // string is also what a live-chat channel would show a real user.
         $cfg = $this->defaultStageConfig();
         $cfg['follow_up']['channels'] = [
             ['type' => 'sms', 'enabled' => true, 'template_name' => null],
@@ -1232,9 +1232,9 @@ class FollowUpLeadActionTest extends TestCase
 
         $this->assertSame(FollowUpOutcomeKindEnum::SKIPPED, $outcome->kind);
         $this->assertStringStartsWith('agent_call_failed: ', (string) $outcome->reason);
-        // The provider error class and message reached the follow-up outcome.
-        $this->assertStringContainsString('[provider_error: RuntimeException', (string) $outcome->reason);
-        $this->assertStringContainsString('Simulated Gemini timeout', (string) $outcome->reason);
+        $this->assertStringContainsString("I ran into a hiccup processing that", (string) $outcome->reason);
+        $this->assertStringNotContainsString('RuntimeException', (string) $outcome->reason);
+        $this->assertStringNotContainsString('Simulated Gemini timeout', (string) $outcome->reason);
 
         // Lead is NOT exhausted — retries next tick.
         $lead->refresh();

--- a/tests/Stubs/Intelligence/ThrowingNeuronHandlerStub.php
+++ b/tests/Stubs/Intelligence/ThrowingNeuronHandlerStub.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Stubs\Intelligence;
+
+use Throwable;
+
+/** Minimal chat() handler double that throws instead of talking to a real provider — for RunNeuronChatAction error-path tests. */
+class ThrowingNeuronHandlerStub
+{
+    public function __construct(private readonly Throwable $exception)
+    {
+    }
+
+    public function chat(mixed $messages = []): never
+    {
+        throw $this->exception;
+    }
+}


### PR DESCRIPTION
1.x cherry-pick of #10724.

## Summary
- `RunNeuronChatAction`'s error fallback embedded the raw exception class + up to 500 chars of its message directly in the reply sent to the channel (Slack/SMS/etc). For a DB constraint violation that includes the full SQL, bindings, and connection host — a duplicate-bill insert once surfaced the production RDS hostname straight into a Slack message.
- The channel-facing fallback is now always humanized: a specific explanation for duplicate-key violations (the case that triggered this), a generic one otherwise.
- Full exception detail is unaffected for debugging — `report($e)` (Sentry) and `KanvasConversationStore`'s `usage` field still get the raw class/message, neither of which is shown to the end user.

## Test plan
- [x] `RunNeuronChatErrorHandlingTest` (2 tests) + updated `FollowUpLeadActionTest` provider-error test — 3/3 passing on 1.x.