### PR TITLE
[dev] fix: align LoCompro service fee calculation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -62,6 +62,7 @@ Sub-directory `CLAUDE.md` files load additively when work touches their tree:
 - `src/Domains/Connectors/CLAUDE.md` — connector-tree-specific gotchas (Octane SDK rule, Activities/ folder, AgentRuntime caveat).
 - `graphql/schemas/CLAUDE.md` — directive conventions, FK-id-vs-relation rule, schema folder rule.
 - `src/Domains/Intelligence/FollowUp/CLAUDE.md` — generic-core vs per-entity-executor split for the agent-driven follow-up engine. Recipe for adopting follow-up on a new entity (Deal, Order, etc.).
+- `src/Domains/Guild/Leads/CLAUDE.md` — receiver → lead → email flow: why the email template comes from the **rotation config** (not the job/receiver), the `user-`/`lead-` template-name prefixing, the `notification_mode`/`notification_user_mode` knobs, and how company onboarding differs from the `kanvas:sa-setup-receivers` default.
 - `src/Domains/Inventory/CLAUDE.md` — product search engine (dynamic per-tenant Algolia/Typesense/Meilisearch resolution + precedence), index naming, `shouldBeSearchable` gating, the tenant-aware reindex command, and Typesense Natural Language Search config for the recommendation agent.
 
 ### Where to put new conventions (don't bloat this file)

--- a/src/Domains/Connectors/ScrapperApi/Actions/AddCostToCartAction.php
+++ b/src/Domains/Connectors/ScrapperApi/Actions/AddCostToCartAction.php
@@ -60,8 +60,10 @@ class AddCostToCartAction
         $total = $fee->sum('total');
         $customTaxTotal = $fee->sum('customTax');
 
-        // Add 15% service fee to shipping only, not custom tax
-        $total = $total + $total * 0.15;
+        // The pricing strategy treats the per-pound service fee and the merchandise
+        // markup as separate charges. The markup applies to merchandise only.
+        $markUp = $cartSubtotal * 0.15;
+        $total += $markUp;
 
         // Collect detailed tax breakdown
         $customTaxDetails = $fee->where('customTaxInfo.customTax', '>', 0)
@@ -105,6 +107,7 @@ class AddCostToCartAction
                 'Shipping Cost' => $fee->sum('shippingCost'),
                 'Other Fees' => $fee->sum('otherFee'),
                 'Service Fee' => $fee->sum('serviceFee'),
+                'Mark-Up / Comm Rev' => $markUp,
                 'Pounds' => $fee->sum('pounds'),
                 'Last Mile' => 0,
                 'Custom Tax' => $customTaxTotal,

--- a/src/Domains/Connectors/ScrapperApi/Actions/CalculateShippingCostAction.php
+++ b/src/Domains/Connectors/ScrapperApi/Actions/CalculateShippingCostAction.php
@@ -38,7 +38,7 @@ class CalculateShippingCostAction
         };
         $localTransfer = (float)($this->app->get(ShippingCostEnum::LOCAL_TRANSFER->value) ?? 0.00);
         $paymentFee = (float)($this->app->get(ShippingCostEnum::PAYMENT_FEE->value) ?? 0.029);
-        $serviceFee = (float)($this->app->get(ShippingCostEnum::SERVICE_FEE->value) ?? 1.90);
+        $serviceFee = (float)($this->app->get(ShippingCostEnum::SERVICE_FEE->value) ?? 1.00);
         $shippingMargin = (float)($this->app->get(ShippingCostEnum::SHIPPING_MARGIN->value) ?? 1.20);
 
         // Calculate

