### PR TITLE
feat(guild): per-receiver lead notification email

### DIFF
--- a/app/GraphQL/Guild/Mutations/Leads/LeadReceiverManagement.php
+++ b/app/GraphQL/Guild/Mutations/Leads/LeadReceiverManagement.php
@@ -26,6 +26,7 @@ class LeadReceiverManagement
             'isDefault' => $request['input']['is_default'],
             'rotation' => $rotation,
             'source' => $request['input']['source_name'],
+            'notificationEmail' => $request['input']['notification_email'] ?? null,
             'lead_sources_id' => $request['input']['lead_sources_id'],
             'lead_types_id' => $request['input']['lead_types_id'],
             'template' => key_exists('template', $request['input']) ? $request['input']['template'] : '',
@@ -36,6 +37,7 @@ class LeadReceiverManagement
 
     public function update(mixed $root, array $request): LeadReceiverModel
     {
+        $leadReceiver = LeadReceiverModel::getById($request['id'], app(Apps::class));
         $rotation = key_exists('rotations_id', $request['input']) ? LeadRotation::getById($request['input']['rotations_id']) : null;
         $dto = LeadReceiver::from([
             'branch' => auth()->user()->getCurrentBranch(),
@@ -46,11 +48,13 @@ class LeadReceiverManagement
             'isDefault' => $request['input']['is_default'],
             'rotation' => $rotation,
             'source' => $request['input']['source_name'],
+            'notificationEmail' => key_exists('notification_email', $request['input'])
+                ? $request['input']['notification_email']
+                : $leadReceiver->notification_email,
             'lead_sources_id' => $request['input']['lead_sources_id'],
             'lead_types_id' => $request['input']['lead_types_id'],
             'template' => key_exists('template', $request['input']) ? $request['input']['template'] : null,
         ]);
-        $leadReceiver = LeadReceiverModel::getById($request['id'], app(Apps::class));
 
         return (new UpdateLeadReceiverAction($leadReceiver, $dto))->execute();
     }

--- a/database/migrations/Guild/2026_08_20_000000_add_notification_email_to_leads_receivers.php
+++ b/database/migrations/Guild/2026_08_20_000000_add_notification_email_to_leads_receivers.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Per-receiver notification address, mirroring `leads_rotations.leads_rotations_email`.
+ *
+ * A rotation is a distribution policy (who works the lead); a receiver is a source (which form it
+ * came from). Routing a form's leads to its own address is a source concern, so cloning the rotation
+ * per form would split the round-robin hit counters to achieve something unrelated to distribution.
+ *
+ * Holds an optional comma-separated list — `SendLeadEmailsAction::parseExtraEmails()` already splits it.
+ */
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::connection('crm')->table('leads_receivers', function (Blueprint $table) {
+            $table->string('notification_email')->nullable()->after('source_name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection('crm')->table('leads_receivers', function (Blueprint $table) {
+            $table->dropColumn('notification_email');
+        });
+    }
+};

