### PR TITLE
fix(event): reject bookings on time slots that already started

### DIFF
--- a/app/GraphQL/Event/Mutations/Booking/TimeSlotBookingMutation.php
+++ b/app/GraphQL/Event/Mutations/Booking/TimeSlotBookingMutation.php
@@ -34,6 +34,10 @@ class TimeSlotBookingMutation
             ->fromCompany($company)
             ->findOrFail($input['time_slot_id']);
 
+        if ($timeSlot->hasStarted()) {
+            throw new ValidationException('This time slot has already started and can no longer be booked. Slot start: ' . $timeSlot->start_at->toDateTimeString());
+        }
+
         // Validate capacity before booking
         $participantCount = count($input['participants'] ?? []);
         if (! $timeSlot->hasAvailableCapacity($participantCount)) {
@@ -112,6 +116,10 @@ class TimeSlotBookingMutation
         $newTimeSlot = TimeSlots::fromApp($app)
             ->fromCompany($company)
             ->findOrFail($input['new_time_slot_id']);
+
+        if ($newTimeSlot->hasStarted()) {
+            throw new ValidationException('This time slot has already started and can no longer be booked. Slot start: ' . $newTimeSlot->start_at->toDateTimeString());
+        }
 
         // Validate capacity for the new time slot
         $participantCount = count($input['participants'] ?? $eventVersion->participants ?? []);

--- a/src/Domains/Event/Events/Models/TimeSlots.php
+++ b/src/Domains/Event/Events/Models/TimeSlots.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Event\Events\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
@@ -62,6 +63,20 @@ class TimeSlots extends BaseModel
     public function isStandalone(): bool
     {
         return $this->schedule_rules_id === null;
+    }
+
+    /**
+     * A slot stops being bookable the moment it starts. Booking a started slot used to be
+     * allowed and only blew up later in CreatePassAction — after the customer had paid.
+     */
+    public function hasStarted(): bool
+    {
+        return $this->start_at !== null && $this->start_at->isPast();
+    }
+
+    public function scopeUpcoming(Builder $query): Builder
+    {
+        return $query->where('start_at', '>', now());
     }
 
     /**

--- a/tests/Event/Integration/TimeSlotBookingTimeValidationTest.php
+++ b/tests/Event/Integration/TimeSlotBookingTimeValidationTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Event\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Notification;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Event\Events\Models\EventCategory;
+use Kanvas\Event\Events\Models\EventType;
+use Kanvas\Event\Events\Models\EventVersion;
+use Kanvas\Event\Events\Models\TimeSlots;
+use Kanvas\Event\Support\Setup;
+use Kanvas\Inventory\Products\Models\Products;
+use Kanvas\Inventory\Variants\Models\Variants;
+use Kanvas\Regions\Models\Regions;
+use Tests\GraphQL\Inventory\Traits\InventoryCases;
+use Tests\TestCase;
+
+/**
+ * Regression: bookTimeSlot only validated capacity, so a slot that had already started (or
+ * finished) could be reserved and paid for. The failure only surfaced afterwards in
+ * CreatePassAction — "Cannot issue a pass for an event that has already finished." — by which
+ * point the customer had been charged.
+ */
+class TimeSlotBookingTimeValidationTest extends TestCase
+{
+    use InventoryCases;
+    use DatabaseTransactions;
+
+    protected $apps;
+    protected $user;
+    protected $company;
+    protected $region;
+    protected Variants $variant;
+
+    protected function connectionsToTransact(): array
+    {
+        return [null, 'event'];
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Notification::fake();
+
+        $this->apps = app(Apps::class);
+        $this->user = Auth::user();
+        $this->company = $this->user->getCurrentCompany();
+        $this->region = Regions::getDefault($this->company, $this->apps);
+
+        $warehouseResponse = $this->createWarehouses((string) $this->region->getId())->json()['data']['createWarehouse'];
+        $channelResponse = $this->createChannel()->json()['data']['createChannel'];
+        $productResponse = $this->createProduct()->json()['data']['createProduct'];
+
+        $this->variant = Products::find($productResponse['id'])->variants()->first();
+
+        $this->addVariantToChannel(
+            variantId: (string) $this->variant->getId(),
+            channelId: $channelResponse['id'],
+            warehouseData: ['id' => $warehouseResponse['id']]
+        );
+
+        $this->addVariantToWarehouse(
+            variantId: (string) $this->variant->getId(),
+            warehouseId: (string) $warehouseResponse['id'],
+            amount: 10
+        );
+
+        $this->company->timezone = 'UTC';
+        $this->company->saveOrFail();
+
+        new Setup($this->apps, $this->user, $this->company)->run();
+    }
+
+    public function testBookingATimeSlotThatAlreadyFinishedIsRejected(): void
+    {
+        $timeSlot = $this->makeTimeSlot(
+            Carbon::now()->subHours(3),
+            Carbon::now()->subHours(2)
+        );
+
+        $response = $this->bookTimeSlot($timeSlot);
+
+        $this->assertStringContainsString(
+            'already started',
+            (string) $response->json('errors.0.message')
+        );
+
+        $this->assertSame(0, EventVersion::where('time_slot_id', $timeSlot->id)->count());
+    }
+
+    /**
+     * The expensive case: the slot is still running, so nothing downstream complains until the
+     * pass is issued after payment.
+     */
+    public function testBookingATimeSlotAlreadyInProgressIsRejected(): void
+    {
+        $timeSlot = $this->makeTimeSlot(
+            Carbon::now()->subMinutes(10),
+            Carbon::now()->addMinutes(50)
+        );
+
+        $response = $this->bookTimeSlot($timeSlot);
+
+        $this->assertStringContainsString(
+            'already started',
+            (string) $response->json('errors.0.message')
+        );
+
+        $this->assertSame(0, EventVersion::where('time_slot_id', $timeSlot->id)->count());
+    }
+
+    public function testBookingAnUpcomingTimeSlotStillSucceeds(): void
+    {
+        $timeSlot = $this->makeTimeSlot(
+            Carbon::now()->addDay(),
+            Carbon::now()->addDay()->addHour()
+        );
+
+        $response = $this->bookTimeSlot($timeSlot);
+
+        $this->assertNull($response->json('errors'), json_encode($response->json('errors')));
+        $this->assertNotNull($response->json('data.bookTimeSlot.id'));
+    }
+
+    public function testMovingABookingToATimeSlotThatAlreadyStartedIsRejected(): void
+    {
+        $upcoming = $this->makeTimeSlot(
+            Carbon::now()->addDay(),
+            Carbon::now()->addDay()->addHour()
+        );
+
+        $eventVersionId = $this->bookTimeSlot($upcoming)->json('data.bookTimeSlot.id');
+        $this->assertNotNull($eventVersionId);
+
+        $started = $this->makeTimeSlot(
+            Carbon::now()->subMinutes(10),
+            Carbon::now()->addMinutes(50)
+        );
+
+        $response = $this->graphQL('
+            mutation updateTimeSlotBooking($input: TimeSlotBookingUpdateInput!) {
+                updateTimeSlotBooking(input: $input) { id }
+            }
+        ', [
+            'input' => [
+                'event_version_id' => (string) $eventVersionId,
+                'new_time_slot_id' => (string) $started->id,
+            ],
+        ], [], $this->bookingHeaders());
+
+        $this->assertStringContainsString(
+            'already started',
+            (string) $response->json('errors.0.message')
+        );
+
+        $this->assertEquals(
+            $upcoming->id,
+            EventVersion::findOrFail($eventVersionId)->time_slot_id
+        );
+    }
+
+    private function makeTimeSlot(Carbon $startAt, Carbon $endAt): TimeSlots
+    {
+        return TimeSlots::create([
+            'apps_id' => $this->apps->getId(),
+            'companies_id' => $this->company->getId(),
+            'resources_id' => $this->variant->getId(),
+            'resources_type' => $this->variant->getMorphClass(),
+            'start_at' => $startAt,
+            'end_at' => $endAt,
+            'initial_capacity' => 5,
+            'status' => 'open',
+        ]);
+    }
+
+    private function bookTimeSlot(TimeSlots $timeSlot)
+    {
+        return $this->graphQL('
+            mutation bookTimeSlot($input: TimeSlotBookingInput!) {
+                bookTimeSlot(input: $input) { id }
+            }
+        ', [
+            'input' => [
+                'time_slot_id' => (string) $timeSlot->id,
+                'event_name' => 'Time validation booking ' . uniqid(),
+                'participants' => [
+                    [
+                        'firstname' => 'John',
+                        'lastname' => 'Doe',
+                        'contacts' => [
+                            ['contacts_types_id' => 1, 'value' => 'john.slot@example.com', 'weight' => 1],
+                        ],
+                    ],
+                ],
+                'metadata' => [
+                    'category_id' => EventCategory::fromCompany($this->company)->fromApp($this->apps)->first()->getId(),
+                    'type_id' => EventType::fromCompany($this->company)->fromApp($this->apps)->first()->getId(),
+                ],
+            ],
+        ], [], $this->bookingHeaders());
+    }
+
+    private function bookingHeaders(): array
+    {
+        return [
+            'X-Kanvas-Location' => $this->company->branch->uuid,
+            'X-Kanvas-App' => $this->apps->key,
+        ];
+    }
+}


### PR DESCRIPTION
bookTimeSlot only validated capacity, so a slot whose start_at had passed could be reserved and paid for. The failure surfaced later in CreatePassAction ("Cannot issue a pass for an event that has already finished"), after the customer had been charged.

Add TimeSlots::hasStarted() and guard both book() and updateTimeSlotBooking() with it before the capacity check.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