--- a/src/Domains/Guild/Leads/CLAUDE.md
+++ b/src/Domains/Guild/Leads/CLAUDE.md
@@ -1,0 +1,57 @@
+# Leads — Kanvas Ecosystem API
+
+Loads when work touches `src/Domains/Guild/Leads/`. Covers the receiver → lead → email flow, because "did the receiver send an email?" is deceptively hard to answer from the code.
+
+## Receiver email flow — where the template REALLY comes from
+
+When a lead arrives through a receiver ([`CreateLeadsFromReceiverJob`](Jobs/CreateLeadsFromReceiverJob.php)), whether an email is sent — and which template renders — is decided by **the rotation record's `config`, not the job**. This trips people up constantly. The chain:
+
+1. **Job reads its own default** — `email_template` from `receiver->configuration`, almost always `null`:
+   ```php
+   $emailTemplate = $this->receiver->configuration['email_template'] ?? null;   // usually null
+   $userFlag      = $this->receiver->configuration['flag'] ?? 'user';
+   ```
+2. **Job passes that null down** to [`SendRotationEmailsAction::execute($payload, $userFlag, $emailTemplate)`](Actions/SendRotationEmailsAction.php).
+3. **The rotation config WINS** — the job's null is only a fallback:
+   ```php
+   // rotation config first; the job's null is only used if the rotation has none
+   $template = $this->leadRotation?->config['email_template'] ?? $defaultEmailTemplate;
+   if ($template === null) {
+       return;   // ← no template anywhere → NOTHING is sent
+   }
+   ```
+   So passing `emailTemplate = null` from the job does **not** mean "no email" — if the receiver points at a rotation whose `config.email_template` is set, that value is used and mail goes out.
+
+**Gotcha: the `sent_email.template` field in the job response is the JOB's value (the null), not the rotation's.** A response showing `"template": null` does NOT prove no email was sent — the rotation may have supplied one. To know for sure, inspect `leadReceiver->rotation->config['email_template']`.
+
+### `user-` / `lead-` template name prefixing (the "concatenation")
+
+[`SendLeadEmailsAction`](Actions/SendLeadEmailsAction.php) does NOT send the base template name as-is. It **prefixes** it per recipient:
+```php
+$userTemplate = 'user-' . $this->emailTemplate;   // e.g. 'user-lead-company-email'  → agents / rotation users / extraEmails
+$leadTemplate = 'lead-' . $this->emailTemplate;   // e.g. 'lead-lead-company-email'  → the lead's own contact email
+```
+So a base template `lead-company-email` requires **two** registered mail templates: `user-lead-company-email` and `lead-lead-company-email`. Register whichever recipients your notification mode targets, or the send silently `report()`s an exception (`safeSend` swallows it).
+
+### Who receives it — two independent rotation-config knobs
+
+Both read off `rotation->config` (see [`SendRotationEmailsAction`](Actions/SendRotationEmailsAction.php) and the two enums in `Enums/`):
+
+- **`notification_mode`** (`LeadNotificationModeEnum`, default `NOTIFY_ALL`) — recipient *axis*:
+  - `NOTIFY_ALL` → agents **and** the lead's contact email
+  - `NOTIFY_AGENTS` → agents only (lead gets nothing)
+  - `NOTIFY_LEAD` → lead's contact only (agents get nothing)
+- **`notification_user_mode`** (`LeadNotificationUserModeEnum`, default `NOTIFY_OWNER`) — *which* users on the agent side:
+  - `NOTIFY_OWNER` → only the receiver's owner (`leadReceiver->user`)
+  - `NOTIFY_ROTATION_USERS` → owner + every active rotation agent, AND `rotation.leads_rotations_email` CCs are injected as `extraEmails`. Falls back to owner-only if the rotation has zero active agents.
+
+The `flag` (`'user'` default) picks the "owner" identity: `flag === 'user'` → `leadReceiver->user`; otherwise the resolved lead owner (`$this->user`). It is **not** concatenated into the template name — that's the `user-`/`lead-` prefixing above, which is separate.
+
+## When defaults are created — company onboarding vs. the SalesAssist command
+
+Two very different creation paths; don't conflate them:
+
+- **Company creation / onboarding** (`OnBoardingJob` → [`Guild\Support\Setup::run()`](../Support/Setup.php)) creates a single **`Default Receiver` with `rotations_id: 0` and no `config`.** No rotation → template resolves to `null` → **a fresh company's default receiver sends no receiver emails.** There is no automatic `email_template` default on company creation.
+- **The `lead-company-email` default is opt-in, per app/company**, applied only by the manual/deploy command `kanvas:sa-setup-receivers` ([`SetupReceiversCommand`](../../../../app/Console/Commands/Connectors/SalesAssist/SetupReceiversCommand.php)). It creates/updates a **`LeadRotation`** with `config = { email_template: 'lead-company-email', notification_mode: NOTIFY_AGENTS, notification_user_mode: NOTIFY_ROTATION_USERS }` and wires the SalesAssist receivers to that rotation. The base template name lives in [`EmailTemplatesEnum::LEAD_COMPANY_EMAIL`](../../Connectors/SalesAssist/Enums/EmailTemplatesEnum.php).
+
+So: **template config lives on the rotation, is set by a command, and is not part of company onboarding.** If a receiver "isn't emailing", check that its rotation exists and its `config.email_template` is populated — not the job or the receiver row.

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Sales/ListOpenSalesOrdersTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Sales/ListOpenSalesOrdersTool.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Neuron\Tools\Sales;
 
