### PR TITLE
feat: add Google Sheets read/write/update tool for Apex and Arc

### DIFF
--- a/src/Domains/Connectors/GoogleSheets/Actions/AbstractSheetAction.php
+++ b/src/Domains/Connectors/GoogleSheets/Actions/AbstractSheetAction.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\GoogleSheets\Actions;
+
+use Baka\Contracts\AppInterface;
+use Google\Service\Sheets as GoogleSheetsService;
+use Kanvas\Connectors\GoogleSheets\Client;
+
+/** Shared constructor + lazy authenticated-service resolution for every Sheets read/write action. */
+abstract class AbstractSheetAction
+{
+    public function __construct(
+        protected AppInterface $app,
+        protected string $spreadsheetId,
+        protected string $range,
+        protected ?GoogleSheetsService $service = null,
+    ) {
+    }
+
+    protected function service(): GoogleSheetsService
+    {
+        return $this->service ??= Client::getInstance($this->app);
+    }
+}

--- a/src/Domains/Connectors/GoogleSheets/Actions/AbstractSheetAction.php
+++ b/src/Domains/Connectors/GoogleSheets/Actions/AbstractSheetAction.php
@@ -14,7 +14,7 @@ abstract class AbstractSheetAction
     public function __construct(
         protected AppInterface $app,
         protected string $spreadsheetId,
-        protected string $range,
+        protected ?string $range = null,
         protected ?GoogleSheetsService $service = null,
     ) {
     }

--- a/src/Domains/Connectors/GoogleSheets/Actions/AppendSheetRowsAction.php
+++ b/src/Domains/Connectors/GoogleSheets/Actions/AppendSheetRowsAction.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\GoogleSheets\Actions;
+
+use Baka\Contracts\AppInterface;
+use Google\Service\Sheets as GoogleSheetsService;
+use Google\Service\Sheets\ValueRange;
+
+/** Appends one or more new rows after the last row of data in the range's sheet — never overwrites existing rows. */
+class AppendSheetRowsAction extends AbstractSheetAction
+{
+    /**
+     * @param array<int, array<int, mixed>> $rows
+     */
+    public function __construct(
+        AppInterface $app,
+        string $spreadsheetId,
+        string $range,
+        protected array $rows,
+        ?GoogleSheetsService $service = null,
+    ) {
+        parent::__construct($app, $spreadsheetId, $range, $service);
+    }
+
+    /**
+     * @return array{updated_range: string, updated_rows: int}
+     */
+    public function execute(): array
+    {
+        $updates = $this->service()->spreadsheets_values->append(
+            $this->spreadsheetId,
+            $this->range,
+            new ValueRange(['values' => $this->rows]),
+            ['valueInputOption' => 'USER_ENTERED', 'insertDataOption' => 'INSERT_ROWS'],
+        )->getUpdates();
+
+        return [
+            'updated_range' => (string) $updates->getUpdatedRange(),
+            'updated_rows' => (int) $updates->getUpdatedRows(),
+        ];
+    }
+}

--- a/src/Domains/Connectors/GoogleSheets/Actions/ClearSheetRangeAction.php
+++ b/src/Domains/Connectors/GoogleSheets/Actions/ClearSheetRangeAction.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\GoogleSheets\Actions;
+
+use Google\Service\Sheets\ClearValuesRequest;
+
+/** Wipes the values in a range without deleting the row/column itself — the safe counterpart to a structural row delete. */
+class ClearSheetRangeAction extends AbstractSheetAction
+{
+    /**
+     * @return array{cleared_range: string}
+     */
+    public function execute(): array
+    {
+        $result = $this->service()->spreadsheets_values->clear(
+            $this->spreadsheetId,
+            $this->range,
+            new ClearValuesRequest(),
+        );
+
+        return ['cleared_range' => (string) $result->getClearedRange()];
+    }
+}

--- a/src/Domains/Connectors/GoogleSheets/Actions/CreateSheetTabAction.php
+++ b/src/Domains/Connectors/GoogleSheets/Actions/CreateSheetTabAction.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Kanvas\Connectors\GoogleSheets\Actions;
 
 use Baka\Contracts\AppInterface;
-use Google\Service\Sheets as GoogleSheetsService;
 use Google\Service\Sheets\AddSheetRequest;
+use Google\Service\Sheets as GoogleSheetsService;
 use Google\Service\Sheets\BatchUpdateSpreadsheetRequest;
 use Google\Service\Sheets\Request as SheetsBatchRequest;
 use Google\Service\Sheets\SheetProperties;

--- a/src/Domains/Connectors/GoogleSheets/Actions/CreateSheetTabAction.php
+++ b/src/Domains/Connectors/GoogleSheets/Actions/CreateSheetTabAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\GoogleSheets\Actions;
+
+use Baka\Contracts\AppInterface;
+use Google\Service\Sheets as GoogleSheetsService;
+use Google\Service\Sheets\AddSheetRequest;
+use Google\Service\Sheets\BatchUpdateSpreadsheetRequest;
+use Google\Service\Sheets\Request as SheetsBatchRequest;
+use Google\Service\Sheets\SheetProperties;
+
+/** Adds a brand-new sheet/tab to an existing spreadsheet document without touching any other tab. */
+class CreateSheetTabAction extends AbstractSheetAction
+{
+    public function __construct(
+        AppInterface $app,
+        string $spreadsheetId,
+        protected string $sheetTitle,
+        ?GoogleSheetsService $service = null,
+    ) {
+        parent::__construct($app, $spreadsheetId, service: $service);
+    }
+
+    /**
+     * @return array{sheet_id: int, title: string}
+     */
+    public function execute(): array
+    {
+        $response = $this->service()->spreadsheets->batchUpdate(
+            $this->spreadsheetId,
+            new BatchUpdateSpreadsheetRequest([
+                'requests' => [
+                    new SheetsBatchRequest([
+                        'addSheet' => new AddSheetRequest([
+                            'properties' => new SheetProperties(['title' => $this->sheetTitle]),
+                        ]),
+                    ]),
+                ],
+            ]),
+        );
+
+        $addedSheetProperties = $response->getReplies()[0]->getAddSheet()->getProperties();
+
+        return [
+            'sheet_id' => (int) $addedSheetProperties->getSheetId(),
+            'title' => (string) $addedSheetProperties->getTitle(),
+        ];
+    }
+}

--- a/src/Domains/Connectors/GoogleSheets/Actions/ReadSheetRangeAction.php
+++ b/src/Domains/Connectors/GoogleSheets/Actions/ReadSheetRangeAction.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\GoogleSheets\Actions;
+
+/** Reads a range's values as a list of rows (each row a list of cell values, left-to-right, top-to-bottom). */
+class ReadSheetRangeAction extends AbstractSheetAction
+{
+    /**
+     * @return array<int, array<int, mixed>>
+     */
+    public function execute(): array
+    {
+        $response = $this->service()->spreadsheets_values->get($this->spreadsheetId, $this->range);
+
+        return $response->getValues() ?? [];
+    }
+}

--- a/src/Domains/Connectors/GoogleSheets/Actions/UpdateSheetRangeAction.php
+++ b/src/Domains/Connectors/GoogleSheets/Actions/UpdateSheetRangeAction.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\GoogleSheets\Actions;
+
+use Baka\Contracts\AppInterface;
+use Google\Service\Sheets as GoogleSheetsService;
+use Google\Service\Sheets\ValueRange;
+
+/** Overwrites the values already in a range in place (e.g. a single cell like "Sheet1!D5") — the counterpart to AppendSheetRowsAction. */
+class UpdateSheetRangeAction extends AbstractSheetAction
+{
+    /**
+     * @param array<int, array<int, mixed>> $values
+     */
+    public function __construct(
+        AppInterface $app,
+        string $spreadsheetId,
+        string $range,
+        protected array $values,
+        ?GoogleSheetsService $service = null,
+    ) {
+        parent::__construct($app, $spreadsheetId, $range, $service);
+    }
+
+    /**
+     * @return array{updated_range: string, updated_cells: int}
+     */
+    public function execute(): array
+    {
+        $result = $this->service()->spreadsheets_values->update(
+            $this->spreadsheetId,
+            $this->range,
+            new ValueRange(['values' => $this->values]),
+            ['valueInputOption' => 'USER_ENTERED'],
+        );
+
+        return [
+            'updated_range' => (string) $result->getUpdatedRange(),
+            'updated_cells' => (int) $result->getUpdatedCells(),
+        ];
+    }
+}

