### PR TITLE
feat: resolve a company default region that can point at a global one

### DIFF
--- a/app/Console/Commands/Movipass/BackfillCompanyDefaultRegionCommand.php
+++ b/app/Console/Commands/Movipass/BackfillCompanyDefaultRegionCommand.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Movipass;
+
+use Baka\Traits\KanvasJobsTrait;
+use Illuminate\Console\Command;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Movipass\Enums\CustomFieldEnum;
+use Kanvas\Enums\AppEnums;
+use Kanvas\Inventory\Regions\Enums\CustomFieldEnum as RegionCustomFieldEnum;
+use Kanvas\Inventory\Regions\Models\Regions;
+use Kanvas\Users\Models\UserCompanyApps;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\table;
+use function Laravel\Prompts\warning;
+
+class BackfillCompanyDefaultRegionCommand extends Command
+{
+    use KanvasJobsTrait;
+
+    protected $signature = 'kanvas-movipass:backfill-company-default-region
+        {app_id : The app whose companies should be backfilled}
+        {--company_id= : Only backfill this company}
+        {--dry-run : List what would be written without making changes}';
+
+    protected $description = 'Copy the legacy movipass_region_id company custom field into the generic default_region_id read by RegionResolutionService.';
+
+    public function handle(): int
+    {
+        /** @var Apps $app */
+        $app = Apps::getById((int) $this->argument('app_id'));
+        $this->overwriteAppService($app);
+
+        $dryRun = (bool) $this->option('dry-run');
+        $rows = [];
+        $skipped = 0;
+
+        foreach ($this->companies($app) as $company) {
+            if (! empty($company->get(RegionCustomFieldEnum::DEFAULT_REGION_ID->value))) {
+                continue;
+            }
+
+            $regionId = $company->get(CustomFieldEnum::COMPANY_REGION_ID->value);
+
+            if (empty($regionId)) {
+                continue;
+            }
+
+            $region = Regions::query()
+                ->fromApp($app)
+                ->notDeleted()
+                ->where('id', (int) $regionId)
+                ->whereIn('companies_id', [AppEnums::GLOBAL_COMPANY_ID->getValue(), $company->getId()])
+                ->first();
+
+            if ($region === null) {
+                warning(sprintf('%s (ID %d) — movipass_region_id %s is not a reachable region, skipped', $company->name, $company->getId(), $regionId));
+                $skipped++;
+
+                continue;
+            }
+
+            if (! $dryRun) {
+                $company->set(RegionCustomFieldEnum::DEFAULT_REGION_ID->value, $region->getId(), isPublic: 1);
+            }
+
+            $rows[] = [$company->getId(), $company->name, $region->getId(), $region->short_slug];
+        }
+
+        if (empty($rows)) {
+            info('Nothing to backfill.' . ($skipped > 0 ? sprintf(' %d company(ies) skipped.', $skipped) : ''));
+
+            return self::SUCCESS;
+        }
+
+        table(['company_id', 'company', 'region_id', 'region'], $rows);
+        info(sprintf(
+            '%s %d company(ies)%s',
+            $dryRun ? 'Would backfill' : 'Backfilled',
+            count($rows),
+            $skipped > 0 ? sprintf(', %d skipped', $skipped) : ''
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return iterable<Companies>
+     */
+    private function companies(Apps $app): iterable
+    {
+        $companyIds = UserCompanyApps::where('apps_id', $app->getId())
+            ->when(
+                $this->option('company_id'),
+                fn ($query, $companyId) => $query->where('companies_id', (int) $companyId)
+            )
+            ->distinct()
+            ->pluck('companies_id');
+
+        foreach ($companyIds as $companyId) {
+            $company = Companies::query()->notDeleted()->find((int) $companyId);
+
+            if ($company !== null) {
+                yield $company;
+            }
+        }
+    }
+}

--- a/app/GraphQL/Inventory/Mutations/Regions/Region.php
+++ b/app/GraphQL/Inventory/Mutations/Regions/Region.php
@@ -90,6 +90,13 @@ class Region
         return true;
     }
 
+    /**
+     * TODO: fold this into createRegion/updateRegion — the UI shouldn't need a third
+     * mutation to mark a region as the company's default. Blocker: RegionObserver's
+     * default bookkeeping only looks at the regions table, while this writes a custom
+     * field (the only form that can point at a global region), so both notions of
+     * "default" have to be reconciled first.
+     */
     public function setCompanyDefaultRegion(mixed $root, array $request): bool
     {
         $company = auth()->user()->getCurrentCompany();

--- a/app/GraphQL/Inventory/Mutations/Regions/Region.php
+++ b/app/GraphQL/Inventory/Mutations/Regions/Region.php
@@ -89,4 +89,17 @@ class Region
 
         return true;
     }
+
+    public function setCompanyDefaultRegion(mixed $root, array $request): bool
+    {
+        $company = auth()->user()->getCurrentCompany();
+        $region = RegionModel::getByIdFromCompanyAppOrGlobal(
+            (int) $request['region_id'],
+            $company,
+            app(Apps::class)
+        );
+        $company->set(CustomFieldEnum::DEFAULT_REGION_ID->value, $region->getId(), isPublic: 1);
+
+        return true;
+    }
 }

--- a/app/GraphQL/Souk/Mutations/Orders/OrderManagementMutation.php
+++ b/app/GraphQL/Souk/Mutations/Orders/OrderManagementMutation.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\GraphQL\Souk\Mutations\Orders;
 
+use Baka\Contracts\CompanyInterface;
 use Baka\Support\IPInfo;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Enums\AppEnums;
 use Kanvas\Exceptions\ValidationException;
 use Kanvas\Guild\Customers\Actions\CreatePeopleFromUserAction;
 use Kanvas\Guild\Customers\DataTransferObject\Address;
+use Kanvas\Inventory\Regions\Models\Regions as InventoryRegions;
 use Kanvas\Inventory\Variants\Models\Variants;
 use Kanvas\Regions\Models\Regions;
+use Kanvas\Regions\Services\RegionResolutionService;
 use Kanvas\Social\Interactions\Actions\CreateInteraction;
 use Kanvas\Social\Interactions\Actions\CreateUserInteractionAction;
 use Kanvas\Social\Interactions\DataTransferObject\Interaction;
@@ -82,6 +85,25 @@ class OrderManagementMutation
         );
     }
 
