### PR TITLE
feat: add status control

### DIFF
--- a/src/Domains/Connectors/WordPress/Actions/PushMessageToWordPressAction.php
+++ b/src/Domains/Connectors/WordPress/Actions/PushMessageToWordPressAction.php
@@ -34,7 +34,11 @@ class PushMessageToWordPressAction
         $company = $this->message->company;
         $client = $this->client ?? new RestClient($app, $company);
 
-        $post = WordPressPost::fromMessage($this->message, $this->defaults + $this->configDefaults());
+        $post = WordPressPost::fromMessage(
+            $this->message,
+            $this->defaults + $this->configDefaults(),
+            $this->statusOverride()
+        );
 
         if (trim(strip_tags($post->content)) === '') {
             throw new ValidationException('Message ' . $this->message->getId() . ' has no content to publish to WordPress');
@@ -116,6 +120,24 @@ class PushMessageToWordPressAction
         if ($attachmentIds !== []) {
             $this->message->set(CustomFieldEnum::MEDIA_IDS->value, $attachmentIds);
         }
+    }
+
+    /**
+     * Publishing status is editorial POLICY, not content: a workflow rule that holds everything for
+     * review must beat an agent that asked for `publish`. Every other rule param stays a default the
+     * message can override — categories and tags describe the article, and the writer knows those
+     * better than the rule does.
+     *
+     * Only the RULE's status is promoted; the connector configuration's default_post_status stays a
+     * default, so a message that names its own status still wins over the site-wide setting.
+     *
+     * @return array<string, string>
+     */
+    private function statusOverride(): array
+    {
+        $status = $this->defaults['status'] ?? null;
+
+        return is_string($status) && trim($status) !== '' ? ['status' => trim($status)] : [];
     }
 
     private function configDefaults(): array

--- a/src/Domains/Connectors/WordPress/Activities/PushMessageToWordPressActivity.php
+++ b/src/Domains/Connectors/WordPress/Activities/PushMessageToWordPressActivity.php
@@ -32,8 +32,10 @@ use Kanvas\Workflow\KanvasActivity;
     ],
     requiredParams: ['message_type_id'],
     params: [
-        'message_type_id' => 'Only messages of this type are published. Leaving it unset does not error — '
-            . 'it publishes EVERY message on the channel to the site, which is why it is required here.',
+        'message_type_id' => 'Only messages of these types are published. One id, a list of ids, or a '
+            . 'comma-separated string — a newsroom publishing from both email and WhatsApp names both. '
+            . 'Leaving it unset does not error — it publishes EVERY message on the channel to the site, '
+            . 'which is why it is required here.',
         'status' => 'draft | pending | publish | private | future. Use "pending" when a human should '
             . 'review before it goes live. Defaults to the site\'s configured default.',
         'categories' => 'Category names, not WordPress ids. Created on the site if term creation is allowed.',
@@ -62,12 +64,13 @@ class PushMessageToWordPressActivity extends KanvasActivity
             integration: IntegrationsEnum::WORDPRESS,
             additionalParams: $params,
             integrationOperation: function (Message $message, Apps $app, mixed $integrationCompany, array $additionalParams): array {
-                $messageTypeId = $additionalParams['message_type_id'] ?? null;
+                $messageTypeIds = $this->messageTypeIds($additionalParams['message_type_id'] ?? null);
 
-                if ($messageTypeId !== null && $message->message_types_id !== (int) $messageTypeId) {
+                if ($messageTypeIds !== [] && ! in_array((int) $message->message_types_id, $messageTypeIds, true)) {
                     return $this->skip(
                         $message,
-                        'Message type ' . $message->message_types_id . ' does not match the configured ' . $messageTypeId
+                        'Message type ' . $message->message_types_id
+                            . ' does not match the configured ' . implode(', ', $messageTypeIds)
                     );
                 }
 
@@ -97,6 +100,22 @@ class PushMessageToWordPressActivity extends KanvasActivity
             },
             company: $company,
         );
+    }
+
+    /**
+     * A rule can name one type or several — a newsroom that publishes what its agent writes over
+     * email AND WhatsApp needs both. Accepts an id, an array of ids, or the comma-separated string
+     * a plain text rule param gives you.
+     *
+     * @return list<int>
+     */
+    private function messageTypeIds(mixed $configured): array
+    {
+        $values = is_string($configured) ? explode(',', $configured) : (array) $configured;
+
+        $ids = array_map(static fn (mixed $id): int => (int) trim((string) $id), $values);
+
+        return array_values(array_unique(array_filter($ids, static fn (int $id): bool => $id > 0)));
     }
 
     /**

--- a/src/Domains/Connectors/WordPress/CLAUDE.md
+++ b/src/Domains/Connectors/WordPress/CLAUDE.md
@@ -106,8 +106,18 @@ since `content` is itself a valid post key.
 
 ### Precedence
 
-`message body wordpress: {}` > `response_json` > `message body top level` > `workflow rule params` >
-connector config.
+`workflow rule status` > `message body wordpress: {}` > `response_json` > `message body top level` >
+`workflow rule params` > connector config.
+
+**`status` from the workflow rule is the one field that outranks the message.** It is editorial
+policy, not content: a rule configured to hold everything for review must not be overruled by an
+agent that wrote `"status": "publish"` into its envelope. Everything else the rule sets stays a
+default the message can override — categories and tags describe the article, and whoever wrote it
+knows those better than the rule does.
+
+The promotion is scoped to the **rule's** status (`PushMessageToWordPressAction::statusOverride()`),
+not the connector's `default_post_status`. That one stays a site-wide default, so a message naming
+its own status still wins over it.
 
 Only the keys wp/v2 understands are read out of each layer, so agent bookkeeping in the message
 body — and the editorial extras a news agent emits (`titulos_alternativos`, `correcciones`) — can

--- a/src/Domains/Connectors/WordPress/DataTransferObject/WordPressPost.php
+++ b/src/Domains/Connectors/WordPress/DataTransferObject/WordPressPost.php
@@ -41,10 +41,15 @@ class WordPressPost
     }
 
     /**
-     * @param array<string, mixed> $defaults workflow-rule params + connector config, lowest precedence
+     * @param array<string, mixed> $defaults  workflow-rule params + connector config, lowest precedence
+     * @param array<string, mixed> $overrides editorial policy the message may not override — see
+     *                                        PushMessageToWordPressAction::statusOverride()
      */
