### PR TITLE
feat(voice): gated cross-app agent resolution for the voice runtime

### DIFF
--- a/app/GraphQL/Intelligence/Queries/Agent/VoiceAgentSpecQuery.php
+++ b/app/GraphQL/Intelligence/Queries/Agent/VoiceAgentSpecQuery.php
@@ -20,7 +20,7 @@ class VoiceAgentSpecQuery
     public function __invoke(mixed $root, array $args): array
     {
         $app = app(Apps::class);
-        $agent = AgentsRepository::getByUuidFromApp((string) $args['uuid'], $app);
+        $agent = AgentsRepository::getByUuidForVoiceRuntime((string) $args['uuid'], $app);
 
         return new VoiceAgentSpecService($agent, $app)->compile();
     }

--- a/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
+++ b/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
@@ -6,20 +6,37 @@ namespace Kanvas\Intelligence\Agents\Repositories;
 
 use Baka\Contracts\AppInterface;
 use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Enums\ConfigurationEnum;
 
 class AgentsRepository
 {
     /**
-     * Fetch a single agent by uuid, scoped to the given app.
+     * Resolve a single agent by uuid for the voice runtime's spec fetch
+     * (server-to-server via app key).
      *
-     * Used by the voice runtime's spec fetch (server-to-server via app key), so
-     * one app's credentials can only resolve its own agents. Throws
-     * ModelNotFoundException when the uuid does not belong to the app.
+     * By default this is app-scoped: an app's credentials can only resolve its
+     * own agents. The voice runtime, however, is a single trusted service that
+     * may serve agents living in DIFFERENT apps. To allow that WITHOUT turning
+     * every app-key into a cross-tenant reader, the calling app must be
+     * explicitly flagged via the VOICE_RUNTIME_CROSS_APP setting — only then do
+     * we resolve by uuid across apps. Any other app stays strictly app-scoped.
+     *
+     * Throws ModelNotFoundException when the uuid does not resolve under the
+     * effective scope.
      */
-    public static function getByUuidFromApp(string $uuid, AppInterface $app): Agent
+    public static function getByUuidForVoiceRuntime(string $uuid, AppInterface $app): Agent
     {
-        return Agent::where('uuid', $uuid)
-            ->where('apps_id', $app->getId())
-            ->firstOrFail();
+        $crossApp = filter_var(
+            $app->get(ConfigurationEnum::VOICE_RUNTIME_CROSS_APP->value),
+            FILTER_VALIDATE_BOOLEAN
+        );
+
+        $query = Agent::where('uuid', $uuid);
+
+        if (! $crossApp) {
+            $query->where('apps_id', $app->getId());
+        }
+
+        return $query->firstOrFail();
     }
 }

--- a/src/Domains/Intelligence/Enums/ConfigurationEnum.php
+++ b/src/Domains/Intelligence/Enums/ConfigurationEnum.php
@@ -45,4 +45,8 @@ enum ConfigurationEnum: string
     case NOTIFICATION_CHANNELS = 'notification_enabled_channels';
     case FIRST_ENGAGEMENT_NOTIFICATION_CHANNELS = 'first_engagement_notification_channels';
     case ENGAGEMENT_NOTIFICATION_CHANNELS = 'engagement_notification_channels';
+    // When truthy on an app, that app's key may resolve voice agents across
+    // apps (voiceAgentSpec by uuid, ignoring apps_id). Enable ONLY on the
+    // trusted voice-runtime app; every other app-key stays app-scoped.
+    case VOICE_RUNTIME_CROSS_APP = 'kanvas-intelligence-voice-runtime-cross-app';
 }


### PR DESCRIPTION
## Problem
The voice runtime is one trusted service that must serve agents across **different apps**, but `voiceAgentSpec` resolved strictly by `apps_id`. An agent in another app returned `No query results for model [Agent]`, so the runtime fell back to the **default Sally** agent (wrong greeting/voice/prompt).

## Fix — opt-in per-app flag (keeps tenant isolation)
- New setting `kanvas-intelligence-voice-runtime-cross-app` (`ConfigurationEnum::VOICE_RUNTIME_CROSS_APP`).
- `AgentsRepository::getByUuidForVoiceRuntime($uuid, $app)`: when the calling app has that flag truthy, resolve the agent **by uuid across apps**; otherwise stay strictly `apps_id`-scoped (unchanged for everyone else).
- `VoiceAgentSpecQuery` uses the new method. Renamed `getByUuidFromApp` → `getByUuidForVoiceRuntime` (single caller).

## Security
- Cross-app reads are enabled **only** on an app you explicitly flag (the trusted voice-runtime app). Every other app-key remains isolated.
- Still behind `@guardByAppKey`; uuids are unguessable v7 UUIDs.

## To enable (on the runtime's app)
```graphql
mutation($i: ModuleConfigInput!){ setAppSetting(input:$i) }
# variables: { "i": { "key": "kanvas-intelligence-voice-runtime-cross-app", "value": true } }
```
Then the runtime (authenticating as that app) can resolve agents in any app.

Verified: `php -l` clean; no remaining `getByUuidFromApp` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)