--- a/database/migrations/Guild/2026_08_20_000000_add_notification_email_to_leads_receivers.php
+++ b/database/migrations/Guild/2026_08_20_000000_add_notification_email_to_leads_receivers.php
@@ -6,15 +6,6 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * Per-receiver notification address, mirroring `leads_rotations.leads_rotations_email`.
- *
- * A rotation is a distribution policy (who works the lead); a receiver is a source (which form it
- * came from). Routing a form's leads to its own address is a source concern, so cloning the rotation
- * per form would split the round-robin hit counters to achieve something unrelated to distribution.
- *
- * Holds an optional comma-separated list — `SendLeadEmailsAction::parseExtraEmails()` already splits it.
- */
 return new class () extends Migration {
     public function up(): void
     {

--- a/graphql/schemas/Guild/leadReceiver.graphql
+++ b/graphql/schemas/Guild/leadReceiver.graphql
@@ -7,6 +7,7 @@ type LeadReceiver {
     agent: User! @belongsTo(relation: "agent")
     name: String!
     source_name: String
+    notification_email: String
     is_default: Boolean!
     template: Mixed
     leadSource: LeadSource @belongsTo(relation: "leadSource")
@@ -22,6 +23,7 @@ input LeadReceiverInput {
     is_default: Boolean!
     rotations_id: ID
     source_name: String
+    notification_email: String
     lead_sources_id: ID!
     lead_types_id: ID!
     template: Mixed
@@ -47,7 +49,14 @@ extend type Query {
         search: String @search
         where: _
             @whereConditions(
-                columns: ["id", "uuid", "name", "source_name", "is_default"]
+                columns: [
+                    "id"
+                    "uuid"
+                    "name"
+                    "source_name"
+                    "notification_email"
+                    "is_default"
+                ]
             )
     ): [LeadReceiver!]!
         @paginate(

--- a/src/Domains/Guild/Leads/Actions/CreateLeadReceiverAction.php
+++ b/src/Domains/Guild/Leads/Actions/CreateLeadReceiverAction.php
@@ -30,6 +30,7 @@ class CreateLeadReceiverAction
             'is_default' => (int) $this->leadReceiver->isDefault,
             'rotations_id' => $this->leadReceiver->rotation ? $this->leadReceiver->rotation->getId() : 0,
             'source_name' => $this->leadReceiver->source,
+            'notification_email' => $this->leadReceiver->notificationEmail,
             'leads_sources_id' => $this->leadReceiver->lead_sources_id,
             'lead_types_id' => $this->leadReceiver->lead_types_id,
             'template' => $this->leadReceiver->template,

--- a/src/Domains/Guild/Leads/Actions/SendRotationEmailsAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendRotationEmailsAction.php
@@ -41,16 +41,10 @@ class SendRotationEmailsAction
             ? collect([$owner])->merge($activeUsers)->all()
             : [$owner];
 
-        // The receiver's own address always fires: it identifies the source (which form the lead came
-        // from), so it must not depend on the rotation's agent-side notification mode.
-        // Commas are trimmed alongside whitespace so a stray "," or " " falls through to the rotation
-        // instead of blocking it and then parsing down to zero recipients.
-        $receiverEmails = trim((string) $this->leadReceiver->notification_email, ", \t\n\r\0\x0B");
+        $extraEmails = $this->resolveExtraEmails($shouldNotifyAgents);
 
-        if ($receiverEmails !== '') {
-            $payload['extraEmails'] = $receiverEmails;
-        } elseif ($shouldNotifyAgents) {
-            $payload['extraEmails'] = $this->leadRotation->leads_rotations_email;
+        if ($extraEmails !== null) {
+            $payload['extraEmails'] = $extraEmails;
         }
 
         $sender = new SendLeadEmailsAction(
@@ -65,6 +59,19 @@ class SendRotationEmailsAction
         );
     }
 
+    // Commas are trimmed alongside whitespace so a stray "," falls through to the rotation instead
+    // of parsing down to zero recipients.
+    private function resolveExtraEmails(bool $shouldNotifyAgents): ?string
+    {
+        $receiverEmails = trim((string) $this->leadReceiver->notification_email, ", \t\n\r\0\x0B");
+
+        if ($receiverEmails !== '') {
+            return $receiverEmails;
+        }
+
+        return $shouldNotifyAgents ? $this->leadRotation->leads_rotations_email : null;
+    }
+
     /**
      * Reads `rotation.config.notification_mode` — controls WHO on the recipient axis gets the email.
      *
@@ -72,9 +79,7 @@ class SendRotationEmailsAction
      * - NOTIFY_AGENTS        → agents only (lead does not get an email)
      * - NOTIFY_LEAD          → the lead's contact email only (agents do not get an email)
      *
-     * Note: `extraEmails` always fires regardless of this mode. When it comes from the rotation
-     * (leads_rotations_email) it is gated by notification_user_mode instead; when it comes from
-     * the receiver (notification_email) it is not gated at all.
+     * Note: `extraEmails` is unaffected by this mode — see resolveExtraEmails().
      */
     private function resolveNotificationMode(): LeadNotificationModeEnum
     {

--- a/src/Domains/Guild/Leads/Actions/SendRotationEmailsAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendRotationEmailsAction.php
@@ -41,7 +41,15 @@ class SendRotationEmailsAction
             ? collect([$owner])->merge($activeUsers)->all()
             : [$owner];
 
-        if ($shouldNotifyAgents) {
+        // The receiver's own address always fires: it identifies the source (which form the lead came
+        // from), so it must not depend on the rotation's agent-side notification mode.
+        // Commas are trimmed alongside whitespace so a stray "," or " " falls through to the rotation
+        // instead of blocking it and then parsing down to zero recipients.
+        $receiverEmails = trim((string) $this->leadReceiver->notification_email, ", \t\n\r\0\x0B");
+
+        if ($receiverEmails !== '') {
+            $payload['extraEmails'] = $receiverEmails;
+        } elseif ($shouldNotifyAgents) {
             $payload['extraEmails'] = $this->leadRotation->leads_rotations_email;
         }
 
@@ -64,8 +72,9 @@ class SendRotationEmailsAction
      * - NOTIFY_AGENTS        → agents only (lead does not get an email)
      * - NOTIFY_LEAD          → the lead's contact email only (agents do not get an email)
      *
-     * Note: `extraEmails` (rotation.leads_rotations_email) currently always fires regardless
-     * of this mode — it is gated by notification_user_mode instead.
+     * Note: `extraEmails` always fires regardless of this mode. When it comes from the rotation
+     * (leads_rotations_email) it is gated by notification_user_mode instead; when it comes from
+     * the receiver (notification_email) it is not gated at all.
      */
     private function resolveNotificationMode(): LeadNotificationModeEnum
     {
@@ -88,7 +97,7 @@ class SendRotationEmailsAction
      *   - NOTIFY_ROTATION_USERS notifies ALL active rotation agents, not just the round-robin
      *     assignee for this lead.
      *   - If the rotation has zero active agents, this mode silently falls back to NOTIFY_OWNER
-     *     behavior (and `extraEmails` does not fire).
+     *     behavior (and the rotation's `extraEmails` does not fire; the receiver's still does).
      */
     private function resolveNotificationUserMode(): LeadNotificationUserModeEnum
     {

--- a/src/Domains/Guild/Leads/Actions/UpdateLeadReceiverAction.php
+++ b/src/Domains/Guild/Leads/Actions/UpdateLeadReceiverAction.php
@@ -27,6 +27,7 @@ class UpdateLeadReceiverAction
             'is_default' => (int) $this->leadReceiverDto->isDefault,
             'rotations_id' => $this->leadReceiverDto->rotation ? $this->leadReceiverDto->rotation->getId() : 0,
             'source_name' => $this->leadReceiverDto->source,
+            'notification_email' => $this->leadReceiverDto->notificationEmail,
             'leads_sources_id' => $this->leadReceiverDto->lead_sources_id,
             'lead_types_id' => $this->leadReceiverDto->lead_types_id,
             'template' => $this->leadReceiverDto->template,

--- a/src/Domains/Guild/Leads/CLAUDE.md
+++ b/src/Domains/Guild/Leads/CLAUDE.md
@@ -51,17 +51,7 @@ The `flag` (`'user'` default) picks the "owner" identity: `flag === 'user'` → 
 
 A rotation is a *distribution policy* (who works the lead); a receiver is a *source* (which form it came from). When several forms share one agent pool but each must notify a different address, the address goes on the receiver — cloning the rotation per form would split the round-robin `hits` counters to achieve something unrelated to distribution.
 
-`notification_email` is a nullable comma-separated string mirroring `leads_rotations_email`. It **overrides** the rotation's address and fires **unconditionally** — unlike the rotation's, it is not gated by `NOTIFY_ROTATION_USERS` + a non-empty agent pool, because a source's address should always receive its own leads:
-
-```php
-if (! empty($this->leadReceiver->notification_email)) {
-    $payload['extraEmails'] = $this->leadReceiver->notification_email;
-} elseif ($shouldNotifyAgents) {
-    $payload['extraEmails'] = $this->leadRotation->leads_rotations_email;
-}
-```
-
-Recipients still get the same `user-<template>` mail, so content is identical across forms — only the address differs.
+`notification_email` is a nullable comma-separated string mirroring `leads_rotations_email`, resolved in `SendRotationEmailsAction::resolveExtraEmails()`. It **overrides** the rotation's address and fires **unconditionally** — unlike the rotation's, it is not gated by `NOTIFY_ROTATION_USERS` + a non-empty agent pool, because a source's address should always receive its own leads. Recipients still get the same `user-<template>` mail, so only the address differs.
 
 **The receiver must be wired to a rotation for this to fire at all.** `CreateLeadsFromReceiverJob::sendEmails()` returns `['no email sent']` on a null owner *before* it constructs `SendRotationEmailsAction`, and with `rotations_id = 0` `resolveOwner()` only produces an owner when the payload carries a `Member` key that matches an Agent. A plain contact form posting to a rotation-less receiver therefore sends nothing — no rotation email, no receiver email — regardless of `notification_email` or a webhook `email_template`. The template itself also still comes only from the rotation (or the webhook fallback).
 

--- a/src/Domains/Guild/Leads/CLAUDE.md
+++ b/src/Domains/Guild/Leads/CLAUDE.md
@@ -47,6 +47,26 @@ Both read off `rotation->config` (see [`SendRotationEmailsAction`](Actions/SendR
 
 The `flag` (`'user'` default) picks the "owner" identity: `flag === 'user'` → `leadReceiver->user`; otherwise the resolved lead owner (`$this->user`). It is **not** concatenated into the template name — that's the `user-`/`lead-` prefixing above, which is separate.
 
+### Per-receiver address: `leads_receivers.notification_email`
+
+A rotation is a *distribution policy* (who works the lead); a receiver is a *source* (which form it came from). When several forms share one agent pool but each must notify a different address, the address goes on the receiver — cloning the rotation per form would split the round-robin `hits` counters to achieve something unrelated to distribution.
+
+`notification_email` is a nullable comma-separated string mirroring `leads_rotations_email`. It **overrides** the rotation's address and fires **unconditionally** — unlike the rotation's, it is not gated by `NOTIFY_ROTATION_USERS` + a non-empty agent pool, because a source's address should always receive its own leads:
+
+```php
+if (! empty($this->leadReceiver->notification_email)) {
+    $payload['extraEmails'] = $this->leadReceiver->notification_email;
+} elseif ($shouldNotifyAgents) {
+    $payload['extraEmails'] = $this->leadRotation->leads_rotations_email;
+}
+```
+
+Recipients still get the same `user-<template>` mail, so content is identical across forms — only the address differs.
+
+**The receiver must be wired to a rotation for this to fire at all.** `CreateLeadsFromReceiverJob::sendEmails()` returns `['no email sent']` on a null owner *before* it constructs `SendRotationEmailsAction`, and with `rotations_id = 0` `resolveOwner()` only produces an owner when the payload carries a `Member` key that matches an Agent. A plain contact form posting to a rotation-less receiver therefore sends nothing — no rotation email, no receiver email — regardless of `notification_email` or a webhook `email_template`. The template itself also still comes only from the rotation (or the webhook fallback).
+
+For attribution you need no config at all — leads already carry `leads_receivers_id` and a copied `source_name`.
+
 ## When defaults are created — company onboarding vs. the SalesAssist command
 
 Two very different creation paths; don't conflate them:

--- a/src/Domains/Guild/Leads/DataTransferObject/LeadReceiver.php
+++ b/src/Domains/Guild/Leads/DataTransferObject/LeadReceiver.php
@@ -26,7 +26,8 @@ class LeadReceiver extends Data
         public int $lead_sources_id = 0,
         public int $lead_types_id = 0,
         public string|array|null $template = null,
-        public ?LeadRotation $rotation = null
+        public ?LeadRotation $rotation = null,
+        public ?string $notificationEmail = null
     ) {
     }
 }

--- a/src/Domains/Guild/Leads/Models/LeadReceiver.php
+++ b/src/Domains/Guild/Leads/Models/LeadReceiver.php
@@ -33,6 +33,7 @@ use Kanvas\Users\Models\Users;
  * @property int $leads_sources_id
  * @property int $leads_types_id
  * @property string $source_name
+ * @property string|null $notification_email
  * @property string|null $template
  * @property int $is_default
  * @property int $total_leads

--- a/tests/GraphQL/Guild/LeadReceiverTest.php
+++ b/tests/GraphQL/Guild/LeadReceiverTest.php
@@ -10,14 +10,14 @@ use Kanvas\Apps\Models\Apps;
 use Kanvas\Guild\Leads\Models\LeadRotation;
 use Kanvas\Guild\Leads\Models\LeadSource;
 use Kanvas\Guild\Leads\Models\LeadType;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class LeadReceiverTest extends TestCase
 {
     use DatabaseTransactions;
 
-    // Receivers are written on `crm`; leaked rows accumulate and push the ones these tests assert on
-    // off page 1 of the paginated leadReceivers list.
+    // Receivers are written on `crm`; leaked rows push the asserted ones off page 1.
     protected $connectionsToTransact = [null, 'crm'];
 
     public function testCreateLeadReceiver(): void
@@ -233,7 +233,16 @@ class LeadReceiverTest extends TestCase
         ]);
     }
 
-    public function testUpdateLeadReceiverKeepsNotificationEmailWhenOmitted(): void
+    public static function notificationEmailUpdateProvider(): array
+    {
+        return [
+            'an omitted key keeps the stored address' => [false, 'ofertas@example.com,contacto@example.com'],
+            'an explicit null clears it' => [true, null],
+        ];
+    }
+
+    #[DataProvider('notificationEmailUpdateProvider')]
+    public function testUpdateLeadReceiverNotificationEmail(bool $sendNull, ?string $expected): void
     {
         $input = [
             'name' => fake()->word,
@@ -261,52 +270,11 @@ class LeadReceiverTest extends TestCase
             ],
         ])->json('data.createLeadReceiver.id');
 
-        unset($input['notification_email']);
-        $input['name'] = 'renamed receiver';
-
-        $this->graphQL(
-            'mutation updateLeadReceiver($id: ID!, $input: LeadReceiverInput!) {
-                updateLeadReceiver(id: $id, input: $input){
-                    name
-                    notification_email
-                }
-            }',
-            [
-                'id' => $id,
-                'input' => $input,
-            ]
-        )->assertJson([
-            'data' => [
-                'updateLeadReceiver' => [
-                    'name' => 'renamed receiver',
-                    'notification_email' => 'ofertas@example.com,contacto@example.com',
-                ],
-            ],
-        ]);
-    }
-
-    public function testUpdateLeadReceiverClearsNotificationEmailWhenExplicitlyNull(): void
-    {
-        $input = [
-            'name' => fake()->word,
-            'agents_id' => auth()->user()->getId(),
-            'is_default' => true,
-            'rotations_id' => 1,
-            'source_name' => 'source',
-            'notification_email' => 'ofertas@example.com',
-            'lead_sources_id' => 0,
-            'lead_types_id' => 0,
-        ];
-        $id = $this->graphQL(
-            'mutation createLeadReceiver($input: LeadReceiverInput!) {
-                createLeadReceiver(input: $input){
-                    id
-                }
-            }',
-            ['input' => $input]
-        )->json('data.createLeadReceiver.id');
-
-        $input['notification_email'] = null;
+        if ($sendNull) {
+            $input['notification_email'] = null;
+        } else {
+            unset($input['notification_email']);
+        }
 
         $this->graphQL(
             'mutation updateLeadReceiver($id: ID!, $input: LeadReceiverInput!) {
@@ -321,7 +289,7 @@ class LeadReceiverTest extends TestCase
         )->assertJson([
             'data' => [
                 'updateLeadReceiver' => [
-                    'notification_email' => null,
+                    'notification_email' => $expected,
                 ],
             ],
         ]);

--- a/tests/GraphQL/Guild/LeadReceiverTest.php
+++ b/tests/GraphQL/Guild/LeadReceiverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\GraphQL\Guild;
 
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Str;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Guild\Leads\Models\LeadRotation;
@@ -13,6 +14,12 @@ use Tests\TestCase;
 
 class LeadReceiverTest extends TestCase
 {
+    use DatabaseTransactions;
+
+    // Receivers are written on `crm`; leaked rows accumulate and push the ones these tests assert on
+    // off page 1 of the paginated leadReceivers list.
+    protected $connectionsToTransact = [null, 'crm'];
+
     public function testCreateLeadReceiver(): void
     {
         $leadRotation = LeadRotation::create([
@@ -221,6 +228,100 @@ class LeadReceiverTest extends TestCase
                     'is_default' => $input['is_default'],
                     'source_name' => $input['source_name'],
                     'template' => $input['template'],
+                ],
+            ],
+        ]);
+    }
+
+    public function testUpdateLeadReceiverKeepsNotificationEmailWhenOmitted(): void
+    {
+        $input = [
+            'name' => fake()->word,
+            'agents_id' => auth()->user()->getId(),
+            'is_default' => true,
+            'rotations_id' => 1,
+            'source_name' => 'source',
+            'notification_email' => 'ofertas@example.com,contacto@example.com',
+            'lead_sources_id' => 0,
+            'lead_types_id' => 0,
+        ];
+        $id = $this->graphQL(
+            'mutation createLeadReceiver($input: LeadReceiverInput!) {
+                createLeadReceiver(input: $input){
+                    id
+                    notification_email
+                }
+            }',
+            ['input' => $input]
+        )->assertJson([
+            'data' => [
+                'createLeadReceiver' => [
+                    'notification_email' => $input['notification_email'],
+                ],
+            ],
+        ])->json('data.createLeadReceiver.id');
+
+        unset($input['notification_email']);
+        $input['name'] = 'renamed receiver';
+
+        $this->graphQL(
+            'mutation updateLeadReceiver($id: ID!, $input: LeadReceiverInput!) {
+                updateLeadReceiver(id: $id, input: $input){
+                    name
+                    notification_email
+                }
+            }',
+            [
+                'id' => $id,
+                'input' => $input,
+            ]
+        )->assertJson([
+            'data' => [
+                'updateLeadReceiver' => [
+                    'name' => 'renamed receiver',
+                    'notification_email' => 'ofertas@example.com,contacto@example.com',
+                ],
+            ],
+        ]);
+    }
+
+    public function testUpdateLeadReceiverClearsNotificationEmailWhenExplicitlyNull(): void
+    {
+        $input = [
+            'name' => fake()->word,
+            'agents_id' => auth()->user()->getId(),
+            'is_default' => true,
+            'rotations_id' => 1,
+            'source_name' => 'source',
+            'notification_email' => 'ofertas@example.com',
+            'lead_sources_id' => 0,
+            'lead_types_id' => 0,
+        ];
+        $id = $this->graphQL(
+            'mutation createLeadReceiver($input: LeadReceiverInput!) {
+                createLeadReceiver(input: $input){
+                    id
+                }
+            }',
+            ['input' => $input]
+        )->json('data.createLeadReceiver.id');
+
+        $input['notification_email'] = null;
+
+        $this->graphQL(
+            'mutation updateLeadReceiver($id: ID!, $input: LeadReceiverInput!) {
+                updateLeadReceiver(id: $id, input: $input){
+                    notification_email
+                }
+            }',
+            [
+                'id' => $id,
+                'input' => $input,
+            ]
+        )->assertJson([
+            'data' => [
+                'updateLeadReceiver' => [
+                    'notification_email' => null,
                 ],
             ],
         ]);

