### PR TITLE
refactor(sales-assist): route AI Assist replies through AgentChatKernel

### DIFF
--- a/src/Domains/Connectors/SalesAssist/Actions/AIAssistAgentResponderAction.php
+++ b/src/Domains/Connectors/SalesAssist/Actions/AIAssistAgentResponderAction.php
@@ -6,12 +6,11 @@ namespace Kanvas\Connectors\SalesAssist\Actions;
 
 use Illuminate\Support\Str;
 use Kanvas\Exceptions\ValidationException;
+use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Actions\BaseAgentChannelReplyAction;
+use Kanvas\Intelligence\Agents\Actions\Chat\AgentChatKernel;
 use Kanvas\Intelligence\Agents\Helpers\ChatHelper;
-use Kanvas\Intelligence\Agents\Services\GoogleADKService;
-use Kanvas\Intelligence\Agents\Types\ADKAgent;
 use Kanvas\Intelligence\Enums\ConfigurationEnum;
-use NeuronAI\Chat\Messages\UserMessage;
 use Override;
 
 class AIAssistAgentResponderAction extends BaseAgentChannelReplyAction
@@ -23,66 +22,51 @@ class AIAssistAgentResponderAction extends BaseAgentChannelReplyAction
     #[Override]
     public function execute(array $params = []): array
     {
-        if ($this->message->entity() === null) {
+        $entity = $this->message->entity();
+
+        if ($entity === null) {
             throw new ValidationException('No entity found');
         }
 
-        $currentAgent = new $this->agent->type->handler();
-        $currentAgent->setConfiguration(
-            agent: $this->agent,
-            entity: $this->message->entity(),
-            user: $this->message->company->getAiAgentUserOrFail(),
-        );
-
-        $aiAssistAppName = $this->channel->company->get(ConfigurationEnum::ADK_AI_ASSIST_APP_NAME->value)
-            ?? $this->channel->app->get(ConfigurationEnum::ADK_AI_ASSIST_APP_NAME->value)
-            ?? null;
-
-        $aiAssistBaseUrl = $this->channel->company->get(ConfigurationEnum::ADK_AI_ASSIST_BASE_URL->value)
-            ?? $this->channel->app->get(ConfigurationEnum::ADK_AI_ASSIST_BASE_URL->value)
-            ?? null;
-
-        $onChunk = function ($text, $data): void {
-            $this->createMessage(
-                Str::markdown($text),
-                'ai-assist',
-                $this->message,
-                $this->channel
-            );
-        };
-
         $messageConversation = $this->message->message['content'];
 
-        if ($currentAgent instanceof ADKAgent) {
-            $adkService = new GoogleADKService(
-                $this->channel->app,
-                $this->channel->company,
-                $aiAssistAppName,
-                $aiAssistBaseUrl
-            );
+        $responseContent = new AgentChatKernel(
+            agent: $this->agent,
+            session: $this->session,
+            message: $messageConversation,
+            user: $this->message->company->getAiAgentUserOrFail(),
+            currentLead: $entity instanceof Lead ? $entity : null,
+            sourceChannel: $this->channel,
+            sourceMessage: $this->message,
+            persistConversation: false,
+            adkAppName: $this->aiAssistConfig(ConfigurationEnum::ADK_AI_ASSIST_APP_NAME),
+            adkBaseUrl: $this->aiAssistConfig(ConfigurationEnum::ADK_AI_ASSIST_BASE_URL),
+        )->execute();
 
-            $sessionId = $this->session ? $this->session->uuid : $this->channel->slug;
-            $userId = (string) $this->channel->entity_id;
+        $responseText = ChatHelper::extractTextFromResponse($responseContent);
 
-            $adkService->startSession($userId, $sessionId);
-
-            $responseContent = $adkService->chat(
-                $userId,
-                $sessionId,
-                $messageConversation,
-                $onChunk,
-                user: $this->message->user
-            );
-        } else {
-            $question = $currentAgent->chat(new UserMessage($messageConversation));
-            $responseContent = $question->getContent();
-            $responseText = ChatHelper::extractTextFromResponse($responseContent);
-            $onChunk($responseText, []);
-        }
+        $this->createMessage(
+            Str::markdown($responseText),
+            'ai-assist',
+            $this->message,
+            $this->channel
+        );
 
         return [
             'message' => $messageConversation,
             'responseText' => $responseContent,
         ];
+    }
+
+    /**
+     * AI Assist talks to its own ADK app (separate from the customer-facing orchestrator),
+     * so the target is read off the channel's company/app config, not the ADK defaults.
+     */
+    private function aiAssistConfig(ConfigurationEnum $key): ?string
+    {
+        $value = $this->channel->company->get($key->value)
+            ?? $this->channel->app->get($key->value);
+
+        return $value !== null && $value !== '' ? (string) $value : null;
     }
 }

