### PR TITLE
fix: retry calendar events without unsupported Meet

### DIFF
--- a/src/Domains/Connectors/Google/Actions/CreateGoogleCalendarMeetingAction.php
+++ b/src/Domains/Connectors/Google/Actions/CreateGoogleCalendarMeetingAction.php
@@ -83,7 +83,17 @@ class CreateGoogleCalendarMeetingAction
             $event->setId($this->externalEventId);
         }
 
-        $saved = $this->insertEvent($service, $calendarId, $event);
+        try {
+            $saved = $this->insertEvent($service, $calendarId, $event);
+        } catch (Throwable $exception) {
+            if (! $this->shouldRetryWithoutMeet($exception)) {
+                throw $exception;
+            }
+
+            $this->withMeetLink = false;
+            $event->setConferenceData(null);
+            $saved = $this->insertEvent($service, $calendarId, $event);
+        }
 
         return $this->formatResult($saved, $calendarId, $emails);
     }
@@ -200,6 +210,12 @@ class CreateGoogleCalendarMeetingAction
         } catch (Throwable $exception) {
             throw new RuntimeException('Google Calendar event creation failed: ' . $exception->getMessage(), 0, $exception);
         }
+    }
+
+    protected function shouldRetryWithoutMeet(Throwable $exception): bool
+    {
+        return $this->withMeetLink
+            && str_contains(strtolower($exception->getMessage()), 'invalid conference type');
     }
 
     protected function findEvent(Calendar $service, string $calendarId, string $eventId): Event

--- a/tests/Connectors/Google/CreateGoogleCalendarMeetingActionTest.php
+++ b/tests/Connectors/Google/CreateGoogleCalendarMeetingActionTest.php
@@ -63,4 +63,57 @@ class CreateGoogleCalendarMeetingActionTest extends TestCase
         $this->assertNotNull($action->insertedEvent?->getConferenceData()?->getCreateRequest());
         $this->assertCount(2, $action->insertedEvent?->getAttendees() ?? []);
     }
+
+    public function testItRetriesWithoutMeetWhenTheCalendarRejectsTheConferenceType(): void
+    {
+        $company = auth()->user()->getCurrentCompany();
+        $company->set(ConfigurationEnum::GOOGLE_CALENDAR_CONFIG->value, [
+            'calendar_id' => 'calendar@example.com',
+            'auth_profiles' => [
+                'service_account' => [
+                    'credentials_json' => ['type' => 'service_account'],
+                ],
+            ],
+        ]);
+
+        $action = new class (
+            company: $company,
+            name: 'Dealership Visit',
+            attendeeEmails: ['lead@example.com'],
+            startDateTime: Carbon::parse('2026-08-13 10:00', 'America/New_York'),
+            endDateTime: Carbon::parse('2026-08-13 10:30', 'America/New_York'),
+        ) extends CreateGoogleCalendarMeetingAction {
+            public int $attempts = 0;
+            public ?Event $insertedEvent = null;
+
+            protected function createCalendarService(array $config): Calendar
+            {
+                return new Calendar(new Client());
+            }
+
+            protected function insertEvent(Calendar $service, string $calendarId, Event $event): Event
+            {
+                $this->attempts++;
+                if ($this->attempts === 1) {
+                    throw new \RuntimeException('Google Calendar event creation failed: Invalid conference type value.');
+                }
+
+                $this->insertedEvent = $event;
+
+                return new Event([
+                    'id' => 'google-event-without-meet',
+                    'summary' => $event->getSummary(),
+                    'htmlLink' => 'https://calendar.google.com/event?id=without-meet',
+                ]);
+            }
+        };
+
+        $result = $action->execute();
+
+        $this->assertSame(2, $action->attempts);
+        $this->assertSame('google-event-without-meet', $result['id']);
+        $this->assertNull($result['meet_link']);
+        $this->assertNull($action->insertedEvent?->getConferenceData());
+        $this->assertSame(['lead@example.com'], $result['attendees']);
+    }
 }


### PR DESCRIPTION
## Summary
- retry Google Calendar event creation without conference data when the calendar rejects the Meet conference type
- preserve attendees and calendar event creation
- add regression coverage for the fallback

## Validation
- PHP syntax checks
- git diff --check