### PR TITLE
hotfix: slack reminder msg

### DIFF
--- a/src/Domains/Intelligence/Agents/Services/AgentProviderService.php
+++ b/src/Domains/Intelligence/Agents/Services/AgentProviderService.php
@@ -170,7 +170,7 @@ class AgentProviderService
         return (string) ($source['model']
             ?? $app->get(ConfigurationEnum::AI_PROVIDER_MODEL->value)
             ?? $app->get(ConfigurationEnum::GEMINI_MODEL->value)
-            ?? 'gemini-3.6-flash');
+            ?? 'gemini-3.7-flash');
     }
 
     /**

--- a/src/Domains/NervousSystem/Scheduling/Actions/DeliverScheduledMessageToChannelAction.php
+++ b/src/Domains/NervousSystem/Scheduling/Actions/DeliverScheduledMessageToChannelAction.php
@@ -15,7 +15,6 @@ use Kanvas\Intelligence\Enums\ConfigurationEnum;
 use Kanvas\Intelligence\Services\KanvasConversationStore;
 use Kanvas\Social\Channels\Models\Channel;
 use Kanvas\Social\Messages\Actions\PostChannelMessageAction;
-use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Users\Models\Users;
 use Nuwave\Lighthouse\Execution\Utils\Subscription;
 use Throwable;
@@ -42,6 +41,10 @@ class DeliverScheduledMessageToChannelAction
         private readonly Users $author,
         private readonly ?Agent $agent = null,
         private readonly ?string $sessionUuid = null,
+        // The session's canal_id — the connector's exact-case destination address (Slack
+        // `slack:{team}:{channel}:{thread}`, WhatsApp `{phone}@s.whatsapp.net`). Set by every connector
+        // webhook when the session is created; the channel slug can't be used (it's lowercased).
+        private readonly ?string $canalId = null,
         private readonly string $verb = 'scheduled-reminder',
     ) {
     }
@@ -154,13 +157,10 @@ class DeliverScheduledMessageToChannelAction
             return false;
         }
 
-        $source = $this->latestMessageWith('slack_channel');
-        $slackChannelId = (string) ($source?->message['slack_channel'] ?? '');
+        [$slackChannelId, $threadTs] = $this->slackTargetFromCanalId();
         if ($slackChannelId === '') {
             return false;
         }
-
-        $threadTs = (string) ($source?->message['slack_thread_ts'] ?? '');
 
         SlackClient::getInstanceByAgent($this->agent)
             ->postMessage($slackChannelId, $this->text, $threadTs !== '' ? $threadTs : null);
@@ -168,15 +168,29 @@ class DeliverScheduledMessageToChannelAction
         return true;
     }
 
+    /**
+     * @return array{0: string, 1: string} [slackChannelId, threadTs] parsed from the session canal_id
+     *                                      `slack:{team}:{channel}:{thread_ts}` (ids are case-sensitive,
+     *                                      so we take them verbatim — never from the lowercased slug)
+     */
+    private function slackTargetFromCanalId(): array
+    {
+        if ($this->canalId === null || ! str_starts_with($this->canalId, 'slack:')) {
+            return ['', ''];
+        }
+
+        $parts = explode(':', $this->canalId);
+
+        return [$parts[2] ?? '', $parts[3] ?? ''];
+    }
+
     private function pushWhatsApp(): bool
     {
-        $source = $this->latestMessageWith('chat_jid');
-        $chatJid = (string) ($source?->message['chat_jid'] ?? '');
-        if ($chatJid === '') {
+        if ($this->canalId === null || ! str_contains($this->canalId, '@s.whatsapp.net')) {
             return false;
         }
 
-        $to = str_replace('@s.whatsapp.net', '', $chatJid);
+        $to = str_replace('@s.whatsapp.net', '', $this->canalId);
 
         new WaSenderMessageService($this->channel->app, $this->channel->company)
             ->sendTextMessage($to, $this->text);
@@ -206,21 +220,5 @@ class DeliverScheduledMessageToChannelAction
             ->create($to, ['from' => $from, 'body' => $this->text]);
 
         return true;
-    }
-
-    /**
-     * The most recent channel message that actually carries the connector key (e.g. `slack_channel`,
-     * `chat_jid`). We must NOT use the plain latest row: execute() posts our own feed message first, and
-     * that reminder row has no connector metadata — reading it would make every native push no-op.
-     */
-    private function latestMessageWith(string $key): ?Message
-    {
-        /** @var Message|null $message */
-        $message = $this->channel->messages()
-            ->whereNotNull("messages.message->{$key}")
-            ->orderByDesc('messages.id')
-            ->first();
-
-        return $message;
     }
 }

