### PR TITLE
Fix null data in create engagement page tool

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/CreateEngagementPageTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/CreateEngagementPageTool.php
@@ -67,12 +67,14 @@ class CreateEngagementPageTool extends Tool
     }
 
     /**
-     * @param array<string, mixed> $data
+     * @param array<string, mixed>|null $data
      *
      * @return array<string, mixed>
      */
-    public function __invoke(int $lead_id, string $action, array $data = []): array
+    public function __invoke(int $lead_id, string $action, ?array $data = null): array
     {
+        $data ??= [];
+
         $action = trim($action);
         if ($action === '') {
             return [

--- a/tests/Intelligence/Agents/Tools/CreateEngagementPageToolTest.php
+++ b/tests/Intelligence/Agents/Tools/CreateEngagementPageToolTest.php
@@ -145,6 +145,47 @@ class CreateEngagementPageToolTest extends TestCase
         $this->assertSame(124, $result['engagement_id']);
     }
 
+    public function testAcceptsNullDataForActionsWithoutPayload(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+        $agent = Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create(['user_id' => $user->getId()]);
+        $lead = Lead::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create();
+        $message = new Message(['message' => ['action_link' => 'https://short.example/credit-app']]);
+        $engagement = new Engagement(['uuid' => '019c166e-c115-7000-8000-000000000003']);
+        $engagement->id = 125;
+        $engagement->setRelation('message', $message);
+
+        $tool = new class ($agent, $engagement) extends CreateEngagementPageTool {
+            public ?EngagementData $receivedData = null;
+
+            public function __construct(Agent $agent, private readonly Engagement $engagementResult)
+            {
+                parent::__construct($agent);
+            }
+
+            protected function createEngagement(EngagementData $data): Engagement
+            {
+                $this->receivedData = $data;
+
+                return $this->engagementResult;
+            }
+        };
+        $tool->withContext($app, $company, $user);
+
+        $result = $tool->__invoke($lead->getId(), 'credit-app', null);
+
+        $this->assertSame('success', $result['status']);
+        $this->assertSame([], $tool->receivedData?->data);
+    }
+
     public function testReportsEngagementCreationFailureWithSafeContext(): void
     {
         $app = app(Apps::class);


### PR DESCRIPTION
## Summary
- accept nullable optional data from Neuron tool dispatch
- normalize null to an empty engagement payload
- add regression coverage for credit-app without data

## Validation
- php -l passed for implementation and test
- git diff --check passed
- PHPUnit could not start locally because installed dependencies require PHP >= 8.5 while the local runtime is PHP 8.4.10