### PR TITLE
feat: mark invoice emails as read once fully processed

### DIFF
--- a/src/Domains/Connectors/Gmail/Actions/MarkEmailAsReadAction.php
+++ b/src/Domains/Connectors/Gmail/Actions/MarkEmailAsReadAction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Gmail\Actions;
+
+use Baka\Contracts\AppInterface;
+use Google\Service\Gmail as GmailService;
+use Google\Service\Gmail\ModifyMessageRequest;
+
+/** Removes the UNREAD label from a message so it doesn't get picked up again by a future has:attachment is:unread search. */
+class MarkEmailAsReadAction extends AbstractGmailAction
+{
+    public function __construct(
+        AppInterface $app,
+        protected string $messageId,
+        ?GmailService $service = null,
+    ) {
+        parent::__construct($app, $service);
+    }
+
+    /**
+     * @return array{message_id: string}
+     */
+    public function execute(): array
+    {
+        $this->service()->users_messages->modify(
+            'me',
+            $this->messageId,
+            new ModifyMessageRequest(['removeLabelIds' => ['UNREAD']]),
+        );
+
+        return ['message_id' => $this->messageId];
+    }
+}

--- a/src/Domains/Connectors/Gmail/CLAUDE.md
+++ b/src/Domains/Connectors/Gmail/CLAUDE.md
@@ -12,6 +12,7 @@ total, dates) from that PDF so it can be tracked in a sheet and pushed to Acumat
 | `read_email_details(message_id)` | Returns From, Date, Subject, body text, and the attachment list (filename + attachment_id) for one message. |
 | `download_attachment(message_id, attachment_id, filename)` | Downloads one attachment and stores it as a real Kanvas Filesystem entry — returns `filesystem_id`/`url`, the same way any other uploaded document is referenced. |
 | `extract_invoice_data(filesystem_id, from_email?, subject?)` (in `Tools/Accounting/`) | Reads a downloaded PDF with Kanvas's existing AI PDF classifier and returns vendor/total/currency/dates/line items. The real invoice numbers live in the PDF, never in the email body/subject — always use this before writing an amount anywhere. |
+| `mark_email_as_read(message_id)` | Removes the `UNREAD` label so the message stops matching a future `has:attachment is:unread` search. Call only after the invoice is fully logged/pushed — never before, so a failed run can still be found and retried. |
 
 ## Configuration
 
@@ -19,6 +20,16 @@ Unlike GoogleSheets (a service account), Gmail does **not** work well with servi
 personal/shared mailbox unless you control a Google Workspace domain with delegated authority.
 The supported approach here is **OAuth 2.0 with a refresh token** — a one-time manual
 authorization that then lets the agent obtain fresh access tokens indefinitely.
+
+**Scope required: `gmail.modify`, not `gmail.readonly`.** `mark_email_as_read` writes to the
+mailbox (removes a label), so the OAuth scope requested during authorization must be
+`https://www.googleapis.com/auth/gmail.modify` (a superset of readonly — covers everything this
+connector does). **A refresh token is permanently scoped to whatever was consented to when it was
+created** — calling `addScope()` in `Client.php` does not retroactively widen an existing token's
+permissions. If your refresh token was generated before `mark_email_as_read` existed (i.e. with
+only the `gmail.readonly` scope), `mark_email_as_read` will fail with an insufficient-scope error
+and you must redo step 4 below with the `gmail.modify` scope checked instead of `gmail.readonly`,
+then replace the stored `gmail-refresh-token` with the new one.
 
 Config keys (stored per Kanvas app via the standard custom-fields mechanism):
 
