### PR TITLE
Stop the automatic invoice-email flow at Kanvas pending (no auto-push to Acumatica)

### DIFF
--- a/src/Domains/Connectors/GoogleSheets/CLAUDE.md
+++ b/src/Domains/Connectors/GoogleSheets/CLAUDE.md
@@ -122,33 +122,40 @@ file itself with the same care as any other production secret: don't commit it, 
 into chat/logs outside the one-time setup, and use a dedicated production service account (never
 reuse a personal/dev one).
 
-## Full invoice-processing flow (Gmail → Sheet → Acumatica)
+## Full invoice-processing flow (Gmail → Kanvas → Sheet)
 
-This connector is one leg of a 3-connector pipeline (see also `src/Domains/Connectors/Gmail/CLAUDE.md`
-and the Acumatica connector). End to end, when Apex/Arc process an emailed invoice, the agent:
+This connector is one leg of a pipeline (see also `src/Domains/Connectors/Gmail/CLAUDE.md` and the
+Acumatica connector). End to end, when Apex/Arc process an emailed invoice, the agent:
 
 1. `list_emails` (Gmail) — finds unread invoice emails.
 2. `read_email_details` (Gmail) — reads the body + attachment list.
 3. `download_attachment` (Gmail) — saves the PDF to Kanvas, returns `filesystem_id`/`url`.
 4. `extract_invoice_data` (Accounting) — reads the PDF with AI, gets the real vendor/total/dates.
    The email body/subject is never the source of truth for these — always read the PDF.