--- a/src/Domains/Connectors/GoogleSheets/CLAUDE.md
+++ b/src/Domains/Connectors/GoogleSheets/CLAUDE.md
@@ -10,8 +10,9 @@ shares a link to — e.g. an invoice tracking list a team keeps outside Kanvas.
 | `read_google_sheet(sheet_url_or_id, range?)` | Reads rows/columns. `range` defaults to `A:Z` on the first sheet. |
 | `write_google_sheet(sheet_url_or_id, range, values)` | Appends one or more new rows after the last row of data — never overwrites. |
 | `update_google_sheet_cell(sheet_url_or_id, range, value)` | Overwrites a specific cell in place, e.g. flipping a status column to "Approved". |
+| `clear_google_sheet_range(sheet_url_or_id, range)` | Wipes the values in a cell/row/range without deleting the row itself — the safe alternative to a structural delete. |
 
-All three accept either a full Sheets URL or a bare spreadsheet id — the id is extracted with a
+All four accept either a full Sheets URL or a bare spreadsheet id — the id is extracted with a
 regex (`SpreadsheetUrlParser::extractId()`), never asked of the LLM directly.
 
 ## Configuration

--- a/src/Domains/Connectors/GoogleSheets/CLAUDE.md
+++ b/src/Domains/Connectors/GoogleSheets/CLAUDE.md
@@ -11,9 +11,12 @@ shares a link to — e.g. an invoice tracking list a team keeps outside Kanvas.
 | `write_google_sheet(sheet_url_or_id, range, values)` | Appends one or more new rows after the last row of data — never overwrites. |
 | `update_google_sheet_cell(sheet_url_or_id, range, value)` | Overwrites a specific cell in place, e.g. flipping a status column to "Approved". |
 | `clear_google_sheet_range(sheet_url_or_id, range)` | Wipes the values in a cell/row/range without deleting the row itself — the safe alternative to a structural delete. |
+| `create_google_sheet_tab(sheet_url_or_id, title)` | Adds a brand-new sheet/tab to the document, without touching any existing tab. |
 
-All four accept either a full Sheets URL or a bare spreadsheet id — the id is extracted with a
-regex (`SpreadsheetUrlParser::extractId()`), never asked of the LLM directly.
+All five accept either a full Sheets URL or a bare spreadsheet id — the id is extracted with a
+regex (`SpreadsheetUrlParser::extractId()`), never asked of the LLM directly. `write_google_sheet`
+and `update_google_sheet_cell` also accept live formulas (e.g. `"=SUM(C2:C10)"`) as cell values —
+`valueInputOption: USER_ENTERED` interprets them exactly as if typed by hand.
 
 ## Configuration
 

--- a/src/Domains/Connectors/GoogleSheets/CLAUDE.md
+++ b/src/Domains/Connectors/GoogleSheets/CLAUDE.md
@@ -1,0 +1,85 @@
+# Google Sheets Connector
+
+Lets Kanvas agents (Apex, Arc) read, append to, and update cells on a Google Sheet the user
+shares a link to — e.g. an invoice tracking list a team keeps outside Kanvas.
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `read_google_sheet(sheet_url_or_id, range?)` | Reads rows/columns. `range` defaults to `A:Z` on the first sheet. |
+| `write_google_sheet(sheet_url_or_id, range, values)` | Appends one or more new rows after the last row of data — never overwrites. |
+| `update_google_sheet_cell(sheet_url_or_id, range, value)` | Overwrites a specific cell in place, e.g. flipping a status column to "Approved". |
+
+All three accept either a full Sheets URL or a bare spreadsheet id — the id is extracted with a
+regex (`SpreadsheetUrlParser::extractId()`), never asked of the LLM directly.
+
+## Configuration
+
+Auth is a Google **service account** — a machine identity, not a per-user OAuth login. The raw
+service-account JSON key is stored per Kanvas app via the standard custom-fields mechanism,
+under the key `google-sheets-credentials` (`ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS`).
+
+### One-time setup (per Google Cloud project)
+
+1. Create/select a project in [Google Cloud Console](https://console.cloud.google.com/).
+2. **APIs & Services → Library** → enable **Google Sheets API**.
+3. **APIs & Services → Credentials → Create Credentials → Service Account**.
+4. Open the service account → **Keys → Add Key → Create new key → JSON**. This downloads the
+   credentials file.
+5. Note the service account's email (e.g. `kanvas-sheets-agent@PROJECT.iam.gserviceaccount.com`).
+
+### Per-app configuration
+
+Store the downloaded JSON on the Kanvas app that will run the tool. There is no admin UI for
+this yet — use the existing `setAppSetting` GraphQL mutation (the same one used to configure
+Acumatica/Google Calendar), authenticated with that app's admin app key:
+
+```graphql
+mutation SetGoogleSheetsCredentials($input: ModuleConfigInput!) {
+    setAppSetting(input: $input)
+}
+```
+
+```json
+{
+  "input": {
+    "key": "google-sheets-credentials",
+    "value": "{\"type\":\"service_account\",\"project_id\":\"...\",\"private_key\":\"...\",\"client_email\":\"...\",...}"
+  }
+}
+```
+
+`value` is the entire downloaded JSON file's content as a single string. Run this once per
+Kanvas app/tenant — every agent on that app then shares the same configured service account.
+
+**Local/dev shortcut** (no GraphQL round-trip needed): from `php artisan tinker` inside the app
+container —
+
+```php
+$app = app(\Kanvas\Apps\Models\Apps::class);
+$app->set(
+    \Kanvas\Connectors\GoogleSheets\Enums\ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value,
+    file_get_contents('/path/to/service-account.json'),
+);
+```
+
+### Per-sheet sharing (always required, cannot be automated)
+
+The service account can only touch a spreadsheet that has been explicitly shared with it. For
+**every** sheet an agent needs to read or write:
+
+1. Open the sheet → **Share**.
+2. Add the service account's email (from step 5 above) as **Editor**.
+
+Without this, every call fails with a permission error from the Sheets API — the credentials
+being configured correctly is not enough on its own.
+
+## Security note
+
+The credentials are stored in plaintext in the `apps_settings` table, same as every other
+connector's credentials in this codebase (Acumatica, Google Calendar, etc.) — this is an
+existing, accepted pattern here, not something specific to this connector. Treat the JSON key
+file itself with the same care as any other production secret: don't commit it, don't paste it
+into chat/logs outside the one-time setup, and use a dedicated production service account (never
+reuse a personal/dev one).

--- a/src/Domains/Connectors/GoogleSheets/Client.php
+++ b/src/Domains/Connectors/GoogleSheets/Client.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\GoogleSheets;
+
+use Baka\Contracts\AppInterface;
+use Google\Client as GoogleApiClient;
+use Google\Service\Sheets as GoogleSheetsService;
+use Kanvas\Connectors\GoogleSheets\Enums\ConfigurationEnum;
+use Kanvas\Exceptions\ValidationException;
+use Throwable;
+
+/** Thin factory for an authenticated Google Sheets API service, scoped to the app's configured service account. */
+class Client
+{
+    public static function getInstance(AppInterface $app): GoogleSheetsService
+    {
+        $raw = $app->get(ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value);
+
+        // The custom-fields store round-trips a JSON string back as an already-decoded array —
+        // accept either shape rather than assuming set() always comes back as the string it was given.
+        $decoded = match (true) {
+            is_array($raw) => $raw,
+            is_string($raw) && $raw !== '' => json_decode($raw, true),
+            default => null,
+        };
+
+        if ($decoded === null) {
+            throw new ValidationException(
+                'Google Sheets is not configured for this app — set GOOGLE_SHEETS_CREDENTIALS to a service-account JSON key.'
+            );
+        }
+
+        if (! is_array($decoded)) {
+            throw new ValidationException('Google Sheets credentials are not valid JSON.');
+        }
+
+        try {
+            $googleClient = new GoogleApiClient();
+            $googleClient->setAuthConfig($decoded);
+            $googleClient->addScope(GoogleSheetsService::SPREADSHEETS);
+
+            return new GoogleSheetsService($googleClient);
+        } catch (Throwable $e) {
+            throw new ValidationException('Could not authenticate with Google Sheets: ' . $e->getMessage());
+        }
+    }
+}

--- a/src/Domains/Connectors/GoogleSheets/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/GoogleSheets/Enums/ConfigurationEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\GoogleSheets\Enums;
+
+enum ConfigurationEnum: string
+{
+    /** The Google service-account key (raw JSON string), set per app via $app->set(). Must have the Sheets API enabled on its project, and be shared as an Editor on every target sheet. */
+    case GOOGLE_SHEETS_CREDENTIALS = 'google-sheets-credentials';
+}

--- a/src/Domains/Connectors/GoogleSheets/Support/SpreadsheetUrlParser.php
+++ b/src/Domains/Connectors/GoogleSheets/Support/SpreadsheetUrlParser.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\GoogleSheets\Support;
+
+class SpreadsheetUrlParser
+{
+    /** Accepts a full Sheets URL (any tab/gid) or a bare spreadsheet id; returns null when neither shape matches. */
+    public static function extractId(string $urlOrId): ?string
+    {
+        if (preg_match('#/spreadsheets/d/([a-zA-Z0-9_-]+)#', $urlOrId, $matches)) {
+            return $matches[1];
+        }
+
+        if (preg_match('#^[a-zA-Z0-9_-]{20,}$#', trim($urlOrId))) {
+            return trim($urlOrId);
+        }
+
+        return null;
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -21,6 +21,7 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateApBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidApBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\AppendGoogleSheetRowsTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ClearGoogleSheetRangeTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\CreateGoogleSheetTabTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ReadGoogleSheetTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\UpdateGoogleSheetCellTool;
 use Override;
@@ -72,6 +73,7 @@ class AccountsPayableAgent extends SystemUserAgent
             new AppendGoogleSheetRowsTool(),
             new UpdateGoogleSheetCellTool(),
             new ClearGoogleSheetRangeTool(),
+            new CreateGoogleSheetTabTool(),
         ]));
     }
 
