### PR TITLE
feat(voice): voiceAgentByNumber query for inbound call routing

### DIFF
--- a/app/GraphQL/Intelligence/Mutations/AgentManagementMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/AgentManagementMutation.php
@@ -17,6 +17,7 @@ use Kanvas\Intelligence\Agents\Models\AgentLlmConfig;
 use Kanvas\Intelligence\Agents\Models\AgentModel;
 use Kanvas\Intelligence\Agents\Models\AgentSwarm;
 use Kanvas\Intelligence\Agents\Models\AgentType as AgentTypeModel;
+use Kanvas\Intelligence\Agents\Repositories\AgentsRepository;
 use Kanvas\NervousSystem\Capability\Models\Tool;
 use Kanvas\Users\Repositories\UsersRepository;
 
@@ -60,7 +61,7 @@ class AgentManagementMutation
             identity: $input['identity'] ?? null,
             userContext: $input['user_context'] ?? null,
             toolsConfig: $input['tools_config'] ?? null,
-            voiceConfig: $input['voice_config'] ?? null,
+            voiceConfig: $this->normalizeVoiceConfigPhone($input['voice_config'] ?? null),
             tools: isset($input['tool_ids']) ? $this->resolveTools($input['tool_ids'], $app) : null,
             parentAgent: $parentAgent,
             createdBy: auth()->user(),
@@ -121,7 +122,7 @@ class AgentManagementMutation
             identity: $input['identity'] ?? null,
             userContext: $input['user_context'] ?? null,
             toolsConfig: $input['tools_config'] ?? null,
-            voiceConfig: $input['voice_config'] ?? null,
+            voiceConfig: $this->normalizeVoiceConfigPhone($input['voice_config'] ?? null),
             parentAgent: $parentAgent,
             isSubAgent: (bool) ($input['is_sub_agent'] ?? false),
             agentLlmConfig: $llmConfig,
@@ -160,6 +161,24 @@ class AgentManagementMutation
         }
 
         return AgentLlmConfig::getByIdFromCompanyApp((int) $input['agent_llm_config_id'], $company, $app);
+    }
+
+    /**
+     * Canonicalize the per-agent phone number inside voice_config on save, so the
+     * stored value is a clean E.164 caller id — valid for Twilio outbound and an
+     * exact match for inbound number routing. Non-array input passes through.
+     */
+    private function normalizeVoiceConfigPhone(mixed $voiceConfig): mixed
+    {
+        if (
+            is_array($voiceConfig)
+            && isset($voiceConfig['phone_number'])
+            && is_string($voiceConfig['phone_number'])
+        ) {
+            $voiceConfig['phone_number'] = AgentsRepository::cleanPhoneNumber($voiceConfig['phone_number']);
+        }
+
+        return $voiceConfig;
     }
 
     /**

--- a/app/GraphQL/Intelligence/Queries/Agent/VoiceAgentByNumberQuery.php
+++ b/app/GraphQL/Intelligence/Queries/Agent/VoiceAgentByNumberQuery.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Intelligence\Queries\Agent;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Intelligence\Agents\Repositories\AgentsRepository;
+
+/**
+ * Inbound routing: given the dialed phone number, return which agent should
+ * answer. The external voice runtime calls this from its Twilio incoming-call
+ * webhook to build TwiML with the right agent_id. Guarded by @guardByAppKey
+ * (server-to-server) and cross-app aware (see AgentsRepository).
+ *
+ * Returns null when no agent claims the number, so the runtime can fall back to
+ * a default agent rather than reject the call.
+ *
+ * @return array<string, mixed>|null
+ */
+class VoiceAgentByNumberQuery
+{
+    public function __invoke(mixed $root, array $args): ?array
+    {
+        $app = app(Apps::class);
+        $agent = AgentsRepository::getByPhoneForVoiceRuntime((string) $args['phone_number'], $app);
+
+        return $agent ? ['agent_id' => $agent->uuid] : null;
+    }
+}

--- a/graphql/schemas/Intelligence/voiceAgent.graphql
+++ b/graphql/schemas/Intelligence/voiceAgent.graphql
@@ -52,10 +52,19 @@ type VoiceAgentContextField {
     default: String
 }
 
+type VoiceAgentByNumber {
+    agent_id: String!
+}
+
 extend type Query @guardByAppKey {
     voiceAgentSpec(uuid: String!): VoiceAgentSpec!
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Queries\\Agent\\VoiceAgentSpecQuery"
+        )
+    "Inbound routing: which agent owns this dialed number? Null if none."
+    voiceAgentByNumber(phone_number: String!): VoiceAgentByNumber
+        @field(
+            resolver: "App\\GraphQL\\Intelligence\\Queries\\Agent\\VoiceAgentByNumberQuery"
         )
 }
 