@@ -63,7 +74,8 @@ search **"Gmail API"** at the top of [console.cloud.google.com](https://console.
 2. Click the ⚙️ gear (top right) → check **"Use your own OAuth credentials"** → paste the Client
    ID and Client Secret from step 3.
 3. In the left panel, find **Gmail API v1** and check the
-   `https://www.googleapis.com/auth/gmail.readonly` scope.
+   `https://www.googleapis.com/auth/gmail.modify` scope (not `gmail.readonly` — this connector
+   also marks messages as read, which needs write access to the mailbox).
    - **Don't leave text in the API search box after selecting the scope** — leftover search text
      (e.g. from typing "gmail" to find the API) gets sent as a literal extra scope and the
      authorization fails with `Error 400: invalid_scope`. Clear the search box before authorizing.
@@ -105,8 +117,9 @@ $app->set(\Kanvas\Connectors\Gmail\Enums\ConfigurationEnum::REFRESH_TOKEN->value
 ## Security note
 
 A Gmail refresh token is a durable, full-mailbox credential — more sensitive than a
-service-account JSON scoped to explicitly-shared sheets, since it grants read access to
-*everything* in that inbox for as long as it stays valid. It's stored in plaintext in the
-`apps_settings` table, same as every other connector's credentials here — treat it accordingly:
+service-account JSON scoped to explicitly-shared sheets, since with the `gmail.modify` scope it
+grants both read access to *everything* in that inbox and the ability to change message state
+(labels), for as long as it stays valid. It's stored in plaintext in the `apps_settings` table,
+same as every other connector's credentials here — treat it accordingly:
 never commit it, never paste it into chat/logs outside the one-time setup, and use a dedicated
 mailbox/service account for production rather than a personal inbox.

--- a/src/Domains/Connectors/Gmail/Client.php
+++ b/src/Domains/Connectors/Gmail/Client.php
@@ -31,7 +31,7 @@ class Client
             $googleClient = new GoogleApiClient();
             $googleClient->setClientId((string) $clientId);
             $googleClient->setClientSecret((string) $clientSecret);
-            $googleClient->addScope(GmailService::GMAIL_READONLY);
+            $googleClient->addScope(GmailService::GMAIL_MODIFY);
             $googleClient->fetchAccessTokenWithRefreshToken((string) $refreshToken);
 
             return new GmailService($googleClient);

--- a/src/Domains/Connectors/GoogleSheets/CLAUDE.md
+++ b/src/Domains/Connectors/GoogleSheets/CLAUDE.md
@@ -121,3 +121,41 @@ existing, accepted pattern here, not something specific to this connector. Treat
 file itself with the same care as any other production secret: don't commit it, don't paste it
 into chat/logs outside the one-time setup, and use a dedicated production service account (never
 reuse a personal/dev one).
+
+## Full invoice-processing flow (Gmail → Sheet → Acumatica)
+
+This connector is one leg of a 3-connector pipeline (see also `src/Domains/Connectors/Gmail/CLAUDE.md`
+and the Acumatica connector). End to end, when Apex/Arc process an emailed invoice, the agent:
+
+1. `list_emails` (Gmail) — finds unread invoice emails.
+2. `read_email_details` (Gmail) — reads the body + attachment list.
+3. `download_attachment` (Gmail) — saves the PDF to Kanvas, returns `filesystem_id`/`url`.
+4. `extract_invoice_data` (Accounting) — reads the PDF with AI, gets the real vendor/total/dates.
+   The email body/subject is never the source of truth for these — always read the PDF.
+5. `write_google_sheet` (this connector) — logs the invoice as a new row (no `sheet_url_or_id`
+   needed — falls back to the default sheet), automatically, without being asked.
+6. `create_ap_bill` / `create_ar_invoice` (Acumatica) — creates + pushes the bill/invoice, using
+   the real amount from step 4, not anything guessed from the email text.
+7. `attach_bill_file` / `attach_invoice_file` (Acumatica) — attaches the file using the `url`
+   from step 3, no re-download needed.
+8. `update_google_sheet_cell` (this connector) — flips the sheet row's status to "Approved".
+9. `mark_email_as_read` (Gmail) — removes the message's `UNREAD` label, only now that every prior
+   step succeeded, so the same invoice doesn't get reprocessed on the next `has:attachment
+   is:unread` search. Never mark it read before this point — a failed run must still be findable.
+
+### Setup checklist — every key that must exist before this flow works
+
+| # | Key | Where it's set | Connector |
+|---|---|---|---|
+| 1 | `gmail-client-id` | Settings → Key Configurations | Gmail |
+| 2 | `gmail-client-secret` | Settings → Key Configurations | Gmail |
+| 3 | `gmail-refresh-token` | Settings → Key Configurations | Gmail |
+| 4 | `google-sheets-credentials` | Settings → Key Configurations | GoogleSheets |
+| 5 | `google-sheets-default-invoice-tracker` | Settings → Key Configurations | GoogleSheets |
+| 6 | Sheet shared as Editor with the service account's `client_email` | Google Sheets UI, per-sheet | GoogleSheets |
+| 7 | Acumatica credentials (see that connector's own docs) | Settings → Key Configurations | Acumatica |
+
+Steps 1–3 come from the OAuth Playground flow in `Gmail/CLAUDE.md`. Steps 4–6 come from the
+service-account flow above. Missing any of 1–6 breaks the flow at that specific step — the tool's
+error `reason` (`no_sheet_configured`, an authentication error from `Client::getInstance()`, etc.)
+tells you which one.

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -22,6 +22,7 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateApBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidApBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\DownloadAttachmentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\ListEmailsTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\MarkEmailAsReadTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\ReadEmailDetailsTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\AppendGoogleSheetRowsTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ClearGoogleSheetRangeTool;
@@ -82,6 +83,7 @@ class AccountsPayableAgent extends SystemUserAgent
             new ReadEmailDetailsTool(),
             new DownloadAttachmentTool(),
             new ExtractInvoiceDataTool(),
+            new MarkEmailAsReadTool(),
         ]));
     }
 
@@ -129,7 +131,11 @@ class AccountsPayableAgent extends SystemUserAgent
             . 'standard step — do not wait to be asked. Call write_google_sheet with range "Invoices!A1" and a '
             . 'row of [invoice_number, vendor_name, total, "Pending"] (omit sheet_url_or_id to use the default '
             . 'sheet), then after the bill is created and pushed, call update_google_sheet_cell to flip that '
-            . 'row\'s status column to "Approved". Do this even when the user only asked you to create the bill.',
+            . 'row\'s status column to "Approved". Do this even when the user only asked you to create the bill. '
+            . 'Only after ALL of that succeeds (sheet logged, bill created and pushed), call '
+            . 'mark_email_as_read on the message_id — this is what stops the same invoice from showing up again '
+            . 'next time you search "has:attachment is:unread". Never mark it read before every step succeeds, '
+            . 'so a failed run can still be found and retried.',
         ]);
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -22,6 +22,7 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidArInvoiceTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\DownloadAttachmentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\ListEmailsTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\MarkEmailAsReadTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\ReadEmailDetailsTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\AppendGoogleSheetRowsTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\GoogleSheets\ClearGoogleSheetRangeTool;
@@ -95,6 +96,7 @@ class AccountsReceivableAgent extends SystemUserAgent
             new ReadEmailDetailsTool(),
             new DownloadAttachmentTool(),
             new ExtractInvoiceDataTool(),
+            new MarkEmailAsReadTool(),
         ]));
     }
 
@@ -149,7 +151,11 @@ class AccountsReceivableAgent extends SystemUserAgent
             . 'standard step — do not wait to be asked. Call write_google_sheet with range "Invoices!A1" and a '
             . 'row of [invoice_number, vendor_name, total, "Pending"] (omit sheet_url_or_id to use the default '
             . 'sheet), then after the invoice is created and pushed, call update_google_sheet_cell to flip that '
-            . 'row\'s status column to "Approved". Do this even when the user only asked you to create the invoice.',
+            . 'row\'s status column to "Approved". Do this even when the user only asked you to create the invoice. '
+            . 'Only after ALL of that succeeds (sheet logged, invoice created and pushed), call '
+            . 'mark_email_as_read on the message_id — this is what stops the same invoice from showing up again '
+            . 'next time you search "has:attachment is:unread". Never mark it read before every step succeeds, '
+            . 'so a failed run can still be found and retried.',
             '- Lead with the headline, then the top 3-5 items. Be honest about freshness.',
         ]);
     }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Gmail/MarkEmailAsReadTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Gmail/MarkEmailAsReadTool.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Gmail;
+
+use Kanvas\Connectors\Gmail\Actions\MarkEmailAsReadAction;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+/** Marks an email as read so it stops matching an is:unread search — call this once an invoice email has been fully processed and logged. */
+#[AgentTool(name: 'Mark Email As Read', category: 'productivity')]
+class MarkEmailAsReadTool extends Tool
+{
+    use HasKanvasContext;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'mark_email_as_read',
+            description: 'Marks an email as read so a future "has:attachment is:unread" search won\'t find it '
+                . 'again. Call this after an invoice email has been fully processed (logged to the sheet, and '
+                . 'the bill/invoice created) — never before, so a failed or interrupted run can still be found '
+                . 'and retried.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'message_id',
+                type: PropertyType::STRING,
+                description: 'The message id from list_emails/read_email_details. Always required.',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(string $message_id): array
+    {
+        try {
+            $result = new MarkEmailAsReadAction($this->app, $message_id)->execute();
+        } catch (Throwable $e) {
+            return [
+                'success' => false,
+                'reason' => 'mark_read_failed',
+                'message' => 'Could not mark the email as read: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'success' => true,
+            ...$result,
+        ];
+    }
+}

--- a/tests/Connectors/Gmail/GmailActionsTest.php
+++ b/tests/Connectors/Gmail/GmailActionsTest.php
@@ -15,6 +15,7 @@ use Google\Service\Gmail\Resource\UsersMessagesAttachments;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\Gmail\Actions\DownloadAttachmentAction;
 use Kanvas\Connectors\Gmail\Actions\ListEmailsAction;
+use Kanvas\Connectors\Gmail\Actions\MarkEmailAsReadAction;
 use Kanvas\Connectors\Gmail\Actions\ReadEmailDetailsAction;
 use Kanvas\Filesystem\Models\Filesystem;
 use Kanvas\Filesystem\Services\FilesystemServices;
@@ -141,5 +142,25 @@ class GmailActionsTest extends TestCase
         $this->assertSame('invoice-4521.pdf', $result['filename']);
         $this->assertSame('https://cdn.example.com/invoice-4521.pdf', $result['url']);
         $this->assertSame(23, $result['size']);
+    }
+
+    public function test_mark_email_as_read_removes_the_unread_label(): void
+    {
+        $messagesResource = Mockery::mock(UsersMessages::class);
+        $messagesResource->shouldReceive('modify')
+            ->once()
+            ->with(
+                'me',
+                'MSG_1',
+                Mockery::on(fn ($body) => $body->getRemoveLabelIds() === ['UNREAD']),
+            )
+            ->andReturn(new Message(['id' => 'MSG_1']));
+
+        $service = Mockery::mock(GmailService::class);
+        $service->users_messages = $messagesResource;
+
+        $result = new MarkEmailAsReadAction(app(Apps::class), 'MSG_1', $service)->execute();
+
+        $this->assertSame('MSG_1', $result['message_id']);
     }
 }

--- a/tests/Connectors/Gmail/GmailToolsTest.php
+++ b/tests/Connectors/Gmail/GmailToolsTest.php
@@ -10,6 +10,7 @@ use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\Gmail\Enums\ConfigurationEnum;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\DownloadAttachmentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\ListEmailsTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\MarkEmailAsReadTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\ReadEmailDetailsTool;
 use Tests\TestCase;
 
@@ -79,6 +80,18 @@ class GmailToolsTest extends TestCase
 
         $this->assertFalse($result['success']);
         $this->assertSame('download_failed', $result['reason']);
+    }
+
+    public function test_mark_email_as_read_surfaces_a_humanized_error_when_gmail_is_not_configured(): void
+    {
+        [$app, $company] = $this->context();
+
+        $result = new MarkEmailAsReadTool()
+            ->withContext($app, $company, static::$cachedUser)
+            ->__invoke(message_id: 'MSG_1');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('mark_read_failed', $result['reason']);
     }
 
     /**


### PR DESCRIPTION
## Summary
1.x mirror of #10824 — stacked on #10823 (default invoice-tracking sheet, 1.x). Same feature, same fix.

Adds `mark_email_as_read(message_id)` (requires `gmail.modify` scope, up from `readonly` — existing refresh tokens must be regenerated) so a fully-processed invoice email stops matching future `has:attachment is:unread` searches.

## Test plan
- [x] `tests/Connectors/Gmail/` — 15/15 passing on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)