--- a/src/Domains/NervousSystem/Scheduling/Actions/DeliverScheduledMessageToChannelAction.php
+++ b/src/Domains/NervousSystem/Scheduling/Actions/DeliverScheduledMessageToChannelAction.php
@@ -154,13 +154,13 @@ class DeliverScheduledMessageToChannelAction
             return false;
         }
 
-        $latest = $this->latestMessage();
-        $slackChannelId = (string) ($latest?->message['slack_channel'] ?? '');
+        $source = $this->latestMessageWith('slack_channel');
+        $slackChannelId = (string) ($source?->message['slack_channel'] ?? '');
         if ($slackChannelId === '') {
             return false;
         }
 
-        $threadTs = (string) ($latest?->message['slack_thread_ts'] ?? '');
+        $threadTs = (string) ($source?->message['slack_thread_ts'] ?? '');
 
         SlackClient::getInstanceByAgent($this->agent)
             ->postMessage($slackChannelId, $this->text, $threadTs !== '' ? $threadTs : null);
@@ -170,8 +170,8 @@ class DeliverScheduledMessageToChannelAction
 
     private function pushWhatsApp(): bool
     {
-        $latest = $this->latestMessage();
-        $chatJid = (string) ($latest?->message['chat_jid'] ?? '');
+        $source = $this->latestMessageWith('chat_jid');
+        $chatJid = (string) ($source?->message['chat_jid'] ?? '');
         if ($chatJid === '') {
             return false;
         }
@@ -208,10 +208,18 @@ class DeliverScheduledMessageToChannelAction
         return true;
     }
 
-    private function latestMessage(): ?Message
+    /**
+     * The most recent channel message that actually carries the connector key (e.g. `slack_channel`,
+     * `chat_jid`). We must NOT use the plain latest row: execute() posts our own feed message first, and
+     * that reminder row has no connector metadata — reading it would make every native push no-op.
+     */
+    private function latestMessageWith(string $key): ?Message
     {
         /** @var Message|null $message */
-        $message = $this->channel->messages()->orderByDesc('messages.id')->first();
+        $message = $this->channel->messages()
+            ->whereNotNull("messages.message->{$key}")
+            ->orderByDesc('messages.id')
+            ->first();
 
         return $message;
     }

--- a/src/Domains/NervousSystem/Scheduling/Jobs/RunScheduledAgentActionJob.php
+++ b/src/Domains/NervousSystem/Scheduling/Jobs/RunScheduledAgentActionJob.php
@@ -24,7 +24,6 @@ use Kanvas\NervousSystem\Scheduling\Enums\ScheduledActionStatusEnum;
 use Kanvas\NervousSystem\Scheduling\Enums\ScheduledActionTypeEnum;
 use Kanvas\NervousSystem\Scheduling\Models\ScheduledAction;
 use Kanvas\NervousSystem\Scheduling\Notifications\ScheduledReminderNotification;
-use Kanvas\Social\Channels\Models\Channel;
 use Kanvas\Users\Models\Users;
 use Throwable;
 
@@ -67,7 +66,8 @@ class RunScheduledAgentActionJob implements ShouldQueue
     private function deliverReminder(): void
     {
         $message = (string) ($this->action->payload['message'] ?? '');
-        $channel = $this->resolveChannel();
+        $session = $this->resolveSessionByUuid();
+        $channel = $session?->channel;
 
         // Deliver into the channel when there is one; if nothing went out natively (no channel, or one we
         // can't push to) fall back to the notification so the recipient is still reached.
@@ -79,6 +79,7 @@ class RunScheduledAgentActionJob implements ShouldQueue
                 author: $this->action->agent?->user ?? $this->action->recipient,
                 agent: $this->action->agent,
                 sessionUuid: $this->action->session_uuid,
+                canalId: $session?->canal_id,
             )->execute();
         }
 
