### PR TITLE
fix: approve_pending_item authorizes the agent's own identity instead of the real human

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -62,7 +62,7 @@ class AccountsPayableAgent extends SystemUserAgent
     #[Override]
     protected function tools(): array
     {
-        return array_merge(parent::tools(), $this->addToolContext([
+        $tools = array_merge(parent::tools(), $this->addToolContext([
             new QueryDataFreshnessTool(),
             new QueryApAgingTool(),
             new ListOpenBillsTool(),
@@ -74,7 +74,6 @@ class AccountsPayableAgent extends SystemUserAgent
             new CreateApBillTool(),
             new VoidApBillTool(),
             new ApplyApPaymentTool(),
-            new ApprovePendingItemTool(),
             new AddBillNoteTool(),
             new AttachBillFileTool(),
             new ReadGoogleSheetTool(),
@@ -89,6 +88,14 @@ class AccountsPayableAgent extends SystemUserAgent
             new MarkEmailAsReadTool(),
             new ReplyToEmailTool(),
         ]));
+
+        // approve_pending_item must authorize against the real human, not actingUser() (the agent itself on @mention/channel surfaces).
+        $requestingHuman = $this->requestingHuman();
+        if ($requestingHuman !== null && $this->app !== null && $this->company !== null) {
+            $tools[] = new ApprovePendingItemTool()->withContext($this->app, $this->company, $requestingHuman);
+        }
+
+        return $tools;
     }
 
     #[Override]

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -68,7 +68,7 @@ class AccountsReceivableAgent extends SystemUserAgent
     #[Override]
     protected function tools(): array
     {
-        return array_merge(parent::tools(), $this->addToolContext([
+        $tools = array_merge(parent::tools(), $this->addToolContext([
             new QueryDataFreshnessTool(),
             new QueryArAgingTool(),
             new ListOverdueInvoicesTool(),
@@ -86,7 +86,6 @@ class AccountsReceivableAgent extends SystemUserAgent
             new CreateArInvoiceTool(),
             new VoidArInvoiceTool(),
             new ApplyArPaymentTool(),
-            new ApprovePendingItemTool(),
             new CreateArCreditMemoTool(),
             new AddInvoiceNoteTool(),
             new AttachInvoiceFileTool(),
@@ -102,6 +101,14 @@ class AccountsReceivableAgent extends SystemUserAgent
             new MarkEmailAsReadTool(),
             new ReplyToEmailTool(),
         ]));
+
+        // approve_pending_item must authorize against the real human, not actingUser() (the agent itself on @mention/channel surfaces).
+        $requestingHuman = $this->requestingHuman();
+        if ($requestingHuman !== null && $this->app !== null && $this->company !== null) {
+            $tools[] = new ApprovePendingItemTool()->withContext($this->app, $this->company, $requestingHuman);
+        }
+
+        return $tools;
     }
 
     #[Override]

--- a/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
@@ -7,6 +7,9 @@ namespace Tests\Scribe\Intelligence;
 use Illuminate\Support\Carbon;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
 use Kanvas\Guild\Organizations\Models\Organization;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Models\AgentType;
+use Kanvas\Intelligence\Agents\Neuron\Accounting\AccountsPayableAgent;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ApprovePendingItemTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindPurchaseOrderTool;
@@ -29,6 +32,7 @@ use Kanvas\Scribe\Ledger\Enums\AccountSubTypeEnum;
 use Kanvas\Scribe\Ledger\Models\Account;
 use Kanvas\Scribe\Purchasing\Models\PurchaseOrder;
 use Kanvas\Scribe\Purchasing\Models\PurchaseOrderLine;
+use Kanvas\Users\Models\Users;
 use NeuronAI\Tools\HasRunKey;
 use Spatie\LaravelData\DataCollection;
 use Tests\Scribe\ScribeTestCase;
@@ -391,6 +395,56 @@ class AccountsPayableAgentToolsTest extends ScribeTestCase
 
         $this->assertFalse($result['approved']);
         $this->assertSame('not_found', $result['reason']);
+    }
+
+    public function test_approve_pending_item_authorizes_the_conversation_human_not_the_agents_own_identity(): void
+    {
+        $this->seedTestOrganization('Windwalk Games Corp');
+        $accountCode = (string) Account::query()
+            ->where('id', $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS))
+            ->value('account_number');
+
+        $created = new CreateApBillTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(
+                vendor_name: 'Windwalk Games Corp',
+                amount: 500.0,
+                gl_account_number: $accountCode,
+                memo: 'Approval flow test',
+                invoice_number: 'APR-3',
+                push_to_acumatica: false,
+            );
+
+        $this->kanvasApp->set(ApprovalConfigurationEnum::APPROVER_EMAIL->value, static::$cachedUser->email);
+
+        // Mirrors an @mention/channel turn: setConfiguration() receives the agent's OWN user, distinct
+        // from the human actually approving, exactly like SlackUserResolverService resolving a DM sender.
+        $agentOwnUser = Users::factory()->create(['email' => 'agent-own-user-' . uniqid() . '@internal.test']);
+        $agentType = AgentType::factory()->withAppId($this->kanvasApp->getId())->create(['provider' => 'neuron']);
+        $agentModel = Agent::factory()
+            ->withAppId($this->kanvasApp->getId())
+            ->withCompanyId($this->company->getId())
+            ->create(['agent_type_id' => $agentType->getId(), 'user_id' => $agentOwnUser->getId()]);
+
+        $handler = new AccountsPayableAgent();
+        $handler->setConfiguration($agentModel, user: $agentOwnUser);
+        $handler->setConversationHuman(static::$cachedUser);
+
+        $approveTool = null;
+        foreach ($handler->getTools() as $tool) {
+            if ($tool instanceof ApprovePendingItemTool) {
+                $approveTool = $tool;
+
+                break;
+            }
+        }
+
+        $this->assertNotNull($approveTool, 'approve_pending_item must be registered once the conversation human is known.');
+
+        $result = $approveTool->__invoke(target_type: 'bill', target_id: (int) $created['bill_id']);
+
+        $this->assertTrue($result['approved'], 'The configured approver must be authorized even when the agent turn is wired with its own identity.');
+        $this->assertSame(static::$cachedUser->email, $result['approved_by']);
     }
 
     public function test_find_vendor_returns_a_dead_end_message_when_nothing_matches(): void

--- a/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
@@ -6,6 +6,9 @@ namespace Tests\Scribe\Intelligence;
 
 use Illuminate\Support\Carbon;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Models\AgentType;
+use Kanvas\Intelligence\Agents\Neuron\Accounting\AccountsReceivableAgent;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ApprovePendingItemTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindCustomerTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindInvoiceTool;
@@ -24,6 +27,7 @@ use Kanvas\Scribe\Invoices\Models\InvoiceLine;
 use Kanvas\Scribe\Invoices\Models\InvoicePaymentAllocation;
 use Kanvas\Scribe\Ledger\Enums\AccountSubTypeEnum;
 use Kanvas\Scribe\Ledger\Models\Account;
+use Kanvas\Users\Models\Users;
 use NeuronAI\Tools\HasRunKey;
 use Tests\Scribe\ScribeTestCase;
 
@@ -277,6 +281,46 @@ class AccountsReceivableAgentToolsTest extends ScribeTestCase
 
         $this->assertFalse($result['approved']);
         $this->assertSame('not_found', $result['reason']);
+    }
+
+    public function test_approve_pending_item_authorizes_the_conversation_human_not_the_agents_own_identity(): void
+    {
+        $this->seedTestOrganization('Approval Flow Customer 3');
+
+        $created = new CreateArInvoiceTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(customer_name: 'Approval Flow Customer 3', amount: 300.0, memo: 'Approval flow test', push_to_acumatica: false);
+
+        $this->kanvasApp->set(ApprovalConfigurationEnum::APPROVER_EMAIL->value, static::$cachedUser->email);
+
+        // Mirrors an @mention/channel turn: setConfiguration() receives the agent's OWN user, distinct
+        // from the human actually approving, exactly like SlackUserResolverService resolving a DM sender.
+        $agentOwnUser = Users::factory()->create(['email' => 'agent-own-user-' . uniqid() . '@internal.test']);
+        $agentType = AgentType::factory()->withAppId($this->kanvasApp->getId())->create(['provider' => 'neuron']);
+        $agentModel = Agent::factory()
+            ->withAppId($this->kanvasApp->getId())
+            ->withCompanyId($this->company->getId())
+            ->create(['agent_type_id' => $agentType->getId(), 'user_id' => $agentOwnUser->getId()]);
+
+        $handler = new AccountsReceivableAgent();
+        $handler->setConfiguration($agentModel, user: $agentOwnUser);
+        $handler->setConversationHuman(static::$cachedUser);
+
+        $approveTool = null;
+        foreach ($handler->getTools() as $tool) {
+            if ($tool instanceof ApprovePendingItemTool) {
+                $approveTool = $tool;
+
+                break;
+            }
+        }
+
+        $this->assertNotNull($approveTool, 'approve_pending_item must be registered once the conversation human is known.');
+
+        $result = $approveTool->__invoke(target_type: 'invoice', target_id: (int) $created['invoice_id']);
+
+        $this->assertTrue($result['approved'], 'The configured approver must be authorized even when the agent turn is wired with its own identity.');
+        $this->assertSame(static::$cachedUser->email, $result['approved_by']);
     }
 
     public function test_match_invoices_for_payment_flags_the_exact_invoice(): void


### PR DESCRIPTION
## Summary
- Production root cause of the "approve bill X" → `not_authorized` failure reported live in Slack: `AccountsPayableAgent`/`AccountsReceivableAgent` wired `approve_pending_item` through `addToolContext()`, which injects `actingUser()` — the agent's OWN Kanvas identity on the @mention/DM/channel surface, not the human actually talking to it (see the doc comment on `actingUser()` in `SystemUserAgent`). So the authorization check (`$this->user->email === ap-bill-approver-email`) was comparing the approver email against Apex's/Arc's own email, never the real speaker's — no value of the config key could ever pass, except by coincidence.
- Fixed by wiring `approve_pending_item` with `requestingHuman()` instead — an existing primitive built for exactly this case ("the person an admin-guarded tool must authorize against — never the agent itself"), already used by the schedule tools (`ScheduleReminderTool`, etc.) but never applied here.
- Added a regression test per agent that reproduces the exact production shape: configures the agent via `setConfiguration()` with the agent's own dedicated user (mirroring an @mention/channel turn) plus `setConversationHuman()` for the real human, then asserts `approve_pending_item` authorizes the human, not the agent. Verified this test fails against the old wiring (`not_authorized`) and passes with the fix.

## Test plan
- [x] `AccountsPayableAgentToolsTest` (40 tests incl. new regression test) — green
- [x] `AccountsReceivableAgentToolsTest` — green
- [x] `UniversalAgentToolsTest` (unaffected agent-tool-wiring coverage) — green
- [x] Confirmed the new test fails on the pre-fix code (reverted locally, reran, got `not_authorized`) and passes after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)