### PR TITLE
feat(voice): agent tools data plane (spec tools + runVoiceAgentTool)

### DIFF
--- a/app/GraphQL/Intelligence/Mutations/VoiceAgentToolMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/VoiceAgentToolMutation.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Intelligence\Mutations;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Intelligence\Agents\Actions\Voice\RunVoiceAgentToolAction;
+use Kanvas\Intelligence\Agents\Repositories\AgentsRepository;
+
+/**
+ * Voice-agent data plane resolver. Server-to-server (@guardByAppKey) and
+ * cross-app aware (via getByUuidForVoiceRuntime): the external voice runtime
+ * calls this to execute one of an agent's tools when the LLM makes a function
+ * call. Returns the tool's JSON result (Mixed).
+ */
+class VoiceAgentToolMutation
+{
+    /**
+     * @param array{agent_uuid: string, tool_name: string, arguments?: mixed} $args
+     */
+    public function run(mixed $root, array $args): mixed
+    {
+        $app = app(Apps::class);
+        $agent = AgentsRepository::getByUuidForVoiceRuntime((string) $args['agent_uuid'], $app);
+
+        $arguments = $args['arguments'] ?? [];
+        if (! is_array($arguments)) {
+            $arguments = [];
+        }
+
+        return new RunVoiceAgentToolAction($agent, (string) $args['tool_name'], $arguments)->execute();
+    }
+}

--- a/graphql/schemas/Intelligence/voiceAgent.graphql
+++ b/graphql/schemas/Intelligence/voiceAgent.graphql
@@ -6,6 +6,7 @@ type VoiceAgentSpec {
     models: VoiceAgentModels!
     telephony: VoiceAgentTelephony
     context_schema: [VoiceAgentContextField!]!
+    tools: [VoiceAgentTool!]!
 }
 
 type VoiceAgentPrompts {
@@ -52,6 +53,13 @@ type VoiceAgentContextField {
     default: String
 }
 
+type VoiceAgentTool {
+    name: String!
+    description: String
+    "JSON Schema for the tool's arguments: { type, properties, required }."
+    parameters: Mixed
+}
+
 type VoiceAgentByNumber {
     agent_id: String!
 }
@@ -81,5 +89,13 @@ extend type Mutation @guard {
     sendVoiceAgentTestCall(id: ID!, to_number: String!): VoiceAgentCallResult!
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Mutations\\VoiceAgentCallMutation@placeTestCall"
+        )
+}
+
+extend type Mutation @guardByAppKey {
+    "Data plane: execute one of an agent's tools (called by the voice runtime on an LLM function call). Returns the tool's JSON result."
+    runVoiceAgentTool(agent_uuid: String!, tool_name: String!, arguments: Mixed): Mixed
+        @field(
+            resolver: "App\\GraphQL\\Intelligence\\Mutations\\VoiceAgentToolMutation@run"
         )
 }

--- a/src/Domains/Intelligence/Agents/Actions/Voice/RunVoiceAgentToolAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/RunVoiceAgentToolAction.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Actions\Voice;
+
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\NervousSystem\Capability\Enums\CapabilityFrameworkEnum;
+use Kanvas\NervousSystem\Capability\Services\CapabilityProvider;
+use NeuronAI\Tools\Tool as NeuronTool;
+use Throwable;
+
+/**
+ * Voice-agent data plane: execute ONE of an agent's tools by name and return its
+ * result. This is what the external voice runtime hits when the LLM makes a
+ * function call mid-call.
+ *
+ * The tool runs with the AGENT's own context — its app, its company, and its
+ * dedicated AI user (a non-request path, so we can't lean on auth()). Entity ids
+ * (lead, product, …) arrive as tool arguments, exactly like a chat-turn tool
+ * call. Reuses NeuronAI's Tool::execute() so argument mapping + dispatch match
+ * the in-process agent path.
+ */
+class RunVoiceAgentToolAction
+{
+    /**
+     * @param array<string, mixed> $arguments the LLM-supplied tool arguments
+     */
+    public function __construct(
+        private readonly Agent $agent,
+        private readonly string $toolName,
+        private readonly array $arguments,
+    ) {
+    }
+
+    /**
+     * @return mixed the tool's result (decoded from its JSON output), or a
+     *               structured error array the LLM can speak
+     */
+    public function execute(): mixed
+    {
+        $catalogTool = new CapabilityProvider()
+            ->getActiveTools($this->agent, CapabilityFrameworkEnum::NEURON->value)
+            ->first(fn ($tool): bool => $tool->name === $this->toolName);
+
+        if ($catalogTool === null) {
+            throw new ValidationException("Agent has no active tool named '{$this->toolName}'.");
+        }
+
+        $handlerClass = $catalogTool->handler;
+        if (empty($handlerClass) || ! class_exists($handlerClass)) {
+            throw new ValidationException("Tool '{$this->toolName}' has no runnable handler.");
+        }
+
+        $handler = app($handlerClass);
+        if (! $handler instanceof NeuronTool) {
+            throw new ValidationException("Tool '{$this->toolName}' is not executable.");
+        }
+
+        // Wire the agent's tenant context onto tools that accept it (withContext
+        // from HasKanvasContext). app/company come from the agent; the acting
+        // user is the company's dedicated AI user for this non-request path.
+        $company = $this->agent->companies_id > 0 ? Companies::find($this->agent->companies_id) : null;
+        if ($company !== null && method_exists($handler, 'withContext')) {
+            $handler->withContext($this->agent->app, $company, $company->getAiAgentUserOrFail());
+        }
+
+        try {
+            $handler->setInputs($this->arguments);
+            $handler->execute();
+        } catch (Throwable $e) {
+            // Never leak a stack trace to the model; hand back calm, speakable copy.
+            return ['status' => 'error', 'message' => $e->getMessage()];
+        }
+
+        // Tools setResult(json_encode($array)); decode so the runtime gets structure.
+        $result = $handler->getResult();
+        $decoded = json_decode($result, true);
+
+        return json_last_error() === JSON_ERROR_NONE ? $decoded : $result;
+    }
+}

