### PR TITLE
docs: add Collaborators section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,10 @@ ansible-playbook playbooks/development-deploy.yaml \
   --diff
 ```
 
+## Collaborators
+
+- [@kaioken](https://github.com/kaioken) — Max Castro
+
 ## Working with kanvas
 - [Coding guideline](https://github.com/bakaphp/kanvas-ecosystem-api/wiki/Coding-Guidelines)
 - [Wiki](https://github.com/alexeymezenin/laravel-best-practices#follow-laravel-naming-conventions)


### PR DESCRIPTION
Test PR.

Adds a `## Collaborators` section to the README, listing [@kaioken](https://github.com/kaioken) (Max Castro), placed right before "Working with kanvas".

Docs-only change — no code touched.