-    public static function fromMessage(Message $message, array $defaults = []): self
-    {
+    public static function fromMessage(
+        Message $message,
+        array $defaults = [],
+        array $overrides = []
+    ): self {
         $body = $message->getMessage();
         $nested = is_array($body['wordpress'] ?? null) ? $body['wordpress'] : [];
 
@@ -53,6 +58,7 @@ class WordPressPost
             self::onlyPostKeys($body),
             self::onlyPostKeys(self::agentEnvelope($body)),
             self::onlyPostKeys($nested),
+            self::onlyPostKeys($overrides),
         );
 
         $content = self::resolveContent(

--- a/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
@@ -161,9 +161,11 @@ class RunNeuronChatAction
                 . 'like me to look into it or handle it a different way.';
         }
 
+        // Any tool can trip the run budget, not just the people lookups this copy used to name —
+        // a reporting tool looping on an empty date range hits it too (KANVAS-ECOSYSTEM-682).
         if ($e instanceof ToolRunsExceededException) {
-            return "I couldn't find a match after a few tries. Could you double-check the name or email "
-                . 'and confirm the person exists, then ask me again?';
+            return 'I kept retrying the same lookup without getting anywhere. Could you narrow it down for me — '
+                . 'an exact name, email, or date range — and ask again?';
         }
 
         return 'I ran into a hiccup processing that. Could you try rephrasing, '

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Sales/SalesRevenueTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Sales/SalesRevenueTool.php
@@ -60,10 +60,25 @@ class SalesRevenueTool extends Tool
             ->when($since !== null && $since !== '', fn ($q) => $q->whereDate('created_at', '>=', $since))
             ->when($until !== null && $until !== '', fn ($q) => $q->whereDate('created_at', '<=', $until));
 
+        $orders = $base()->count();
+
         $result = [
+            'since' => $since !== null && $since !== '' ? $since : 'all-time',
+            'until' => $until !== null && $until !== '' ? $until : 'open-ended',
             'total_revenue' => round((float) $base()->sum('total_gross_amount'), 2),
-            'orders' => $base()->count(),
+            'orders' => $orders,
         ];
+
+        // A bare {revenue: 0, orders: 0} reads to the model as "the call didn't work", and it
+        // retries the identical arguments until Neuron kills the turn with ToolRunsExceededException
+        // (Sentry KANVAS-ECOSYSTEM-682). Saying the zero is final — and where the data actually
+        // starts and ends — turns a retry loop into a single corrected call or a plain answer.
+        if ($orders === 0) {
+            $result['message'] = 'Zero is the complete, correct answer for this range — no booked orders fall in it. '
+                . 'Calling this tool again with the same since/until returns the same zero. Report it as-is, or call '
+                . 'once more with a range inside first_booked_order_date..last_booked_order_date.';
+            $result += $this->bookedOrderDateBounds();
+        }
 
         if ($by_month === true) {
             $result['by_month'] = $base()
@@ -79,5 +94,27 @@ class SalesRevenueTool extends Tool
         }
 
         return $result;
+    }
+
+    /**
+     * The window the tenant actually has booked orders in, so a model that queried an empty range can
+     * correct itself in one call instead of probing dates. Both null when the tenant has no orders at all.
+     *
+     * @return array{first_booked_order_date: string|null, last_booked_order_date: string|null}
+     */
+    private function bookedOrderDateBounds(): array
+    {
+        $bounds = Order::query()
+            ->where('apps_id', $this->app->getId())
+            ->where('companies_id', $this->company->getId())
+            ->where('is_deleted', false)
+            ->whereNotIn('status', self::EXCLUDED_STATUSES)
+            ->selectRaw('MIN(created_at) as first_at, MAX(created_at) as last_at')
+            ->first();
+
+        return [
+            'first_booked_order_date' => $bounds?->first_at !== null ? substr((string) $bounds->first_at, 0, 10) : null,
+            'last_booked_order_date' => $bounds?->last_at !== null ? substr((string) $bounds->last_at, 0, 10) : null,
+        ];
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Traits/HasKanvasAgentBehavior.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Traits/HasKanvasAgentBehavior.php
@@ -13,6 +13,7 @@ use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Common\CurrentTimeTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\DynamicSubAgentTool;
 use Kanvas\Intelligence\Agents\Services\AgentProviderService;
+use Kanvas\Intelligence\Agents\Traits\HasTemporalContext;
 use Kanvas\Intelligence\Sessions\Models\Session;
 use Kanvas\NervousSystem\Capability\Models\Tool;
 use Kanvas\Users\Models\Users;
@@ -23,6 +24,8 @@ use Override;
 
 trait HasKanvasAgentBehavior
 {
+    use HasTemporalContext;
+
     protected ?Agent $agent = null;
     protected ?Apps $app = null;
     protected ?Companies $company = null;
@@ -337,7 +340,11 @@ trait HasKanvasAgentBehavior
         $role = $this->agent->role ?? [];
 
         return new SystemPrompt(
-            background: [...explode("\n", $role['background'] ?? ''), ...self::platformContext()],
+            background: [
+                ...explode("\n", $role['background'] ?? ''),
+                ...$this->temporalContextLines($this->resolveTenantTimezone()),
+                ...self::platformContext(),
+            ],
             steps: explode("\n", $role['steps'] ?? ''),
             output: explode("\n", $role['output'] ?? ''),
         )->__toString();

--- a/tests/Connectors/Integration/WordPress/PushMessageToWordPressActionTest.php
+++ b/tests/Connectors/Integration/WordPress/PushMessageToWordPressActionTest.php
@@ -123,18 +123,30 @@ final class PushMessageToWordPressActionTest extends TestCase
         });
     }
 
+    /**
+     * True for every param except `status`, which the rule owns outright — see
+     * testTheRuleStatusOverridesTheAgentsOwn().
+     */
     public function testWorkflowDefaultsLoseToTheMessageBody(): void
     {
         $this->fakeWordPress();
 
-        $message = $this->makeMessage(['content' => 'Body', 'status' => 'publish']);
+        $message = $this->makeMessage([
+            'content' => 'Body',
+            'title' => 'Written by the agent',
+            'excerpt' => 'From the message',
+        ]);
 
-        new PushMessageToWordPressAction($message, defaults: ['status' => 'draft'])->execute();
+        new PushMessageToWordPressAction(
+            $message,
+            defaults: ['title' => 'From the rule', 'excerpt' => 'From the rule']
+        )->execute();
 
         Http::assertSent(function (Request $request): bool {
             return $request->method() === 'POST'
                 && str_ends_with($request->url(), '/wp/v2/posts')
-                && $request->data()['status'] === 'publish';
+                && $request->data()['title'] === 'Written by the agent'
+                && $request->data()['excerpt'] === 'From the message';
         });
     }
 
@@ -255,6 +267,83 @@ final class PushMessageToWordPressActionTest extends TestCase
                 && $body['content'] === '<p>El Nuevo Diario, LA ROMANA.- Un hombre falleció este jueves.</p>'
                 && $body['categories'] === [7];
         });
