### PR TITLE
feat(voice): sendVoiceAgentTestCall mutation (Test call button backend)

### DIFF
--- a/app/GraphQL/Intelligence/Mutations/VoiceAgentCallMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/VoiceAgentCallMutation.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Intelligence\Mutations;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Intelligence\Agents\Actions\PlaceVoiceTestCallAction;
+use Kanvas\Intelligence\Agents\Models\Agent;
+
+/**
+ * User-guarded mutation (admin UI) that triggers a one-off TEST call for an
+ * agent through the external voice runtime. Company-scoped: the agent must
+ * belong to the caller's current company.
+ */
+class VoiceAgentCallMutation
+{
+    /**
+     * @param array{id: int|string, to_number: string} $args
+     *
+     * @return array<string, mixed>
+     */
+    public function placeTestCall(mixed $root, array $args): array
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+        $agent = Agent::getByIdFromCompanyApp((int) $args['id'], $company, $app);
+
+        return new PlaceVoiceTestCallAction($agent, $app, $company, (string) $args['to_number'])->execute();
+    }
+}

--- a/app/GraphQL/Intelligence/Mutations/VoiceAgentCallMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/VoiceAgentCallMutation.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\GraphQL\Intelligence\Mutations;
 
 use Kanvas\Apps\Models\Apps;
