### PR TITLE
fix: align LoCompro service fee calculation

### DIFF
--- a/src/Domains/Connectors/ScrapperApi/Actions/AddCostToCartAction.php
+++ b/src/Domains/Connectors/ScrapperApi/Actions/AddCostToCartAction.php
@@ -60,8 +60,10 @@ class AddCostToCartAction
         $total = $fee->sum('total');
         $customTaxTotal = $fee->sum('customTax');
 
-        // Add 15% service fee to shipping only, not custom tax
-        $total = $total + $total * 0.15;
+        // The pricing strategy treats the per-pound service fee and the merchandise
+        // markup as separate charges. The markup applies to merchandise only.
+        $markUp = $cartSubtotal * 0.15;
+        $total += $markUp;
 
         // Collect detailed tax breakdown
         $customTaxDetails = $fee->where('customTaxInfo.customTax', '>', 0)
@@ -105,6 +107,7 @@ class AddCostToCartAction
                 'Shipping Cost' => $fee->sum('shippingCost'),
                 'Other Fees' => $fee->sum('otherFee'),
                 'Service Fee' => $fee->sum('serviceFee'),
+                'Mark-Up / Comm Rev' => $markUp,
                 'Pounds' => $fee->sum('pounds'),
                 'Last Mile' => 0,
                 'Custom Tax' => $customTaxTotal,

--- a/src/Domains/Connectors/ScrapperApi/Actions/CalculateShippingCostAction.php
+++ b/src/Domains/Connectors/ScrapperApi/Actions/CalculateShippingCostAction.php
@@ -38,7 +38,7 @@ class CalculateShippingCostAction
         };
         $localTransfer = (float)($this->app->get(ShippingCostEnum::LOCAL_TRANSFER->value) ?? 0.00);
         $paymentFee = (float)($this->app->get(ShippingCostEnum::PAYMENT_FEE->value) ?? 0.029);
-        $serviceFee = (float)($this->app->get(ShippingCostEnum::SERVICE_FEE->value) ?? 1.90);
+        $serviceFee = (float)($this->app->get(ShippingCostEnum::SERVICE_FEE->value) ?? 1.00);
         $shippingMargin = (float)($this->app->get(ShippingCostEnum::SHIPPING_MARGIN->value) ?? 1.20);
 
         // Calculate

--- a/tests/Connectors/ScrapperApi/AddCostToCartActionTest.php
+++ b/tests/Connectors/ScrapperApi/AddCostToCartActionTest.php
@@ -9,6 +9,7 @@ use Illuminate\Session\ArraySessionHandler;
 use Illuminate\Session\Store;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\ScrapperApi\Actions\AddCostToCartAction;
+use Kanvas\Connectors\ScrapperApi\Actions\CalculateShippingCostAction;
 use Kanvas\Connectors\ScrapperApi\Enums\ShippingCostEnum;
 use Kanvas\Inventory\Variants\Models\Variants;
 use Mockery;
@@ -21,6 +22,25 @@ use Wearepixel\Cart\CartCondition;
 class AddCostToCartActionTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
+
+    public function testUsesOneDollarPerPoundAsTheDefaultServiceFee(): void
+    {
+        $app = Mockery::mock(Apps::class)->makePartial();
+        $app->shouldReceive('get')->andReturnNull();
+
+        $variant = Mockery::mock(Variants::class)->makePartial();
+        $variant->shouldReceive('getAttributeByName')
+            ->once()
+            ->andReturn((object) ['value' => 453.59237]);
+        $variant->shouldReceive('getPriceInfoFromDefaultChannel')
+            ->once()
+            ->andReturn((object) ['price' => 50.0]);
+
+        $cost = new CalculateShippingCostAction($app, $variant, 2)->execute();
+
+        $this->assertSame(2.0, $cost['pounds']);
+        $this->assertSame(2.0, $cost['serviceFee']);
+    }
 
     public function testAggregatesShippingAndOfficialTaxesForACartOverTwoHundredDollars(): void
     {
@@ -85,9 +105,11 @@ class AddCostToCartActionTest extends TestCase
         $shipping = $cart->getCondition('Shipping');
         $attributes = $shipping->getAttributes();
 
-        $this->assertSame('+98.75', $shipping->getValue());
+        $this->assertSame('+147.5', $shipping->getValue());
         $this->assertSame(70.0, $attributes['Custom Tax']);
         $this->assertSame(15.0, $attributes['Shipping Cost']);
+        $this->assertSame(6.0, $attributes['Service Fee']);
+        $this->assertSame(52.5, $attributes['Mark-Up / Comm Rev']);
         $this->assertSame(0.0, $attributes['Tax Breakdown']['Total Tasa Aduanal']);
         $this->assertCount(2, $attributes['Custom Tax Details']);
     }
@@ -131,9 +153,10 @@ class AddCostToCartActionTest extends TestCase
         $shipping = $cart->getCondition('Shipping');
         $attributes = $shipping->getAttributes();
 
-        $this->assertSame('+17.25', $shipping->getValue());
+        $this->assertSame('+45', $shipping->getValue());
         $this->assertSame(0, $attributes['Custom Tax']);
         $this->assertSame([], $attributes['Custom Tax Details']);
+        $this->assertSame(30.0, $attributes['Mark-Up / Comm Rev']);
     }
 
     public function testIgnoresExistingShippingConditionWhenEvaluatingTaxThreshold(): void
@@ -184,9 +207,10 @@ class AddCostToCartActionTest extends TestCase
         $shipping = $cart->getCondition('Shipping');
         $attributes = $shipping->getAttributes();
 
-        $this->assertSame('+17.25', $shipping->getValue());
+        $this->assertSame('+30', $shipping->getValue());
         $this->assertSame(0, $attributes['Custom Tax']);
         $this->assertSame([], $attributes['Custom Tax Details']);
+        $this->assertSame(15.0, $attributes['Mark-Up / Comm Rev']);
     }
 
     private function enabledApp(): Apps


### PR DESCRIPTION
## Summary\n- calculate the 15% merchandise markup from the cart subtotal instead of logistics costs\n- keep the per-pound service fee separate and expose the markup in cart condition attributes\n- align the default service fee with the pricing strategy at USD 1.00 per pound\n- update cart calculation coverage for above/below USD 200 and stale shipping conditions\n- add coverage for the default per-pound service fee\n\n## Validation\n- PHP syntax checks passed\n- git diff --check passed\n- PHPUnit could not run locally because dependencies require PHP >= 8.5 and the available runtime is PHP 8.4.10; no PHP container is currently running