--- a/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
+++ b/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
@@ -39,4 +39,30 @@ class AgentsRepository
 
         return $query->firstOrFail();
     }
+
+    /**
+     * Resolve the agent that owns a given inbound phone number (the per-agent
+     * voice_config.phone_number set in the admin UI), for the voice runtime's
+     * inbound routing. Returns null when no agent claims the number so the
+     * caller can fall back to a default agent instead of dropping the call.
+     *
+     * Same cross-app trust model as getByUuidForVoiceRuntime: app-scoped unless
+     * the calling app is flagged VOICE_RUNTIME_CROSS_APP.
+     */
+    public static function getByPhoneForVoiceRuntime(string $phoneNumber, AppInterface $app): ?Agent
+    {
+        $crossApp = filter_var(
+            $app->get(ConfigurationEnum::VOICE_RUNTIME_CROSS_APP->value),
+            FILTER_VALIDATE_BOOLEAN
+        );
+
+        $query = Agent::where('voice_config->phone_number', $phoneNumber)
+            ->notDeleted();
+
+        if (! $crossApp) {
+            $query->where('apps_id', $app->getId());
+        }
+
+        return $query->first();
+    }
 }

--- a/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
+++ b/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
@@ -51,18 +51,47 @@ class AgentsRepository
      */
     public static function getByPhoneForVoiceRuntime(string $phoneNumber, AppInterface $app): ?Agent
     {
+        $normalized = self::normalizePhoneNumber($phoneNumber);
+        if ($normalized === '') {
+            return null;
+        }
+
         $crossApp = filter_var(
             $app->get(ConfigurationEnum::VOICE_RUNTIME_CROSS_APP->value),
             FILTER_VALIDATE_BOOLEAN
         );
 
-        $query = Agent::where('voice_config->phone_number', $phoneNumber)
-            ->notDeleted();
+        // Match on a digits-only form of BOTH sides so a stored number carrying
+        // spaces / dashes / parens / a leading + still matches Twilio's strict
+        // E.164 `To`. JSON_VALID guards rows whose voice_config is null or not
+        // JSON. NOTE: this REPLACE/JSON chain can't use an index — fine at
+        // per-app agent counts; if it ever gets hot, normalize on write and
+        // index a generated column instead.
+        $digitsOnly = "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE("
+            . "JSON_UNQUOTE(JSON_EXTRACT(voice_config, '$.phone_number')),"
+            . " ' ', ''), '-', ''), '(', ''), ')', ''), '.', ''), '+', '')";
+
+        $query = Agent::query()
+            ->notDeleted()
+            ->whereRaw('JSON_VALID(voice_config)')
+            ->whereRaw("{$digitsOnly} = ?", [$normalized])
+            ->orderBy('id');
 
         if (! $crossApp) {
             $query->where('apps_id', $app->getId());
         }
 
         return $query->first();
+    }
+
+    /**
+     * Canonicalize a phone number for matching: digits only. Drops '+', spaces,
+     * dashes, dots, parentheses, etc. so any human-entered format lines up with
+     * Twilio's E.164 (e.g. "+1 (555) 123-4567" and "+15551234567" both become
+     * "15551234567").
+     */
+    public static function normalizePhoneNumber(string $number): string
+    {
+        return preg_replace('/\D+/', '', $number) ?? '';
     }
 }

--- a/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
+++ b/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
@@ -63,13 +63,13 @@ class AgentsRepository
 
         // Match on a digits-only form of BOTH sides so a stored number carrying
         // spaces / dashes / parens / a leading + still matches Twilio's strict
-        // E.164 `To`. JSON_VALID guards rows whose voice_config is null or not
-        // JSON. NOTE: this REPLACE/JSON chain can't use an index — fine at
-        // per-app agent counts; if it ever gets hot, normalize on write and
-        // index a generated column instead.
-        $digitsOnly = "REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE("
-            . "JSON_UNQUOTE(JSON_EXTRACT(voice_config, '$.phone_number')),"
-            . " ' ', ''), '-', ''), '(', ''), ')', ''), '.', ''), '+', '')";
+        // E.164 `To`. REGEXP_REPLACE strips every non-digit — the SQL mirror of
+        // normalizePhoneNumber's `\D` — so it can't drift from the PHP side.
+        // JSON_VALID guards rows whose voice_config is null or not JSON.
+        // NOTE: this can't use an index — fine at per-app agent counts; if it
+        // ever gets hot, normalize on write and index a generated column.
+        $digitsOnly =
+            "REGEXP_REPLACE(JSON_UNQUOTE(JSON_EXTRACT(voice_config, '$.phone_number')), '[^0-9]', '')";
 
         $query = Agent::query()
             ->notDeleted()