-5. `create_ap_bill` / `create_ar_invoice` (Acumatica) — creates + pushes the bill/invoice using the
-   real data from step 4, giving back the **Kanvas bill/invoice id** and the Acumatica ref.
-6. `attach_bill_file` / `attach_invoice_file` (Acumatica) — attaches the file using the `url`
-   from step 3, no re-download needed.
-7. `write_google_sheet` (this connector) — logs the invoice as a new row (no `sheet_url_or_id`
+5. `create_ap_bill` / `create_ar_invoice` (Acumatica) with **`push_to_acumatica: false`** — creates
+   the bill/invoice in Kanvas only (status `pending_approval` for bills, `draft` for invoices),
+   giving back the **Kanvas bill/invoice id**. Does **not** push to Acumatica and does not call
+   `attach_bill_file`/`attach_invoice_file` (both require an existing Acumatica push) — those
+   happen later, as a separate manual step once a human approves the bill/invoice in Kanvas.
+6. `write_google_sheet` (this connector) — logs the invoice as a new row (no `sheet_url_or_id`
    needed — falls back to the default sheet), automatically, without being asked. **The "ID
    invoice" column holds the Kanvas bill/invoice id from step 5** (not the vendor/customer's own
-   invoice number) — this only works because the bill/invoice is created *before* this step, not
-   after.
-8. `update_google_sheet_cell` (this connector) — flips the sheet row's status to "Approved".
-9. `mark_email_as_read` (Gmail) — removes the message's `UNREAD` label, only now that every prior
-   step succeeded, so the same invoice doesn't get reprocessed on the next `has:attachment
-   is:unread` search. Never mark it read before this point — a failed run must still be findable.
+   invoice number), with status **"Pending"**.
+7. `mark_email_as_read` (Gmail) — removes the message's `UNREAD` label, only now that steps 5–6
+   succeeded, so the same invoice doesn't get reprocessed on the next `has:attachment is:unread`
+   search. Never mark it read before this point — a failed run must still be findable.
 
-The agent's final reply must always give the complete breakdown (Kanvas id, Acumatica ref, vendor,
-invoice number, amount, GL account, subaccount, memo, status, attached file) — the user looks this
-up in Acumatica/Kanvas afterward and needs every field, not a short summary.
+**The Acumatica push, the sheet's flip to "Approved", and the file attachment are explicitly out of
+scope of this automatic flow** — they happen later, as a separate (currently manual) step once a
+human reviews and approves the bill/invoice sitting in Kanvas. That later step is not built yet as
+of this writing; `create_ap_bill`/`create_ar_invoice` still support pushing in one call (the
+default, `push_to_acumatica: true`) for the explicit "create and push this bill/invoice right now"
+request, which is a different, still-supported use case from the automatic email flow above.
+
+The agent's final reply must always give the complete breakdown of what happened so far (Kanvas
+id, vendor, invoice number, amount, GL account, subaccount, memo, status) — the user looks this up
+in Kanvas afterward and needs every field, not a short summary. There is no Acumatica reference at
+this stage — say so plainly instead of omitting it.
 
 ### Setup checklist — every key that must exist before this flow works
 
@@ -160,9 +167,10 @@ up in Acumatica/Kanvas afterward and needs every field, not a short summary.
 | 4 | `google-sheets-credentials` | Settings → Key Configurations | GoogleSheets |
 | 5 | `google-sheets-default-invoice-tracker` | Settings → Key Configurations | GoogleSheets |
 | 6 | Sheet shared as Editor with the service account's `client_email` | Google Sheets UI, per-sheet | GoogleSheets |
-| 7 | Acumatica credentials (see that connector's own docs) | Settings → Key Configurations | Acumatica |
 
 Steps 1–3 come from the OAuth Playground flow in `Gmail/CLAUDE.md`. Steps 4–6 come from the
 service-account flow above. Missing any of 1–6 breaks the flow at that specific step — the tool's
 error `reason` (`no_sheet_configured`, an authentication error from `Client::getInstance()`, etc.)
-tells you which one.
+tells you which one. Acumatica credentials are no longer required for this automatic flow (nothing
+is pushed to Acumatica here) — they're still needed for the separate `push_to_acumatica: true`
+use case and the future manual-approval step.

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -105,8 +105,10 @@ class AccountsPayableAgent extends SystemUserAgent
             '- Resolving a vendor name off an invoice → find_vendor; if more than one candidate, confirm which.',
             '- Lead with the headline (e.g. "Total payables: $84,200 across 12 vendors; $19,500 overdue"), then '
             . 'the top 3-5 items. Be honest about freshness; never invent precision the data lacks.',
-            '- "Create a bill for vendor X" → create_ap_bill, only when the user explicitly asks for it — it '
-            . 'writes straight to Acumatica, bypassing human approval.',
+            '- "Create a bill for vendor X" → create_ap_bill, only when the user explicitly asks for it — by '
+            . 'default it writes straight to Acumatica, bypassing human approval. Pass push_to_acumatica: false '
+            . 'only when you specifically want it to stop at pending_approval instead (e.g. the automatic '
+            . 'invoice-email flow below).',
             '- "Void/cancel/undo that bill" → void_ap_bill, given the bill_id from create_ap_bill.',
             '- "Pay a vendor bill" / "record a payment against bill Y" → apply_ap_payment, only when the user '
             . 'explicitly asks to record a real payment. Needs the bill_id, amount, and a payment reference.',
@@ -128,20 +130,21 @@ class AccountsPayableAgent extends SystemUserAgent
             . 'asked — this is a standard step of processing an invoice email, not a separate favor: '
             . '(1) list_emails → read_email_details → download_attachment → extract_invoice_data, to get the '
             . 'real vendor/total/dates and the file\'s url. '
-            . '(2) create_ap_bill using that real data — this both creates the Kanvas bill and pushes it to '
-            . 'Acumatica, giving you the Kanvas bill_id and the Acumatica bill_ref. '
-            . '(3) attach_bill_file with the bill_id from step 2 and the url from step 1\'s download_attachment '
-            . '— no need to re-download or re-host the file anywhere. '
-            . '(4) write_google_sheet to log the row — range "Invoices!A1", omit sheet_url_or_id to use the '
+            . '(2) create_ap_bill with push_to_acumatica: false, using that real data — this creates the Kanvas '
+            . 'bill and submits it for approval (status: pending_approval), giving you the Kanvas bill_id. Do '
+            . 'NOT push to Acumatica in this flow — a human approves the bill later and the push happens as a '
+            . 'separate, later step, not something you do here. Skip attach_bill_file too — it requires the '
+            . 'bill to already be pushed to Acumatica, which hasn\'t happened yet. '
+            . '(3) write_google_sheet to log the row — range "Invoices!A1", omit sheet_url_or_id to use the '
             . 'default sheet — with the ID invoice column set to the Kanvas bill_id from step 2 (NOT the '
             . 'vendor\'s own invoice number), then [vendor_name, total, "Pending"]. '
-            . '(5) update_google_sheet_cell to flip that row\'s status column to "Approved". '
-            . '(6) mark_email_as_read on the message_id — only now, after every step above succeeded, so a '
+            . '(4) mark_email_as_read on the message_id — only now, after both steps above succeeded, so a '
             . 'failed run can still be found and retried on the next "has:attachment is:unread" search. '
-            . '(7) In your final reply, always give the complete breakdown of everything that happened: Kanvas '
-            . 'bill_id, Acumatica bill_ref, vendor, invoice number, amount, GL account, subaccount, memo, '
-            . 'status, and the attached file — never a short summary, the user needs every field to look this '
-            . 'up in Acumatica and Kanvas afterward.',
+            . '(5) In your final reply, always give the complete breakdown of everything that happened so far: '
+            . 'Kanvas bill_id, vendor, invoice number, amount, GL account, subaccount, memo, and status '
+            . '(pending_approval in Kanvas / "Pending" in the sheet) — never a short summary. There is no '
+            . 'Acumatica reference yet at this stage — say so plainly rather than leaving it out; the push to '
+            . 'Acumatica and the file attachment happen later, once a human approves the bill.',
         ]);
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -122,7 +122,9 @@ class AccountsReceivableAgent extends SystemUserAgent
             '- "Send a sample" / "give a reviewer a free unit" → first find_product to turn the product NAME into a SKU, then create_sample_order (customer email+name, SKU, qty). If the customer email is missing, ask for it — it is a real shipment. It creates a $0 DRAFT in Kanvas; tell the user it pushes to the ERP only after a human approves it.',
             '- If asked about a PURCHASE order or a vendor BILL, say that is Accounts Payable, not your area.',
             '- "Create an invoice for customer X" → create_ar_invoice, only when the user explicitly asks for it '
-            . '— it writes straight to Acumatica, bypassing human approval.',
+            . '— by default it writes straight to Acumatica, bypassing human approval. Pass push_to_acumatica: '
+            . 'false only when you specifically want it to stop at draft instead (e.g. the automatic '
+            . 'invoice-email flow below).',
             '- "Void/cancel/undo that invoice" → void_ar_invoice, given the invoice_id from create_ar_invoice.',
             '- "Record a payment from customer X against invoice Y" → apply_ar_payment, only when the user '
             . 'explicitly asks to record a real payment. Needs the invoice_id, amount, and a payment reference.',
@@ -148,20 +150,21 @@ class AccountsReceivableAgent extends SystemUserAgent
             . 'asked — this is a standard step of processing an invoice email, not a separate favor: '
             . '(1) list_emails → read_email_details → download_attachment → extract_invoice_data, to get the '
             . 'real vendor/total/dates and the file\'s url. '
-            . '(2) create_ar_invoice using that real data — this both creates the Kanvas invoice and pushes it '
-            . 'to Acumatica, giving you the Kanvas invoice_id and the Acumatica invoice_ref. '
-            . '(3) attach_invoice_file with the invoice_id from step 2 and the url from step 1\'s '
-            . 'download_attachment — no need to re-download or re-host the file anywhere. '
-            . '(4) write_google_sheet to log the row — range "Invoices!A1", omit sheet_url_or_id to use the '
+            . '(2) create_ar_invoice with push_to_acumatica: false, using that real data — this creates the '
+            . 'Kanvas invoice (status: draft), giving you the Kanvas invoice_id. Do NOT issue or push to '
+            . 'Acumatica in this flow — a human approves it later and the push happens as a separate, later '
+            . 'step, not something you do here. Skip attach_invoice_file too — it requires the invoice to '
+            . 'already be pushed to Acumatica, which hasn\'t happened yet. '
+            . '(3) write_google_sheet to log the row — range "Invoices!A1", omit sheet_url_or_id to use the '
             . 'default sheet — with the ID invoice column set to the Kanvas invoice_id from step 2 (NOT the '
             . 'customer\'s own invoice number), then [vendor_name, total, "Pending"]. '
-            . '(5) update_google_sheet_cell to flip that row\'s status column to "Approved". '
-            . '(6) mark_email_as_read on the message_id — only now, after every step above succeeded, so a '
+            . '(4) mark_email_as_read on the message_id — only now, after both steps above succeeded, so a '
             . 'failed run can still be found and retried on the next "has:attachment is:unread" search. '
-            . '(7) In your final reply, always give the complete breakdown of everything that happened: Kanvas '
-            . 'invoice_id, Acumatica invoice_ref, customer, invoice number, amount, GL account, subaccount, '
-            . 'memo, status, and the attached file — never a short summary, the user needs every field to look '
-            . 'this up in Acumatica and Kanvas afterward.',
+            . '(5) In your final reply, always give the complete breakdown of everything that happened so far: '
+            . 'Kanvas invoice_id, customer, invoice number, amount, GL account, subaccount, memo, and status '
+            . '(draft in Kanvas / "Pending" in the sheet) — never a short summary. There is no Acumatica '
+            . 'reference yet at this stage — say so plainly rather than leaving it out; the push to Acumatica '
+            . 'and the file attachment happen later, once a human approves the invoice.',
             '- Lead with the headline, then the top 3-5 items. Be honest about freshness.',
         ]);
     }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -27,7 +27,7 @@ use Override;
 use Spatie\LaravelData\DataCollection;
 use Throwable;
 
-/** Creates a one-line AP bill, auto-approves it, and pushes it to Acumatica, bypassing the normal human-approval gate. */
+/** Creates a one-line AP bill and, by default, auto-approves it and pushes it to Acumatica in one step. */
 #[AgentTool(name: 'Create AP Bill', category: 'accounting')]
 class CreateApBillTool extends Tool
 {
@@ -37,9 +37,12 @@ class CreateApBillTool extends Tool
     {
         parent::__construct(
             name: 'create_ap_bill',
-            description: 'Creates a one-line AP bill, auto-approves it, and pushes it to Acumatica in one step, '
-                . 'returning the Acumatica bill reference. Bypasses the normal human approval gate — use only '
-                . 'when the user explicitly asks to create a bill this way, never on a whim.',
+            description: 'Creates a one-line AP bill. By default also auto-approves it and pushes it to Acumatica '
+                . 'in one step, returning the Acumatica bill reference — bypassing the normal human approval gate, '
+                . 'so only do this when the user explicitly asks to create a bill this way, never on a whim. Set '
+                . 'push_to_acumatica to false to just create the bill and submit it for approval (status: '
+                . 'pending_approval) without touching Acumatica — this is the default for the standard automatic '
+                . 'invoice-processing flow, where a human approves it later and the push happens separately.',
         );
     }
 
@@ -96,6 +99,15 @@ class CreateApBillTool extends Tool
                 description: 'Currency code. Defaults to USD.',
                 required: false,
             ),
+            new ToolProperty(
+                name: 'push_to_acumatica',
+                type: PropertyType::BOOLEAN,
+                description: 'Whether to auto-approve and push this bill to Acumatica immediately. Defaults to '
+                    . 'true. Set to false to just create the bill and submit it for approval (status: '
+                    . 'pending_approval) and stop there — used by the standard automatic invoice-processing '
+                    . 'flow, where a human approves it later and the Acumatica push happens as a separate step.',
+                required: false,
+            ),
         ];
     }
 
@@ -110,6 +122,7 @@ class CreateApBillTool extends Tool
         string $invoice_number,
         ?string $subaccount = null,
         ?string $currency = null,
+        bool $push_to_acumatica = true,
     ): array {
         $app = $this->app;
         $company = $this->company;
@@ -187,7 +200,25 @@ class CreateApBillTool extends Tool
             $actingUser,
         )->execute();
 
-        new SubmitBillForApprovalAction($bill, $actingUser)->execute();
+        $bill = new SubmitBillForApprovalAction($bill, $actingUser)->execute();
+
+        if (! $push_to_acumatica) {
+            return [
+                'created' => true,
+                'pushed' => false,
+                'bill_id' => $bill->getId(),
+                'bill_number' => $bill->bill_number,
+                'document_status' => $bill->document_status->value,
+                'vendor' => $vendor->name,
+                'amount' => $amount,
+                'currency' => $currency,
+                'gl_account' => $gl_account_number,
+                'subaccount' => $subaccount,
+                'memo' => $memo,
+                'next' => 'Bill created and submitted for approval in Kanvas (status: pending_approval). Not '
+                    . 'pushed to Acumatica — that happens separately once a human approves it.',
+            ];
+        }
 
         /** @var Organization $approvalVendor */
         $approvalVendor = Organization::query()->where('id', $bill->vendor_organization_id)->first();

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
@@ -23,7 +23,7 @@ use Override;
 use Spatie\LaravelData\DataCollection;
 use Throwable;
 
-/** Creates a one-line AR invoice, issues it, and pushes it to Acumatica — the AR mirror of CreateApBillTool. Stays open; use apply_ar_payment to record a payment against it separately. */
+/** Creates a one-line AR invoice and, by default, issues it and pushes it to Acumatica — the AR mirror of CreateApBillTool. Stays open; use apply_ar_payment to record a payment against it separately. */
 #[AgentTool(name: 'Create AR Invoice', category: 'accounting')]
 class CreateArInvoiceTool extends Tool
 {
@@ -33,10 +33,13 @@ class CreateArInvoiceTool extends Tool
     {
         parent::__construct(
             name: 'create_ar_invoice',
-            description: 'Creates a one-line AR invoice for a customer, issues it, and pushes it to Acumatica — '
-                . 'returning the invoice ref. The invoice stays open; use apply_ar_payment separately to record a '
-                . 'payment against it. Bypasses the normal human approval gate — use only when the user explicitly '
-                . 'asks to create an invoice this way, never on a whim.',
+            description: 'Creates a one-line AR invoice for a customer. By default also issues it and pushes it '
+                . 'to Acumatica in one step, returning the invoice ref — bypassing the normal human approval gate, '
+                . 'so only do this when the user explicitly asks to create an invoice this way, never on a whim. '
+                . 'The invoice stays open; use apply_ar_payment separately to record a payment against it. Set '
+                . 'push_to_acumatica to false to just create the invoice (status: draft) and stop there — this is '
+                . 'the default for the standard automatic invoice-processing flow, where a human issues/pushes it '
+                . 'later as a separate step.',
         );
     }
 
@@ -72,6 +75,15 @@ class CreateArInvoiceTool extends Tool
                 description: 'Currency code. Defaults to USD.',
                 required: false,
             ),
+            new ToolProperty(
+                name: 'push_to_acumatica',
+                type: PropertyType::BOOLEAN,
+                description: 'Whether to issue and push this invoice to Acumatica immediately. Defaults to true. '
+                    . 'Set to false to just create the invoice (status: draft) and stop there — used by the '
+                    . 'standard automatic invoice-processing flow, where a human issues/pushes it later as a '
+                    . 'separate step.',
+                required: false,
+            ),
         ];
     }
 
@@ -83,6 +95,7 @@ class CreateArInvoiceTool extends Tool
         float $amount,
         string $memo,
         ?string $currency = null,
+        bool $push_to_acumatica = true,
     ): array {
         $app = $this->app;
         $company = $this->company;
@@ -132,6 +145,22 @@ class CreateArInvoiceTool extends Tool
             ),
             $actingUser,
         )->execute();
+
+        if (! $push_to_acumatica) {
+            return [
+                'created' => true,
+                'invoice_pushed' => false,
+                'invoice_id' => $invoice->getId(),
+                'invoice_number' => $invoice->invoice_number,
+                'document_status' => $invoice->document_status->value,
+                'customer' => $customer->name,
+                'amount' => $amount,
+                'currency' => $currency,
+                'memo' => $memo,
+                'next' => 'Invoice created in Kanvas (status: draft). Not issued or pushed to Acumatica — that '
+                    . 'happens separately once a human approves it.',
+            ];
+        }
 
         $invoice = new IssueInvoiceAction($invoice, $customer, $actingUser)->execute();
 

--- a/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
@@ -21,6 +21,7 @@ use Kanvas\Scribe\Bills\Actions\CreateBillAction;
 use Kanvas\Scribe\Bills\Actions\ReceiveBillAction;
 use Kanvas\Scribe\Bills\DataTransferObject\Bill as BillData;
 use Kanvas\Scribe\Bills\DataTransferObject\BillLine as BillLineData;
+use Kanvas\Scribe\Bills\Enums\BillDocumentStatusEnum;
 use Kanvas\Scribe\Bills\Models\Bill;
 use Kanvas\Scribe\Ledger\Enums\AccountSubTypeEnum;
 use Kanvas\Scribe\Ledger\Models\Account;
@@ -283,6 +284,33 @@ class AccountsPayableAgentToolsTest extends ScribeTestCase
 
         $this->assertSame('1498', $bill->bill_number);
         $this->assertSame('BB-0G-M1', $bill->lines->first()->subaccount->sub_code);
+    }
+
+    public function test_create_ap_bill_with_push_to_acumatica_false_stops_at_pending_approval(): void
+    {
+        $this->seedTestOrganization('Windwalk Games Corp');
+        $accountId = $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS);
+        $accountCode = (string) Account::query()->where('id', $accountId)->value('account_number');
+
+        $result = new CreateApBillTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(
+                vendor_name: 'Windwalk Games Corp',
+                amount: 750.0,
+                gl_account_number: $accountCode,
+                memo: 'Pending flow test',
+                invoice_number: 'PEND-1',
+                push_to_acumatica: false,
+            );
+
+        $this->assertTrue($result['created']);
+        $this->assertFalse($result['pushed']);
+        $this->assertSame('pending_approval', $result['document_status']);
+        $this->assertArrayNotHasKey('bill_ref', $result);
+        $this->assertArrayNotHasKey('acumatica_bill_id', $result);
+
+        $bill = Bill::query()->where('id', $result['bill_id'])->first();
+        $this->assertSame(BillDocumentStatusEnum::PENDING_APPROVAL, $bill->document_status);
     }
 
     public function test_find_vendor_returns_a_dead_end_message_when_nothing_matches(): void

--- a/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
@@ -195,6 +195,25 @@ class AccountsReceivableAgentToolsTest extends ScribeTestCase
         $this->assertSame(0, $allocations);
     }
 
+    public function test_create_ar_invoice_with_push_to_acumatica_false_stops_at_draft(): void
+    {
+        $customer = $this->seedTestOrganization('Pending Invoice Customer');
+        $customer->set(CustomFieldEnum::CUSTOMER_ID->value, 'C0001000');
+
+        $result = new CreateArInvoiceTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(customer_name: 'Pending Invoice Customer', amount: 275.0, memo: 'Pending flow test', push_to_acumatica: false);
+
+        $this->assertTrue($result['created']);
+        $this->assertFalse($result['invoice_pushed']);
+        $this->assertSame('draft', $result['document_status']);
+        $this->assertArrayNotHasKey('invoice_ref', $result);
+        $this->assertArrayNotHasKey('acumatica_invoice_id', $result);
+
+        $invoice = Invoice::query()->where('id', $result['invoice_id'])->first();
+        $this->assertSame(InvoiceDocumentStatusEnum::DRAFT, $invoice->document_status);
+    }
+
     public function test_match_invoices_for_payment_flags_the_exact_invoice(): void
     {
         $customer = $this->seedTestOrganization('Acme Corporation');


### PR DESCRIPTION
## Summary
- `create_ap_bill` / `create_ar_invoice` now accept a `push_to_acumatica` param (default `true` — unchanged behavior for the explicit "create and push" request).
- Apex/Arc's automatic invoice-processing flow (triggered by an unread invoice email) now calls these tools with `push_to_acumatica: false`, so it:
  1. Creates the bill/invoice in Kanvas only — status `pending_approval` (bills) / `draft` (invoices).
  2. Logs the row in the tracking sheet with the Kanvas id and status **"Pending"**.
  3. Marks the email as read.
- It no longer auto-approves, pushes to Acumatica, or attaches the file in this flow — `attach_bill_file`/`attach_invoice_file` require an existing Acumatica push, so they're skipped here. The push + file attachment become a separate, later step once a human approves the bill/invoice in Kanvas (not built yet).
- Updated `AccountsPayableAgent`/`AccountsReceivableAgent` guidance and `GoogleSheets/CLAUDE.md` to document the new flow and the deferred Acumatica step.

1.x mirror of #10869.

## Test plan
- [x] `tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php` + `AccountsReceivableAgentToolsTest.php` — 33/33 passing, including 2 new tests asserting `push_to_acumatica: false` stops at `pending_approval`/`draft` with no `bill_ref`/`invoice_ref`.
- [x] `tests/Intelligence/Agents/UniversalAgentToolsTest.php` — 7/7 passing.
- [ ] Manual: send Apex/Arc an unread invoice email and confirm it stops at Kanvas pending + "Pending" in the sheet, with no Acumatica reference in the reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)