+    /**
+     * RegionMiddleware binds the request's region (X-Kanvas-Region header / geo-ip) on
+     * multi-country apps; without it fall back to the company's configured default.
+     */
+    private function resolveOrderRegion(Apps $app, CompanyInterface $company): Regions
+    {
+        $region = app()->bound(InventoryRegions::class)
+            ? app(InventoryRegions::class)
+            : new RegionResolutionService($app)->forCompany($company);
+
+        if (! $region instanceof Regions) {
+            throw new ValidationException(
+                'No default region configured for company ' . $company->getId() . ', set a default region before creating orders'
+            );
+        }
+
+        return $region;
+    }
+
     private function handleCreateOrderFromCart(array $request, string $actionClass): array
     {
         $user = auth()->user();
@@ -89,7 +111,7 @@ class OrderManagementMutation
         $app = app(Apps::class);
         $company = B2BConfigurationService::getConfiguredB2BCompany($app, $user->getCurrentCompany());
 
-        $region = Regions::getDefault($company, $app);
+        $region = $this->resolveOrderRegion($app, $company);
         $orderCustomer = OrderCustomer::from($request['input']['customer']);
         $createPeople = new CreatePeopleFromUserAction(
             $app,
@@ -219,7 +241,7 @@ class OrderManagementMutation
             throw new ValidationException('Extended reservation is not allowed');
         }
 
-        $region = Regions::getDefault($company, $app);
+        $region = $this->resolveOrderRegion($app, $company);
         $orderCustomer = OrderCustomer::from($request['input']['customer']);
         $createPeople = new CreatePeopleFromUserAction(
             $app,

--- a/graphql/schemas/Inventory/region.graphql
+++ b/graphql/schemas/Inventory/region.graphql
@@ -89,4 +89,9 @@ extend type Mutation @guard {
         @field(
             resolver: "App\\GraphQL\\Inventory\\Mutations\\Regions\\Region@setDefaultRegion"
         )
+    setCompanyDefaultRegion(region_id: ID!): Boolean!
+        @guardByAdmin
+        @field(
+            resolver: "App\\GraphQL\\Inventory\\Mutations\\Regions\\Region@setCompanyDefaultRegion"
+        )
 }

--- a/src/Domains/Connectors/Movipass/Actions/EnableCorporateModeAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/EnableCorporateModeAction.php
@@ -17,6 +17,7 @@ use Kanvas\Connectors\Movipass\Enums\CustomFieldEnum;
 use Kanvas\Connectors\Movipass\Jobs\MigrateCorporateUserVariantsJob;
 use Kanvas\Connectors\Movipass\Workflows\Activities\AutoApproveCorporateLeadActivity;
 use Kanvas\Exceptions\ValidationException;
+use Kanvas\Inventory\Regions\Enums\CustomFieldEnum as RegionCustomFieldEnum;
 use Kanvas\Inventory\Regions\Models\Regions;
 use Kanvas\Services\SetupService;
 use Kanvas\Users\Actions\AssignCompanyAction;
@@ -102,10 +103,18 @@ class EnableCorporateModeAction
                 $this->user->getCurrentCompany(),
                 $this->app,
             );
-            $company->set(CustomFieldEnum::COMPANY_REGION_ID->value, $region->getId());
+            $this->setCompanyRegion($company, $region->getId());
         } elseif (app()->bound(Regions::class)) {
-            $company->set(CustomFieldEnum::COMPANY_REGION_ID->value, app(Regions::class)->getId());
+            $this->setCompanyRegion($company, app(Regions::class)->getId());
         }