--- a/src/Domains/Intelligence/Agents/Services/VoiceAgentSpecService.php
+++ b/src/Domains/Intelligence/Agents/Services/VoiceAgentSpecService.php
@@ -9,6 +9,11 @@ use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\Twilio\Enums\ConfigurationEnum as TwilioConfigurationEnum;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Enums\ConfigurationEnum;
+use Kanvas\NervousSystem\Capability\Enums\CapabilityFrameworkEnum;
+use Kanvas\NervousSystem\Capability\Services\CapabilityProvider;
+use NeuronAI\Tools\Tool as NeuronTool;
+use stdClass;
+use Throwable;
 
 /**
  * Compiles an Agent into the "voice agent spec" the external voice runtime
@@ -73,7 +78,56 @@ class VoiceAgentSpecService
             ],
             'telephony' => $this->telephony(),
             'context_schema' => array_values($voice['context_schema'] ?? []),
+            'tools' => $this->tools(),
         ];
+    }
+
+    /**
+     * The agent's callable tools, advertised so the voice runtime can register
+     * them as function-calling tools on the LLM. Only NEURON-framework tools
+     * whose handler class can be introspected are included; anything that fails
+     * to instantiate is skipped rather than breaking the whole spec fetch.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function tools(): array
+    {
+        $tools = [];
+
+        foreach (new CapabilityProvider()->getActiveTools($this->agent, CapabilityFrameworkEnum::NEURON->value) as $catalogTool) {
+            $handlerClass = $catalogTool->handler;
+            if (empty($handlerClass) || ! class_exists($handlerClass)) {
+                continue;
+            }
+
+            try {
+                $handler = app($handlerClass);
+            } catch (Throwable) {
+                continue;
+            }
+
+            if (! $handler instanceof NeuronTool) {
+                continue;
+            }
+
+            $properties = [];
+            foreach ($handler->getProperties() as $property) {
+                $properties[$property->getName()] = $property->getJsonSchema();
+            }
+
+            $tools[] = [
+                'name' => $handler->getName(),
+                'description' => $handler->getDescription(),
+                'parameters' => [
+                    'type' => 'object',
+                    // stdClass so an empty set serializes as JSON {}, not [].
+                    'properties' => $properties === [] ? new stdClass() : $properties,
+                    'required' => $handler->getRequiredProperties(),
+                ],
+            ];
+        }
+
+        return $tools;
     }
 
     /**


### PR DESCRIPTION
The **data plane** for voice agents — lets the LLM call an agent's Kanvas tools mid-call and get results back. Backend half (runtime PR follows).

## Changes
- **`VoiceAgentSpecService`** now emits `tools`: for each active **NEURON** tool the agent has (`CapabilityProvider::getActiveTools`), its `{name, description, parameters}` where `parameters` is a JSON Schema built from the handler class (`getProperties()` → `getJsonSchema()`, `getRequiredProperties()`). Handlers that can't be introspected are skipped — never breaks the spec fetch.
- **`RunVoiceAgentToolAction`** (`Actions/Voice/`): finds the named tool among the agent's active tools, wires the agent's tenant context (`withContext(app, company, dedicated AI user)` for tools using `HasKanvasContext`), then reuses **NeuronAI `Tool::execute()`** (`setInputs` → `__invoke`) so argument mapping/dispatch match the in-process agent path. Returns the decoded JSON result; exceptions come back as `{status:error, message}` the LLM can speak.
- **`runVoiceAgentTool(agent_uuid, tool_name, arguments): Mixed`** mutation — `@guardByAppKey`, cross-app aware (`getByUuidForVoiceRuntime`) — plus `VoiceAgentTool` type and `tools` on `VoiceAgentSpec`.

## First vertical slice
Aimed at **`inventory_search`** (no constructor deps, one string param, read-only) as the first tool to prove the whole chain end-to-end. The mechanism is general — any active NEURON tool is advertised + runnable.

## Needs on-env validation
`vendor/neuron-core` isn't in the worktree, so this is written against the installed NeuronAI API (`Tool::getProperties/getJsonSchema/setInputs/execute/getResult`, `ToolProperty::getJsonSchema`) — verified by reading the framework in the main checkout. Worth a quick live check that `runVoiceAgentTool` executes `inventory_search` and that tenant scoping (company) is right for it. `php -l` clean.

## Pairs with
Runtime PR (kanvas-voice-agents): register the spec's tools as Gemini function calls and POST each call to `runVoiceAgentTool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)