--- a/src/Domains/Connectors/SalesAssist/Actions/CreateSocialChannelsAfterPullAction.php
+++ b/src/Domains/Connectors/SalesAssist/Actions/CreateSocialChannelsAfterPullAction.php
@@ -55,7 +55,7 @@ class CreateSocialChannelsAfterPullAction
             new CreateAIAssistChannelAction(
                 $this->lead,
                 $this->app,
-                $this->agentId,
+                $params['ai_assist_agent_id'] ?? $this->agentId,
             )->execute();
         }
 

--- a/src/Domains/Intelligence/Agents/Actions/Chat/AgentChatKernel.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/AgentChatKernel.php
@@ -56,6 +56,8 @@ class AgentChatKernel
         protected readonly array $documents = [],
         protected readonly array $additionalTools = [],
         protected readonly bool $privateUserTurn = false,
+        protected readonly ?string $adkAppName = null,
+        protected readonly ?string $adkBaseUrl = null,
     ) {
     }
 
@@ -177,6 +179,8 @@ class AgentChatKernel
                 user: $this->user,
                 sourceChannel: $this->sourceChannel,
                 sourceMessage: $this->sourceMessage,
+                appName: $this->adkAppName,
+                baseUrl: $this->adkBaseUrl,
             )->execute();
         }
 

--- a/src/Domains/Intelligence/Agents/Actions/Chat/RunADKChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/RunADKChatAction.php
@@ -24,6 +24,8 @@ class RunADKChatAction
         protected readonly Users $user,
         protected readonly ?Channel $sourceChannel = null,
         protected readonly ?SocialMessage $sourceMessage = null,
+        protected readonly ?string $appName = null,
+        protected readonly ?string $baseUrl = null,
     ) {
     }
 
@@ -32,7 +34,12 @@ class RunADKChatAction
         $sessionId = $this->session?->uuid ?? $this->sourceChannel?->slug ?? '';
         $userId = $this->resolveUserId();
 
-        $service = new GoogleADKService($this->agent->app, $this->agent->company);
+        $service = new GoogleADKService(
+            $this->agent->app,
+            $this->agent->company,
+            $this->appName,
+            $this->baseUrl
+        );
         $service->startSession($userId, $sessionId);
 
         $response = $service->chat($userId, $sessionId, $this->message);


### PR DESCRIPTION
## What

`AIAssistAgentResponderAction` still did the pre-kernel thing: `new $this->agent->type->handler()` + `setConfiguration()` by hand, an `instanceof ADKAgent` branch talking to `GoogleADKService` directly, and a Neuron `UserMessage` fallback. That's the shape the AgentChatKernel refactor removed everywhere else.

Now it delegates to `AgentChatKernel` like the other channel responders (WaSender, Mailgun, RespondIO, Twilio), so all four backends (Neuron, Laravel, ADK, Runtime) work.

## ADK overrides

AI Assist points at its own ADK app (`google_orchestrator_ai_assist_app_name` / `_base_url`, resolved company-then-app), which the kernel didn't support. Added optional `adkAppName` / `adkBaseUrl` params to `AgentChatKernel` → `RunADKChatAction` → `GoogleADKService`. Both default to `null`, so the other kernel call sites are untouched. Without this the AI Assist agent would fall back to the default `orchestrator` app.

## Behavior change

The old ADK path passed an `$onChunk` callback that persisted a `Message` per SSE chunk. The kernel has no streaming callback, so the reply is now persisted once, complete — same as every other connector.

## Also

`CreateSocialChannelsAfterPullAction` now honors `ai_assist_agent_id` from `$params` when creating the AI Assist channel, falling back to the action's `agentId`.

## Tests

- `tests/Connectors/Integration/SalesAssists/AIAssistRespondsWhenLeadAiOffTest.php` — green
- `tests/Intelligence/Agents/InternalAgentChannelResponderActionTest.php` — green
- `tests/Intelligence/Agents/Outreach/AgentReachOutActivityEndToEndTest.php` — fails locally on a pre-existing env issue (Typesense: `Field 'embedding' must have 768 dimensions`), unrelated to this change
