### PR TITLE
feat: agent schedule

### DIFF
--- a/app/GraphQL/NervousSystem/Mutations/ScheduledActionMutation.php
+++ b/app/GraphQL/NervousSystem/Mutations/ScheduledActionMutation.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\NervousSystem\Mutations;
+
+use App\GraphQL\Concerns\ResolvesActingContext;
+use Kanvas\NervousSystem\Scheduling\Actions\CancelScheduledActionAction;
+use Kanvas\NervousSystem\Scheduling\Actions\PauseScheduledActionAction;
+use Kanvas\NervousSystem\Scheduling\Actions\ResumeScheduledActionAction;
+use Kanvas\NervousSystem\Scheduling\Models\ScheduledAction;
+
+class ScheduledActionMutation
+{
+    use ResolvesActingContext;
+
+    public function pause(mixed $rootValue, array $request): ScheduledAction
+    {
+        return new PauseScheduledActionAction($this->scheduledAction($request))->execute();
+    }
+
+    public function resume(mixed $rootValue, array $request): ScheduledAction
+    {
+        return new ResumeScheduledActionAction($this->scheduledAction($request))->execute();
+    }
+
+    public function cancel(mixed $rootValue, array $request): ScheduledAction
+    {
+        return new CancelScheduledActionAction($this->scheduledAction($request))->execute();
+    }
+
+    private function scheduledAction(array $request): ScheduledAction
+    {
+        $ctx = $this->actingContext();
+
+        /** @var ScheduledAction $action */
+        $action = ScheduledAction::getByIdFromCompanyApp(
+            (int) $request['id'],
+            $ctx->company,
+            $ctx->app
+        );
+
+        return $action;
+    }
+}

--- a/graphql/schemas/NervousSystem/nervousSystemScheduledAction.graphql
+++ b/graphql/schemas/NervousSystem/nervousSystemScheduledAction.graphql
@@ -1,0 +1,69 @@
+type NervousSystemScheduledAction {
+    id: ID!
+    uuid: String!
+    company: Company! @belongsTo(relation: "company")
+    recipient: User @belongsTo(relation: "recipient")
+    agent: AgentAi @belongsTo(relation: "agent")
+    action_type: String!
+    status: String!
+    run_at: DateTime!
+    timezone: String!
+    is_recurring: Boolean! @method(name: "isRecurring")
+    recurrence_cron: String
+    recurrence_ends_at: DateTime
+    max_occurrences: Int
+    occurrences_count: Int!
+    payload: Mixed
+    channel: String
+    session_uuid: String
+    source_entity_type: String
+    source_entity_id: String
+    attempts: Int!
+    last_error: String
+    last_fired_at: DateTime
+    executed_at: DateTime
+    created_at: DateTime!
+    updated_at: DateTime
+}
+
+extend type Query @guard {
+    nervousSystemScheduledActions(
+        where: _
+            @whereConditions(
+                columns: [
+                    "id"
+                    "uuid"
+                    "users_id"
+                    "agent_id"
+                    "status"
+                    "action_type"
+                    "channel"
+                    "run_at"
+                ]
+            )
+        orderBy: _
+            @orderBy(columns: ["id", "run_at", "created_at", "last_fired_at"])
+    ): [NervousSystemScheduledAction!]!
+        @paginate(
+            model: "Kanvas\\NervousSystem\\Scheduling\\Models\\ScheduledAction"
+            scopes: ["fromApp", "fromCompany", "notDeleted"]
+            defaultCount: 25
+        )
+}
+
+extend type Mutation @guard {
+    pauseNervousSystemScheduledAction(id: ID!): NervousSystemScheduledAction!
+        @field(
+            resolver: "App\\GraphQL\\NervousSystem\\Mutations\\ScheduledActionMutation@pause"
+        )
+
+    resumeNervousSystemScheduledAction(id: ID!): NervousSystemScheduledAction!
+        @field(
+            resolver: "App\\GraphQL\\NervousSystem\\Mutations\\ScheduledActionMutation@resume"
+        )
+
+    cancelNervousSystemScheduledAction(id: ID!): NervousSystemScheduledAction!
+        @field(
+            resolver: "App\\GraphQL\\NervousSystem\\Mutations\\ScheduledActionMutation@cancel"
+        )
+}

