### PR TITLE
Fix: use full Google Calendar OAuth scope

### DIFF
--- a/src/Domains/Connectors/Google/Actions/CreateGoogleCalendarMeetingAction.php
+++ b/src/Domains/Connectors/Google/Actions/CreateGoogleCalendarMeetingAction.php
@@ -142,7 +142,7 @@ class CreateGoogleCalendarMeetingAction
     {
         $client = new Client();
         $client->setApplicationName((string) ($config['application_name'] ?? 'Kanvas Calendar'));
-        $client->setScopes([Calendar::CALENDAR_EVENTS]);
+        $client->setScopes([Calendar::CALENDAR]);
         $client->setAccessType('offline');
 
         $profile = (string) ($config['default_auth_profile'] ?? 'service_account');


### PR DESCRIPTION
## Summary
- request the full Google Calendar OAuth scope instead of calendar.events
- align the SDK authentication scope with the currently authorized Domain-Wide Delegation configuration

## Validation
- php -l
- git diff --check

## Follow-up
This is a temporary compatibility change. Once calendar.events is authorized in Google Admin, the scope can be reduced again.