-use Kanvas\Intelligence\Agents\Actions\PlaceVoiceTestCallAction;
+use Kanvas\Intelligence\Agents\Actions\Voice\PlaceVoiceTestCallAction;
 use Kanvas\Intelligence\Agents\Models\Agent;
 
 /**

--- a/graphql/schemas/Intelligence/voiceAgent.graphql
+++ b/graphql/schemas/Intelligence/voiceAgent.graphql
@@ -58,3 +58,19 @@ extend type Query @guardByAppKey {
             resolver: "App\\GraphQL\\Intelligence\\Queries\\Agent\\VoiceAgentSpecQuery"
         )
 }
+
+type VoiceAgentCallResult {
+    call_id: String
+    twilio_sid: String
+    status: String
+    to: String
+    tenant_id: String
+}
+
+extend type Mutation @guard {
+    "Place a one-off test call for an agent via the external voice runtime."
+    sendVoiceAgentTestCall(id: ID!, to_number: String!): VoiceAgentCallResult!
+        @field(
+            resolver: "App\\GraphQL\\Intelligence\\Mutations\\VoiceAgentCallMutation@placeTestCall"
+        )
+}

--- a/src/Domains/Intelligence/Agents/Actions/PlaceVoiceTestCallAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/PlaceVoiceTestCallAction.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Actions;
+
+use Baka\Contracts\AppInterface;
+use Baka\Contracts\CompanyInterface;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Enums\ConfigurationEnum;
+use Throwable;
+
+use function Sentry\captureException;
+
+/**
+ * Place a one-off TEST outbound call for an agent through the external voice
+ * runtime (Pipecat / Cloud Run). This is the config-plane trigger behind the
+ * admin UI's "Test call" button: it POSTs to the runtime's `POST /outbound`,
+ * which dials the number and streams the answered call to this agent. The agent
+ * speaks with its own voice config and dials FROM its own number
+ * (voice_config.phone_number → the spec's telephony.from_number).
+ *
+ * The runtime endpoint + bearer token are per-app settings:
+ *   ConfigurationEnum::VOICE_RUNTIME_URL        → the runtime base URL
+ *   ConfigurationEnum::VOICE_RUNTIME_API_TOKEN  → the runtime's RUNTIME_API_TOKEN
+ * so a company can point at its own runtime without a code change.
+ */
+class PlaceVoiceTestCallAction
+{
+    // E.164: leading +, first digit 1-9, up to 15 digits total.
+    private const E164 = '/^\+[1-9]\d{6,14}$/';
+
+    public function __construct(
+        private readonly Agent $agent,
+        private readonly AppInterface $app,
+        private readonly CompanyInterface $company,
+        private readonly string $toNumber,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed> the runtime's call record (call_id, twilio_sid,
+     *                              status, to, tenant_id)
+     */
+    public function execute(): array
+    {
+        if (! preg_match(self::E164, $this->toNumber)) {
+            throw new ValidationException(
+                "The number to call must be in E.164 format, e.g. +15551234567 (got '{$this->toNumber}')."
+            );
+        }
+
+        $url = trim((string) $this->app->get(ConfigurationEnum::VOICE_RUNTIME_URL->value));
+        $token = trim((string) $this->app->get(ConfigurationEnum::VOICE_RUNTIME_API_TOKEN->value));
+
+        if ($url === '' || $token === '') {
+            throw new ValidationException(
+                'The voice runtime is not configured for this app. Set the "' .
+                ConfigurationEnum::VOICE_RUNTIME_URL->value . '" and "' .
+                ConfigurationEnum::VOICE_RUNTIME_API_TOKEN->value . '" app settings.'
+            );
+        }
+
+        try {
+            $response = Http::withToken($token)
+                ->acceptJson()
+                ->timeout(20)
+                ->post(rtrim($url, '/') . '/outbound', [
+                    'to' => $this->toNumber,
+                    // The runtime requires a tenant id; the company uuid keeps the
+                    // call attributable without leaking internal ids.
+                    'tenant_id' => $this->company->uuid,
+                    'run_spec' => [
+                        'agent_id' => $this->agent->uuid,
+                    ],
+                ]);
+        } catch (Throwable $e) {
+            // Network / DNS / timeout reaching the runtime — track it, surface calm copy.
+            captureException($e);
+
+            throw new ValidationException('Could not reach the voice runtime: ' . $e->getMessage());
+        }
+
+        if ($response->failed()) {
+            // Surface the runtime's own error detail (FastAPI sends `detail`).
+            $detail = $response->json('detail') ?? $response->body();
+            $detail = is_array($detail) ? json_encode($detail) : (string) $detail;
+
+            throw new ValidationException(
+                "The voice runtime rejected the call (HTTP {$response->status()}): {$detail}"
+            );
+        }
+
+        return $response->json() ?? [];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Actions/Voice/PlaceVoiceTestCallAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/PlaceVoiceTestCallAction.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Kanvas\Intelligence\Agents\Actions;
+namespace Kanvas\Intelligence\Agents\Actions\Voice;
 
 use Baka\Contracts\AppInterface;
 use Baka\Contracts\CompanyInterface;

--- a/src/Domains/Intelligence/Enums/ConfigurationEnum.php
+++ b/src/Domains/Intelligence/Enums/ConfigurationEnum.php
@@ -17,6 +17,10 @@ enum ConfigurationEnum: string
     case OPEN_AI_EMBEDDINGS_MODEL = 'kanvas-intelligence-openai-embeddings-model';
     case PINECONE_API_KEY = 'kanvas-intelligence-pinecone-api-key';
     case PINECONE_INDEX_URL = 'kanvas-intelligence-pinecone-index-url';
+    // External voice runtime (Pipecat / Cloud Run): base URL + the runtime's
+    // RUNTIME_API_TOKEN, used to trigger outbound/test calls via POST /outbound.
+    case VOICE_RUNTIME_URL = 'kanvas-intelligence-voice-runtime-url';
+    case VOICE_RUNTIME_API_TOKEN = 'kanvas-intelligence-voice-runtime-api-token';
     case ADK_BASE_URL = 'google_orchestrator_base_url';
     case ADK_API_KEY = 'google_orchestrator_api_key';
     case ADK_APP_NAME = 'google_orchestrator_app_name';


### PR DESCRIPTION
Backend for the admin UI's **"Test call"** button. Adds a user-guarded, company-scoped GraphQL mutation that triggers a one-off outbound call for an agent through the external voice runtime.

## Flow
`sendVoiceAgentTestCall(id, to_number)` → resolve agent (company-scoped) → `PlaceVoiceTestCallAction` → `POST {runtime}/outbound` with a Bearer token → runtime dials the number and streams the answered call to the agent (its own voice config, dialing from its own number).

## Changes
- **`ConfigurationEnum`**: two per-app settings
  - `VOICE_RUNTIME_URL` — the runtime base URL
  - `VOICE_RUNTIME_API_TOKEN` — the runtime's `RUNTIME_API_TOKEN` bearer
- **`PlaceVoiceTestCallAction`**: validates E.164, checks the runtime is configured, POSTs `{to, tenant_id: company.uuid, run_spec:{agent_id}}`, and surfaces the runtime's own error `detail` as a `ValidationException` (with `captureException` for network failures).
- **`VoiceAgentCallMutation@placeTestCall`**: `getByIdFromCompanyApp` scoping.
- **Schema**: `VoiceAgentCallResult` + `sendVoiceAgentTestCall(id: ID!, to_number: String!)` under `extend type Mutation @guard`.

## Config required to use it
Set `VOICE_RUNTIME_URL` and `VOICE_RUNTIME_API_TOKEN` on the app (the token must match the runtime's `RUNTIME_API_TOKEN`). Until set, the mutation returns a clear "voice runtime is not configured" validation error.

## Pairs with
- kanvas-core-admin-v2: the "Test call" button (frontend PR — next)
- Runtime `POST /outbound` (kanvas-voice-agents, already deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)