--- a/src/Domains/NervousSystem/Scheduling/Actions/PauseScheduledActionAction.php
+++ b/src/Domains/NervousSystem/Scheduling/Actions/PauseScheduledActionAction.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\NervousSystem\Scheduling\Actions;
+
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\NervousSystem\Scheduling\Enums\ScheduledActionStatusEnum;
+use Kanvas\NervousSystem\Scheduling\Models\ScheduledAction;
+
+class PauseScheduledActionAction
+{
+    public function __construct(
+        protected readonly ScheduledAction $action,
+    ) {
+    }
+
+    public function execute(): ScheduledAction
+    {
+        $status = ScheduledActionStatusEnum::from($this->action->status);
+
+        if ($status === ScheduledActionStatusEnum::PAUSED) {
+            return $this->action;
+        }
+
+        // EXECUTING is mid-fire and already claimed by a sweeper — pausing it would race the worker
+        // that owns the row. Terminal rows have nothing left to pause.
+        if ($status !== ScheduledActionStatusEnum::PENDING) {
+            throw new ValidationException(
+                "A scheduled action in status '{$status->value}' cannot be paused.",
+            );
+        }
+
+        $this->action->status = ScheduledActionStatusEnum::PAUSED->value;
+        $this->action->saveOrFail();
+
+        $this->action->emitLedgerEvent('scheduled_action.paused', payload: [
+            'action_type' => $this->action->action_type,
+            'recurring' => $this->action->isRecurring(),
+            'run_at' => $this->action->run_at->toIso8601String(),
+        ]);
+
+        return $this->action;
+    }
+}

--- a/src/Domains/NervousSystem/Scheduling/Actions/ResumeScheduledActionAction.php
+++ b/src/Domains/NervousSystem/Scheduling/Actions/ResumeScheduledActionAction.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\NervousSystem\Scheduling\Actions;
+
+use Illuminate\Support\Carbon;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\NervousSystem\Scheduling\Enums\ScheduledActionStatusEnum;
+use Kanvas\NervousSystem\Scheduling\Models\ScheduledAction;
+
+class ResumeScheduledActionAction
+{
+    public function __construct(
+        protected readonly ScheduledAction $action,
+    ) {
+    }
+
+    public function execute(): ScheduledAction
+    {
+        $status = ScheduledActionStatusEnum::from($this->action->status);
+
+        if ($status === ScheduledActionStatusEnum::PENDING) {
+            return $this->action;
+        }
+
+        if ($status !== ScheduledActionStatusEnum::PAUSED) {
+            throw new ValidationException(
+                "A scheduled action in status '{$status->value}' cannot be resumed.",
+            );
+        }
+
+        $rearmed = $this->rearmRunAt();
+
+        $this->action->status = ScheduledActionStatusEnum::PENDING->value;
+        $this->action->saveOrFail();
+
+        $this->action->emitLedgerEvent('scheduled_action.resumed', payload: [
+            'action_type' => $this->action->action_type,
+            'recurring' => $this->action->isRecurring(),
+            'run_at' => $this->action->run_at->toIso8601String(),
+            'rearmed' => $rearmed,
+        ]);
+
+        return $this->action;
+    }
+
+    /**
+     * A recurring row that sat paused past its slot must advance to the next FUTURE occurrence —
+     * otherwise resuming replays a stale slot immediately and then fires again on schedule.
+     *
+     * A one-off is left alone on purpose: its run_at is the whole point of the row, so a late fire on
+     * the next sweep is the useful outcome. Silently dropping it would leave a row the user can only
+     * cancel.
+     */
+    private function rearmRunAt(): bool
+    {
+        $now = Carbon::now();
+
+        if (! $this->action->isRecurring() || $this->action->run_at->greaterThan($now)) {
+            return false;
+        }
+
+        $this->action->run_at = Carbon::instance($this->action->nextRunAt($now));
+
+        return true;
+    }
+}