--- a/tests/GraphQL/Guild/SendLeadEmailsTest.php
+++ b/tests/GraphQL/Guild/SendLeadEmailsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\GraphQL\Guild;
 
 use Baka\Support\Str;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Notification;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Guild\Leads\Actions\SendLeadEmailsAction;
@@ -23,6 +24,12 @@ use Tests\TestCase;
 
 class SendLeadEmailsTest extends TestCase
 {
+    use DatabaseTransactions;
+
+    // Guild models write on `crm`; without it listed here the rotations these tests create commit
+    // and survive, eventually pushing LeadRotationTest's own rotation off page 1 of leadsRotations.
+    protected $connectionsToTransact = [null, 'crm'];
+
     public function testSendLeadEmailsFromReceiverConfig(): void
     {
         Notification::fake();
@@ -235,5 +242,181 @@ class SendLeadEmailsTest extends TestCase
         Notification::assertSentTo($user, NewLeadNotification::class, function ($notification, $channels) {
             return in_array(NotificationChannelEnum::getNotificationChannelBySlug('database'), $channels);
         });
+    }
+
+    public function testReceiverNotificationEmailFiresUnderNotifyOwner(): void
+    {
+        Notification::fake();
+        $user = auth()->user();
+
+        $leadRotation = $this->makeRotation('rotation@example.com', LeadNotificationUserModeEnum::NOTIFY_OWNER);
+        $leadReceiver = $this->makeReceiver($leadRotation, 'ofertas@example.com,contacto@example.com');
+        $lead = Lead::factory()->withReceiverId($leadReceiver->getId())->create();
+
+        new SendRotationEmailsAction(
+            $lead,
+            $leadReceiver,
+            $leadRotation,
+            $user
+        )->execute($this->leadPayload(), 'user');
+
+        Notification::assertSentOnDemandTimes(NewLeadNotification::class, 2);
+
+        foreach (['ofertas@example.com', 'contacto@example.com'] as $email) {
+            Notification::assertSentOnDemand(
+                NewLeadNotification::class,
+                fn ($notification, $channels, $notifiable) => $notifiable->routes['mail'] === $email
+            );
+        }
+    }
+
+    public function testReceiverNotificationEmailOverridesRotationEmail(): void
+    {
+        Notification::fake();
+        $user = auth()->user();
+
+        $leadRotation = $this->makeRotation('rotation@example.com', LeadNotificationUserModeEnum::NOTIFY_ROTATION_USERS);
+        $leadReceiver = $this->makeReceiver($leadRotation, 'tradein@example.com');
+        $lead = Lead::factory()->withReceiverId($leadReceiver->getId())->create();
+
+        new SendRotationEmailsAction(
+            $lead,
+            $leadReceiver,
+            $leadRotation,
+            $user
+        )->execute($this->leadPayload(), 'user');
+
+        Notification::assertSentOnDemandTimes(NewLeadNotification::class, 1);
+        Notification::assertSentOnDemand(
+            NewLeadNotification::class,
+            fn ($notification, $channels, $notifiable) => $notifiable->routes['mail'] === 'tradein@example.com'
+        );
+    }
+
+    public function testRotationEmailStillUsedWhenReceiverHasNone(): void
+    {
+        Notification::fake();
+        $user = auth()->user();
+
+        $leadRotation = $this->makeRotation('rotation@example.com', LeadNotificationUserModeEnum::NOTIFY_ROTATION_USERS);
+        $leadReceiver = $this->makeReceiver($leadRotation);
+        $lead = Lead::factory()->withReceiverId($leadReceiver->getId())->create();
+
+        new SendRotationEmailsAction(
+            $lead,
+            $leadReceiver,
+            $leadRotation,
+            $user
+        )->execute($this->leadPayload(), 'user');
+
+        Notification::assertSentOnDemandTimes(NewLeadNotification::class, 1);
+        Notification::assertSentOnDemand(
+            NewLeadNotification::class,
+            fn ($notification, $channels, $notifiable) => $notifiable->routes['mail'] === 'rotation@example.com'
+        );
+    }
+
+    public function testBlankReceiverNotificationEmailFallsBackToRotation(): void
+    {
+        Notification::fake();
+        $user = auth()->user();
+
+        $leadRotation = $this->makeRotation('rotation@example.com', LeadNotificationUserModeEnum::NOTIFY_ROTATION_USERS);
+        $leadReceiver = $this->makeReceiver($leadRotation, ' , ');
+        $lead = Lead::factory()->withReceiverId($leadReceiver->getId())->create();
+
+        new SendRotationEmailsAction(
+            $lead,
+            $leadReceiver,
+            $leadRotation,
+            $user
+        )->execute($this->leadPayload(), 'user');
+
+        Notification::assertSentOnDemandTimes(NewLeadNotification::class, 1);
+        Notification::assertSentOnDemand(
+            NewLeadNotification::class,
+            fn ($notification, $channels, $notifiable) => $notifiable->routes['mail'] === 'rotation@example.com'
+        );
+    }
+
+    private function makeRotation(string $rotationEmail, LeadNotificationUserModeEnum $userMode): LeadRotation
+    {
+        $user = auth()->user();
+        $app = app(Apps::class);
+        $company = $user->getCurrentCompany();
+
+        $leadRotation = LeadRotation::create([
+            'apps_id' => $app->getId(),
+            'companies_id' => $company->getId(),
+            'name' => 'Lead Rotation',
+            'hits' => 1,
+            'leads_rotations_email' => $rotationEmail,
+            'config' => [
+                'email_template' => 'new-lead',
+                'notification_mode' => LeadNotificationModeEnum::NOTIFY_AGENTS->value,
+                'notification_user_mode' => $userMode->value,
+            ],
+        ]);
+
+        LeadRotationAgent::create([
+            'leads_rotations_id' => $leadRotation->getId(),
+            'companies_id' => $company->getId(),
+            'users_id' => $user->getId(),
+            'percent' => 100,
+        ]);
+
+        return $leadRotation;
+    }
+
+    private function makeReceiver(LeadRotation $leadRotation, ?string $notificationEmail = null): LeadReceiver
+    {
+        $user = auth()->user();
+        $app = app(Apps::class);
+        $company = $user->getCurrentCompany();
+
+        $leadType = LeadType::create([
+            'apps_id' => $app->getId(),
+            'companies_id' => $company->getId(),
+            'name' => 'Lead Type',
+            'description' => 'Lead Type Description',
+            'is_active' => true,
+            'uuid' => Str::uuid(),
+        ]);
+
+        return LeadReceiver::create([
+            'name' => fake()->word,
+            'agents_id' => $user->getId(),
+            'companies_id' => $company->getId(),
+            'apps_id' => $app->getId(),
+            'users_id' => $user->getId(),
+            'is_default' => true,
+            'rotations_id' => $leadRotation->getId(),
+            'source_name' => 'source',
+            'notification_email' => $notificationEmail,
+            'lead_types_id' => $leadType->getId(),
+            'template' => 'template',
+        ]);
+    }
+
+    private function leadPayload(): array
+    {
+        return [
+            'title' => fake()->title(),
+            'people' => [
+                'contacts' => [
+                    ['value' => 'jdoe@example.com', 'weight' => 0, 'contacts_types_id' => 1],
+                    ['value' => '8292001222', 'weight' => 0, 'contacts_types_id' => 2],
+                ],
+                'lastname' => 'Doe',
+                'firstname' => 'John',
+            ],
+            'custom_fields' => [
+                [
+                    'data' => '7',
+                    'name' => 'share_left',
+                ],
+            ],
+            'pipeline_stage_id' => 0,
+        ];
     }
 }

