### PR TITLE
docs: log the Kanvas bill/invoice id in the sheet, not the vendor's own number

### DIFF
--- a/src/Domains/Connectors/GoogleSheets/CLAUDE.md
+++ b/src/Domains/Connectors/GoogleSheets/CLAUDE.md
@@ -132,16 +132,23 @@ and the Acumatica connector). End to end, when Apex/Arc process an emailed invoi
 3. `download_attachment` (Gmail) — saves the PDF to Kanvas, returns `filesystem_id`/`url`.
 4. `extract_invoice_data` (Accounting) — reads the PDF with AI, gets the real vendor/total/dates.
    The email body/subject is never the source of truth for these — always read the PDF.
-5. `write_google_sheet` (this connector) — logs the invoice as a new row (no `sheet_url_or_id`
-   needed — falls back to the default sheet), automatically, without being asked.
-6. `create_ap_bill` / `create_ar_invoice` (Acumatica) — creates + pushes the bill/invoice, using
-   the real amount from step 4, not anything guessed from the email text.
-7. `attach_bill_file` / `attach_invoice_file` (Acumatica) — attaches the file using the `url`
+5. `create_ap_bill` / `create_ar_invoice` (Acumatica) — creates + pushes the bill/invoice using the
+   real data from step 4, giving back the **Kanvas bill/invoice id** and the Acumatica ref.
+6. `attach_bill_file` / `attach_invoice_file` (Acumatica) — attaches the file using the `url`
    from step 3, no re-download needed.