--- a/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
+++ b/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
@@ -61,27 +61,27 @@ class AgentsRepository
             FILTER_VALIDATE_BOOLEAN
         );
 
-        // Match on a digits-only form of BOTH sides so a stored number carrying
-        // spaces / dashes / parens / a leading + still matches Twilio's strict
-        // E.164 `To`. REGEXP_REPLACE strips every non-digit — the SQL mirror of
-        // normalizePhoneNumber's `\D` — so it can't drift from the PHP side.
-        // JSON_VALID guards rows whose voice_config is null or not JSON.
-        // NOTE: this can't use an index — fine at per-app agent counts; if it
-        // ever gets hot, normalize on write and index a generated column.
-        $digitsOnly =
-            "REGEXP_REPLACE(JSON_UNQUOTE(JSON_EXTRACT(voice_config, '$.phone_number')), '[^0-9]', '')";
-
+        // Narrow to voice-configured agents in SQL (a small set — only agents
+        // with a voice_config), then match in PHP with the SAME
+        // normalizePhoneNumber on both sides. One canonical, unit-testable
+        // normalizer, no raw/DB-specific SQL, and no risk of a SQL form drifting
+        // from the PHP one. Fine at per-agent counts; if the voice-agent set ever
+        // grows large, normalize on write and index the number instead.
         $query = Agent::query()
             ->notDeleted()
-            ->whereRaw('JSON_VALID(voice_config)')
-            ->whereRaw("{$digitsOnly} = ?", [$normalized])
+            ->whereNotNull('voice_config')
             ->orderBy('id');
 
         if (! $crossApp) {
             $query->where('apps_id', $app->getId());
         }
 
-        return $query->first();
+        return $query->get()->first(function (Agent $agent) use ($normalized): bool {
+            $stored = $agent->voice_config['phone_number'] ?? null;
+
+            return $stored !== null
+                && self::normalizePhoneNumber((string) $stored) === $normalized;
+        });
     }
 
     /**

--- a/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
+++ b/src/Domains/Intelligence/Agents/Repositories/AgentsRepository.php
@@ -94,4 +94,22 @@ class AgentsRepository
     {
         return preg_replace('/\D+/', '', $number) ?? '';
     }
+
+    /**
+     * Canonicalize a phone number for STORAGE: strip spaces, dashes, parens,
+     * etc. but PRESERVE a leading + so it stays a valid E.164 Twilio caller id.
+     * Unlike normalizePhoneNumber (digits only, for lenient matching), this keeps
+     * the +. e.g. "+1 (555) 123-4567" -> "+15551234567", "5551234567" -> "5551234567".
+     */
+    public static function cleanPhoneNumber(string $number): string
+    {
+        $number = trim($number);
+        $digits = preg_replace('/\D+/', '', $number) ?? '';
+
+        if ($digits === '') {
+            return '';
+        }
+
+        return str_starts_with($number, '+') ? '+' . $digits : $digits;
+    }
 }


### PR DESCRIPTION
Backend for **inbound** voice routing. Given a dialed phone number, return which agent should answer — by the per-agent `voice_config.phone_number` set in the admin UI. The external voice runtime calls this from its Twilio incoming-call webhook to build TwiML with the right `agent_id`.

## Changes
- `AgentsRepository::getByPhoneForVoiceRuntime($number, $app)` — matches `voice_config->phone_number`; returns **null** when no agent claims the number (so the runtime falls back to a default agent instead of dropping the call). Same cross-app trust model as `getByUuidForVoiceRuntime` (app-scoped unless the calling app is flagged `VOICE_RUNTIME_CROSS_APP`).
- `VoiceAgentByNumberQuery` + schema: `voiceAgentByNumber(phone_number: String!): VoiceAgentByNumber` under `extend type Query @guardByAppKey` (nullable result).

## Pairs with
- kanvas-voice-agents: the `/twilio/incoming` webhook (runtime PR — next) that calls this.
- The per-agent phone number (already shipped) — that number is what callers dial.

Verified: `php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)