### PR TITLE
feat(voice): per-agent telephony number with company fallback

### DIFF
--- a/src/Domains/Intelligence/Agents/Services/VoiceAgentSpecService.php
+++ b/src/Domains/Intelligence/Agents/Services/VoiceAgentSpecService.php
@@ -17,8 +17,9 @@ use Kanvas\Intelligence\Enums\ConfigurationEnum;
  * This is the read-only config-plane compilation: it assembles the same system
  * prompt the in-process NeuronAI agent uses (soul → instructions →
  * output_format, with AgentType fallback — see Agents\Types\BaseAgent), the
- * resolved model name, the per-agent voice_config, and the company's telephony
- * number. It never returns credentials — Twilio secrets stay out of this payload.
+ * resolved model name, the per-agent voice_config, and the agent's telephony
+ * number (per-agent, falling back to the company). It never returns credentials
+ * — Twilio secrets stay out of this payload.
  */
 class VoiceAgentSpecService
 {
@@ -125,24 +126,35 @@ class VoiceAgentSpecService
     }
 
     /**
-     * The dealership's outbound caller-id number, read from company settings.
+     * The outbound caller-id number for this agent. Preference order:
+     *   1. the per-agent number set in voice_config.phone_number (admin UI)
+     *   2. the owning company's Twilio from-number setting
+     *   3. the company's `phone` column
      * Credentials (account sid / auth token) are deliberately NOT included here.
      *
      * @return array<string, mixed>
      */
     private function telephony(): array
     {
+        // A number configured on the agent itself wins over the company default,
+        // so each agent can have its own caller id. Blank/unset falls through.
+        $voice = $this->agent->voice_config ?? [];
+        $agentNumber = $voice['phone_number'] ?? null;
+
         // Load the owning company defensively — find() returns null instead of
         // throwing on a missing/invalid companies_id, so a telephony problem can
-        // never 503 the whole spec fetch. Prefer the configured Twilio
-        // from-number setting; fall back to the company's `phone` column.
+        // never 503 the whole spec fetch.
         $company = $this->agent->companies_id > 0
             ? Companies::find($this->agent->companies_id)
             : null;
 
+        $fromNumber = ($agentNumber !== null && $agentNumber !== '')
+            ? $agentNumber
+            : ($company?->get(TwilioConfigurationEnum::TWILIO_FROM_PHONE_NUMBER->value)
+                ?? $company?->phone);
+
         return [
-            'from_number' => $company?->get(TwilioConfigurationEnum::TWILIO_FROM_PHONE_NUMBER->value)
-                ?? $company?->phone,
+            'from_number' => $fromNumber,
         ];
     }
 


### PR DESCRIPTION
## What
The voice agent spec's `telephony.from_number` now prefers a number configured **per agent** (`voice_config.phone_number`, set from the admin UI Voice tab), falling back to the company's Twilio from-number setting and then the company's `phone` column.

Preference order:
1. `agent.voice_config.phone_number` (new — per agent)
2. company `TWILIO_FROM_PHONE_NUMBER` setting
3. company `phone` column

## Why
Each agent can now have its own outbound caller ID instead of all agents in a company sharing one number.

## Notes
- Non-breaking: agents without a configured number keep using the company number exactly as before.
- No credentials are added to the payload (Twilio secrets stay out of the spec).
- Pairs with the admin UI Voice-tab phone field (kanvas-core-admin-v2 PR #943).

🤖 Generated with [Claude Code](https://claude.com/claude-code)