+7. `write_google_sheet` (this connector) — logs the invoice as a new row (no `sheet_url_or_id`
+   needed — falls back to the default sheet), automatically, without being asked. **The "ID
+   invoice" column holds the Kanvas bill/invoice id from step 5** (not the vendor/customer's own
+   invoice number) — this only works because the bill/invoice is created *before* this step, not
+   after.
 8. `update_google_sheet_cell` (this connector) — flips the sheet row's status to "Approved".
 9. `mark_email_as_read` (Gmail) — removes the message's `UNREAD` label, only now that every prior
    step succeeded, so the same invoice doesn't get reprocessed on the next `has:attachment
    is:unread` search. Never mark it read before this point — a failed run must still be findable.
+
+The agent's final reply must always give the complete breakdown (Kanvas id, Acumatica ref, vendor,
+invoice number, amount, GL account, subaccount, memo, status, attached file) — the user looks this
+up in Acumatica/Kanvas afterward and needs every field, not a short summary.
 
 ### Setup checklist — every key that must exist before this flow works
 

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -123,19 +123,25 @@ class AccountsPayableAgent extends SystemUserAgent
             . 'download_attachment with the message_id + attachment_id from read_email_details — it saves the '
             . 'file to Kanvas and returns a filesystem_id/url. The real vendor/total/dates are inside the PDF, '
             . 'never in the email body/subject — after downloading, call extract_invoice_data with the '
-            . 'filesystem_id to read the amount and other fields before writing them anywhere (e.g. a sheet). '
-            . 'To get an emailed invoice into Acumatica: download_attachment first, then pass its returned url '
-            . 'straight into attach_bill_file\'s file_url — no need to re-download or re-host it anywhere.',
-            '- Whenever you process an invoice email end-to-end (found via list_emails, read, downloaded, and '
-            . 'extracted with extract_invoice_data), ALWAYS log it in the default invoice-tracking sheet as a '
-            . 'standard step — do not wait to be asked. Call write_google_sheet with range "Invoices!A1" and a '
-            . 'row of [invoice_number, vendor_name, total, "Pending"] (omit sheet_url_or_id to use the default '
-            . 'sheet), then after the bill is created and pushed, call update_google_sheet_cell to flip that '
-            . 'row\'s status column to "Approved". Do this even when the user only asked you to create the bill. '
-            . 'Only after ALL of that succeeds (sheet logged, bill created and pushed), call '
-            . 'mark_email_as_read on the message_id — this is what stops the same invoice from showing up again '
-            . 'next time you search "has:attachment is:unread". Never mark it read before every step succeeds, '
-            . 'so a failed run can still be found and retried.',
+            . 'filesystem_id to read the amount and other fields before writing them anywhere (e.g. a sheet).',
+            '- When you process an invoice email end-to-end, follow this exact order every time, without being '
+            . 'asked — this is a standard step of processing an invoice email, not a separate favor: '
+            . '(1) list_emails → read_email_details → download_attachment → extract_invoice_data, to get the '
+            . 'real vendor/total/dates and the file\'s url. '
+            . '(2) create_ap_bill using that real data — this both creates the Kanvas bill and pushes it to '
+            . 'Acumatica, giving you the Kanvas bill_id and the Acumatica bill_ref. '
+            . '(3) attach_bill_file with the bill_id from step 2 and the url from step 1\'s download_attachment '
+            . '— no need to re-download or re-host the file anywhere. '
+            . '(4) write_google_sheet to log the row — range "Invoices!A1", omit sheet_url_or_id to use the '
+            . 'default sheet — with the ID invoice column set to the Kanvas bill_id from step 2 (NOT the '
+            . 'vendor\'s own invoice number), then [vendor_name, total, "Pending"]. '
+            . '(5) update_google_sheet_cell to flip that row\'s status column to "Approved". '
+            . '(6) mark_email_as_read on the message_id — only now, after every step above succeeded, so a '
+            . 'failed run can still be found and retried on the next "has:attachment is:unread" search. '
+            . '(7) In your final reply, always give the complete breakdown of everything that happened: Kanvas '
+            . 'bill_id, Acumatica bill_ref, vendor, invoice number, amount, GL account, subaccount, memo, '
+            . 'status, and the attached file — never a short summary, the user needs every field to look this '
+            . 'up in Acumatica and Kanvas afterward.',
         ]);
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -143,19 +143,25 @@ class AccountsReceivableAgent extends SystemUserAgent
             . 'download_attachment with the message_id + attachment_id from read_email_details — it saves the '
             . 'file to Kanvas and returns a filesystem_id/url. The real vendor/total/dates are inside the PDF, '
             . 'never in the email body/subject — after downloading, call extract_invoice_data with the '
-            . 'filesystem_id to read the amount and other fields before writing them anywhere (e.g. a sheet). '
-            . 'To get an emailed invoice into Acumatica: download_attachment first, then pass its returned url '
-            . 'straight into attach_invoice_file\'s file_url — no need to re-download or re-host it anywhere.',
-            '- Whenever you process an invoice email end-to-end (found via list_emails, read, downloaded, and '
-            . 'extracted with extract_invoice_data), ALWAYS log it in the default invoice-tracking sheet as a '
-            . 'standard step — do not wait to be asked. Call write_google_sheet with range "Invoices!A1" and a '
-            . 'row of [invoice_number, vendor_name, total, "Pending"] (omit sheet_url_or_id to use the default '
-            . 'sheet), then after the invoice is created and pushed, call update_google_sheet_cell to flip that '
-            . 'row\'s status column to "Approved". Do this even when the user only asked you to create the invoice. '
-            . 'Only after ALL of that succeeds (sheet logged, invoice created and pushed), call '
-            . 'mark_email_as_read on the message_id — this is what stops the same invoice from showing up again '
-            . 'next time you search "has:attachment is:unread". Never mark it read before every step succeeds, '
-            . 'so a failed run can still be found and retried.',
+            . 'filesystem_id to read the amount and other fields before writing them anywhere (e.g. a sheet).',
+            '- When you process an invoice email end-to-end, follow this exact order every time, without being '
+            . 'asked — this is a standard step of processing an invoice email, not a separate favor: '
+            . '(1) list_emails → read_email_details → download_attachment → extract_invoice_data, to get the '
+            . 'real vendor/total/dates and the file\'s url. '
+            . '(2) create_ar_invoice using that real data — this both creates the Kanvas invoice and pushes it '
+            . 'to Acumatica, giving you the Kanvas invoice_id and the Acumatica invoice_ref. '
+            . '(3) attach_invoice_file with the invoice_id from step 2 and the url from step 1\'s '
+            . 'download_attachment — no need to re-download or re-host the file anywhere. '
+            . '(4) write_google_sheet to log the row — range "Invoices!A1", omit sheet_url_or_id to use the '
+            . 'default sheet — with the ID invoice column set to the Kanvas invoice_id from step 2 (NOT the '
+            . 'customer\'s own invoice number), then [vendor_name, total, "Pending"]. '
+            . '(5) update_google_sheet_cell to flip that row\'s status column to "Approved". '
+            . '(6) mark_email_as_read on the message_id — only now, after every step above succeeded, so a '
+            . 'failed run can still be found and retried on the next "has:attachment is:unread" search. '
+            . '(7) In your final reply, always give the complete breakdown of everything that happened: Kanvas '
+            . 'invoice_id, Acumatica invoice_ref, customer, invoice number, amount, GL account, subaccount, '
+            . 'memo, status, and the attached file — never a short summary, the user needs every field to look '
+            . 'this up in Acumatica and Kanvas afterward.',
             '- Lead with the headline, then the top 3-5 items. Be honest about freshness.',
         ]);
     }


### PR DESCRIPTION
## Summary
1.x mirror of #10840 — same guidance reordering fix.

The sheet's "ID invoice" column now holds the real Kanvas bill/invoice id (created before logging to the sheet, so the id actually exists), not the vendor/customer's own invoice number. The agent's final reply must always include the full breakdown (Kanvas id, Acumatica ref, vendor, invoice number, amount, GL account, subaccount, memo, status, file).

Pure guidance/prompt text change — no tool code or schema changes.

## Test plan
- [x] `tests/Intelligence/Agents/UniversalAgentToolsTest.php` — 7/7 passing on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)