--- a/src/Domains/NervousSystem/Scheduling/Enums/ScheduledActionStatusEnum.php
+++ b/src/Domains/NervousSystem/Scheduling/Enums/ScheduledActionStatusEnum.php
@@ -7,6 +7,11 @@ namespace Kanvas\NervousSystem\Scheduling\Enums;
 enum ScheduledActionStatusEnum: string
 {
     case PENDING = 'pending';
+    /**
+     * Disabled from the UI. Not terminal — the row keeps its schedule and can be resumed. The sweep
+     * only claims PENDING rows, so a paused row simply never becomes due.
+     */
+    case PAUSED = 'paused';
     case EXECUTING = 'executing';
     case EXECUTED = 'executed';
     case COMPLETED = 'completed';

--- a/tests/GraphQL/NervousSystem/ScheduledActionMutationTest.php
+++ b/tests/GraphQL/NervousSystem/ScheduledActionMutationTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\GraphQL\NervousSystem;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Carbon;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\NervousSystem\Scheduling\Actions\CreateScheduledActionAction;
+use Kanvas\NervousSystem\Scheduling\DataTransferObject\ScheduledAction as ScheduledActionData;
+use Kanvas\NervousSystem\Scheduling\Enums\ScheduledActionStatusEnum;
+use Kanvas\NervousSystem\Scheduling\Enums\ScheduledActionTypeEnum;
+use Kanvas\NervousSystem\Scheduling\Models\ScheduledAction;
+use Kanvas\NervousSystem\Scheduling\Services\ScheduledActionSweepService;
+use Kanvas\Users\Models\Users;
+use Tests\TestCase;
+
+class ScheduledActionMutationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected array $connectionsToTransact = ['mysql', 'intelligence'];
+
+    private function makeAction(?string $cron = null, ?Carbon $runAt = null): ScheduledAction
+    {
+        $app = app(Apps::class);
+        /** @var Users $user */
+        $user = auth()->user();
+        /** @var Companies $company */
+        $company = $user->getCurrentCompany();
+
+        return new CreateScheduledActionAction(
+            new ScheduledActionData(
+                app: $app,
+                company: $company,
+                user: $user,
+                type: ScheduledActionTypeEnum::REMINDER,
+                timezone: 'UTC',
+                runAt: $runAt ?? Carbon::now()->addDay(),
+                message: 'Ping the client',
+                recurrenceCron: $cron,
+            ),
+        )->execute();
+    }
+
+    public function testQueryListsScheduledActionsForCurrentCompany(): void
+    {
+        $action = $this->makeAction(cron: '0 9 * * *');
+
+        $response = $this->graphQL('
+            query {
+                nervousSystemScheduledActions(
+                    where: { column: UUID, operator: EQ, value: "' . $action->uuid . '" }
+                ) {
+                    data {
+                        id
+                        uuid
+                        action_type
+                        status
+                        timezone
+                        is_recurring
+                        recurrence_cron
+                        payload
+                        recipient { id }
+                    }
+                    paginatorInfo { total }
+                }
+            }
+        ')->assertSuccessful();
+
+        $row = $response->json('data.nervousSystemScheduledActions.data.0');
+
+        $this->assertSame(1, $response->json('data.nervousSystemScheduledActions.paginatorInfo.total'));
+        $this->assertSame($action->uuid, $row['uuid']);
+        $this->assertSame(ScheduledActionTypeEnum::REMINDER->value, $row['action_type']);
+        $this->assertSame(ScheduledActionStatusEnum::PENDING->value, $row['status']);
+        $this->assertTrue($row['is_recurring']);
+        $this->assertSame('0 9 * * *', $row['recurrence_cron']);
+        $this->assertSame('Ping the client', $row['payload']['message']);
+        $this->assertSame((string) auth()->user()->getId(), (string) $row['recipient']['id']);
+    }
+
+    public function testPauseKeepsRowOutOfTheSweep(): void
+    {
+        $action = $this->makeAction();
+
+        $response = $this->graphQL('
+            mutation {
+                pauseNervousSystemScheduledAction(id: ' . $action->getId() . ') {
+                    id
+                    status
+                }
+            }
+        ')->assertSuccessful();
+
+        $this->assertSame(
+            ScheduledActionStatusEnum::PAUSED->value,
+            $response->json('data.pauseNervousSystemScheduledAction.status'),
+        );
+
+        // Make it due; a paused row must still never be claimed.
+        $action->refresh();
+        $action->run_at = Carbon::now()->subMinute();
+        $action->saveOrFail();
+
+        $claimed = new ScheduledActionSweepService()->claimDue();
+
+        $this->assertNotContains($action->getId(), $claimed->pluck('id')->all());
+        $this->assertSame(ScheduledActionStatusEnum::PAUSED->value, $action->refresh()->status);
+    }
+
+    public function testResumeRearmsARecurringRowThatSatPausedPastItsSlot(): void
+    {
+        $action = $this->makeAction(cron: '*/30 * * * *');
+
+        $this->graphQL('
+            mutation {
+                pauseNervousSystemScheduledAction(id: ' . $action->getId() . ') { id }
+            }
+        ')->assertSuccessful();
+
+        $action->refresh();
+        $action->run_at = Carbon::now()->subHours(3);
+        $action->saveOrFail();
+
+        $response = $this->graphQL('
+            mutation {
+                resumeNervousSystemScheduledAction(id: ' . $action->getId() . ') {
+                    id
+                    status
+                }
+            }
+        ')->assertSuccessful();
+
+        $this->assertSame(
+            ScheduledActionStatusEnum::PENDING->value,
+            $response->json('data.resumeNervousSystemScheduledAction.status'),
+        );
+        $this->assertTrue($action->refresh()->run_at->greaterThan(Carbon::now()));
+    }
+
+    public function testResumeLeavesAOneOffRunAtAloneSoItFiresLate(): void
+    {
+        $action = $this->makeAction();
+
+        $this->graphQL('
+            mutation {
+                pauseNervousSystemScheduledAction(id: ' . $action->getId() . ') { id }
+            }
+        ')->assertSuccessful();
+
+        $action->refresh();
+        $pastRunAt = Carbon::now()->subHours(2);
+        $action->run_at = $pastRunAt;
+        $action->saveOrFail();
+
+        $this->graphQL('
+            mutation {
+                resumeNervousSystemScheduledAction(id: ' . $action->getId() . ') { id }
+            }
+        ')->assertSuccessful();
+
+        $action->refresh();
+
+        $this->assertSame(ScheduledActionStatusEnum::PENDING->value, $action->status);
+        $this->assertSame($pastRunAt->toDateTimeString(), $action->run_at->toDateTimeString());
+    }
+
+    public function testCancelIsTerminalAndBlocksAFollowUpPause(): void
+    {
+        $action = $this->makeAction();
+
+        $response = $this->graphQL('
+            mutation {
+                cancelNervousSystemScheduledAction(id: ' . $action->getId() . ') {
+                    id
+                    status
+                }
+            }
+        ')->assertSuccessful();
+
+        $this->assertSame(
+            ScheduledActionStatusEnum::CANCELLED->value,
+            $response->json('data.cancelNervousSystemScheduledAction.status'),
+        );
+
+        $this->graphQL('
+            mutation {
+                pauseNervousSystemScheduledAction(id: ' . $action->getId() . ') { id }
+            }
+        ')->assertGraphQLErrorMessage("A scheduled action in status 'cancelled' cannot be paused.");
+    }
+}


### PR DESCRIPTION
Adds a generic, reusable approval queue on top of ApprovalQueueItem so a
human can approve a pending bill/invoice over Slack, in natural language,
with no admin UI needed:

