### PR TITLE
feat(calendar): sync Google events from event versions

### DIFF
--- a/src/Domains/Connectors/Google/Actions/CreateGoogleCalendarMeetingAction.php
+++ b/src/Domains/Connectors/Google/Actions/CreateGoogleCalendarMeetingAction.php
@@ -37,20 +37,6 @@ class CreateGoogleCalendarMeetingAction
         $calendarId = $this->resolveCalendarId($config);
         $service = $this->createCalendarService($config);
 
-        if ($this->externalEventId !== null) {
-            try {
-                return $this->formatResult(
-                    $this->findEvent($service, $calendarId, $this->externalEventId),
-                    $calendarId,
-                    $this->sanitizeEmails($this->attendeeEmails),
-                );
-            } catch (Throwable $exception) {
-                if ((int) $exception->getCode() !== 404) {
-                    throw $exception;
-                }
-            }
-        }
-
         $emails = $this->sanitizeEmails($this->attendeeEmails);
 
         $event = new Event([
@@ -84,15 +70,21 @@ class CreateGoogleCalendarMeetingAction
         }
 
         try {
-            $saved = $this->insertEvent($service, $calendarId, $event);
+            $saved = $this->externalEventId !== null
+                ? $this->updateEvent($service, $calendarId, $this->externalEventId, $event)
+                : $this->insertEvent($service, $calendarId, $event);
         } catch (Throwable $exception) {
-            if (! $this->shouldRetryWithoutMeet($exception)) {
+            if ($this->externalEventId !== null && (int) $exception->getCode() === 404) {
+                $saved = $this->insertEvent($service, $calendarId, $event);
+            } elseif (! $this->shouldRetryWithoutMeet($exception)) {
                 throw $exception;
+            } else {
+                $this->withMeetLink = false;
+                unset($event->conferenceData);
+                $saved = $this->externalEventId !== null
+                    ? $this->updateEvent($service, $calendarId, $this->externalEventId, $event)
+                    : $this->insertEvent($service, $calendarId, $event);
             }
-
-            $this->withMeetLink = false;
-            $event->setConferenceData(null);
-            $saved = $this->insertEvent($service, $calendarId, $event);
         }
 
         return $this->formatResult($saved, $calendarId, $emails);
@@ -221,5 +213,17 @@ class CreateGoogleCalendarMeetingAction
     protected function findEvent(Calendar $service, string $calendarId, string $eventId): Event
     {
         return $service->events->get($calendarId, $eventId);
+    }
+
+    protected function updateEvent(Calendar $service, string $calendarId, string $eventId, Event $event): Event
+    {
+        try {
+            return $service->events->update($calendarId, $eventId, $event, [
+                'conferenceDataVersion' => $this->withMeetLink ? 1 : 0,
+                'sendUpdates' => 'all',
+            ]);
+        } catch (Throwable $exception) {
+            throw new RuntimeException('Google Calendar event update failed: ' . $exception->getMessage(), (int) $exception->getCode(), $exception);
+        }
     }
 }

--- a/src/Domains/Connectors/Google/Actions/SyncEventToGoogleCalendarAction.php
+++ b/src/Domains/Connectors/Google/Actions/SyncEventToGoogleCalendarAction.php
@@ -6,57 +6,62 @@ namespace Kanvas\Connectors\Google\Actions;
 
 use Carbon\Carbon;
 use Kanvas\Connectors\Google\Enums\CustomFieldEnum;
-use Kanvas\Event\Events\Models\Event;
+use Kanvas\Event\Events\Models\EventVersion;
 use Kanvas\Exceptions\ValidationException;
 
 class SyncEventToGoogleCalendarAction
 {
-    public function __construct(protected Event $event)
+    public function __construct(protected EventVersion $eventVersion)
     {
     }
 
     public function execute(): array
     {
-        $externalId = $this->event->get(CustomFieldEnum::GOOGLE_CALENDAR_EVENT_ID->value);
+        $this->eventVersion->loadMissing(['dates', 'event.company']);
+        $event = $this->eventVersion->event;
+        $externalId = $this->eventVersion->get(CustomFieldEnum::GOOGLE_CALENDAR_EVENT_ID->value)
+            ?: $event->get(CustomFieldEnum::GOOGLE_CALENDAR_EVENT_ID->value);
 
-        $version = $this->event->versions()->with('dates')->latest('version')->first();
-        if ($version === null || $version->dates->isEmpty()) {
+        if ($this->eventVersion->dates->isEmpty()) {
             throw new ValidationException('Event has no dated version to synchronize.');
         }
 
-        $dates = $version->dates->sortBy('event_date');
+        $dates = $this->eventVersion->dates->sortBy('event_date');
         $first = $dates->first();
         $last = $dates->last();
-        $timezone = $this->event->company->timezone ?: 'UTC';
+        $timezone = $event->company->timezone ?: 'UTC';
         $start = Carbon::createFromFormat('Y-m-d H:i:s', $first->event_date->format('Y-m-d') . ' ' . $first->start_time, $timezone);
         $end = Carbon::createFromFormat('Y-m-d H:i:s', $last->event_date->format('Y-m-d') . ' ' . $last->end_time, $timezone);
-        $googleEventId = is_string($externalId) && $externalId !== ''
-            ? $externalId
-            : hash('sha256', 'kanvas-event-' . $this->event->uuid);
+        $googleEventId = is_string($externalId) && $externalId !== '' ? $externalId : null;
         $result = $this->createMeeting($start, $end, $googleEventId);
 
-        $this->event->set(CustomFieldEnum::GOOGLE_CALENDAR_EVENT_ID->value, $result['id']);
+        $this->eventVersion->set(CustomFieldEnum::GOOGLE_CALENDAR_EVENT_ID->value, $result['id']);
         if (! empty($result['html_link'])) {
-            $this->event->set(CustomFieldEnum::GOOGLE_CALENDAR_HTML_LINK->value, $result['html_link']);
+            $this->eventVersion->set(CustomFieldEnum::GOOGLE_CALENDAR_HTML_LINK->value, $result['html_link']);
         }
         if (! empty($result['meet_link'])) {
-            $this->event->set(CustomFieldEnum::GOOGLE_CALENDAR_MEET_LINK->value, $result['meet_link']);
-            $this->event->meeting_link = $result['meet_link'];
-            $this->event->saveQuietly();
+            $this->eventVersion->set(CustomFieldEnum::GOOGLE_CALENDAR_MEET_LINK->value, $result['meet_link']);
+            $event->meeting_link = $result['meet_link'];
+            $event->saveQuietly();
         }
 
-        return ['status' => 'success', 'event_id' => $this->event->getId(), 'google_event' => $result];
+        return [
+            'status' => 'success',
+            'event_id' => $event->getId(),
+            'event_version_id' => $this->eventVersion->getId(),
+            'google_event' => $result,
+        ];
     }
 
-    protected function createMeeting(Carbon $start, Carbon $end, string $externalEventId): array
+    protected function createMeeting(Carbon $start, Carbon $end, ?string $externalEventId): array
     {
         return new CreateGoogleCalendarMeetingAction(
-            company: $this->event->company,
-            name: $this->event->name,
+            company: $this->eventVersion->event->company,
+            name: $this->eventVersion->name,
             attendeeEmails: $this->resolveAttendeeEmails(),
             startDateTime: $start,
             endDateTime: $end,
-            description: $this->event->description,
+            description: $this->eventVersion->description,
             withMeetLink: true,
             externalEventId: $externalEventId,
         )->execute();
@@ -64,8 +69,7 @@ class SyncEventToGoogleCalendarAction
 
     protected function resolveAttendeeEmails(): array
     {
-        $version = $this->event->versions()->latest('version')->first();
-        $configuredEmails = $version?->metadata['google_calendar']['attendee_emails'] ?? [];
+        $configuredEmails = $this->eventVersion->metadata['google_calendar']['attendee_emails'] ?? [];
         if (is_array($configuredEmails) && $configuredEmails !== []) {
             $validConfiguredEmails = collect($configuredEmails)
                 ->filter(fn (mixed $email): bool => is_string($email) && filter_var($email, FILTER_VALIDATE_EMAIL) !== false)
@@ -76,7 +80,21 @@ class SyncEventToGoogleCalendarAction
             }
         }
 
-        $people = $this->event->resource?->people;
+        $participantEmails = $this->eventVersion->participants()
+            ->with('people.contacts')
+            ->get()
+            ->flatMap(fn ($participant) => $participant->people?->contacts ?? [])
+            ->whereIn('contacts_types_id', [1, 9, 10])
+            ->where('is_opt_out', 0)
+            ->pluck('value')
+            ->filter(fn (mixed $email): bool => is_string($email) && filter_var($email, FILTER_VALIDATE_EMAIL) !== false)
+            ->unique()->values()->all();
+
+        if ($participantEmails !== []) {
+            return $participantEmails;
+        }
+
+        $people = $this->eventVersion->event->resource?->people;
         if ($people === null) {
             return [];
         }

--- a/src/Domains/Connectors/Google/Activities/CreateGoogleCalendarEventActivity.php
+++ b/src/Domains/Connectors/Google/Activities/CreateGoogleCalendarEventActivity.php
@@ -8,8 +8,10 @@ use Baka\Contracts\AppInterface;
 use Illuminate\Database\Eloquent\Model;
 use Kanvas\Connectors\Google\Actions\SyncEventToGoogleCalendarAction;
 use Kanvas\Event\Events\Models\Event;
+use Kanvas\Event\Events\Models\EventVersion;
 use Kanvas\Workflow\Attributes\WorkflowAction;
 use Kanvas\Workflow\Contracts\WorkflowActivityInterface;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Kanvas\Workflow\KanvasActivity;
 use Override;
 
@@ -21,15 +23,30 @@ class CreateGoogleCalendarEventActivity extends KanvasActivity implements Workfl
     {
         $this->overwriteAppService($app);
 
-        if (! $entity instanceof Event) {
-            return $this->failWorkflow(['status' => 'error', 'message' => 'This activity only supports Event entities.']);
+        if (! $entity instanceof EventVersion && ! $entity instanceof Event) {
+            return $this->failWorkflow(['status' => 'error', 'message' => 'This activity only supports EventVersion or Event entities.']);
         }
 
-        $event = $entity;
-        if ($event->apps_id !== $app->getId()) {
-            return $this->failWorkflow(['status' => 'error', 'message' => 'Event does not belong to the workflow app.']);
+        $eventVersion = $entity instanceof EventVersion
+            ? $entity
+            : $entity->versions()->latest('version')->first();
+
+        if ($eventVersion === null) {
+            return $this->failWorkflow(['status' => 'error', 'message' => 'Event has no version to synchronize.']);
         }
 
-        return new SyncEventToGoogleCalendarAction($event)->execute();
+        if ((int) $eventVersion->apps_id !== $app->getId()) {
+            return $this->failWorkflow(['status' => 'error', 'message' => 'Event version does not belong to the workflow app.']);
+        }
+
+        return $this->executeIntegration(
+            entity: $eventVersion,
+            app: $app,
+            integration: IntegrationsEnum::INTERNAL,
+            integrationOperation: static fn (EventVersion $version): array => (new SyncEventToGoogleCalendarAction($version))->execute(),
+            additionalParams: $params,
+            company: $eventVersion->company,
+            throwException: true,
+        );
     }
 }

--- a/src/Domains/Event/Events/Actions/CreateEventVersionAction.php
+++ b/src/Domains/Event/Events/Actions/CreateEventVersionAction.php
@@ -77,10 +77,12 @@ class CreateEventVersionAction
 
         if ($this->runWorkflow) {
             $eventVersion->fireWorkflow(
-                WorkflowEnum::CREATED->value,
+                WorkflowEnum::EVENT_VERSIONS_WORKFLOW->value,
                 true,
                 [
                     'app' => $this->eventVersion->event->app,
+                    'company' => $this->eventVersion->event->company,
+                    'event_version_change' => WorkflowEnum::CREATED->value,
                 ],
             );
         }

--- a/src/Domains/Event/Events/Observers/EventVersionParticipantObserver.php
+++ b/src/Domains/Event/Events/Observers/EventVersionParticipantObserver.php
@@ -12,28 +12,45 @@ class EventVersionParticipantObserver
     public function created(EventVersionParticipant $eventVersionParticipant): void
     {
         $eventVersionParticipant->eventVersion->incrementAttendees();
-        $eventVersionParticipant->fireWorkflow(
-            WorkflowEnum::CREATED->value,
-            true,
-        );
+        $this->fireEventVersionWorkflow($eventVersionParticipant, 'participant-added');
     }
 
     public function deleted(EventVersionParticipant $eventVersionParticipant): void
     {
         $eventVersionParticipant->eventVersion->decrementAttendees();
+        $this->fireEventVersionWorkflow($eventVersionParticipant, 'participant-removed');
     }
 
     public function updated(EventVersionParticipant $eventVersionParticipant): void
     {
-        if (! $eventVersionParticipant->isDeleted()) {
-            $eventVersionParticipant->eventVersion->incrementAttendees();
-        } else {
-            $eventVersionParticipant->eventVersion->decrementAttendees();
+        if (! $eventVersionParticipant->wasChanged('is_deleted')) {
+            return;
         }
 
-        $eventVersionParticipant->fireWorkflow(
-            WorkflowEnum::UPDATED->value,
+        $eventVersionParticipant->isDeleted()
+            ? $eventVersionParticipant->eventVersion->decrementAttendees()
+            : $eventVersionParticipant->eventVersion->incrementAttendees();
+
+        $this->fireEventVersionWorkflow(
+            $eventVersionParticipant,
+            $eventVersionParticipant->isDeleted() ? 'participant-removed' : 'participant-added',
+        );
+    }
+
+    protected function fireEventVersionWorkflow(
+        EventVersionParticipant $eventVersionParticipant,
+        string $change,
+    ): void {
+        $eventVersion = $eventVersionParticipant->eventVersion;
+        $eventVersion->fireWorkflow(
+            WorkflowEnum::EVENT_VERSIONS_WORKFLOW->value,
             true,
+            [
+                'app' => $eventVersion->app,
+                'company' => $eventVersion->company,
+                'event_version_change' => $change,
+                'event_version_participant_id' => $eventVersionParticipant->getId(),
+            ],
         );
     }
 }

--- a/src/Domains/Workflow/Enums/WorkflowEnum.php
+++ b/src/Domains/Workflow/Enums/WorkflowEnum.php
@@ -53,6 +53,7 @@ enum WorkflowEnum: string
     case AFTER_ONBOARDING = 'after-onboarding';
     case AFTER_CONFIGURATION = 'after-configuration';
     case AFTER_MERGE = 'after-merge';
+    case EVENT_VERSIONS_WORKFLOW = 'event-versions-workflow';
 
     /**
      * Get the enum case by its value.

--- a/tests/Connectors/Google/CreateGoogleCalendarMeetingActionTest.php
+++ b/tests/Connectors/Google/CreateGoogleCalendarMeetingActionTest.php
@@ -124,4 +124,57 @@ class CreateGoogleCalendarMeetingActionTest extends TestCase
         $this->assertNull($action->insertedEvent?->getConferenceData());
         $this->assertSame(['lead@example.com'], $result['attendees']);
     }
+
+    public function testItUpdatesAnExistingEventWithTheLatestDetailsAndAttendees(): void
+    {
+        $company = auth()->user()->getCurrentCompany();
+        $company->set(ConfigurationEnum::GOOGLE_CALENDAR_CONFIG->value, [
+            'calendar_id' => 'calendar@example.com',
+            'auth_profiles' => [
+                'service_account' => [
+                    'credentials_json' => ['type' => 'service_account'],
+                ],
+            ],
+        ]);
+
+        $action = new class (
+            company: $company,
+            name: 'Updated Meeting',
+            attendeeEmails: ['new-attendee@example.com'],
+            startDateTime: Carbon::parse('2026-08-13 11:00', 'America/New_York'),
+            endDateTime: Carbon::parse('2026-08-13 11:30', 'America/New_York'),
+            description: 'Updated description',
+            externalEventId: 'google-event-123',
+        ) extends CreateGoogleCalendarMeetingAction {
+            public ?Event $updatedEvent = null;
+            public ?string $updatedEventId = null;
+
+            protected function createCalendarService(array $config): Calendar
+            {
+                return new Calendar(new Client());
+            }
+
+            protected function updateEvent(Calendar $service, string $calendarId, string $eventId, Event $event): Event
+            {
+                $this->updatedEventId = $eventId;
+                $this->updatedEvent = $event;
+
+                return new Event([
+                    'id' => $eventId,
+                    'summary' => $event->getSummary(),
+                    'description' => $event->getDescription(),
+                    'hangoutLink' => 'https://meet.google.com/updated',
+                    'htmlLink' => 'https://calendar.google.com/event?id=updated',
+                ]);
+            }
+        };
+
+        $result = $action->execute();
+
+        $this->assertSame('google-event-123', $action->updatedEventId);
+        $this->assertSame('google-event-123', $result['id']);
+        $this->assertSame('Updated Meeting', $action->updatedEvent?->getSummary());
+        $this->assertSame('Updated description', $action->updatedEvent?->getDescription());
+        $this->assertSame('new-attendee@example.com', $action->updatedEvent?->getAttendees()[0]->getEmail());
+    }
 }


### PR DESCRIPTION
## Summary
- add the event-versions-workflow trigger for EventVersion creation and participant changes
- synchronize Google Calendar events from EventVersion with create/update behavior
- persist Google event metadata on the version and keep integration history
- fix participant attendee counts and add update coverage

## Validation
- tests/Connectors/Google/CreateGoogleCalendarMeetingActionTest.php (3 tests, 16 assertions)

## Notes
- existing .gitignore and docker-compose.yml worktree changes are intentionally excluded.