### PR TITLE
feat: hide price and mileage flags on engagement message

### DIFF
--- a/src/Domains/ActionEngine/Engagements/Actions/CreateEngagementAction.php
+++ b/src/Domains/ActionEngine/Engagements/Actions/CreateEngagementAction.php
@@ -395,8 +395,14 @@ class CreateEngagementAction
             channel_id: $this->engagementData->data['channel_id'] ?? null,
         );
 
+        $data = $engagementMessage->toArray();
+        if ($this->company->get('hide_millage')) {
+            $data['data']['hide_price'] = true;
+            $data['data']['hide_mileage'] = true;
+        }
+
         $messageInput = [
-            'message' => $engagementMessage->toArray(),
+            'message' => $data,
             'reactions_count' => 0,
             'comments_count' => 0,
             'total_liked' => 0,


### PR DESCRIPTION
Adds `hide_price` and `hide_mileage` flags to the engagement message payload when the company has the `hide_millage` setting enabled.

- `CreateEngagementAction::createMessage()` now builds the message array first and injects both flags into `data` when `$this->company->get('hide_millage')` is truthy.