### PR TITLE
hotfix: brodcast issue

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,12 +8,13 @@ Guidelines for working with the Kanvas Ecosystem API codebase.
 - **Domain-driven design**: Code is organized by domain under `src/Domains/{DomainName}/`
 - **GraphQL API**: Uses Lighthouse PHP framework with schema files in `graphql/schemas/`
 - **PHP 8.4**: Use modern syntax (e.g., `new Foo(...)->execute()` not `(new Foo(...))->execute()`)
-- **Method formatting**: When a method **call** or **signature** has 3 or more arguments/parameters, format vertically with one per line. Applies to our own methods; native functions (`str_replace`, `preg_replace`, ...) stay inline.
+- **Method formatting — the rule of 4**: When a method **call** or **signature** has **4 or more** arguments/parameters, format vertically with one per line. 3 or fewer stays inline. Applies to our own methods; native functions (`str_replace`, `preg_replace`, ...) stay inline regardless.
   ```php
-  // 2 or fewer — inline is fine
+  // 3 or fewer — inline is fine
   $this->doSomething($a, $b);
+  $this->fetchPeopleCandidates($app, $company, $terms);
 
-  // 3+ — always vertical, calls and signatures alike
+  // 4+ — always vertical, calls and signatures alike
   $this->uploadImageToEntity(
       $company,
       app(Apps::class),
@@ -22,11 +23,12 @@ Guidelines for working with the Kanvas Ecosystem API codebase.
       'photo'
   );
 
-  private function rememberPost(
-      RestClient $client,
-      array $result,
-      ?int $featuredMediaId
-  ): void {
+  protected function assembleBulkResults(
+      array $terms,
+      array $candidates,
+      int $maxMatches,
+      callable $present
+  ): array {
   ```
 - **Use PHP 8+ named arguments to skip optional positional `null`s.** When you would otherwise pass `null` for an optional middle parameter just to reach a later one, switch to named arguments instead. The positional `null` is a readability and refactor-safety footgun (rename a parameter or add a new optional in between, every caller silently breaks).
   ```php

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\Broadcast;
 use Illuminate\Support\ServiceProvider;
 
 class BroadcastServiceProvider extends ServiceProvider
@@ -16,8 +15,6 @@ class BroadcastServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Broadcast::routes();
-
         require base_path('routes/channels.php');
     }
 }

--- a/src/Domains/Connectors/Twilio/Workflows/AgentChannelResponderActivity.php
+++ b/src/Domains/Connectors/Twilio/Workflows/AgentChannelResponderActivity.php
@@ -38,7 +38,7 @@ class AgentChannelResponderActivity extends KanvasActivity
             app: $app,
             integration: IntegrationsEnum::TWILIO,
             additionalParams: $params,
-            integrationOperation: function ($channel, $app, $integrationCompany, $additionalParams) use ($message, $user, $defaultAgentId, $allowedChannels, $channelAgentMapping, $params) {
+            integrationOperation: function ($channel, $app, $integrationCompany, $additionalParams) use ($message, $user, $defaultAgentId, $allowedChannels, $channelAgentMapping, $params): array {
                 if (empty($message)) {
                     return [
                         'message' => 'Message or user not found',

--- a/src/Domains/Guild/Search/MatchesBulkNameTerms.php
+++ b/src/Domains/Guild/Search/MatchesBulkNameTerms.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Str;
 trait MatchesBulkNameTerms
 {
     protected const int BULK_MAX_TERMS = 100;
+    protected const int BULK_MAX_BATCHED_TERMS = 1000;
     protected const int BULK_MAX_CANDIDATE_ROWS = 2000;
     protected const int BULK_MIN_TOKEN_LENGTH = 3;
     protected const int BULK_DEFAULT_MATCHES_PER_TERM = 3;
@@ -26,8 +27,9 @@ trait MatchesBulkNameTerms
     /**
      * @return list<array{query: string, tokens: list<string>}>
      */
-    protected function parseBulkTerms(string $input): array
+    protected function parseBulkTerms(string $input, ?int $limit = null): array
     {
+        $max = $limit ?? static::BULK_MAX_TERMS;
         $terms = [];
         $seen = [];
 
@@ -42,7 +44,7 @@ trait MatchesBulkNameTerms
             $seen[implode(' ', $tokens)] = true;
             $terms[] = ['query' => $query, 'tokens' => $tokens];
 
-            if (count($terms) >= static::BULK_MAX_TERMS) {
+            if (count($terms) >= $max) {
                 break;
             }
         }
@@ -54,11 +56,11 @@ trait MatchesBulkNameTerms
      * parseBulkTerms() caps silently, which is fine for a chat answer the model can narrate but not for
      * a file — a 500-name export that quietly holds 100 rows reads as "these are the only matches".
      */
-    protected function bulkTermsExceedLimit(string $input): bool
+    protected function bulkTermsExceedLimit(string $input, ?int $limit = null): bool
     {
         $parts = preg_split('/[,;\r\n]+/', trim($input), -1, PREG_SPLIT_NO_EMPTY) ?: [];
 
-        return count($parts) > static::BULK_MAX_TERMS;
+        return count($parts) > ($limit ?? static::BULK_MAX_TERMS);
     }
 
     /**
@@ -67,8 +69,12 @@ trait MatchesBulkNameTerms
      * @param callable(mixed, int): array<string, mixed> $present
      * @return array{searched: int, matched: int, not_found: list<string>, results: list<array<string, mixed>>}
      */
-    protected function assembleBulkResults(array $terms, array $candidates, int $maxMatches, callable $present): array
-    {
+    protected function assembleBulkResults(
+        array $terms,
+        array $candidates,
+        int $maxMatches,
+        callable $present
+    ): array {
         $results = [];
         $notFound = [];
         $matched = 0;

--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentChannelReplyAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentChannelReplyAction.php
@@ -98,7 +98,7 @@ class BaseAgentChannelReplyAction
         ?string $from = null
     ): Message {
         if (empty($text)) {
-            throw new Exception('Empty message was created');
+            throw new AgentReplySkippedException('Empty message was created');
         }
         $user = $this->channel->company->getAiAgentUser() ?? $message->user;
         $type = $this->getMessageType($message->app);

--- a/src/Domains/Intelligence/Agents/Neuron/Exporters/PeopleMatchRecordExporter.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Exporters/PeopleMatchRecordExporter.php
@@ -18,7 +18,8 @@ use Override;
  * file can't launder a guess as a lookup.
  *
  * One row per input name, in the order given, so the result joins straight back onto the caller's
- * own spreadsheet.
+ * own spreadsheet — which is why the ceiling here is a whole list rather than one query's worth:
+ * three files of 100 rows don't join back onto anything.
  */
 class PeopleMatchRecordExporter implements RecordExporterInterface
 {
@@ -34,8 +35,12 @@ class PeopleMatchRecordExporter implements RecordExporterInterface
     #[Override]
     public function filtersHint(): string
     {
-        return 'names (required) — every name to cross-reference, separated by commas or new lines, '
-            . 'max 100 per export; one row per name in the order given with Found yes/no';
+        return sprintf(
+            'names (required) — EVERY name to cross-reference in ONE call, separated by commas or new '
+            . 'lines, up to %d per export; never split the list across several calls, that hands the '
+            . 'user one file per batch. One row per name in the order given with Found yes/no',
+            self::BULK_MAX_BATCHED_TERMS,
+        );
     }
 
     #[Override]
@@ -56,14 +61,19 @@ class PeopleMatchRecordExporter implements RecordExporterInterface
             );
         }
 
-        if ($this->bulkTermsExceedLimit($names)) {
+        if ($this->bulkTermsExceedLimit($names, self::BULK_MAX_BATCHED_TERMS)) {
             throw new ValidationException(sprintf(
                 'people_match takes at most %d names per export. Split the list into batches and export each one.',
-                self::BULK_MAX_TERMS,
+                self::BULK_MAX_BATCHED_TERMS,
             ));
         }
 
-        $matches = $this->matchPeopleByName($app, $company, $names);
+        $matches = $this->matchPeopleByName(
+            $app,
+            $company,
+            $names,
+            maxTerms: self::BULK_MAX_BATCHED_TERMS,
+        );
 
         if ($matches['searched'] === 0) {
             throw new ValidationException(

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Traits/MatchesPeopleByName.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Traits/MatchesPeopleByName.php
@@ -22,6 +22,11 @@ trait MatchesPeopleByName
     use MatchesBulkNameTerms;
 
     /**
+     * $maxTerms raises the ceiling past one query's worth; the list is always resolved in batches of
+     * BULK_MAX_TERMS because BULK_MAX_CANDIDATE_ROWS is a per-QUERY budget — one prefilter over too
+     * many names fills it with whatever a common surname pulled in, and a name that does match comes
+     * back "not found". Dedup happens once over the whole list, before chunking.
+     *
      * @return array{searched: int, matched: int, not_found: list<string>, results: list<array<string, mixed>>}
      */
     protected function matchPeopleByName(
@@ -29,31 +34,40 @@ trait MatchesPeopleByName
         Companies $company,
         string $names,
         ?int $maxMatchesPerName = null,
+        ?int $maxTerms = null,
     ): array {
-        $terms = $this->parseBulkTerms($names);
+        $maxMatches = $this->clampBulkMatchesPerTerm($maxMatchesPerName);
+        $merged = [
+            'searched' => 0,
+            'matched' => 0,
+            'not_found' => [],
+            'results' => [],
+        ];
 
-        if ($terms === []) {
-            return [
-                'searched' => 0,
-                'matched' => 0,
-                'not_found' => [],
-                'results' => [],
-            ];
+        $batches = array_chunk($this->parseBulkTerms($names, $maxTerms), static::BULK_MAX_TERMS);
+
+        foreach ($batches as $terms) {
+            $batch = $this->assembleBulkResults(
+                $terms,
+                $this->fetchPeopleCandidates($app, $company, $terms),
+                $maxMatches,
+                fn (People $person, int $score): array => [
+                    'person_id' => $person->getId(),
+                    'name' => $person->getName(),
+                    'email' => $this->primaryEmail($person),
+                    'phone' => $this->primaryPhone($person),
+                    'organization' => $person->organizations->first()?->name,
+                    'matched_tokens' => $score,
+                ],
+            );
+
+            $merged['searched'] += $batch['searched'];
+            $merged['matched'] += $batch['matched'];
+            $merged['not_found'] = [...$merged['not_found'], ...$batch['not_found']];
+            $merged['results'] = [...$merged['results'], ...$batch['results']];
         }
 
-        return $this->assembleBulkResults(
-            $terms,
-            $this->fetchPeopleCandidates($app, $company, $terms),
-            $this->clampBulkMatchesPerTerm($maxMatchesPerName),
-            fn (People $person, int $score): array => [
-                'person_id' => $person->getId(),
-                'name' => $person->getName(),
-                'email' => $this->primaryEmail($person),
-                'phone' => $this->primaryPhone($person),
-                'organization' => $person->organizations->first()?->name,
-                'matched_tokens' => $score,
-            ],
-        );
+        return $merged;
     }
 
     /**

--- a/tests/Ecosystem/Api/BroadcastAuthRouteTest.php
+++ b/tests/Ecosystem/Api/BroadcastAuthRouteTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Ecosystem\Api;
+
+use App\Http\Kernel;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+final class BroadcastAuthRouteTest extends TestCase
+{
+    public function testBroadcastingAuthRouteIsNotRegistered(): void
+    {
+        $this->assertNull(
+            Route::getRoutes()->getByName('broadcasting.auth'),
+            'Broadcast::routes() must not be called — it defaults to the `web` middleware group, which this app does not define.',
+        );
+
+        $response = $this->post('/broadcasting/auth');
+
+        $response->assertStatus(404);
+        $this->assertNotSame(500, $response->getStatusCode());
+    }
+
+    public function testNoRouteDependsOnTheMissingWebMiddlewareGroup(): void
+    {
+        $groups = app(Kernel::class)->getMiddlewareGroups();
+
+        $offenders = [];
+
+        foreach (Route::getRoutes() as $route) {
+            if (in_array('web', $route->gatherMiddleware(), true) && ! isset($groups['web'])) {
+                $offenders[] = $route->uri();
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            'These routes reference the undefined `web` middleware group and will 500 with "Target class [web] does not exist": ' . implode(', ', $offenders),
+        );
+    }
+}

--- a/tests/Intelligence/Agents/AgentReplySkippedTest.php
+++ b/tests/Intelligence/Agents/AgentReplySkippedTest.php
@@ -17,6 +17,8 @@ use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Social\MessagesTypes\Models\MessageType;
 use Kanvas\SystemModules\Models\SystemModules;
 use Kanvas\Workflow\Contracts\SilentWorkflowException;
+use ReflectionClass;
+use ReflectionMethod;
 use Tests\TestCase;
 
 final class AgentReplySkippedTest extends TestCase
@@ -32,6 +34,27 @@ final class AgentReplySkippedTest extends TestCase
         $this->assertInstanceOf(
             SilentWorkflowException::class,
             new AgentReplySkippedException('Ai Agent Off for this lead')
+        );
+    }
+
+    /**
+     * An agent that returns nothing is a business outcome, not a fault — it must be flagged FAILED
+     * in the integration history without reaching Sentry (KANVAS-ECOSYSTEM-5T1, 64 events).
+     */
+    public function testEmptyReplyThrowsSilentSkip(): void
+    {
+        $action = new ReflectionClass(AgentChannelResponderAction::class)->newInstanceWithoutConstructor();
+        $createMessage = new ReflectionMethod($action, 'createMessage');
+
+        $this->expectException(AgentReplySkippedException::class);
+        $this->expectExceptionMessage('Empty message was created');
+
+        $createMessage->invoke(
+            $action,
+            '',
+            '+13123884288',
+            new Message(),
+            new Channel()
         );
     }
 

--- a/tests/Intelligence/Agents/Exporters/PeopleMatchRecordExporterTest.php
+++ b/tests/Intelligence/Agents/Exporters/PeopleMatchRecordExporterTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Intelligence\Agents\Exporters;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Intelligence\Agents\Neuron\Exporters\PeopleMatchRecordExporter;
+use Kanvas\Users\Models\Users;
+use Tests\TestCase;
+
+final class PeopleMatchRecordExporterTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected array $connectionsToTransact = ['mysql', 'crm'];
+
+    private Apps $currentApp;
+    private Companies $currentCompany;
+    private Users $actingUser;
+    private string $tag;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->currentApp = app(Apps::class);
+        $this->actingUser = static::$cachedUser;
+        $this->currentCompany = $this->actingUser->getCurrentCompany();
+        $this->tag = 'Match' . uniqid();
+    }
+
+    /**
+     * A 300-name sheet used to throw "at most 100 names per export", and the model obeyed that error
+     * literally — three exporter calls, three CSVs the user had to stitch back together.
+     */
+    public function test_a_list_longer_than_one_query_batch_exports_as_a_single_row_set(): void
+    {
+        $first = $this->makePerson('Adanela', 'Cedeno');
+        $late = $this->makePerson('Jorgelina', 'Duran');
+        $last = $this->makePerson('Karina', 'Piantini');
+
+        $names = $this->fillerNames(250);
+        $names[0] = $this->fullName('Adanela', 'Cedeno');
+        $names[180] = $this->fullName('Jorgelina', 'Duran');
+        $names[249] = $this->fullName('Karina', 'Piantini');
+
+        $rows = $this->exporter()->rows(
+            $this->currentApp,
+            $this->currentCompany,
+            ['names' => implode("\n", $names)],
+        );
+
+        $this->assertCount(250, $rows);
+
+        foreach ($rows as $index => $row) {
+            $this->assertSame($names[$index], $row[0], 'Row ' . $index . ' lost its input order');
+        }
+
+        $this->assertSame('Yes', $rows[0][1]);
+        $this->assertSame((int) $first->getId(), $rows[0][2]);
+
+        $this->assertSame('Yes', $rows[180][1]);
+        $this->assertSame((int) $late->getId(), $rows[180][2]);
+
+        $this->assertSame('Yes', $rows[249][1]);
+        $this->assertSame((int) $last->getId(), $rows[249][2]);
+    }
+
+    public function test_a_name_past_the_first_batch_is_still_found(): void
+    {
+        $person = $this->makePerson('Celenia', 'Vidal');
+
+        $names = $this->fillerNames(150);
+        $names[149] = $this->fullName('Celenia', 'Vidal');
+
+        $rows = $this->exporter()->rows(
+            $this->currentApp,
+            $this->currentCompany,
+            ['names' => implode(',', $names)],
+        );
+
+        $this->assertSame('Yes', $rows[149][1]);
+        $this->assertSame((int) $person->getId(), $rows[149][2]);
+    }
+
+    public function test_unmatched_names_stay_in_place_as_blank_rows(): void
+    {
+        $names = $this->fillerNames(120);
+
+        $rows = $this->exporter()->rows(
+            $this->currentApp,
+            $this->currentCompany,
+            ['names' => implode("\n", $names)],
+        );
+
+        $this->assertCount(120, $rows);
+        $this->assertSame('No', $rows[110][1]);
+        $this->assertSame('', $rows[110][2]);
+        $this->assertSame('', $rows[110][3]);
+    }
+
+    public function test_a_duplicate_across_the_batch_boundary_collapses_to_one_row(): void
+    {
+        $names = $this->fillerNames(150);
+        $names[149] = $names[10];
+
+        $rows = $this->exporter()->rows(
+            $this->currentApp,
+            $this->currentCompany,
+            ['names' => implode("\n", $names)],
+        );
+
+        $this->assertCount(149, $rows);
+    }
+
+    public function test_a_list_beyond_the_export_ceiling_still_errors(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('at most 1000 names per export');
+
+        $this->exporter()->rows(
+            $this->currentApp,
+            $this->currentCompany,
+            ['names' => implode("\n", $this->fillerNames(1001))],
+        );
+    }
+
+    public function test_missing_names_is_an_actionable_error(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->exporter()->rows($this->currentApp, $this->currentCompany, []);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function fillerNames(int $count): array
+    {
+        return array_map(
+            fn (int $i): string => 'Ausente' . $this->tag . $i . ' Nohay' . $this->tag . $i,
+            range(1, $count),
+        );
+    }
+
+    private function fullName(string $first, string $last): string
+    {
+        return $first . $this->tag . ' ' . $last . $this->tag;
+    }
+
+    private function exporter(): PeopleMatchRecordExporter
+    {
+        return new PeopleMatchRecordExporter();
+    }
+
+    private function makePerson(string $first, string $last): People
+    {
+        return People::factory()
+            ->withAppId($this->currentApp->getId())
+            ->withCompanyId($this->currentCompany->getId())
+            ->withUserId($this->actingUser->getId())
+            ->create([
+                'firstname' => $first . $this->tag,
+                'lastname' => $last . $this->tag,
+            ]);
+    }
+}

--- a/tests/Intelligence/Agents/Tools/PeopleToolsTest.php
+++ b/tests/Intelligence/Agents/Tools/PeopleToolsTest.php
@@ -348,9 +348,25 @@ final class PeopleToolsTest extends TestCase
         $this->assertArrayHasKey('error', $result);
     }
 
-    public function test_export_records_people_match_rejects_more_than_the_term_cap(): void
+    public function test_export_records_people_match_exports_past_the_term_cap_as_one_file(): void
     {
+        $this->fakeCsvUpload();
+
         $names = implode(',', array_map(fn (int $i): string => 'Personuniq Number' . $i, range(1, 101)));
+
+        $result = $this->tool(new ExportRecordsTool())->__invoke(
+            record_type: 'people_match',
+            filters: ['names' => $names],
+        );
+
+        $this->assertArrayNotHasKey('error', $result);
+        $this->assertStringStartsWith('https://fake.test/people_match', $result['file_url']);
+        $this->assertSame(101, $result['row_count']);
+    }
+
+    public function test_export_records_people_match_rejects_more_than_the_export_ceiling(): void
+    {
+        $names = implode(',', array_map(fn (int $i): string => 'Personuniq Number' . $i, range(1, 1001)));
 
         $result = $this->tool(new ExportRecordsTool())->__invoke(
             record_type: 'people_match',


### PR DESCRIPTION
…entions

Slack gives a bot token history only for conversations the bot has JOINED —
there is no workspace-wide firehose short of the Enterprise Grid Discovery
API. So "read all channels" is two problems: subscribe to the room-message
events, and get the bot into the rooms.