--- a/tests/GraphQL/Guild/SendLeadEmailsTest.php
+++ b/tests/GraphQL/Guild/SendLeadEmailsTest.php
@@ -20,14 +20,14 @@ use Kanvas\Guild\Leads\Models\LeadType;
 use Kanvas\Guild\Leads\Notifications\NewLeadNotification;
 use Kanvas\Guild\LeadSources\Models\LeadSource;
 use Kanvas\Notifications\Enums\NotificationChannelEnum;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class SendLeadEmailsTest extends TestCase
 {
     use DatabaseTransactions;
 
-    // Guild models write on `crm`; without it listed here the rotations these tests create commit
-    // and survive, eventually pushing LeadRotationTest's own rotation off page 1 of leadsRotations.
+    // Rotations are written on `crm`; leaked rows push LeadRotationTest's own off page 1.
     protected $connectionsToTransact = [null, 'crm'];
 
     public function testSendLeadEmailsFromReceiverConfig(): void
@@ -244,99 +244,59 @@ class SendLeadEmailsTest extends TestCase
         });
     }
 
-    public function testReceiverNotificationEmailFiresUnderNotifyOwner(): void
+    public static function extraEmailsProvider(): array
     {
-        Notification::fake();
-        $user = auth()->user();
+        return [
+            'receiver address fires even under NOTIFY_OWNER' => [
+                LeadNotificationUserModeEnum::NOTIFY_OWNER,
+                'ofertas@example.com,contacto@example.com',
+                ['ofertas@example.com', 'contacto@example.com'],
+            ],
+            'receiver address overrides the rotation one' => [
+                LeadNotificationUserModeEnum::NOTIFY_ROTATION_USERS,
+                'tradein@example.com',
+                ['tradein@example.com'],
+            ],
+            'rotation address is used when the receiver has none' => [
+                LeadNotificationUserModeEnum::NOTIFY_ROTATION_USERS,
+                null,
+                ['rotation@example.com'],
+            ],
+            'blank receiver address falls back to the rotation' => [
+                LeadNotificationUserModeEnum::NOTIFY_ROTATION_USERS,
+                ' , ',
+                ['rotation@example.com'],
+            ],
+        ];
+    }
 