@@ -125,6 +126,8 @@ class RunScheduledAgentActionJob implements ShouldQueue
                 text: $response,
                 author: $agent->user,
                 agent: $agent,
+                sessionUuid: $session->uuid,
+                canalId: $session->canal_id,
                 verb: 'scheduled-agent-reply',
             )->execute();
         }
@@ -135,7 +138,7 @@ class RunScheduledAgentActionJob implements ShouldQueue
         ]);
     }
 
-    private function resolveChannel(): ?Channel
+    private function resolveSessionByUuid(): ?Session
     {
         if ($this->action->session_uuid === null) {
             return null;
@@ -144,7 +147,7 @@ class RunScheduledAgentActionJob implements ShouldQueue
         /** @var Session|null $session */
         $session = Session::query()->where('uuid', $this->action->session_uuid)->first();
 
-        return $session?->channel;
+        return $session;
     }
 
     private function resolveSession(Agent $agent): Session

--- a/tests/Intelligence/NervousSystem/ScheduledActionChannelDeliveryTest.php
+++ b/tests/Intelligence/NervousSystem/ScheduledActionChannelDeliveryTest.php
@@ -26,7 +26,6 @@ use Kanvas\NervousSystem\Scheduling\Notifications\ScheduledReminderNotification;
 use Kanvas\Social\Channels\Actions\CreateChannelAction;
 use Kanvas\Social\Channels\DataTransferObject\Channel as ChannelDto;
 use Kanvas\Social\Channels\Models\Channel;
-use Kanvas\Social\Messages\Actions\PostChannelMessageAction;
 use Kanvas\Users\Models\Users;
 use NeuronAI\Chat\Messages\AssistantMessage;
 use NeuronAI\Chat\Messages\UserMessage;
@@ -234,43 +233,25 @@ class ScheduledActionChannelDeliveryTest extends TestCase
         $this->assertSame(1, (int) $replyRow->is_public, 'A normal turn stays visible.');
     }
 
-    public function testNativeSlackPushReadsConnectorMetadataFromTheInboundMessageNotOurOwnFeedPost(): void
+    public function testSlackTargetIsParsedFromSessionCanalIdInExactCase(): void
     {
         [$app, $company, $user] = $this->context();
         $agent = $this->makeAgent($app, $company, $user);
         $channel = $this->makeChannel($app, $company, $user);
 
-        // The real inbound Slack message carries the connector metadata (slack_channel / thread ts).
-        new PostChannelMessageAction(
-            channel: $channel,
-            author: $user,
-            verb: 'slack-inbound',
-            content: 'hey agent',
-            extraPayload: ['slack_channel' => 'C0INBOUND', 'slack_thread_ts' => '123.45'],
-            runWorkflow: false,
-        )->execute();
-
-        // A LATER feed post with NO connector metadata — exactly what execute() writes before pushing.
-        // The old code read this row and found no slack_channel, so the Slack DM never went out.
-        new PostChannelMessageAction(
-            channel: $channel,
-            author: $user,
-            verb: 'scheduled-reminder',
-            content: 'your reminder',
-            extraPayload: ['from_ia' => true],
-            runWorkflow: false,
-        )->execute();
-
+        // The session's canal_id carries the connector destination in ORIGINAL case; the channel slug is
+        // lowercased and would 404 against the Slack API. `slack:{team}:{channel}:{thread_ts}`.
         $action = new DeliverScheduledMessageToChannelAction(
             channel: $channel,
             text: 'ping',
             author: $user,
             agent: $agent,
+            canalId: 'slack:T0BC3HTQYAC:D0BKWG1JJ2X:1699999999.001',
         );
 
-        $found = new ReflectionMethod($action, 'latestMessageWith')->invoke($action, 'slack_channel');
+        [$slackChannelId, $threadTs] = new ReflectionMethod($action, 'slackTargetFromCanalId')->invoke($action);
 
-        $this->assertNotNull($found, 'A message carrying slack_channel must still be found after a later feed post.');
-        $this->assertSame('C0INBOUND', $found->message['slack_channel']);
+        $this->assertSame('D0BKWG1JJ2X', $slackChannelId);
+        $this->assertSame('1699999999.001', $threadTs);
     }
 }

