### PR TITLE
fix: keep order correction evidence out of order metadata

### DIFF
--- a/src/Domains/Connectors/Movipass/Actions/Corrections/AddObservationsAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/Corrections/AddObservationsAction.php
@@ -31,7 +31,6 @@ class AddObservationsAction extends BaseOrderCorrectionAction
             $metadata['data']['observations'] = $this->observations;
             $this->order->metadata = $metadata;
 
-            $this->appendEvidenceImages($this->evidenceUrls);
             $this->order->saveOrFail();
 
             $this->logCorrection(

--- a/src/Domains/Connectors/Movipass/Actions/Corrections/CorrectVehiclePlateAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/Corrections/CorrectVehiclePlateAction.php
@@ -34,7 +34,6 @@ class CorrectVehiclePlateAction extends BaseOrderCorrectionAction
 
             $this->order->reference = "{$brand} / {$this->newPlate} - #{$this->order->order_number}";
 
-            $this->appendEvidenceImages($this->evidenceUrls);
             $this->order->saveOrFail();
 
             $this->logCorrection(

--- a/src/Domains/Connectors/Movipass/Actions/Corrections/MarkOrderAsDuplicateAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/Corrections/MarkOrderAsDuplicateAction.php
@@ -30,7 +30,6 @@ class MarkOrderAsDuplicateAction extends BaseOrderCorrectionAction
             $metadata['data']['duplicate_of_order_number'] = $this->originalOrder->order_number;
             $this->order->metadata = $metadata;
 
-            $this->appendEvidenceImages($this->evidenceUrls);
             $this->order->saveOrFail();
 
             $this->logCorrection(

--- a/src/Domains/Connectors/Movipass/Actions/Corrections/RelocateVehicleAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/Corrections/RelocateVehicleAction.php
@@ -61,7 +61,6 @@ class RelocateVehicleAction extends BaseOrderCorrectionAction
 
             $metadata['data']['carDeposit'] = $this->carDeposit;
             $this->order->metadata = $metadata;
-            $this->appendEvidenceImages($this->evidenceUrls);
             $this->order->saveOrFail();
 
             $this->order->calculateTotal();

--- a/src/Domains/Souk/Orders/Actions/Corrections/BaseOrderCorrectionAction.php
+++ b/src/Domains/Souk/Orders/Actions/Corrections/BaseOrderCorrectionAction.php
@@ -65,17 +65,4 @@ abstract class BaseOrderCorrectionAction
             ])
             ->log($correctionType);
     }
-
-    // Does NOT call saveOrFail() — the concrete action owns the save within transact().
-    protected function appendEvidenceImages(array $urls): void
-    {
-        if (empty($urls)) {
-            return;
-        }
-
-        $metadata = is_array($this->order->metadata) ? $this->order->metadata : [];
-        $existing = $metadata['data']['images'] ?? [];
-        $metadata['data']['images'] = array_values(array_unique(array_merge($existing, $urls)));
-        $this->order->metadata = $metadata;
-    }
 }

--- a/tests/Connectors/Integration/Movipass/AddObservationsActionTest.php
+++ b/tests/Connectors/Integration/Movipass/AddObservationsActionTest.php
@@ -87,7 +87,7 @@ final class AddObservationsActionTest extends TestCase
         $this->assertEquals('Observación registrada al momento del ingreso', $log->properties['reason']);
     }
 
-    public function testItReplacesExistingObservationAndAppendsEvidence(): void
+    public function testItReplacesExistingObservationAndKeepsEvidenceOutOfOrderImages(): void
     {
         $app = app(Apps::class);
         $user = Auth::user();
@@ -114,9 +114,7 @@ final class AddObservationsActionTest extends TestCase
         );
 
         $this->assertEquals('Observación actualizada', $result->metadata['data']['observations']);
-        $this->assertContains('https://s3.example.com/old.jpg', $result->metadata['data']['images']);
-        $this->assertContains('https://s3.example.com/evidence.jpg', $result->metadata['data']['images']);
-        $this->assertCount(2, $result->metadata['data']['images']);
+        $this->assertEquals(['https://s3.example.com/old.jpg'], $result->metadata['data']['images']);
 
         $log = Activity::where('subject_id', $order->id)
             ->where('subject_type', Order::class)

--- a/tests/Connectors/Integration/Movipass/CorrectVehiclePlateActionTest.php
+++ b/tests/Connectors/Integration/Movipass/CorrectVehiclePlateActionTest.php
@@ -86,7 +86,7 @@ final class CorrectVehiclePlateActionTest extends TestCase
         $this->assertEquals('Placa registrada incorrectamente', $log->properties['reason']);
     }
 
-    public function testItAppendsEvidenceImages(): void
+    public function testItKeepsEvidenceImagesOutOfOrderMetadata(): void
     {
         $app = app(Apps::class);
         $user = Auth::user();
@@ -113,11 +113,17 @@ final class CorrectVehiclePlateActionTest extends TestCase
             )->execute()
         );
 
-        $images = $result->metadata['data']['images'];
-        $this->assertContains('https://s3.example.com/existing.jpg', $images);
-        $this->assertContains('https://s3.example.com/evidence1.jpg', $images);
-        $this->assertContains('https://s3.example.com/evidence2.jpg', $images);
-        $this->assertCount(3, $images);
+        $this->assertEquals(['https://s3.example.com/existing.jpg'], $result->metadata['data']['images']);
+
+        $log = Activity::where('subject_id', $order->id)
+            ->where('subject_type', Order::class)
+            ->where('description', 'correct-plate')
+            ->first();
+
+        $this->assertEquals(
+            ['https://s3.example.com/evidence1.jpg', 'https://s3.example.com/evidence2.jpg'],
+            $log->properties['evidence']
+        );
     }
 
     private function resolveReleasedStatus(Apps $app): OrderStatus


### PR DESCRIPTION
Correction evidence images are audit artifacts, not operational vehicle photos. Appending them to order.metadata.data.images polluted the images clients render for the order.

Evidence stays in the activity log (properties.evidence), which every correction already writes.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