@@ -104,7 +106,7 @@ class AccountsPayableAgent extends SystemUserAgent
             . 'rows to the sheet" → write_google_sheet. "Mark that row as X in the sheet" → '
             . 'update_google_sheet_cell, only after confirming the exact cell with read_google_sheet first — '
             . 'never guess a row/column. "Clear/wipe that row/cell" → clear_google_sheet_range — this empties '
-            . 'the values but never removes the row itself.',
+            . 'the values but never removes the row itself. "Create a new tab called X" → create_google_sheet_tab.',
         ]);
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -20,6 +20,7 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AttachBillFileTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateApBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidApBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\AppendGoogleSheetRowsTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ClearGoogleSheetRangeTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ReadGoogleSheetTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\UpdateGoogleSheetCellTool;
 use Override;
@@ -70,6 +71,7 @@ class AccountsPayableAgent extends SystemUserAgent
             new ReadGoogleSheetTool(),
             new AppendGoogleSheetRowsTool(),
             new UpdateGoogleSheetCellTool(),
+            new ClearGoogleSheetRangeTool(),
         ]));
     }
 
@@ -101,7 +103,8 @@ class AccountsPayableAgent extends SystemUserAgent
             '- "Read/check this Google Sheet" → read_google_sheet, given the URL the user shared. "Add these '
             . 'rows to the sheet" → write_google_sheet. "Mark that row as X in the sheet" → '
             . 'update_google_sheet_cell, only after confirming the exact cell with read_google_sheet first — '
