### PR TITLE
hotfix: fix Gemini 400 crash from write_google_sheet's array parameter

### DIFF
--- a/src/Domains/Connectors/GoogleSheets/CLAUDE.md
+++ b/src/Domains/Connectors/GoogleSheets/CLAUDE.md
@@ -8,7 +8,7 @@ shares a link to — e.g. an invoice tracking list a team keeps outside Kanvas.
 | Tool | Purpose |
 |---|---|
 | `read_google_sheet(sheet_url_or_id, range?)` | Reads rows/columns. `range` defaults to `A:Z` on the first sheet. |
-| `write_google_sheet(sheet_url_or_id, range, values)` | Appends one or more new rows after the last row of data — never overwrites. |
+| `write_google_sheet(sheet_url_or_id, range, values)` | Appends one or more new rows after the last row of data — never overwrites. `values` is a JSON-encoded string (e.g. `'[["1498","Vendor",250.00,"Pending"]]'`), not a native array — see note below. |
 | `update_google_sheet_cell(sheet_url_or_id, range, value)` | Overwrites a specific cell in place, e.g. flipping a status column to "Approved". |
 | `clear_google_sheet_range(sheet_url_or_id, range)` | Wipes the values in a cell/row/range without deleting the row itself — the safe alternative to a structural delete. |
 | `create_google_sheet_tab(sheet_url_or_id, title)` | Adds a brand-new sheet/tab to the document, without touching any existing tab. |
@@ -17,6 +17,15 @@ All five accept either a full Sheets URL or a bare spreadsheet id — the id is 
 regex (`SpreadsheetUrlParser::extractId()`), never asked of the LLM directly. `write_google_sheet`
 and `update_google_sheet_cell` also accept live formulas (e.g. `"=SUM(C2:C10)"`) as cell values —
 `valueInputOption: USER_ENTERED` interprets them exactly as if typed by hand.
+
+**Why `values` is a JSON string, not `PropertyType::ARRAY`:** NeuronAI's `ToolProperty::getJsonSchema()`
+never emits an `items` sub-schema for array-type parameters. Gemini's function-calling schema
+validation requires `items` on any `array`-typed parameter and rejects the whole request with a
+`400 GenerateContentRequest.tools[...].parameters...` error otherwise — and since Gemini validates
+every tool in the array together, one bad array-typed property breaks every tool call on that
+agent, not just this one. `write_google_sheet` sidesteps it by declaring `values` as `STRING` and
+`json_decode()`-ing it in `__invoke()`. Do the same for any future tool parameter that would
+naturally be an array/object, until NeuronAI adds `items`/`properties` sub-schema support.
 
 ## Configuration
 

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/AppendGoogleSheetRowsTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/GoogleSheets/AppendGoogleSheetRowsTool.php
@@ -54,22 +54,21 @@ class AppendGoogleSheetRowsTool extends Tool
             ),
             new ToolProperty(
                 name: 'values',
-                type: PropertyType::ARRAY,
-                description: 'Array of rows to append, each row itself an array of cell values in column order, '
-                    . 'e.g. [["1498", "Windwalk Games Corp", 250.00, "Pending"]]. At least one row is required. '
-                    . 'A cell value starting with "=" is entered as a live formula (e.g. "=SUM(C2:C10)"), exactly '
-                    . 'as if typed into the sheet by hand — not stored as plain text.',
+                type: PropertyType::STRING,
+                description: 'A JSON-encoded array of rows to append, each row itself an array of cell values in '
+                    . 'column order, e.g. \'[["1498", "Windwalk Games Corp", 250.00, "Pending"]]\'. Encode it as a '
+                    . 'JSON string, not a native array — this tool decodes it internally. At least one row is '
+                    . 'required. A cell value starting with "=" is entered as a live formula (e.g. "=SUM(C2:C10)"), '
+                    . 'exactly as if typed into the sheet by hand — not stored as plain text.',
                 required: true,
             ),
         ];
     }
 
     /**
-     * @param array<int, array<int, mixed>> $values
-     *
      * @return array<string, mixed>
      */