+    }
+
+    // movipass_region_id predates the generic key; keep writing both until the legacy
+    // readers are gone, so RegionResolutionService::forCompany() sees corporate companies.
+    private function setCompanyRegion(Companies $company, int $regionId): void
+    {
+        $company->set(CustomFieldEnum::COMPANY_REGION_ID->value, $regionId);
+        $company->set(RegionCustomFieldEnum::DEFAULT_REGION_ID->value, $regionId);
     }
 
     private function setUserFields(): void

--- a/src/Domains/Connectors/Movipass/Actions/RelinkVariantsToCompanyWarehouseAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/RelinkVariantsToCompanyWarehouseAction.php
@@ -20,6 +20,7 @@ use Kanvas\Inventory\Warehouses\Actions\CreateWarehouseAction;
 use Kanvas\Inventory\Warehouses\DataTransferObject\Warehouses as WarehousesDto;
 use Kanvas\Inventory\Warehouses\Models\Warehouses;
 use Kanvas\Regions\Models\Regions;
+use Kanvas\Regions\Services\RegionResolutionService;
 use Kanvas\Users\Models\Users;
 
 /**
@@ -132,6 +133,8 @@ class RelinkVariantsToCompanyWarehouseAction
 
     private function resolveRegion(): Regions
     {
+        // Legacy key first: companies onboarded before the generic default_region_id
+        // only carry movipass_region_id until the backfill command runs.
         $regionId = $this->company->get(CustomFieldEnum::COMPANY_REGION_ID->value);
 
         if (! empty($regionId)) {
@@ -147,7 +150,7 @@ class RelinkVariantsToCompanyWarehouseAction
             }
         }
 
-        return Regions::getDefault($this->company, $this->app)
+        return new RegionResolutionService($this->app)->forCompany($this->company)
             ?? throw new ValidationException(
                 "No region available for company '{$this->company->name}' — cannot provision its warehouse."
             );

--- a/src/Domains/Connectors/Movipass/Workflows/Activities/AutoApproveCorporateLeadActivity.php
+++ b/src/Domains/Connectors/Movipass/Workflows/Activities/AutoApproveCorporateLeadActivity.php
@@ -18,6 +18,7 @@ use Kanvas\Connectors\Movipass\Actions\ValidateCorporateFieldsAction;
 use Kanvas\Connectors\Movipass\Enums\ConfigurationEnum;
 use Kanvas\Connectors\Movipass\Enums\CustomFieldEnum;
 use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Inventory\Regions\Enums\CustomFieldEnum as RegionCustomFieldEnum;
 use Kanvas\Inventory\Regions\Models\Regions;
 use Kanvas\Notifications\Templates\Blank;
 use Kanvas\Users\Models\Users;
@@ -192,10 +193,18 @@ class AutoApproveCorporateLeadActivity extends KanvasActivity implements Workflo
 
         $regionId = $lead->get('region_id');
         if (! empty($regionId)) {
-            $company->set(CustomFieldEnum::COMPANY_REGION_ID->value, $regionId);
+            $this->setCompanyRegion($company, (int) $regionId);
         } elseif (app()->bound(Regions::class)) {
-            $company->set(CustomFieldEnum::COMPANY_REGION_ID->value, app(Regions::class)->getId());
+            $this->setCompanyRegion($company, app(Regions::class)->getId());
         }
+    }
+
+    // movipass_region_id predates the generic key; keep writing both until the legacy
+    // readers are gone, so RegionResolutionService::forCompany() sees corporate companies.
+    private function setCompanyRegion(Companies $company, int $regionId): void
+    {
+        $company->set(CustomFieldEnum::COMPANY_REGION_ID->value, $regionId);
+        $company->set(RegionCustomFieldEnum::DEFAULT_REGION_ID->value, $regionId);
     }
 
     private function findOrCreateInvite(Lead $lead, Companies $company, AppInterface $app, Users $appOwner): UsersInvite

--- a/src/Kanvas/Regions/Services/RegionResolutionService.php
+++ b/src/Kanvas/Regions/Services/RegionResolutionService.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Kanvas\Regions\Services;
 
 use Baka\Contracts\AppInterface;
+use Baka\Contracts\CompanyInterface;
 use Baka\Support\IPInfo;
 use Baka\Users\Contracts\UserInterface;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use Kanvas\Enums\AppEnums;
 use Kanvas\Inventory\Regions\Enums\ConfigurationEnum;
 use Kanvas\Inventory\Regions\Enums\CustomFieldEnum;
 use Kanvas\Inventory\Regions\Models\Regions;
@@ -27,6 +29,31 @@ class RegionResolutionService
         return $this->fromUserProfile($user)
             ?? $this->fromGeoIp($request)
             ?? $this->fromAppDefault();
+    }
+
+    /**
+     * A company's default region is a custom field pointing at either one of its own regions
+     * or an app-global one (companies_id = 0) — the regions table itself can't express
+     * "this global region is my default", since is_default there is app-wide.
+     */
+    public function forCompany(CompanyInterface $company): ?Regions
+    {
+        $regionId = $company->get(CustomFieldEnum::DEFAULT_REGION_ID->value);
+
+        if (! empty($regionId)) {
+            $region = Regions::query()
+                ->fromApp($this->app)
+                ->notDeleted()
+                ->where('id', (int) $regionId)
+                ->whereIn('companies_id', [AppEnums::GLOBAL_COMPANY_ID->getValue(), $company->getId()])
+                ->first();
+
+            if ($region !== null) {
+                return $region;
+            }
+        }
+
+        return Regions::getDefault($company, $this->app);
     }
 
     protected function fromUserProfile(?UserInterface $user): ?Regions

--- a/tests/Connectors/Integration/Movipass/CompanyDefaultRegionTest.php
+++ b/tests/Connectors/Integration/Movipass/CompanyDefaultRegionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Integration\Movipass;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Auth;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Movipass\Enums\CustomFieldEnum as MovipassCustomFieldEnum;
+use Kanvas\Currencies\Models\Currencies;
+use Kanvas\Inventory\Regions\Enums\CustomFieldEnum;
+use Kanvas\Regions\Models\Regions;
+use Kanvas\Regions\Services\RegionResolutionService;
+use Tests\TestCase;
+
+final class CompanyDefaultRegionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected array $connectionsToTransact = ['mysql', 'ecosystem'];
+
+    private Apps $appInstance;
+    private Companies $company;
+    private RegionResolutionService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (getenv('GITHUB_ACTIONS')) {
+            $this->markTestSkipped('Movipass region tests are skipped in CI');
+        }
+
+        $this->appInstance = app(Apps::class);
+        $this->company = Auth::user()->getCurrentCompany();
+        $this->service = new RegionResolutionService($this->appInstance);
+
+        $this->company->del(CustomFieldEnum::DEFAULT_REGION_ID->value);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->company->del(CustomFieldEnum::DEFAULT_REGION_ID->value);
+
+        parent::tearDown();
+    }
+
+    public function testResolvesGlobalRegionAssignedToCompany(): void
+    {
+        $global = $this->makeGlobalRegion('test-company-default-sv', 'TCDSV');
+
+        $this->company->set(CustomFieldEnum::DEFAULT_REGION_ID->value, $global->getId());
+
+        $resolved = $this->service->forCompany($this->company);
+
+        $this->assertNotNull($resolved);
+        $this->assertEquals($global->getId(), $resolved->getId());
+        $this->assertEquals(0, (int) $resolved->companies_id);
+    }
+
+    public function testFallsBackToDefaultWhenCustomFieldNotSet(): void
+    {
+        $resolved = $this->service->forCompany($this->company);
+        $expected = Regions::getDefault($this->company, $this->appInstance);
+
+        $this->assertEquals($expected?->getId(), $resolved?->getId());
+    }
+
+    public function testIgnoresRegionOutsideCompanyAndGlobalScope(): void
+    {
+        $foreign = $this->makeGlobalRegion('test-company-default-foreign', 'TCDFO');
+        $foreign->companies_id = $this->company->getId() + 999999;
+        $foreign->saveOrFail();
+
+        $this->company->set(CustomFieldEnum::DEFAULT_REGION_ID->value, $foreign->getId());
+
+        $resolved = $this->service->forCompany($this->company);
+        $expected = Regions::getDefault($this->company, $this->appInstance);
+
+        $this->assertEquals($expected?->getId(), $resolved?->getId());
+        $this->assertNotEquals($foreign->getId(), $resolved?->getId());
+    }
+
+    public function testBackfillCopiesLegacyMovipassRegionId(): void
+    {
+        $global = $this->makeGlobalRegion('test-company-default-backfill', 'TCDBF');
+
+        $this->company->set(MovipassCustomFieldEnum::COMPANY_REGION_ID->value, $global->getId());
+
+        $this->artisan('kanvas-movipass:backfill-company-default-region', [
+            'app_id' => $this->appInstance->getId(),
+            '--company_id' => $this->company->getId(),
+        ])->assertExitCode(0);
+
+        $this->assertEquals(
+            $global->getId(),
+            (int) $this->company->get(CustomFieldEnum::DEFAULT_REGION_ID->value)
+        );
+
+        $this->company->del(MovipassCustomFieldEnum::COMPANY_REGION_ID->value);
+    }
+
+    private function makeGlobalRegion(string $slug, string $shortSlug): Regions
+    {
+        $region = new Regions();
+        $region->apps_id = $this->appInstance->getId();
+        $region->companies_id = 0;
+        $region->users_id = 0;
+        $region->name = $slug;
+        $region->slug = $slug;
+        $region->short_slug = $shortSlug;
+        $region->currency_id = Currencies::getByCode('USD')->getId();
+        $region->is_default = 0;
+        $region->saveOrFail();
+
+        return $region;
+    }
+}


### PR DESCRIPTION
createOrderFromCart crashed with a TypeError when Regions::getDefault() returned null: it matches companies_id exactly and then falls back to the app-wide global default, so there was no way to say "this company's default is the global SV region".

RegionResolutionService::forCompany() reads the generic default_region_id company custom field, accepting a region owned by the company or a global one (companies_id = 0), and falls back to Regions::getDefault().

Order creation now resolves in order: the region bound by RegionMiddleware (X-Kanvas-Region header / geo-ip), then forCompany(), then a clear ValidationException. Previously the middleware-resolved region was ignored entirely, so an SV reservation was created under the DR region with the wrong currency and payment gateway.

setCompanyDefaultRegion assigns it — the existing setDefaultRegion writes to the user, not the company.

Movipass keeps writing the legacy movipass_region_id alongside the generic key; kanvas-movipass:backfill-company-default-region copies it over for companies onboarded before this.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