-        $leadRotation = $this->makeRotation('rotation@example.com', LeadNotificationUserModeEnum::NOTIFY_OWNER);
-        $leadReceiver = $this->makeReceiver($leadRotation, 'ofertas@example.com,contacto@example.com');
+    #[DataProvider('extraEmailsProvider')]
+    public function testExtraEmailsResolution(
+        LeadNotificationUserModeEnum $userMode,
+        ?string $receiverEmail,
+        array $expectedEmails
+    ): void {
+        Notification::fake();
+
+        $leadRotation = $this->makeRotation('rotation@example.com', $userMode);
+        $leadReceiver = $this->makeReceiver($leadRotation, $receiverEmail);
         $lead = Lead::factory()->withReceiverId($leadReceiver->getId())->create();
 
         new SendRotationEmailsAction(
             $lead,
             $leadReceiver,
             $leadRotation,
-            $user
+            auth()->user()
         )->execute($this->leadPayload(), 'user');
 
-        Notification::assertSentOnDemandTimes(NewLeadNotification::class, 2);
+        Notification::assertSentOnDemandTimes(NewLeadNotification::class, count($expectedEmails));
 
-        foreach (['ofertas@example.com', 'contacto@example.com'] as $email) {
+        foreach ($expectedEmails as $email) {
             Notification::assertSentOnDemand(
                 NewLeadNotification::class,
                 fn ($notification, $channels, $notifiable) => $notifiable->routes['mail'] === $email
             );
         }
-    }
-
-    public function testReceiverNotificationEmailOverridesRotationEmail(): void
-    {
-        Notification::fake();
-        $user = auth()->user();
-
-        $leadRotation = $this->makeRotation('rotation@example.com', LeadNotificationUserModeEnum::NOTIFY_ROTATION_USERS);
-        $leadReceiver = $this->makeReceiver($leadRotation, 'tradein@example.com');
-        $lead = Lead::factory()->withReceiverId($leadReceiver->getId())->create();
-
-        new SendRotationEmailsAction(
-            $lead,
-            $leadReceiver,
-            $leadRotation,
-            $user
-        )->execute($this->leadPayload(), 'user');
-
-        Notification::assertSentOnDemandTimes(NewLeadNotification::class, 1);
-        Notification::assertSentOnDemand(
-            NewLeadNotification::class,
-            fn ($notification, $channels, $notifiable) => $notifiable->routes['mail'] === 'tradein@example.com'
-        );
-    }
-
-    public function testRotationEmailStillUsedWhenReceiverHasNone(): void
-    {
-        Notification::fake();
-        $user = auth()->user();
-
-        $leadRotation = $this->makeRotation('rotation@example.com', LeadNotificationUserModeEnum::NOTIFY_ROTATION_USERS);
-        $leadReceiver = $this->makeReceiver($leadRotation);
-        $lead = Lead::factory()->withReceiverId($leadReceiver->getId())->create();
-
-        new SendRotationEmailsAction(
-            $lead,
-            $leadReceiver,
-            $leadRotation,
-            $user
-        )->execute($this->leadPayload(), 'user');
-
-        Notification::assertSentOnDemandTimes(NewLeadNotification::class, 1);
-        Notification::assertSentOnDemand(
-            NewLeadNotification::class,
-            fn ($notification, $channels, $notifiable) => $notifiable->routes['mail'] === 'rotation@example.com'
-        );
-    }
-
-    public function testBlankReceiverNotificationEmailFallsBackToRotation(): void
-    {
-        Notification::fake();
-        $user = auth()->user();
-
-        $leadRotation = $this->makeRotation('rotation@example.com', LeadNotificationUserModeEnum::NOTIFY_ROTATION_USERS);
-        $leadReceiver = $this->makeReceiver($leadRotation, ' , ');
-        $lead = Lead::factory()->withReceiverId($leadReceiver->getId())->create();
-
-        new SendRotationEmailsAction(
-            $lead,
-            $leadReceiver,
-            $leadRotation,
-            $user
-        )->execute($this->leadPayload(), 'user');
-
-        Notification::assertSentOnDemandTimes(NewLeadNotification::class, 1);
-        Notification::assertSentOnDemand(
-            NewLeadNotification::class,
-            fn ($notification, $channels, $notifiable) => $notifiable->routes['mail'] === 'rotation@example.com'
-        );
     }
 
     private function makeRotation(string $rotationEmail, LeadNotificationUserModeEnum $userMode): LeadRotation


### PR DESCRIPTION
Leads arriving through different site forms need to notify different addresses while sharing one agent pool. The address identifies the source, not the distribution policy, so it belongs on the receiver: cloning a rotation per form would split the round-robin hit counters and lose fairness across total volume, to achieve something unrelated to distribution.

Adds leads_receivers.notification_email, a nullable comma-separated list mirroring leads_rotations_email. It overrides the rotation address and fires unconditionally, bypassing the NOTIFY_ROTATION_USERS gate the rotation address is subject to, since a form's address should always receive its own leads. Recipients get the same user-<template> mail, so only the address differs.

Existing behavior is unchanged: with the column null the resolution falls through to the current rotation branch, the DTO parameter is optional and last so the connector callers are unaffected, and the GraphQL field is optional.

Notes:
- updateLeadReceiver uses key_exists so an omitted key preserves the stored address while an explicit null clears it.
- Commas are trimmed alongside whitespace, so a stray ',' falls through to the rotation instead of blocking it and then parsing down to zero recipients.
- SendLeadEmailsTest and LeadReceiverTest now declare connectionsToTransact [null, 'crm']; without it the rotations and receivers they create committed and survived, eventually pushing LeadRotationTest's own rotation off page 1 of the paginated list.
- A receiver still needs a rotation for any mail to send at all: CreateLeadsFromReceiverJob bails on a null owner before SendRotationEmailsAction is built.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
