### PR TITLE
fix: calculate LoCompro fees per order

### DIFF
--- a/src/Domains/Connectors/ScrapperApi/Actions/AddCostToCartAction.php
+++ b/src/Domains/Connectors/ScrapperApi/Actions/AddCostToCartAction.php
@@ -57,13 +57,15 @@ class AddCostToCartAction
         }, $this->cart->getContent()->toArray());
 
         $fee = collect($fees);
-        $total = $fee->sum('total');
         $customTaxTotal = $fee->sum('customTax');
-
-        // The pricing strategy treats the per-pound service fee and the merchandise
-        // markup as separate charges. The markup applies to merchandise only.
-        $markUp = $cartSubtotal * 0.15;
-        $total += $markUp;
+        $shippingCost = (float) ($this->app->get(ShippingCostEnum::SHIPPING_HANDLING_FEE->value) ?? 2.50);
+        $airportFee = (float) ($this->app->get(ShippingCostEnum::AIRPORT_FEE->value) ?? 0.07);
+        $customsFee = (float) ($this->app->get(ShippingCostEnum::CUSTOM_SERVICE->value) ?? 0.15);
+        $fuelSurcharge = (float) ($this->app->get(ShippingCostEnum::FUEL->value) ?? 1.02);
+        $insurance = $cartSubtotal > 100 ? $cartSubtotal * 0.016 : 0.0;
+        $otherFees = $airportFee + $customsFee + $fuelSurcharge + $insurance;
+        $serviceFee = (float) ($this->app->get(ShippingCostEnum::SERVICE_FEE->value) ?? 3.50);
+        $total = $shippingCost + $otherFees + $serviceFee;
 
         // Collect detailed tax breakdown
         $customTaxDetails = $fee->where('customTaxInfo.customTax', '>', 0)
@@ -104,10 +106,10 @@ class AddCostToCartAction
             'target' => 'subtotal',
             'value' => '+' . ($total + $customTaxTotal),
             'attributes' => [
-                'Shipping Cost' => $fee->sum('shippingCost'),
-                'Other Fees' => $fee->sum('otherFee'),
-                'Service Fee' => $fee->sum('serviceFee'),
-                'Mark-Up / Comm Rev' => $markUp,
+                'Shipping Cost' => $shippingCost,
+                'Other Fees' => $otherFees,
+                'Service Fee' => $serviceFee,
+                'Insurance Fee' => $insurance,
                 'Pounds' => $fee->sum('pounds'),
                 'Last Mile' => 0,
                 'Custom Tax' => $customTaxTotal,

--- a/src/Domains/Connectors/ScrapperApi/Actions/CalculateShippingCostAction.php
+++ b/src/Domains/Connectors/ScrapperApi/Actions/CalculateShippingCostAction.php
@@ -38,7 +38,6 @@ class CalculateShippingCostAction
         };
         $localTransfer = (float)($this->app->get(ShippingCostEnum::LOCAL_TRANSFER->value) ?? 0.00);
         $paymentFee = (float)($this->app->get(ShippingCostEnum::PAYMENT_FEE->value) ?? 0.029);
-        $serviceFee = (float)($this->app->get(ShippingCostEnum::SERVICE_FEE->value) ?? 1.00);
         $shippingMargin = (float)($this->app->get(ShippingCostEnum::SHIPPING_MARGIN->value) ?? 1.20);
 
         // Calculate
@@ -50,14 +49,12 @@ class CalculateShippingCostAction
 
         $shippingCost = $courierCostWeight * $shippingMargin;
         $otherFee = $costFuel + $customServiceCost + $airportFeeCost + $insuranceCost;