-            . 'never guess a row/column.',
+            . 'never guess a row/column. "Clear/wipe that row/cell" → clear_google_sheet_range — this empties '
+            . 'the values but never removes the row itself.',
         ]);
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -19,6 +19,9 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\ApplyApPaymentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AttachBillFileTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateApBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidApBillTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\AppendGoogleSheetRowsTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ReadGoogleSheetTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\UpdateGoogleSheetCellTool;
 use Override;
 
 /**
@@ -64,6 +67,9 @@ class AccountsPayableAgent extends SystemUserAgent
             new ApplyApPaymentTool(),
             new AddBillNoteTool(),
             new AttachBillFileTool(),
+            new ReadGoogleSheetTool(),
+            new AppendGoogleSheetRowsTool(),
+            new UpdateGoogleSheetCellTool(),
         ]));
     }
 
@@ -92,6 +98,10 @@ class AccountsPayableAgent extends SystemUserAgent
             . 'explicitly asks to record a real payment. Needs the bill_id, amount, and a payment reference.',
             '- "Add a note to bill Y" → add_bill_note; "attach this file to bill Y" → attach_bill_file. Both '
             . 'require the bill to already be pushed to Acumatica.',
+            '- "Read/check this Google Sheet" → read_google_sheet, given the URL the user shared. "Add these '
+            . 'rows to the sheet" → write_google_sheet. "Mark that row as X in the sheet" → '
+            . 'update_google_sheet_cell, only after confirming the exact cell with read_google_sheet first — '
+            . 'never guess a row/column.',
         ]);
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -19,6 +19,9 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AttachInvoiceFileTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArCreditMemoTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidArInvoiceTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\AppendGoogleSheetRowsTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ReadGoogleSheetTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\UpdateGoogleSheetCellTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Sales\CreateSampleOrderTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Sales\FindProductTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Sales\FindSalesOrderTool;
@@ -77,6 +80,9 @@ class AccountsReceivableAgent extends SystemUserAgent
             new CreateArCreditMemoTool(),
             new AddInvoiceNoteTool(),
             new AttachInvoiceFileTool(),
+            new ReadGoogleSheetTool(),
+            new AppendGoogleSheetRowsTool(),
+            new UpdateGoogleSheetCellTool(),
         ]));
     }
 
@@ -112,6 +118,10 @@ class AccountsReceivableAgent extends SystemUserAgent
             . 'amount each.',
             '- "Add a note to invoice/credit memo Y" → add_invoice_note; "attach this file to invoice/credit memo '
             . 'Y" → attach_invoice_file. Both require the document to already be pushed to Acumatica.',
+            '- "Read/check this Google Sheet" → read_google_sheet, given the URL the user shared. "Add these '
+            . 'rows to the sheet" → write_google_sheet. "Mark that row as X in the sheet" → '
+            . 'update_google_sheet_cell, only after confirming the exact cell with read_google_sheet first — '
+            . 'never guess a row/column.',
             '- Lead with the headline, then the top 3-5 items. Be honest about freshness.',
         ]);
     }

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -20,6 +20,7 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArCreditMemoTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\AppendGoogleSheetRowsTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ClearGoogleSheetRangeTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ReadGoogleSheetTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\UpdateGoogleSheetCellTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Sales\CreateSampleOrderTool;
@@ -83,6 +84,7 @@ class AccountsReceivableAgent extends SystemUserAgent
             new ReadGoogleSheetTool(),
             new AppendGoogleSheetRowsTool(),
             new UpdateGoogleSheetCellTool(),
+            new ClearGoogleSheetRangeTool(),
         ]));
     }
 
@@ -121,7 +123,8 @@ class AccountsReceivableAgent extends SystemUserAgent
             '- "Read/check this Google Sheet" → read_google_sheet, given the URL the user shared. "Add these '
             . 'rows to the sheet" → write_google_sheet. "Mark that row as X in the sheet" → '
             . 'update_google_sheet_cell, only after confirming the exact cell with read_google_sheet first — '
-            . 'never guess a row/column.',
+            . 'never guess a row/column. "Clear/wipe that row/cell" → clear_google_sheet_range — this empties '
+            . 'the values but never removes the row itself.',
             '- Lead with the headline, then the top 3-5 items. Be honest about freshness.',
         ]);
     }

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -21,6 +21,7 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\AppendGoogleSheetRowsTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ClearGoogleSheetRangeTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\CreateGoogleSheetTabTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ReadGoogleSheetTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\UpdateGoogleSheetCellTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Sales\CreateSampleOrderTool;
@@ -85,6 +86,7 @@ class AccountsReceivableAgent extends SystemUserAgent
             new AppendGoogleSheetRowsTool(),
             new UpdateGoogleSheetCellTool(),
             new ClearGoogleSheetRangeTool(),
+            new CreateGoogleSheetTabTool(),
         ]));
     }
 
@@ -124,7 +126,7 @@ class AccountsReceivableAgent extends SystemUserAgent
             . 'rows to the sheet" → write_google_sheet. "Mark that row as X in the sheet" → '
             . 'update_google_sheet_cell, only after confirming the exact cell with read_google_sheet first — '
             . 'never guess a row/column. "Clear/wipe that row/cell" → clear_google_sheet_range — this empties '
-            . 'the values but never removes the row itself.',
+            . 'the values but never removes the row itself. "Create a new tab called X" → create_google_sheet_tab.',
             '- Lead with the headline, then the top 3-5 items. Be honest about freshness.',
         ]);
     }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/AppendGoogleSheetRowsTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/AppendGoogleSheetRowsTool.php
@@ -56,7 +56,9 @@ class AppendGoogleSheetRowsTool extends Tool
                 name: 'values',
                 type: PropertyType::ARRAY,
                 description: 'Array of rows to append, each row itself an array of cell values in column order, '
-                    . 'e.g. [["1498", "Windwalk Games Corp", 250.00, "Pending"]]. At least one row is required.',
+                    . 'e.g. [["1498", "Windwalk Games Corp", 250.00, "Pending"]]. At least one row is required. '
+                    . 'A cell value starting with "=" is entered as a live formula (e.g. "=SUM(C2:C10)"), exactly '
+                    . 'as if typed into the sheet by hand — not stored as plain text.',
                 required: true,
             ),
         ];

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/AppendGoogleSheetRowsTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/AppendGoogleSheetRowsTool.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets;
+
+use Kanvas\Connectors\GoogleSheets\Actions\AppendSheetRowsAction;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\ResolvesSpreadsheetIdForTool;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+/** Appends new rows to a Google Sheet the user shared, e.g. adding invoices to a shared tracking list. */
+#[AgentTool(name: 'Write Google Sheet Rows', category: 'productivity')]
+class AppendGoogleSheetRowsTool extends Tool
+{
+    use HasKanvasContext;
+    use ResolvesSpreadsheetIdForTool;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'write_google_sheet',
+            description: 'Appends one or more new rows to the end of a Google Sheet the user shared a link to. '
+                . 'Never overwrites existing rows — use update_google_sheet_cell for that. The sheet must already '
+                . 'be shared as an Editor with this app\'s Google service account.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'sheet_url_or_id',
+                type: PropertyType::STRING,
+                description: 'The full Google Sheets URL the user shared, or a bare spreadsheet id. Always required.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'range',
+                type: PropertyType::STRING,
+                description: 'A1 notation range identifying the sheet/table to append after, e.g. "Sheet1!A1" or '
+                    . '"Invoices!A:D". Only the sheet name matters for an append — Google finds the first empty '
+                    . 'row on its own.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'values',
+                type: PropertyType::ARRAY,
+                description: 'Array of rows to append, each row itself an array of cell values in column order, '
+                    . 'e.g. [["1498", "Windwalk Games Corp", 250.00, "Pending"]]. At least one row is required.',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @param array<int, array<int, mixed>> $values
+     *
+     * @return array<string, mixed>
+     */
+    public function __invoke(string $sheet_url_or_id, string $range, array $values): array
+    {
+        $spreadsheetId = $this->resolveSpreadsheetId($sheet_url_or_id);
+
+        if (is_array($spreadsheetId)) {
+            return ['success' => false, ...$spreadsheetId];
+        }
+
+        if ($values === []) {
+            return [
+                'success' => false,
+                'reason' => 'values_required',
+                'message' => 'At least one row (an array of cell values) is required.',
+            ];
+        }
+
+        try {
+            $result = new AppendSheetRowsAction($this->app, $spreadsheetId, $range, $values)->execute();
+        } catch (Throwable $e) {
+            return [
+                'success' => false,
+                'reason' => 'write_failed',
+                'message' => 'Could not write to the sheet: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'success' => true,
+            'spreadsheet_id' => $spreadsheetId,
+            ...$result,
+        ];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/ClearGoogleSheetRangeTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/ClearGoogleSheetRangeTool.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets;
+
+use Kanvas\Connectors\GoogleSheets\Actions\ClearSheetRangeAction;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\ResolvesSpreadsheetIdForTool;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+/** Wipes the contents of a cell/row/range on a Google Sheet without deleting the row itself, e.g. clearing a cancelled invoice's data. */
+#[AgentTool(name: 'Clear Google Sheet Range', category: 'productivity')]
+class ClearGoogleSheetRangeTool extends Tool
+{
+    use HasKanvasContext;
+    use ResolvesSpreadsheetIdForTool;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'clear_google_sheet_range',
+            description: 'Wipes the contents of a cell, row, or range on a Google Sheet the user shared a link to '
+                . '— e.g. clearing out a cancelled invoice row. This does NOT delete the row itself, only its '
+                . 'values; the row stays in place and other rows are never shifted. The sheet must already be '
+                . 'shared as an Editor with this app\'s Google service account.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'sheet_url_or_id',
+                type: PropertyType::STRING,
+                description: 'The full Google Sheets URL the user shared, or a bare spreadsheet id. Always required.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'range',
+                type: PropertyType::STRING,
+                description: 'A1 notation reference to the cell/row/range to clear, e.g. "Sheet1!A5:D5" or '
+                    . '"Invoices!C12". Always required — never guess the row without confirming it first via '
+                    . 'read_google_sheet.',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(string $sheet_url_or_id, string $range): array
+    {
+        $spreadsheetId = $this->resolveSpreadsheetId($sheet_url_or_id);
+
+        if (is_array($spreadsheetId)) {
+            return ['success' => false, ...$spreadsheetId];
+        }
+
+        try {
+            $result = new ClearSheetRangeAction($this->app, $spreadsheetId, $range)->execute();
+        } catch (Throwable $e) {
+            return [
+                'success' => false,
+                'reason' => 'clear_failed',
+                'message' => 'Could not clear the sheet range: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'success' => true,
+            'spreadsheet_id' => $spreadsheetId,
+            ...$result,
+        ];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/CreateGoogleSheetTabTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/CreateGoogleSheetTabTool.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets;
+
+use Kanvas\Connectors\GoogleSheets\Actions\CreateSheetTabAction;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\ResolvesSpreadsheetIdForTool;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+/** Adds a brand-new sheet/tab to an existing Google Sheets document, e.g. a new "Q3" tab alongside existing ones. */
+#[AgentTool(name: 'Create Google Sheet Tab', category: 'productivity')]
+class CreateGoogleSheetTabTool extends Tool
+{
+    use HasKanvasContext;
+    use ResolvesSpreadsheetIdForTool;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'create_google_sheet_tab',
+            description: 'Creates a brand-new sheet/tab inside an existing Google Sheets document the user shared '
+                . 'a link to — e.g. adding a new "Q3 Invoices" tab. Does not touch or remove any existing tab. '
+                . 'The sheet must already be shared as an Editor with this app\'s Google service account.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'sheet_url_or_id',
+                type: PropertyType::STRING,
+                description: 'The full Google Sheets URL the user shared, or a bare spreadsheet id. Always required.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'title',
+                type: PropertyType::STRING,
+                description: 'The name for the new tab, e.g. "Q3 Invoices". Always required.',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(string $sheet_url_or_id, string $title): array
+    {
+        $spreadsheetId = $this->resolveSpreadsheetId($sheet_url_or_id);
+
+        if (is_array($spreadsheetId)) {
+            return ['success' => false, ...$spreadsheetId];
+        }
+
+        try {
+            $result = new CreateSheetTabAction($this->app, $spreadsheetId, $title)->execute();
+        } catch (Throwable $e) {
+            return [
+                'success' => false,
+                'reason' => 'create_tab_failed',
+                'message' => 'Could not create the sheet tab: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'success' => true,
+            'spreadsheet_id' => $spreadsheetId,
+            ...$result,
+        ];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/ReadGoogleSheetTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/ReadGoogleSheetTool.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets;
+
+use Kanvas\Connectors\GoogleSheets\Actions\ReadSheetRangeAction;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\ResolvesSpreadsheetIdForTool;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+/** Reads a range of cells from a Google Sheet the user shared, given its URL or bare id. */
+#[AgentTool(name: 'Read Google Sheet', category: 'productivity')]
+class ReadGoogleSheetTool extends Tool
+{
+    use HasKanvasContext;
+    use ResolvesSpreadsheetIdForTool;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'read_google_sheet',
+            description: 'Reads rows/columns from a Google Sheet the user shared a link to (e.g. an invoice '
+                . 'list). The sheet must already be shared as an Editor with this app\'s Google service account.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'sheet_url_or_id',
+                type: PropertyType::STRING,
+                description: 'The full Google Sheets URL the user shared (e.g. '
+                    . '"https://docs.google.com/spreadsheets/d/1A_B_C_D_12345/edit#gid=0"), or a bare '
+                    . 'spreadsheet id. Always required.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'range',
+                type: PropertyType::STRING,
+                description: 'A1 notation range to read, e.g. "Sheet1!A1:E50" or "Invoices!A:D". Defaults to '
+                    . '"A:Z" on the first sheet when omitted.',
+                required: false,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(string $sheet_url_or_id, ?string $range = null): array
+    {
+        $spreadsheetId = $this->resolveSpreadsheetId($sheet_url_or_id);
+
+        if (is_array($spreadsheetId)) {
+            return ['success' => false, ...$spreadsheetId];
+        }
+
+        $range = $range !== null && trim($range) !== '' ? $range : 'A:Z';
+
+        try {
+            $rows = new ReadSheetRangeAction($this->app, $spreadsheetId, $range)->execute();
+        } catch (Throwable $e) {
+            return [
+                'success' => false,
+                'reason' => 'read_failed',
+                'message' => 'Could not read the sheet: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'success' => true,
+            'spreadsheet_id' => $spreadsheetId,
+            'range' => $range,
+            'row_count' => count($rows),
+            'rows' => $rows,
+        ];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/UpdateGoogleSheetCellTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/UpdateGoogleSheetCellTool.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets;
+
+use Kanvas\Connectors\GoogleSheets\Actions\UpdateSheetRangeAction;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\ResolvesSpreadsheetIdForTool;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+/** Overwrites a specific cell (or range) already on a Google Sheet, e.g. flipping an invoice's status to "Approved". */
+#[AgentTool(name: 'Update Google Sheet Cell', category: 'productivity')]
+class UpdateGoogleSheetCellTool extends Tool
+{
+    use HasKanvasContext;
+    use ResolvesSpreadsheetIdForTool;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'update_google_sheet_cell',
+            description: 'Overwrites a specific cell (or small range) on a Google Sheet the user shared a link '
+                . 'to — e.g. changing an invoice row\'s status column to "Approved". Use write_google_sheet '
+                . 'instead when adding brand-new rows. The sheet must already be shared as an Editor with this '
+                . 'app\'s Google service account.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'sheet_url_or_id',
+                type: PropertyType::STRING,
+                description: 'The full Google Sheets URL the user shared, or a bare spreadsheet id. Always required.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'range',
+                type: PropertyType::STRING,
+                description: 'A1 notation reference to the exact cell to overwrite, e.g. "Sheet1!D5" or '
+                    . '"Invoices!C12". Always required — never guess the row without confirming it first via '
+                    . 'read_google_sheet.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'value',
+                type: PropertyType::STRING,
+                description: 'The new value for that cell, e.g. "Approved" or "250.00".',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(string $sheet_url_or_id, string $range, string $value): array
+    {
+        $spreadsheetId = $this->resolveSpreadsheetId($sheet_url_or_id);
+
+        if (is_array($spreadsheetId)) {
+            return ['success' => false, ...$spreadsheetId];
+        }
+
+        try {
+            $result = new UpdateSheetRangeAction($this->app, $spreadsheetId, $range, [[$value]])->execute();
+        } catch (Throwable $e) {
+            return [
+                'success' => false,
+                'reason' => 'update_failed',
+                'message' => 'Could not update the sheet: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'success' => true,
+            'spreadsheet_id' => $spreadsheetId,
+            ...$result,
+        ];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/UpdateGoogleSheetCellTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/UpdateGoogleSheetCellTool.php
@@ -56,7 +56,9 @@ class UpdateGoogleSheetCellTool extends Tool
             new ToolProperty(
                 name: 'value',
                 type: PropertyType::STRING,
-                description: 'The new value for that cell, e.g. "Approved" or "250.00".',
+                description: 'The new value for that cell, e.g. "Approved" or "250.00". A value starting with "=" '
+                    . 'is entered as a live formula (e.g. "=SUM(C2:C10)" or "=VLOOKUP(A5,Sheet2!A:B,2,FALSE)"), '
+                    . 'exactly as if typed into the sheet by hand — not stored as plain text.',
                 required: true,
             ),
         ];

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Traits/ResolvesSpreadsheetIdForTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Traits/ResolvesSpreadsheetIdForTool.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Traits;
+
+use Kanvas\Connectors\GoogleSheets\Support\SpreadsheetUrlParser;
+
+/** Extracts a spreadsheet id from a URL/id a tool received. Returns the id, or an LLM-facing error array the caller merges into its own response shape. */
+trait ResolvesSpreadsheetIdForTool
+{
+    /**
+     * @return string|array{reason: string, message: string}
+     */
+    protected function resolveSpreadsheetId(string $sheetUrlOrId): string|array
+    {
+        $spreadsheetId = SpreadsheetUrlParser::extractId($sheetUrlOrId);
+
+        if ($spreadsheetId === null) {
+            return [
+                'reason' => 'invalid_sheet_reference',
+                'message' => "\"{$sheetUrlOrId}\" doesn't look like a Google Sheets URL or id.",
+            ];
+        }
+
+        return $spreadsheetId;
+    }
+}

--- a/tests/Connectors/GoogleSheets/ClientTest.php
+++ b/tests/Connectors/GoogleSheets/ClientTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\GoogleSheets;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\GoogleSheets\Client;
+use Kanvas\Connectors\GoogleSheets\Enums\ConfigurationEnum;
+use Kanvas\Exceptions\ValidationException;
+use Tests\TestCase;
+
+class ClientTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /**
+     * GOOGLE_SHEETS_CREDENTIALS lives on the app's custom-fields store, which persists outside the
+     * ambient test transaction — DatabaseTransactions does NOT roll it back. Since app(Apps::class)
+     * resolves the one shared app every test in this suite runs against (including a real, live
+     * service-account key in some environments), save/restore it explicitly so this test never
+     * clobbers a real credential.
+     */
+    private mixed $originalCredentials = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalCredentials = app(Apps::class)->get(ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value);
+    }
+
+    protected function tearDown(): void
+    {
+        app(Apps::class)->set(ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value, $this->originalCredentials);
+
+        parent::tearDown();
+    }
+
+    private function fakeServiceAccountJson(): string
+    {
+        return json_encode([
+            'type' => 'service_account',
+            'project_id' => 'test-project',
+            'private_key_id' => 'abc123',
+            // Not PEM-shaped on purpose — a "BEGIN/END PRIVATE KEY" placeholder trips secret scanners; setAuthConfig() never validates the key's structure anyway.
+            'private_key' => 'not-a-real-key-value',
+            'client_email' => 'kanvas-sheets-agent@test-project.iam.gserviceaccount.com',
+            'client_id' => '123456789',
+            'auth_uri' => 'https://accounts.google.com/o/oauth2/auth',
+            'token_uri' => 'https://oauth2.googleapis.com/token',
+        ]) ?: '';
+    }
+
+    public function test_builds_a_client_when_the_config_round_trips_as_an_already_decoded_array(): void
+    {
+        // Kanvas's custom-fields store decodes a stored JSON string back into an array on get() —
+        // this is the shape that actually comes back in production, and once broke this with an
+        // "Array to string conversion" error from a blind (string) cast.
+        $app = app(Apps::class);
+        $app->set(ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value, json_decode($this->fakeServiceAccountJson(), true));
+
+        $service = Client::getInstance($app);
+
+        $this->assertNotNull($service->spreadsheets_values);
+    }
+
+    public function test_builds_a_client_when_the_config_is_still_a_raw_json_string(): void
+    {
+        $app = app(Apps::class);
+        $app->set(ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value, $this->fakeServiceAccountJson());
+
+        $service = Client::getInstance($app);
+
+        $this->assertNotNull($service->spreadsheets_values);
+    }
+
+    public function test_throws_a_clear_error_when_nothing_is_configured(): void
+    {
+        $app = app(Apps::class);
+        // Explicitly set then clear within the same test — proves the "nothing configured" path
+        // rather than relying on ordering to find the key still unset from a fresh app.
+        $app->set(ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value, $this->fakeServiceAccountJson());
+        $app->set(ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value, '');
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessageMatches('/not configured/');
+
+        Client::getInstance($app);
+    }
+}

--- a/tests/Connectors/GoogleSheets/GoogleSheetsActionsTest.php
+++ b/tests/Connectors/GoogleSheets/GoogleSheetsActionsTest.php
@@ -116,6 +116,33 @@ class GoogleSheetsActionsTest extends TestCase
         $this->assertSame(1, $result['updated_cells']);
     }
 
+    public function test_update_sheet_range_passes_a_formula_value_through_unmodified(): void
+    {
+        $valuesResource = Mockery::mock(SpreadsheetsValues::class);
+        $valuesResource->shouldReceive('update')
+            ->once()
+            ->with(
+                'SHEET_ID',
+                'Invoices!E2',
+                Mockery::on(fn (ValueRange $body) => $body->getValues() === [['=SUM(C2:C10)']]),
+                ['valueInputOption' => 'USER_ENTERED'],
+            )
+            ->andReturn(new UpdateValuesResponse(['updatedRange' => 'Invoices!E2', 'updatedCells' => 1]));
+
+        $service = Mockery::mock(GoogleSheetsService::class);
+        $service->spreadsheets_values = $valuesResource;
+
+        $result = new UpdateSheetRangeAction(
+            app: app(Apps::class),
+            spreadsheetId: 'SHEET_ID',
+            range: 'Invoices!E2',
+            values: [['=SUM(C2:C10)']],
+            service: $service,
+        )->execute();
+
+        $this->assertSame(1, $result['updated_cells']);
+    }
+
     public function test_clear_sheet_range_wipes_the_target_range_without_deleting_it(): void
     {
         $valuesResource = Mockery::mock(SpreadsheetsValues::class);

--- a/tests/Connectors/GoogleSheets/GoogleSheetsActionsTest.php
+++ b/tests/Connectors/GoogleSheets/GoogleSheetsActionsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\GoogleSheets;
+
+use Google\Service\Sheets as GoogleSheetsService;
+use Google\Service\Sheets\AppendValuesResponse;
+use Google\Service\Sheets\Resource\SpreadsheetsValues;
+use Google\Service\Sheets\UpdateValuesResponse;
+use Google\Service\Sheets\ValueRange;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\GoogleSheets\Actions\AppendSheetRowsAction;
+use Kanvas\Connectors\GoogleSheets\Actions\ReadSheetRangeAction;
+use Kanvas\Connectors\GoogleSheets\Actions\UpdateSheetRangeAction;
+use Mockery;
+use Tests\TestCase;
+
+class GoogleSheetsActionsTest extends TestCase
+{
+    public function test_read_sheet_range_returns_the_values_from_the_response(): void
+    {
+        $valuesResource = Mockery::mock(SpreadsheetsValues::class);
+        $valuesResource->shouldReceive('get')
+            ->once()
+            ->with('SHEET_ID', 'Invoices!A:D')
+            ->andReturn(new ValueRange(['values' => [
+                ['ID Factura', 'Proveedor', 'Monto', 'Estado'],
+                ['1498', 'Windwalk Games Corp', '250.00', 'Pending'],
+            ]]));
+
+        $service = Mockery::mock(GoogleSheetsService::class);
+        $service->spreadsheets_values = $valuesResource;
+
+        $rows = new ReadSheetRangeAction(
+            app: app(Apps::class),
+            spreadsheetId: 'SHEET_ID',
+            range: 'Invoices!A:D',
+            service: $service,
+        )->execute();
+
+        $this->assertCount(2, $rows);
+        $this->assertSame(['1498', 'Windwalk Games Corp', '250.00', 'Pending'], $rows[1]);
+    }
+
+    public function test_read_sheet_range_returns_an_empty_array_for_an_empty_range(): void
+    {
+        $valuesResource = Mockery::mock(SpreadsheetsValues::class);
+        $valuesResource->shouldReceive('get')->once()->andReturn(new ValueRange());
+
+        $service = Mockery::mock(GoogleSheetsService::class);
+        $service->spreadsheets_values = $valuesResource;
+
+        $rows = new ReadSheetRangeAction(app(Apps::class), 'SHEET_ID', 'Sheet1!A:Z', $service)->execute();
+
+        $this->assertSame([], $rows);
+    }
+
+    public function test_append_sheet_rows_sends_the_rows_and_returns_the_updated_range(): void
+    {
+        $valuesResource = Mockery::mock(SpreadsheetsValues::class);
+        $valuesResource->shouldReceive('append')
+            ->once()
+            ->with(
+                'SHEET_ID',
+                'Invoices!A1',
+                Mockery::on(fn (ValueRange $body) => $body->getValues() === [['1498', 'Windwalk Games Corp', 250.0, 'Pending']]),
+                ['valueInputOption' => 'USER_ENTERED', 'insertDataOption' => 'INSERT_ROWS'],
+            )
+            ->andReturn(new AppendValuesResponse([
+                'updates' => new UpdateValuesResponse(['updatedRange' => 'Invoices!A5:D5', 'updatedRows' => 1]),
+            ]));
+
+        $service = Mockery::mock(GoogleSheetsService::class);
+        $service->spreadsheets_values = $valuesResource;
+
+        $result = new AppendSheetRowsAction(
+            app: app(Apps::class),
+            spreadsheetId: 'SHEET_ID',
+            range: 'Invoices!A1',
+            rows: [['1498', 'Windwalk Games Corp', 250.0, 'Pending']],
+            service: $service,
+        )->execute();
+
+        $this->assertSame('Invoices!A5:D5', $result['updated_range']);
+        $this->assertSame(1, $result['updated_rows']);
+    }
+
+    public function test_update_sheet_range_overwrites_the_target_cell(): void
+    {
+        $valuesResource = Mockery::mock(SpreadsheetsValues::class);
+        $valuesResource->shouldReceive('update')
+            ->once()
+            ->with(
+                'SHEET_ID',
+                'Invoices!D5',
+                Mockery::on(fn (ValueRange $body) => $body->getValues() === [['Approved']]),
+                ['valueInputOption' => 'USER_ENTERED'],
+            )
+            ->andReturn(new UpdateValuesResponse(['updatedRange' => 'Invoices!D5', 'updatedCells' => 1]));
+
+        $service = Mockery::mock(GoogleSheetsService::class);
+        $service->spreadsheets_values = $valuesResource;
+
+        $result = new UpdateSheetRangeAction(
+            app: app(Apps::class),
+            spreadsheetId: 'SHEET_ID',
+            range: 'Invoices!D5',
+            values: [['Approved']],
+            service: $service,
+        )->execute();
+
+        $this->assertSame('Invoices!D5', $result['updated_range']);
+        $this->assertSame(1, $result['updated_cells']);
+    }
+}

--- a/tests/Connectors/GoogleSheets/GoogleSheetsActionsTest.php
+++ b/tests/Connectors/GoogleSheets/GoogleSheetsActionsTest.php
@@ -5,14 +5,21 @@ declare(strict_types=1);
 namespace Tests\Connectors\GoogleSheets;
 
 use Google\Service\Sheets as GoogleSheetsService;
+use Google\Service\Sheets\AddSheetResponse;
 use Google\Service\Sheets\AppendValuesResponse;
+use Google\Service\Sheets\BatchUpdateSpreadsheetRequest;
+use Google\Service\Sheets\BatchUpdateSpreadsheetResponse;
 use Google\Service\Sheets\ClearValuesResponse;
+use Google\Service\Sheets\Resource\Spreadsheets;
 use Google\Service\Sheets\Resource\SpreadsheetsValues;
+use Google\Service\Sheets\Response as SheetsBatchResponse;
+use Google\Service\Sheets\SheetProperties;
 use Google\Service\Sheets\UpdateValuesResponse;
 use Google\Service\Sheets\ValueRange;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\GoogleSheets\Actions\AppendSheetRowsAction;
 use Kanvas\Connectors\GoogleSheets\Actions\ClearSheetRangeAction;
+use Kanvas\Connectors\GoogleSheets\Actions\CreateSheetTabAction;
 use Kanvas\Connectors\GoogleSheets\Actions\ReadSheetRangeAction;
 use Kanvas\Connectors\GoogleSheets\Actions\UpdateSheetRangeAction;
 use Mockery;
@@ -162,5 +169,39 @@ class GoogleSheetsActionsTest extends TestCase
         )->execute();
 
         $this->assertSame('Invoices!A5:D5', $result['cleared_range']);
+    }
+
+    public function test_create_sheet_tab_adds_a_new_tab_and_returns_its_id_and_title(): void
+    {
+        $spreadsheetsResource = Mockery::mock(Spreadsheets::class);
+        $spreadsheetsResource->shouldReceive('batchUpdate')
+            ->once()
+            ->with(
+                'SHEET_ID',
+                Mockery::on(fn (BatchUpdateSpreadsheetRequest $body) => $body->getRequests()[0]->getAddSheet()
+                    ->getProperties()->getTitle() === 'Q3 Invoices'),
+            )
+            ->andReturn(new BatchUpdateSpreadsheetResponse([
+                'replies' => [
+                    new SheetsBatchResponse([
+                        'addSheet' => new AddSheetResponse([
+                            'properties' => new SheetProperties(['sheetId' => 987654321, 'title' => 'Q3 Invoices']),
+                        ]),
+                    ]),
+                ],
+            ]));
+
+        $service = Mockery::mock(GoogleSheetsService::class);
+        $service->spreadsheets = $spreadsheetsResource;
+
+        $result = new CreateSheetTabAction(
+            app: app(Apps::class),
+            spreadsheetId: 'SHEET_ID',
+            sheetTitle: 'Q3 Invoices',
+            service: $service,
+        )->execute();
+
+        $this->assertSame(987654321, $result['sheet_id']);
+        $this->assertSame('Q3 Invoices', $result['title']);
     }
 }

--- a/tests/Connectors/GoogleSheets/GoogleSheetsActionsTest.php
+++ b/tests/Connectors/GoogleSheets/GoogleSheetsActionsTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Connectors\GoogleSheets;
 
-use Google\Service\Sheets as GoogleSheetsService;
 use Google\Service\Sheets\AddSheetResponse;
 use Google\Service\Sheets\AppendValuesResponse;
+use Google\Service\Sheets as GoogleSheetsService;
 use Google\Service\Sheets\BatchUpdateSpreadsheetRequest;
 use Google\Service\Sheets\BatchUpdateSpreadsheetResponse;
 use Google\Service\Sheets\ClearValuesResponse;

--- a/tests/Connectors/GoogleSheets/GoogleSheetsActionsTest.php
+++ b/tests/Connectors/GoogleSheets/GoogleSheetsActionsTest.php
@@ -6,11 +6,13 @@ namespace Tests\Connectors\GoogleSheets;
 
 use Google\Service\Sheets as GoogleSheetsService;
 use Google\Service\Sheets\AppendValuesResponse;
+use Google\Service\Sheets\ClearValuesResponse;
 use Google\Service\Sheets\Resource\SpreadsheetsValues;
 use Google\Service\Sheets\UpdateValuesResponse;
 use Google\Service\Sheets\ValueRange;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\GoogleSheets\Actions\AppendSheetRowsAction;
+use Kanvas\Connectors\GoogleSheets\Actions\ClearSheetRangeAction;
 use Kanvas\Connectors\GoogleSheets\Actions\ReadSheetRangeAction;
 use Kanvas\Connectors\GoogleSheets\Actions\UpdateSheetRangeAction;
 use Mockery;
@@ -112,5 +114,26 @@ class GoogleSheetsActionsTest extends TestCase
 
         $this->assertSame('Invoices!D5', $result['updated_range']);
         $this->assertSame(1, $result['updated_cells']);
+    }
+
+    public function test_clear_sheet_range_wipes_the_target_range_without_deleting_it(): void
+    {
+        $valuesResource = Mockery::mock(SpreadsheetsValues::class);
+        $valuesResource->shouldReceive('clear')
+            ->once()
+            ->with('SHEET_ID', 'Invoices!A5:D5', Mockery::type('Google\Service\Sheets\ClearValuesRequest'))
+            ->andReturn(new ClearValuesResponse(['clearedRange' => 'Invoices!A5:D5']));
+
+        $service = Mockery::mock(GoogleSheetsService::class);
+        $service->spreadsheets_values = $valuesResource;
+
+        $result = new ClearSheetRangeAction(
+            app: app(Apps::class),
+            spreadsheetId: 'SHEET_ID',
+            range: 'Invoices!A5:D5',
+            service: $service,
+        )->execute();
+
+        $this->assertSame('Invoices!A5:D5', $result['cleared_range']);
     }
 }

--- a/tests/Connectors/GoogleSheets/GoogleSheetsToolsTest.php
+++ b/tests/Connectors/GoogleSheets/GoogleSheetsToolsTest.php
@@ -9,6 +9,7 @@ use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\AppendGoogleSheetRowsTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ClearGoogleSheetRangeTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\CreateGoogleSheetTabTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ReadGoogleSheetTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\UpdateGoogleSheetCellTool;
 use Tests\TestCase;
@@ -76,6 +77,18 @@ class GoogleSheetsToolsTest extends TestCase
         $result = new ClearGoogleSheetRangeTool()
             ->withContext($app, $company, static::$cachedUser)
             ->__invoke(sheet_url_or_id: 'nope', range: 'Sheet1!A5:D5');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('invalid_sheet_reference', $result['reason']);
+    }
+
+    public function test_create_google_sheet_tab_rejects_a_url_that_is_not_a_sheet(): void
+    {
+        [$app, $company] = $this->context();
+
+        $result = new CreateGoogleSheetTabTool()
+            ->withContext($app, $company, static::$cachedUser)
+            ->__invoke(sheet_url_or_id: 'nope', title: 'Q3 Invoices');
 
         $this->assertFalse($result['success']);
         $this->assertSame('invalid_sheet_reference', $result['reason']);

--- a/tests/Connectors/GoogleSheets/GoogleSheetsToolsTest.php
+++ b/tests/Connectors/GoogleSheets/GoogleSheetsToolsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\GoogleSheets;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\AppendGoogleSheetRowsTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ReadGoogleSheetTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\UpdateGoogleSheetCellTool;
+use Tests\TestCase;
+
+class GoogleSheetsToolsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_read_google_sheet_rejects_a_url_that_is_not_a_sheet(): void
+    {
+        [$app, $company] = $this->context();
+
+        $result = new ReadGoogleSheetTool()
+            ->withContext($app, $company, static::$cachedUser)
+            ->__invoke(sheet_url_or_id: 'https://example.com/not-a-sheet');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('invalid_sheet_reference', $result['reason']);
+    }
+
+    public function test_write_google_sheet_rejects_a_url_that_is_not_a_sheet(): void
+    {
+        [$app, $company] = $this->context();
+
+        $result = new AppendGoogleSheetRowsTool()
+            ->withContext($app, $company, static::$cachedUser)
+            ->__invoke(sheet_url_or_id: 'not-a-sheet-url', range: 'Sheet1!A1', values: [['1']]);
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('invalid_sheet_reference', $result['reason']);
+    }
+
+    public function test_write_google_sheet_requires_at_least_one_row(): void
+    {
+        [$app, $company] = $this->context();
+
+        $result = new AppendGoogleSheetRowsTool()
+            ->withContext($app, $company, static::$cachedUser)
+            ->__invoke(
+                sheet_url_or_id: 'https://docs.google.com/spreadsheets/d/1A_B_C_D_12345/edit',
+                range: 'Sheet1!A1',
+                values: [],
+            );
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('values_required', $result['reason']);
+    }
+
+    public function test_update_google_sheet_cell_rejects_a_url_that_is_not_a_sheet(): void
+    {
+        [$app, $company] = $this->context();
+
+        $result = new UpdateGoogleSheetCellTool()
+            ->withContext($app, $company, static::$cachedUser)
+            ->__invoke(sheet_url_or_id: 'nope', range: 'Sheet1!D5', value: 'Approved');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('invalid_sheet_reference', $result['reason']);
+    }
+
+    /**
+     * @return array{0: Apps, 1: Companies}
+     */
+    private function context(): array
+    {
+        $app = app(Apps::class);
+        $company = static::$cachedUser->getCurrentCompany();
+
+        return [$app, $company];
+    }
+}

--- a/tests/Connectors/GoogleSheets/GoogleSheetsToolsTest.php
+++ b/tests/Connectors/GoogleSheets/GoogleSheetsToolsTest.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\AppendGoogleSheetRowsTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ClearGoogleSheetRangeTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ReadGoogleSheetTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\UpdateGoogleSheetCellTool;
 use Tests\TestCase;
@@ -63,6 +64,18 @@ class GoogleSheetsToolsTest extends TestCase
         $result = new UpdateGoogleSheetCellTool()
             ->withContext($app, $company, static::$cachedUser)
             ->__invoke(sheet_url_or_id: 'nope', range: 'Sheet1!D5', value: 'Approved');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('invalid_sheet_reference', $result['reason']);
+    }
+
+    public function test_clear_google_sheet_range_rejects_a_url_that_is_not_a_sheet(): void
+    {
+        [$app, $company] = $this->context();
+
+        $result = new ClearGoogleSheetRangeTool()
+            ->withContext($app, $company, static::$cachedUser)
+            ->__invoke(sheet_url_or_id: 'nope', range: 'Sheet1!A5:D5');
 
         $this->assertFalse($result['success']);
         $this->assertSame('invalid_sheet_reference', $result['reason']);

--- a/tests/Connectors/GoogleSheets/SpreadsheetUrlParserTest.php
+++ b/tests/Connectors/GoogleSheets/SpreadsheetUrlParserTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\GoogleSheets;
+
+use Kanvas\Connectors\GoogleSheets\Support\SpreadsheetUrlParser;
+use Tests\TestCase;
+
+class SpreadsheetUrlParserTest extends TestCase
+{
+    public function test_extracts_the_id_from_a_full_url_with_a_tab_fragment(): void
+    {
+        $id = SpreadsheetUrlParser::extractId(
+            'https://docs.google.com/spreadsheets/d/1A_B_C_D_12345/edit#gid=0'
+        );
+
+        $this->assertSame('1A_B_C_D_12345', $id);
+    }
+
+    public function test_extracts_the_id_from_a_url_with_no_trailing_path(): void
+    {
+        $id = SpreadsheetUrlParser::extractId('https://docs.google.com/spreadsheets/d/1A_B_C_D_12345');
+
+        $this->assertSame('1A_B_C_D_12345', $id);
+    }
+
+    public function test_accepts_a_bare_spreadsheet_id(): void
+    {
+        $id = SpreadsheetUrlParser::extractId('1A_B_C_D_12345678901234567890');
+
+        $this->assertSame('1A_B_C_D_12345678901234567890', $id);
+    }
+
+    public function test_returns_null_for_an_unrelated_url(): void
+    {
+        $this->assertNull(SpreadsheetUrlParser::extractId('https://example.com/not-a-sheet'));
+    }
+
+    public function test_returns_null_for_a_too_short_bare_string(): void
+    {
+        $this->assertNull(SpreadsheetUrlParser::extractId('short'));
+    }
+}


### PR DESCRIPTION
Task #249 — Build Excel/Google Sheets integration tool for Kanvas agents.

## Summary
- Lets Apex (AP) and Arc (AR) read, append rows to, and update cells on a Google Sheet the user shares a link to (e.g. an invoice tracking list kept outside Kanvas).
- Three tools: `read_google_sheet(sheet_url_or_id, range?)`, `write_google_sheet(sheet_url_or_id, range, values)`, `update_google_sheet_cell(sheet_url_or_id, range, value)`. The spreadsheet id is extracted from the URL via regex — the LLM never has to parse it itself.
- Auth is a Google **service account** (machine identity, not per-user OAuth), configured per Kanvas app via the existing `setAppSetting` custom-fields mechanism (same one already used for Acumatica config) under `google-sheets-credentials`.
- Every sheet an agent touches must be separately shared with the service account's email as Editor — this can't be automated; documented in the connector's [README](src/Domains/Connectors/GoogleSheets/README.md).

## Test plan
- [x] Unit tests: `SpreadsheetUrlParserTest`, `GoogleSheetsActionsTest` (mocked Sheets API service), `ClientTest` (credential-shape handling — array vs raw-JSON-string round-trip from the custom-fields store), `GoogleSheetsToolsTest` (validation paths). 16/16 passing.
- [x] Live-verified against a real Google Sheet with a real service account before opening this PR: read (7 rows), append (new row), update (cell) all confirmed against the live document.