+    }
+
+    /**
+     * Status is the one field the rule owns outright: an editor who configured "hold for review" must
+     * not be overruled by an agent that wrote `publish` into its envelope.
+     */
+    public function testTheRuleStatusOverridesTheAgentsOwn(): void
+    {
+        $this->fakeWordPress();
+
+        $message = $this->makeMessage([
+            'content' => '<p>Body.</p>',
+            'response_json' => ['title' => 'Agent post', 'content' => '<p>Body.</p>', 'status' => 'publish'],
+        ]);
+
+        new PushMessageToWordPressAction($message, ['status' => 'pending'])->execute();
+
+        Http::assertSent(fn (Request $request): bool => $request->method() === 'POST'
+            && str_ends_with($request->url(), '/wp/v2/posts')
+            && $request->data()['status'] === 'pending');
+    }
+
+    /**
+     * The promotion is scoped to status — the article's own terms still come from whoever wrote it.
+     */
+    public function testTheRuleDoesNotOverrideTheAgentsTerms(): void
+    {
+        $this->fakeWordPress();
+
+        $message = $this->makeMessage([
+            'content' => '<p>Body.</p>',
+            'response_json' => ['title' => 'Agent post', 'content' => '<p>Body.</p>', 'categories' => ['News']],
+        ]);
+
+        new PushMessageToWordPressAction($message, ['status' => 'pending', 'categories' => ['Ignored']])->execute();
+
+        Http::assertSent(fn (Request $request): bool => $request->method() === 'POST'
+            && str_ends_with($request->url(), '/wp/v2/posts')
+            && $request->data()['categories'] === [7]);
+    }
+
+    /**
+     * The site-wide default is NOT policy — a message that names its own status still wins over it.
+     */
+    public function testTheConfiguredDefaultStatusDoesNotOverrideTheMessage(): void
+    {
+        $this->fakeWordPress();
+        $this->company()->set(ConfigurationEnum::DEFAULT_POST_STATUS->value, 'pending');
+
+        $message = $this->makeMessage([
+            'content' => '<p>Body.</p>',
+            'response_json' => ['title' => 'Agent post', 'content' => '<p>Body.</p>', 'status' => 'publish'],
+        ]);
+
+        new PushMessageToWordPressAction($message)->execute();
+
+        $this->company()->del(ConfigurationEnum::DEFAULT_POST_STATUS->value);
+
+        Http::assertSent(fn (Request $request): bool => $request->method() === 'POST'
+            && str_ends_with($request->url(), '/wp/v2/posts')
+            && $request->data()['status'] === 'publish');
+    }
+
+    public function testTheRuleParamStatusAppliesWhenTheAgentOmitsIt(): void
+    {
+        $this->fakeWordPress();
+
+        $message = $this->makeMessage([
+            'content' => '<p>Body.</p>',
+            'response_json' => ['title' => 'Agent post', 'content' => '<p>Body.</p>'],
+        ]);
+
+        new PushMessageToWordPressAction($message, ['status' => 'pending'])->execute();
+
+        Http::assertSent(fn (Request $request): bool => $request->method() === 'POST'
+            && str_ends_with($request->url(), '/wp/v2/posts')
+            && $request->data()['status'] === 'pending');
     }
 
     public function testRejectsAMessageWithNoContent(): void

--- a/tests/Connectors/Integration/WordPress/PushMessageToWordPressActivityTest.php
+++ b/tests/Connectors/Integration/WordPress/PushMessageToWordPressActivityTest.php
@@ -79,6 +79,61 @@ final class PushMessageToWordPressActivityTest extends TestCase
         Http::assertNothingSent();
     }
 