-use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use Kanvas\Souk\Orders\Models\Order;
 use NeuronAI\Tools\PropertyType;

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Sales/ListOpenSalesOrdersTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Sales/ListOpenSalesOrdersTool.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Agents\Neuron\Tools\Sales;
 
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use Kanvas\Souk\Orders\Models\Order;
 use NeuronAI\Tools\PropertyType;
@@ -67,13 +68,27 @@ class ListOpenSalesOrdersTool extends Tool
             ->where('companies_id', $company->getId())
             ->where('is_deleted', false)
             ->whereNotIn('status', ['completed', 'canceled', 'cancelled', 'voided'])
-            ->when($customer !== null && $customer !== '', function ($q) use ($customer): void {
-                $q->where(function ($sub) use ($customer): void {
-                    $sub->where('user_email', 'like', '%' . $customer . '%')
-                        ->orWhereHas('people', function ($p) use ($customer): void {
-                            $p->where('firstname', 'like', '%' . $customer . '%')
-                                ->orWhere('lastname', 'like', '%' . $customer . '%');
-                        });
+            ->when($customer !== null && $customer !== '', function ($q) use ($customer, $app, $company): void {
+                // People lives on the `crm` connection while Order is on `commerce`; a cross-database
+                // whereHas would emit `kanvas_commerce.peoples` (nonexistent). Resolve matching people
+                // ids on their own connection first, then filter orders by people_id.
+                $peopleIds = People::query()
+                    ->fromApp($app)
+                    ->fromCompany($company)
+                    ->notDeleted()
+                    ->where(function ($p) use ($customer): void {
+                        $p->where('firstname', 'like', '%' . $customer . '%')
+                            ->orWhere('lastname', 'like', '%' . $customer . '%');
+                    })
+                    ->pluck('id')
+                    ->all();
+
+                $q->where(function ($sub) use ($customer, $peopleIds): void {
+                    $sub->where('user_email', 'like', '%' . $customer . '%');
+
+                    if ($peopleIds !== []) {
+                        $sub->orWhereIn('people_id', $peopleIds);
+                    }
                 });
             })
             ->orderByDesc('created_at')

--- a/tests/Connectors/ScrapperApi/AddCostToCartActionTest.php
+++ b/tests/Connectors/ScrapperApi/AddCostToCartActionTest.php
@@ -9,6 +9,7 @@ use Illuminate\Session\ArraySessionHandler;
 use Illuminate\Session\Store;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\ScrapperApi\Actions\AddCostToCartAction;
+use Kanvas\Connectors\ScrapperApi\Actions\CalculateShippingCostAction;
 use Kanvas\Connectors\ScrapperApi\Enums\ShippingCostEnum;
 use Kanvas\Inventory\Variants\Models\Variants;
 use Mockery;
@@ -21,6 +22,25 @@ use Wearepixel\Cart\CartCondition;
 class AddCostToCartActionTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
+
+    public function testUsesOneDollarPerPoundAsTheDefaultServiceFee(): void
+    {
+        $app = Mockery::mock(Apps::class)->makePartial();
+        $app->shouldReceive('get')->andReturnNull();
+
+        $variant = Mockery::mock(Variants::class)->makePartial();
+        $variant->shouldReceive('getAttributeByName')
+            ->once()
+            ->andReturn((object) ['value' => 453.59237]);
+        $variant->shouldReceive('getPriceInfoFromDefaultChannel')
+            ->once()
+            ->andReturn((object) ['price' => 50.0]);
+
+        $cost = new CalculateShippingCostAction($app, $variant, 2)->execute();
+
+        $this->assertSame(2.0, $cost['pounds']);
+        $this->assertSame(2.0, $cost['serviceFee']);
+    }
 
     public function testAggregatesShippingAndOfficialTaxesForACartOverTwoHundredDollars(): void
     {
@@ -85,9 +105,11 @@ class AddCostToCartActionTest extends TestCase
         $shipping = $cart->getCondition('Shipping');
         $attributes = $shipping->getAttributes();
 
-        $this->assertSame('+98.75', $shipping->getValue());
+        $this->assertSame('+147.5', $shipping->getValue());
         $this->assertSame(70.0, $attributes['Custom Tax']);
         $this->assertSame(15.0, $attributes['Shipping Cost']);
+        $this->assertSame(6.0, $attributes['Service Fee']);
+        $this->assertSame(52.5, $attributes['Mark-Up / Comm Rev']);
         $this->assertSame(0.0, $attributes['Tax Breakdown']['Total Tasa Aduanal']);
         $this->assertCount(2, $attributes['Custom Tax Details']);
     }
@@ -131,9 +153,10 @@ class AddCostToCartActionTest extends TestCase
         $shipping = $cart->getCondition('Shipping');
         $attributes = $shipping->getAttributes();
 
-        $this->assertSame('+17.25', $shipping->getValue());
+        $this->assertSame('+45', $shipping->getValue());
         $this->assertSame(0, $attributes['Custom Tax']);
         $this->assertSame([], $attributes['Custom Tax Details']);
+        $this->assertSame(30.0, $attributes['Mark-Up / Comm Rev']);
     }
 
     public function testIgnoresExistingShippingConditionWhenEvaluatingTaxThreshold(): void
@@ -184,9 +207,10 @@ class AddCostToCartActionTest extends TestCase
         $shipping = $cart->getCondition('Shipping');
         $attributes = $shipping->getAttributes();
 
-        $this->assertSame('+17.25', $shipping->getValue());
+        $this->assertSame('+30', $shipping->getValue());
         $this->assertSame(0, $attributes['Custom Tax']);
         $this->assertSame([], $attributes['Custom Tax Details']);
+        $this->assertSame(15.0, $attributes['Mark-Up / Comm Rev']);
     }
 
     private function enabledApp(): Apps

--- a/tests/Intelligence/Agents/Tools/ListOpenSalesOrdersToolTest.php
+++ b/tests/Intelligence/Agents/Tools/ListOpenSalesOrdersToolTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Intelligence\Agents\Tools;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Auth;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Sales\ListOpenSalesOrdersTool;
+use Kanvas\Souk\Orders\Models\Order;
+use Tests\TestCase;
+
+final class ListOpenSalesOrdersToolTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected array $connectionsToTransact = ['mysql', 'commerce', 'crm'];
+
+    protected Apps $apps;
+    protected $user;
+    protected $company;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->apps = app(Apps::class);
+        $this->user = Auth::user();
+        $this->company = $this->user->getCurrentCompany();
+    }
+
+    public function testFilterByCustomerNameResolvesAcrossDatabaseBoundary(): void
+    {
+        // People lives on `crm`, Order on `commerce`. A cross-database whereHas used to emit
+        // `kanvas_commerce.peoples` and blow up (Sentry KANVAS-ECOSYSTEM-64P). This asserts the
+        // customer-name filter resolves people ids on their own connection instead.
+        $firstname = 'Fraylin' . uniqid();
+        $people = People::factory()
+            ->withAppId($this->apps->getId())
+            ->withCompanyId($this->company->getId())
+            ->withUserId($this->user->getId())
+            ->create(['firstname' => $firstname, 'lastname' => 'Gonzalez']);
+
+        $order = $this->createOrder(['people_id' => $people->getId(), 'status' => 'pending']);
+
+        $result = new ListOpenSalesOrdersTool()
+            ->withContext($this->apps, $this->company, $this->user)
+            ->__invoke(customer: $firstname);
+
+        $orderNumbers = array_column($result['orders'], 'order_number');
+        $this->assertContains($order->order_number, $orderNumbers);
+    }
+
+    public function testFilterByUnknownCustomerReturnsNoOrders(): void
+    {
+        $this->createOrder(['status' => 'pending']);
+
+        $result = new ListOpenSalesOrdersTool()
+            ->withContext($this->apps, $this->company, $this->user)
+            ->__invoke(customer: 'NoSuchCustomer' . uniqid());
+
+        $this->assertSame(0, $result['count']);
+        $this->assertSame([], $result['orders']);
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    private function createOrder(array $attributes = []): Order
+    {
+        return Order::factory()
+            ->withAppId($this->apps->getId())
+            ->withCompanyId($this->company->getId())
+            ->withUserId($this->user->getId())
+            ->create(array_merge([
+                'order_number' => crc32(uniqid('ord', true)),
+                'is_deleted' => 0,
+            ], $attributes));
+    }
+}


### PR DESCRIPTION
## Summary\n- calculate the 15% merchandise markup from the cart subtotal instead of logistics costs\n- keep the per-pound service fee separate and expose the markup in cart condition attributes\n- align the default service fee with the pricing strategy at USD 1.00 per pound\n- update cart calculation coverage for above/below USD 200 and stale shipping conditions\n- add coverage for the default per-pound service fee\n\n## Validation\n- PHP syntax checks passed\n- git diff --check passed\n- PHPUnit could not run locally because dependencies require PHP >= 8.5 and the available runtime is PHP 8.4.10; no PHP container is currently running