-    public function __invoke(string $sheet_url_or_id, string $range, array $values): array
+    public function __invoke(string $sheet_url_or_id, string $range, string $values): array
     {
         $spreadsheetId = $this->resolveSpreadsheetId($sheet_url_or_id);
 
@@ -77,16 +76,19 @@ class AppendGoogleSheetRowsTool extends Tool
             return ['success' => false, ...$spreadsheetId];
         }
 
-        if ($values === []) {
+        $decodedValues = json_decode($values, true);
+
+        if (! is_array($decodedValues) || $decodedValues === []) {
             return [
                 'success' => false,
                 'reason' => 'values_required',
-                'message' => 'At least one row (an array of cell values) is required.',
+                'message' => 'values must be a JSON-encoded array with at least one row, e.g. '
+                    . '\'[["1498", "Windwalk Games Corp", 250.00, "Pending"]]\'.',
             ];
         }
 
         try {
-            $result = new AppendSheetRowsAction($this->app, $spreadsheetId, $range, $values)->execute();
+            $result = new AppendSheetRowsAction($this->app, $spreadsheetId, $range, $decodedValues)->execute();
         } catch (Throwable $e) {
             return [
                 'success' => false,

--- a/tests/Connectors/GoogleSheets/GoogleSheetsToolsTest.php
+++ b/tests/Connectors/GoogleSheets/GoogleSheetsToolsTest.php
@@ -36,7 +36,7 @@ class GoogleSheetsToolsTest extends TestCase
 
         $result = new AppendGoogleSheetRowsTool()
             ->withContext($app, $company, static::$cachedUser)
-            ->__invoke(sheet_url_or_id: 'not-a-sheet-url', range: 'Sheet1!A1', values: [['1']]);
+            ->__invoke(sheet_url_or_id: 'not-a-sheet-url', range: 'Sheet1!A1', values: '[["1"]]');
 
         $this->assertFalse($result['success']);
         $this->assertSame('invalid_sheet_reference', $result['reason']);
@@ -51,7 +51,23 @@ class GoogleSheetsToolsTest extends TestCase
             ->__invoke(
                 sheet_url_or_id: 'https://docs.google.com/spreadsheets/d/1A_B_C_D_12345/edit',
                 range: 'Sheet1!A1',
-                values: [],
+                values: '[]',
+            );
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('values_required', $result['reason']);
+    }
+
+    public function test_write_google_sheet_rejects_a_non_json_values_string(): void
+    {
+        [$app, $company] = $this->context();
+
+        $result = new AppendGoogleSheetRowsTool()
+            ->withContext($app, $company, static::$cachedUser)
+            ->__invoke(
+                sheet_url_or_id: 'https://docs.google.com/spreadsheets/d/1A_B_C_D_12345/edit',
+                range: 'Sheet1!A1',
+                values: 'not json',
             );
 
         $this->assertFalse($result['success']);


### PR DESCRIPTION
## Summary
**Production incident** — Apex (AP agent, Gemini-backed) fails EVERY chat message with a generic "hiccup processing that" fallback. Real error underneath: `400 Bad Request` from `generativelanguage.googleapis.com` — `GenerateContentRequest.tools[0].function_declarations[N].parameters...`.

**Root cause:** NeuronAI's `ToolProperty::getJsonSchema()` never emits an `items` sub-schema for `PropertyType::ARRAY`. Gemini's function-calling schema validation rejects the *entire* tools array when any one declaration is malformed — so `write_google_sheet`'s `values` (declared as `ARRAY`) broke every tool call on the whole agent, not just that tool.

**Fix:** `values` is now `STRING` (JSON-encoded), decoded with `json_decode()` inside `__invoke()` — sidesteps the framework limitation without touching vendor code.

**Also flagged, not fixed here:** `CreateArCreditMemoTool`, `ExportRecordsTool`, `CreateEngagementPageTool`, `CreatePersonTool`, `SetPersonCustomFieldsTool` have the same `ARRAY`/`OBJECT`-typed-parameter issue and will break the same way on any Gemini-backed agent using them — separate follow-up.

## Test plan
- [x] `tests/Connectors/GoogleSheets/` — 22/22 passing, including new/updated tests for the JSON-string `values` param
- [ ] Live verification on the real production AP agent once merged/deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)