+    public function testPublishesWhenTheMessageTypeIsOneOfSeveralConfigured(): void
+    {
+        $this->configureSite();
+        $this->registerIntegration();
+        $this->fakeWordPress();
+
+        $message = $this->makeMessage(['content' => 'Body']);
+
+        $result = $this->activity()->execute(
+            $message,
+            app(Apps::class),
+            ['message_type_id' => [$message->message_types_id + 1, $message->message_types_id]]
+        );
+
+        $this->assertSame(101, $result['id']);
+    }
+
+    /**
+     * A rule param typed into a plain text field arrives as a string, not an array.
+     */
+    public function testAcceptsACommaSeparatedListOfMessageTypes(): void
+    {
+        $this->configureSite();
+        $this->registerIntegration();
+        $this->fakeWordPress();
+
+        $message = $this->makeMessage(['content' => 'Body']);
+
+        $result = $this->activity()->execute(
+            $message,
+            app(Apps::class),
+            ['message_type_id' => ($message->message_types_id + 1) . ', ' . $message->message_types_id]
+        );
+
+        $this->assertSame(101, $result['id']);
+    }
+
+    public function testSkipsWhenTheMessageTypeIsInNoneOfTheConfigured(): void
+    {
+        $this->configureSite();
+        $this->registerIntegration();
+        $this->fakeWordPress();
+
+        $message = $this->makeMessage(['content' => 'Body']);
+
+        $result = $this->activity()->execute(
+            $message,
+            app(Apps::class),
+            ['message_type_id' => [$message->message_types_id + 1, $message->message_types_id + 2]]
+        );
+
+        $this->assertStringContainsString('does not match', $result['message']);
+        Http::assertNothingSent();
+    }
+
     /**
      * Both sides of a channel conversation carry the same message type, so without this guard the
      * customer's own email publishes as a post — and succeeds, since `content` is a valid post key.

--- a/tests/Intelligence/Agents/SystemUserAgentTest.php
+++ b/tests/Intelligence/Agents/SystemUserAgentTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Intelligence\Agents;
 
+use Illuminate\Support\Carbon;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Intelligence\Agents\Models\Agent;
@@ -208,5 +209,37 @@ class SystemUserAgentTest extends TestCase
         $appProp = new ReflectionProperty($resolved, 'app');
         $this->assertTrue($appProp->isInitialized($resolved), 'withContext must have filled the tenant context');
         $this->assertSame($app->getId(), $appProp->getValue($resolved)->getId());
+    }
+
+    /**
+     * Without a date in the prompt the model dates every tool call from its training cutoff — a
+     * reporting agent then queries a range with no orders, reads the zero as a failed call, and
+     * retries until Neuron aborts the turn (Sentry KANVAS-ECOSYSTEM-682).
+     */
+    public function testInstructionsGroundTheAgentOnTodaysDate(): void
+    {
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        $handler = new SystemUserAgent();
+        $handler->setConfiguration(agent: $this->makeAgent(), entity: $user, user: $user);
+
+        // Mirrors HasKanvasAgentBehavior::resolveTenantTimezone(): company, then user, then UTC.
+        $timezone = 'UTC';
+        foreach ([$company->timezone, $user->timezone] as $candidate) {
+            if (is_string($candidate) && in_array($candidate, timezone_identifiers_list(), true)) {
+                $timezone = $candidate;
+
+                break;
+            }
+        }
+
+        $instructions = $handler->instructions();
+
+        $this->assertStringContainsString(
+            'Current date: ' . Carbon::now($timezone)->format('l, Y-m-d'),
+            $instructions,
+        );
+        $this->assertStringContainsString('do not use dates from your training data', $instructions);
     }
 }

--- a/tests/Souk/Orders/SalesReportToolsTest.php
+++ b/tests/Souk/Orders/SalesReportToolsTest.php
@@ -91,4 +91,39 @@ class SalesReportToolsTest extends TestCase
         $this->assertGreaterThanOrEqual(1, (int) $result['orders']);
         $this->assertNotEmpty($result['by_month']);
     }
+
+    /**
+     * A bare {total_revenue: 0, orders: 0} reads to the model as "the call failed", so it re-calls the
+     * same arguments until Neuron aborts the turn with ToolRunsExceededException (KANVAS-ECOSYSTEM-682).
+     */
+    public function test_sales_revenue_on_an_empty_range_says_the_zero_is_final_and_shows_the_real_bounds(): void
+    {
+        [$app, $company, $user] = $this->bookedOrder();
+
+        $result = new SalesRevenueTool()
+            ->withContext($app, $company, $user)
+            ->__invoke(since: '1999-01-01', until: '1999-01-02');
+
+        $this->assertSame(0, (int) $result['orders']);
+        $this->assertSame(0.0, (float) $result['total_revenue']);
+        $this->assertSame('1999-01-01', $result['since']);
+        $this->assertSame('1999-01-02', $result['until']);
+        $this->assertStringContainsString('same since/until returns the same zero', $result['message']);
+        $this->assertSame(
+            now()->format('Y-m-d'),
+            $result['last_booked_order_date'],
+            'The bounds let the model correct its range in one call instead of probing dates',
+        );
+    }
+
+    public function test_sales_revenue_with_results_carries_no_retry_message(): void
+    {
+        [$app, $company, $user] = $this->bookedOrder();
+
+        $result = new SalesRevenueTool()->withContext($app, $company, $user)->__invoke();
+
+        $this->assertArrayNotHasKey('message', $result);
+        $this->assertSame('all-time', $result['since']);
+        $this->assertSame('open-ended', $result['until']);
+    }
 }


### PR DESCRIPTION
Adds a generic, reusable approval queue on top of ApprovalQueueItem so a
human can approve a pending bill/invoice over Slack, in natural language,
with no admin UI needed:
