### PR TITLE
fix(universal-seguros): add a per-company flag to skip TLS verificati…

### DIFF
--- a/src/Domains/Connectors/UniversalSeguros/CLAUDE.md
+++ b/src/Domains/Connectors/UniversalSeguros/CLAUDE.md
@@ -80,6 +80,8 @@ The `integrations` row (name `universal_seguros`, `apps_id=0`) is seeded by
 `database/migrations/Workflow/2026_06_29_120000_add_universal_seguros_integration.php`. Its `config`
 describes the setup fields: `environment`, `client_id`, `client_secret`, `scopes`,
 `insurer_companies_id`. `IntegrationsEnum::UNIVERSAL_SEGUROS = 'universal_seguros'`.
+That `config` is descriptive only — `BaseIntegration` hands `setup()` the raw `$data`, so a
+field the handler reads works whether or not it is listed there (`verify_ssl` is one).
 
 `insurer_companies_id` is **Universal's own company in Kanvas** — the owner of the seeded
 catalog Products. Setup refuses without it rather than seeding them under the aliado by
@@ -123,6 +125,23 @@ Cross-field rules they enforce and the doc omits:
 - `esCeroKm: true` is only accepted when `anio` is the current year, the previous one or the next.
 
 ## Gotchas / open items
+
+- **`cURL error 60` on QA is Universal's TLS, not ours.** Since their 2026-07-23 reissue,
+  `qa.universal.com.do` serves a chain terminating in `GoDaddy TLS Root CA - R1` (created
+  Aug 2025). That root is **not in Mozilla's store** — checked against `curl.se/ca/cacert.pem`
+  dated 2026-08-13, which ships only `Go Daddy Root Certificate Authority - G2`. So it fails on
+  Debian/Alpine/Java/Python/Node alike; it *looks* fine in a browser because Windows and macOS
+  trust it (Microsoft's program has it) and Schannel chases AIA. **Prod is unaffected** —
+  `api.universal.com.do` and `idp.universal.com.do` chain to DigiCert Global Root G2 and verify
+  cleanly from the container. The fix is theirs: reissue QA under the same CA as prod, or serve
+  a cross-signed chain to the G2 root.
+
+  Meanwhile `ConfigurationEnum::VERIFY_SSL` (`universal_seguros_verify_ssl`, also `verify_ssl`
+  in the `integrationCompany` setup payload) turns Guzzle's peer verification off **per
+  company**. Unset/absent/garbage ⇒ verification stays **on** — it only goes off on an explicit
+  falsy value. Set it on the QA aliado company only; a prod company with this off is
+  MITM-able on a flow carrying policy and cardholder-adjacent data. Revert it the moment
+  Universal fixes QA. Regression: `tests/Connectors/UniversalSeguros/ClientSslVerificationTest.php`.
 
 - **"Campo no obligatorio" means OMIT the key, not send `null`.** Their deserialiser throws a
   bare `500 "Ha ocurrido un error desconocido"` on at least one explicit null —

--- a/src/Domains/Connectors/UniversalSeguros/Client.php
+++ b/src/Domains/Connectors/UniversalSeguros/Client.php
@@ -27,6 +27,7 @@ class Client
     protected string $clientSecret;
     protected string $scopes;
     protected string $redisKey;
+    protected bool $verifySsl;
 
     public function __construct(
         protected AppInterface $app,
@@ -57,7 +58,33 @@ class Client
             $environment->value
         );
 
-        $this->client = new GuzzleClient(['timeout' => 60]);
+        $this->verifySsl = self::resolveVerifySsl($company->get(ConfigurationEnum::VERIFY_SSL->value));
+
+        $this->client = new GuzzleClient([
+            'timeout' => 60,
+            'verify' => $this->verifySsl,
+        ]);
+    }
+
+    public function verifiesSsl(): bool
+    {
+        return $this->verifySsl;
+    }
+
+    /**
+     * Escape hatch for Universal's QA host only. Since their 2026-07-23 reissue,
+     * qa.universal.com.do chains to `GoDaddy TLS Root CA - R1`, a root Mozilla's
+     * store still doesn't ship (checked against cacert.pem of 2026-08-13), so every
+     * OpenSSL client fails with cURL 60 until they reissue it. Prod chains to
+     * DigiCert Global Root G2 and verifies fine — leave the flag unset there.
+     */
+    protected static function resolveVerifySsl(mixed $flag): bool
+    {
+        if ($flag === null || $flag === '') {
+            return true;
+        }
+
+        return filter_var($flag, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true;
     }
 
     public function auth(): string

--- a/src/Domains/Connectors/UniversalSeguros/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/UniversalSeguros/Enums/ConfigurationEnum.php
@@ -10,6 +10,7 @@ enum ConfigurationEnum: string
     case CLIENT_ID = 'universal_seguros_client_id';
     case CLIENT_SECRET = 'universal_seguros_client_secret';
     case SCOPES = 'universal_seguros_scopes';
+    case VERIFY_SSL = 'universal_seguros_verify_ssl';
 
     public const BASE_SCOPES = 'unit.serviceplattform.externos unit.serviceplattform.cotizaciones unit.serviceplattform.polizas';
 

--- a/src/Domains/Connectors/UniversalSeguros/Handlers/UniversalSegurosHandler.php
+++ b/src/Domains/Connectors/UniversalSeguros/Handlers/UniversalSegurosHandler.php
@@ -25,6 +25,7 @@ class UniversalSegurosHandler extends BaseIntegration
         $clientSecret = (string) ($this->data['client_secret'] ?? '');
         $environment = (string) ($this->data['environment'] ?? EnvironmentEnum::QA->value);
         $scopes = (string) ($this->data['scopes'] ?? ConfigurationEnum::defaultScopes());
+        $verifySsl = filter_var($this->data['verify_ssl'] ?? true, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true;
 
         if ($clientId === '' || $clientSecret === '') {
             throw new ValidationException('Universal Seguros client_id and client_secret are required');
@@ -40,6 +41,9 @@ class UniversalSegurosHandler extends BaseIntegration
         $this->company->set(ConfigurationEnum::CLIENT_SECRET->value, $clientSecret);
         $this->company->set(ConfigurationEnum::ENVIRONMENT->value, $environment);
         $this->company->set(ConfigurationEnum::SCOPES->value, $scopes);
+        // Stored as '1'/'0' because a stored false round-trips as an empty string,
+        // which Client::resolveVerifySsl reads as "unset" and defaults back to true.
+        $this->company->set(ConfigurationEnum::VERIFY_SSL->value, $verifySsl ? '1' : '0');
         $this->company->set(InsuranceCustomFieldEnum::INSURER_COMPANY_ID->value, $insurerCompany->getId());
 
         // Without a default, every insuranceQuote would have to name the provider.

--- a/tests/Connectors/Traits/HasUniversalSegurosConfiguration.php
+++ b/tests/Connectors/Traits/HasUniversalSegurosConfiguration.php
@@ -20,6 +20,7 @@ trait HasUniversalSegurosConfiguration
         $company->set(ConfigurationEnum::CLIENT_ID->value, getenv('TEST_UNIVERSAL_SEGUROS_CLIENT_ID'));
         $company->set(ConfigurationEnum::CLIENT_SECRET->value, getenv('TEST_UNIVERSAL_SEGUROS_CLIENT_SECRET'));
         $company->set(ConfigurationEnum::SCOPES->value, getenv('TEST_UNIVERSAL_SEGUROS_SCOPES') ?: ConfigurationEnum::defaultScopes());
+        $company->set(ConfigurationEnum::VERIFY_SSL->value, getenv('TEST_UNIVERSAL_SEGUROS_VERIFY_SSL') ?: '1');
 
         return new Client($app, $company);
     }

--- a/tests/Connectors/UniversalSeguros/ClientSslVerificationTest.php
+++ b/tests/Connectors/UniversalSeguros/ClientSslVerificationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\UniversalSeguros;
+
+use Baka\Contracts\AppInterface;
+use Baka\Contracts\CompanyInterface;
+use GuzzleHttp\Client as GuzzleClient;
+use Kanvas\Connectors\UniversalSeguros\Client;
+use Kanvas\Connectors\UniversalSeguros\Enums\ConfigurationEnum;
+use Kanvas\Connectors\UniversalSeguros\Enums\EnvironmentEnum;
+use Mockery;
+use ReflectionProperty;
+use Tests\TestCase;
+
+/**
+ * Universal's QA host chains to a GoDaddy root Mozilla doesn't ship yet, so QA-only
+ * setups need to turn peer verification off. Verification must stay on everywhere
+ * else, including when the flag is missing or garbage.
+ */
+class ClientSslVerificationTest extends TestCase
+{
+    public function testVerificationIsOnWhenTheFlagIsNotSet(): void
+    {
+        $this->assertTrue($this->clientWith(null)->verifiesSsl());
+    }
+
+    public function testFalsyFlagValuesTurnVerificationOff(): void
+    {
+        foreach (['0', 'false', 'off', 'no', false, 0] as $flag) {
+            $this->assertFalse(
+                $this->clientWith($flag)->verifiesSsl(),
+                var_export($flag, true) . ' should disable peer verification'
+            );
+        }
+    }
+
+    public function testTruthyFlagValuesKeepVerificationOn(): void
+    {
+        foreach (['1', 'true', 'on', 'yes', true, 1] as $flag) {
+            $this->assertTrue(
+                $this->clientWith($flag)->verifiesSsl(),
+                var_export($flag, true) . ' should keep peer verification on'
+            );
+        }
+    }
+
+    public function testUnreadableFlagValuesFailClosedIntoVerification(): void
+    {
+        foreach (['', 'maybe', 'null', []] as $flag) {
+            $this->assertTrue(
+                $this->clientWith($flag)->verifiesSsl(),
+                var_export($flag, true) . ' should fall back to peer verification'
+            );
+        }
+    }
+
+    public function testTheFlagReachesGuzzleAndNotJustOurGetter(): void
+    {
+        $this->assertFalse($this->guzzleVerifyOption($this->clientWith('0')));
+        $this->assertTrue($this->guzzleVerifyOption($this->clientWith(null)));
+    }
+
+    private function clientWith(mixed $verifySslFlag): Client
+    {
+        $app = Mockery::mock(AppInterface::class);
+        $app->shouldReceive('getId')->andReturn(1);
+
+        $config = [
+            ConfigurationEnum::ENVIRONMENT->value => EnvironmentEnum::QA->value,
+            ConfigurationEnum::CLIENT_ID->value => 'client-id',
+            ConfigurationEnum::CLIENT_SECRET->value => 'client-secret',
+            ConfigurationEnum::SCOPES->value => ConfigurationEnum::defaultScopes(),
+            ConfigurationEnum::VERIFY_SSL->value => $verifySslFlag,
+        ];
+
+        $company = Mockery::mock(CompanyInterface::class);
+        $company->shouldReceive('getId')->andReturn(2);
+        $company->shouldReceive('get')->andReturnUsing(fn (string $key) => $config[$key] ?? null);
+
+        return new Client($app, $company);
+    }
+
+    private function guzzleVerifyOption(Client $client): mixed
+    {
+        $guzzleProperty = new ReflectionProperty(Client::class, 'client');
+        /** @var GuzzleClient $guzzle */
+        $guzzle = $guzzleProperty->getValue($client);
+
+        $configProperty = new ReflectionProperty(GuzzleClient::class, 'config');
+
+        return $configProperty->getValue($guzzle)['verify'] ?? null;
+    }
+}


### PR DESCRIPTION
…on on QA

Since Universal reissued their QA certificate on 2026-07-23, qa.universal.com.do serves a chain terminating in "GoDaddy TLS Root CA - R1", a root that is not in Mozilla's store (checked against cacert.pem of 2026-08-13). Every OpenSSL-based client fails with "cURL error 60: unable to get local issuer certificate", which surfaced as an ApolloError on quoting.

This is Universal's to fix — prod (api/idp.universal.com.do) chains to DigiCert Global Root G2 and verifies cleanly. Until they reissue QA, the new universal_seguros_verify_ssl company config (also verify_ssl on the integrationCompany setup payload) turns Guzzle peer verification off for that company only.

Resolution fails closed: unset, empty or unparseable values keep verification on, so only an explicit falsy value disables it. Stored as '1'/'0' because a stored boolean false round-trips as an empty string.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