--- a/tests/Intelligence/NervousSystem/ScheduledActionChannelDeliveryTest.php
+++ b/tests/Intelligence/NervousSystem/ScheduledActionChannelDeliveryTest.php
@@ -18,6 +18,7 @@ use Kanvas\Intelligence\Enums\ConfigurationEnum;
 use Kanvas\Intelligence\Sessions\Actions\CreateSessionAction;
 use Kanvas\Intelligence\Sessions\DataTransferObject\Session as SessionDto;
 use Kanvas\NervousSystem\Scheduling\Actions\CreateScheduledActionAction;
+use Kanvas\NervousSystem\Scheduling\Actions\DeliverScheduledMessageToChannelAction;
 use Kanvas\NervousSystem\Scheduling\DataTransferObject\ScheduledAction as ScheduledActionData;
 use Kanvas\NervousSystem\Scheduling\Enums\ScheduledActionTypeEnum;
 use Kanvas\NervousSystem\Scheduling\Jobs\RunScheduledAgentActionJob;
@@ -25,9 +26,11 @@ use Kanvas\NervousSystem\Scheduling\Notifications\ScheduledReminderNotification;
 use Kanvas\Social\Channels\Actions\CreateChannelAction;
 use Kanvas\Social\Channels\DataTransferObject\Channel as ChannelDto;
 use Kanvas\Social\Channels\Models\Channel;
+use Kanvas\Social\Messages\Actions\PostChannelMessageAction;
 use Kanvas\Users\Models\Users;
 use NeuronAI\Chat\Messages\AssistantMessage;
 use NeuronAI\Chat\Messages\UserMessage;
+use ReflectionMethod;
 use Tests\TestCase;
 
 class ScheduledActionChannelDeliveryTest extends TestCase
@@ -229,5 +232,45 @@ class ScheduledActionChannelDeliveryTest extends TestCase
             ->where('conversation_id', $conversationId)->where('role', 'assistant')->first();
         $this->assertNotNull($replyRow);
         $this->assertSame(1, (int) $replyRow->is_public, 'A normal turn stays visible.');
+    }
+
+    public function testNativeSlackPushReadsConnectorMetadataFromTheInboundMessageNotOurOwnFeedPost(): void
+    {
+        [$app, $company, $user] = $this->context();
+        $agent = $this->makeAgent($app, $company, $user);
+        $channel = $this->makeChannel($app, $company, $user);
+
+        // The real inbound Slack message carries the connector metadata (slack_channel / thread ts).
+        new PostChannelMessageAction(
+            channel: $channel,
+            author: $user,
+            verb: 'slack-inbound',
+            content: 'hey agent',
+            extraPayload: ['slack_channel' => 'C0INBOUND', 'slack_thread_ts' => '123.45'],
+            runWorkflow: false,
+        )->execute();
+
+        // A LATER feed post with NO connector metadata — exactly what execute() writes before pushing.
+        // The old code read this row and found no slack_channel, so the Slack DM never went out.
+        new PostChannelMessageAction(
+            channel: $channel,
+            author: $user,
+            verb: 'scheduled-reminder',
+            content: 'your reminder',
+            extraPayload: ['from_ia' => true],
+            runWorkflow: false,
+        )->execute();
+
+        $action = new DeliverScheduledMessageToChannelAction(
+            channel: $channel,
+            text: 'ping',
+            author: $user,
+            agent: $agent,
+        );
+
+        $found = new ReflectionMethod($action, 'latestMessageWith')->invoke($action, 'slack_channel');
+
+        $this->assertNotNull($found, 'A message carrying slack_channel must still be found after a later feed post.');
+        $this->assertSame('C0INBOUND', $found->message['slack_channel']);
     }
 }


### PR DESCRIPTION
Lets agents push short notifications to a company user's registered
devices through Kanvas notifications (OneSignal + Expo). The recipient
email is verified against app + company membership before sending,
following the same destination-safety shape as send_email_to_user.