-        $serviceFeeCost = $pounds * $serviceFee;
-        $totalLoCompro = $shippingCost + $otherFee + $serviceFeeCost;
+        $totalLoCompro = $shippingCost + $otherFee;
         $paymentFeeCost = (($linePrice + $totalLoCompro) * $paymentFee) + 3;
 
         return [
             'shippingCost' => $shippingCost,
             'otherFee' => $otherFee,
-            'serviceFee' => $serviceFeeCost,
             'total' => $totalLoCompro,
             'pounds' => $pounds,
             // Freight and insurance are exposed separately because they are the two

--- a/src/Domains/Connectors/ScrapperApi/Enums/ShippingCostEnum.php
+++ b/src/Domains/Connectors/ScrapperApi/Enums/ShippingCostEnum.php
@@ -6,6 +6,7 @@ namespace Kanvas\Connectors\ScrapperApi\Enums;
 
 enum ShippingCostEnum: string
 {
+    case SHIPPING_HANDLING_FEE = 'shipping_handling_fee';
     case DELIVERY_COST_LAST_MILE = 'delivery_cost_last_mile';
     case COURIER_COST = 'courier_cost';
     case FUEL = 'fuel';

--- a/tests/Connectors/ScrapperApi/AddCostToCartActionTest.php
+++ b/tests/Connectors/ScrapperApi/AddCostToCartActionTest.php
@@ -9,7 +9,6 @@ use Illuminate\Session\ArraySessionHandler;
 use Illuminate\Session\Store;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\ScrapperApi\Actions\AddCostToCartAction;
-use Kanvas\Connectors\ScrapperApi\Actions\CalculateShippingCostAction;
 use Kanvas\Connectors\ScrapperApi\Enums\ShippingCostEnum;
 use Kanvas\Inventory\Variants\Models\Variants;
 use Mockery;
@@ -22,25 +21,6 @@ use Wearepixel\Cart\CartCondition;
 class AddCostToCartActionTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
-
-    public function testUsesOneDollarPerPoundAsTheDefaultServiceFee(): void
-    {
-        $app = Mockery::mock(Apps::class)->makePartial();
-        $app->shouldReceive('get')->andReturnNull();
-
-        $variant = Mockery::mock(Variants::class)->makePartial();
-        $variant->shouldReceive('getAttributeByName')
-            ->once()
-            ->andReturn((object) ['value' => 453.59237]);
-        $variant->shouldReceive('getPriceInfoFromDefaultChannel')
-            ->once()
-            ->andReturn((object) ['price' => 50.0]);
-
-        $cost = new CalculateShippingCostAction($app, $variant, 2)->execute();
-
-        $this->assertSame(2.0, $cost['pounds']);
-        $this->assertSame(2.0, $cost['serviceFee']);
-    }
 
     public function testAggregatesShippingAndOfficialTaxesForACartOverTwoHundredDollars(): void
     {
@@ -105,11 +85,12 @@ class AddCostToCartActionTest extends TestCase
         $shipping = $cart->getCondition('Shipping');
         $attributes = $shipping->getAttributes();
 
-        $this->assertSame('+147.5', $shipping->getValue());
+        $this->assertSame('+82.84', $shipping->getValue());
         $this->assertSame(70.0, $attributes['Custom Tax']);
-        $this->assertSame(15.0, $attributes['Shipping Cost']);
-        $this->assertSame(6.0, $attributes['Service Fee']);
-        $this->assertSame(52.5, $attributes['Mark-Up / Comm Rev']);
+        $this->assertSame(2.5, $attributes['Shipping Cost']);
+        $this->assertSame(3.5, $attributes['Service Fee']);
+        $this->assertEqualsWithDelta(5.6, $attributes['Insurance Fee'], 0.000001);
+        $this->assertArrayNotHasKey('Mark-Up / Comm Rev', $attributes);
         $this->assertSame(0.0, $attributes['Tax Breakdown']['Total Tasa Aduanal']);
         $this->assertCount(2, $attributes['Custom Tax Details']);
     }
@@ -153,10 +134,11 @@ class AddCostToCartActionTest extends TestCase
         $shipping = $cart->getCondition('Shipping');
         $attributes = $shipping->getAttributes();
 
-        $this->assertSame('+45', $shipping->getValue());
+        $this->assertSame('+10.44', $shipping->getValue());
         $this->assertSame(0, $attributes['Custom Tax']);
         $this->assertSame([], $attributes['Custom Tax Details']);
-        $this->assertSame(30.0, $attributes['Mark-Up / Comm Rev']);
+        $this->assertSame(3.5, $attributes['Service Fee']);
+        $this->assertSame(3.2, $attributes['Insurance Fee']);
     }
 
     public function testIgnoresExistingShippingConditionWhenEvaluatingTaxThreshold(): void
@@ -207,18 +189,19 @@ class AddCostToCartActionTest extends TestCase
         $shipping = $cart->getCondition('Shipping');
         $attributes = $shipping->getAttributes();
 
-        $this->assertSame('+30', $shipping->getValue());
+        $this->assertSame('+7.24', $shipping->getValue());
         $this->assertSame(0, $attributes['Custom Tax']);
         $this->assertSame([], $attributes['Custom Tax Details']);
-        $this->assertSame(15.0, $attributes['Mark-Up / Comm Rev']);
+        $this->assertSame(3.5, $attributes['Service Fee']);
+        $this->assertSame(0.0, $attributes['Insurance Fee']);
     }
 
     private function enabledApp(): Apps
     {
         $app = Mockery::mock(Apps::class)->makePartial();
-        $app->shouldReceive('get')
-            ->with(ShippingCostEnum::LOCOMPRO_COST->value)
-            ->andReturn(true);
+        $app->shouldReceive('get')->andReturnUsing(
+            fn (string $key): mixed => $key === ShippingCostEnum::LOCOMPRO_COST->value ? true : null,
+        );
 
         return $app;
     }


### PR DESCRIPTION
## Summary
- remove the obsolete 15% merchandise markup from the cart
- charge a USD 3.50 service fee once per order
- calculate shipping from the fixed handling, airport, customs, and fuel components
- add 1.60% insurance only when the products subtotal is greater than USD 100
- keep the existing official customs-tax calculation unchanged
- expose every charged amount through attributes consumed by the LoCompro frontend

## Formula

    shipping = 2.50 + 0.07 + 0.15 + 1.02
             + (products subtotal > 100 ? products subtotal * 1.60% : 0)
    service fee = 3.50 per order

## Validation
- PHP syntax checks passed for all changed files
- git diff --check passed
- tests cover multiple products, the USD 100 insurance boundary, the USD 200 customs-tax boundary, and stale shipping conditions
- PHPUnit could not run locally because dependencies require PHP >= 8.5 while the available runtime is PHP 8.4.10
