### PR TITLE
feat(voice): voiceAgentLeadContext — recognize the lead/contact behind a phone number

### DIFF
--- a/app/GraphQL/Intelligence/Queries/Agent/VoiceAgentLeadContextQuery.php
+++ b/app/GraphQL/Intelligence/Queries/Agent/VoiceAgentLeadContextQuery.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\GraphQL\Intelligence\Queries\Agent;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Intelligence\Agents\Actions\Voice\BuildVoiceAgentLeadContextAction;
+use Kanvas\Intelligence\Agents\Repositories\AgentsRepository;
+
+/**
+ * Outbound call context: given the number being dialed, resolve the lead and
+ * return a compact context (who + recent history) for the voice agent. Guarded
+ * by @guardByAppKey (server-to-server) and cross-app aware. Null when no lead.
+ *
+ * @return array<string, mixed>|null
+ */
+class VoiceAgentLeadContextQuery
+{
+    public function __invoke(mixed $root, array $args): ?array
+    {
+        $app = app(Apps::class);
+        $agent = AgentsRepository::getByUuidForVoiceRuntime((string) $args['agent_uuid'], $app);
+
+        return new BuildVoiceAgentLeadContextAction($agent, (string) $args['phone'])->execute();
+    }
+}

--- a/graphql/schemas/Intelligence/voiceAgent.graphql
+++ b/graphql/schemas/Intelligence/voiceAgent.graphql
@@ -72,6 +72,8 @@ type VoiceAgentLeadContext {
     owner: String
     vehicle_interest: String
     context_info: String
+    "True when we already know this number (has a lead, or a prior contact)."
+    is_returning: Boolean
     "Short natural-language block (who + recent history) for the LLM."
     summary: String
 }

--- a/graphql/schemas/Intelligence/voiceAgent.graphql
+++ b/graphql/schemas/Intelligence/voiceAgent.graphql
@@ -64,6 +64,18 @@ type VoiceAgentByNumber {
     agent_id: String!
 }
 
+type VoiceAgentLeadContext {
+    lead_id: Int
+    name: String
+    status: String
+    stage: String
+    owner: String
+    vehicle_interest: String
+    context_info: String
+    "Short natural-language block (who + recent history) for the LLM."
+    summary: String
+}
+
 extend type Query @guardByAppKey {
     voiceAgentSpec(uuid: String!): VoiceAgentSpec!
         @field(
@@ -73,6 +85,11 @@ extend type Query @guardByAppKey {
     voiceAgentByNumber(phone_number: String!): VoiceAgentByNumber
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Queries\\Agent\\VoiceAgentByNumberQuery"
+        )
+    "Outbound: resolve the lead for a dialed number and return compact context. Null if none."
+    voiceAgentLeadContext(agent_uuid: String!, phone: String!): VoiceAgentLeadContext
+        @field(
+            resolver: "App\\GraphQL\\Intelligence\\Queries\\Agent\\VoiceAgentLeadContextQuery"
         )
 }
 

--- a/src/Domains/Intelligence/Agents/Actions/Voice/BuildVoiceAgentLeadContextAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/BuildVoiceAgentLeadContextAction.php
@@ -151,8 +151,8 @@ class BuildVoiceAgentLeadContextAction
             'context_info' => null,
             'is_returning' => true,
             'summary' => $name !== null
-                ? "Ya conocemos a este contacto: {$name}. Aún no hay un lead abierto; ya ha contactado antes."
-                : 'Este número ya ha contactado antes, pero todavía no tenemos su nombre.',
+                ? "We already know this contact: {$name}. There's no open lead yet; they've reached out before."
+                : "This number has reached out before, but we don't have their name yet.",
         ];
     }
 
@@ -192,21 +192,21 @@ class BuildVoiceAgentLeadContextAction
     {
         $lines = [];
         $lines[] = $c['name'] !== null
-            ? "Estás llamando a {$c['name']}."
-            : 'Estás llamando a un cliente.';
+            ? "You're speaking with {$c['name']}."
+            : "You're speaking with a customer.";
 
         $state = trim(($c['status'] ?? '') . ' / ' . ($c['stage'] ?? ''), ' /');
         if ($state !== '') {
-            $lines[] = "Estado: {$state}.";
+            $lines[] = "Status: {$state}.";
         }
         if ($c['owner'] !== null) {
-            $lines[] = "Vendedor asignado: {$c['owner']}.";
+            $lines[] = "Assigned salesperson: {$c['owner']}.";
         }
         if ($c['vehicle_interest'] !== null) {
-            $lines[] = "Interés: {$c['vehicle_interest']}.";
+            $lines[] = "Interest: {$c['vehicle_interest']}.";
         }
         if ($c['context_info'] !== null) {
-            $lines[] = "Contexto del lead: {$c['context_info']}";
+            $lines[] = "Lead context: {$c['context_info']}";
         }
 
         return implode("\n", $lines);

--- a/src/Domains/Intelligence/Agents/Actions/Voice/BuildVoiceAgentLeadContextAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/BuildVoiceAgentLeadContextAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Actions\Voice;
 
+use Baka\Support\Str;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\SalesAssist\Enums\LeadCustomFieldEnum;
 use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
@@ -110,21 +111,18 @@ class BuildVoiceAgentLeadContextAction
     }
 
     /**
-     * Digit-only variants to match stored contacts (getByPhoneNumber compares on
-     * digits). A US-style 11-digit "1XXXXXXXXXX" also matches the 10-digit local.
+     * The number variants to feed getByPhoneNumber — the local (normalized) form
+     * and the country-code form. Mirrors the shared pattern used elsewhere for
+     * this exact lookup (see ProcessTwilioWebhookJob::processContactFromMessage).
      *
      * @return array<int, string>
      */
     private function phoneVariants(): array
     {
-        $digits = preg_replace('/\D+/', '', $this->phone) ?? '';
-        $variants = array_filter([$digits]);
-
-        if (strlen($digits) === 11 && str_starts_with($digits, '1')) {
-            $variants[] = substr($digits, 1);
-        }
-
-        return array_values(array_unique($variants));
+        return array_values(array_unique(array_filter([
+            Str::normalizePhoneNumber($this->phone),
+            str_replace('+', '', $this->phone),
+        ])));
     }
 
     /**

--- a/src/Domains/Intelligence/Agents/Actions/Voice/BuildVoiceAgentLeadContextAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/BuildVoiceAgentLeadContextAction.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Actions\Voice;
+
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\SalesAssist\Enums\LeadCustomFieldEnum;
+use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Guild\Leads\Repositories\LeadsRepository;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Enums\ConfigurationEnum;
+use Throwable;
+
+use function Sentry\captureException;
+
+/**
+ * Resolve the Lead behind a phone number and assemble a compact context an
+ * OUTBOUND voice agent can use — so the agent knows who it's calling and their
+ * recent history instead of just a number.
+ *
+ * Reuses Kanvas's own resolution (PeoplesRepository::getByPhoneNumber +
+ * LeadsRepository::getPeopleActiveLead) and the pre-built LEAD_CONTEXT_INFO
+ * custom field. Scoped to the agent's company/app.
+ *
+ * Best-effort: returns null (no context) rather than throwing, so a placing
+ * call is never blocked by a lookup miss. The `summary` is a short, bounded,
+ * natural-language block suitable to hand the LLM as call context.
+ */
+class BuildVoiceAgentLeadContextAction
+{
+    // Keep the payload small enough to ride along as a Twilio <Stream> parameter.
+    private const CONTEXT_INFO_MAX = 800;
+
+    public function __construct(
+        private readonly Agent $agent,
+        private readonly string $phone,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>|null compact lead context, or null when none resolves
+     */
+    public function execute(): ?array
+    {
+        try {
+            $lead = $this->resolveLead();
+            if ($lead === null) {
+                return null;
+            }
+
+            $name = trim(($lead->firstname ?? '') . ' ' . ($lead->lastname ?? ''));
+            if ($name === '') {
+                $name = (string) ($lead->title ?? '');
+            }
+
+            $vehicle = trim((string) $lead->get(LeadCustomFieldEnum::VEHICLE_OF_INTEREST->value));
+            $contextInfo = trim((string) $lead->get(ConfigurationEnum::LEAD_CONTEXT_INFO->value));
+            if ($contextInfo !== '') {
+                $contextInfo = mb_substr($contextInfo, 0, self::CONTEXT_INFO_MAX);
+            }
+
+            $context = [
+                'lead_id' => $lead->getId(),
+                'name' => $name !== '' ? $name : null,
+                'status' => $lead->status?->name,
+                'stage' => $lead->stage?->name,
+                'owner' => $lead->owner?->displayname,
+                'vehicle_interest' => $vehicle !== '' ? $vehicle : null,
+                'context_info' => $contextInfo !== '' ? $contextInfo : null,
+            ];
+            $context['summary'] = $this->summarize($context);
+
+            return $context;
+        } catch (Throwable $e) {
+            captureException($e);
+
+            return null; // never block placing the call over a context miss
+        }
+    }
+
+    private function resolveLead(): ?Lead
+    {
+        $company = $this->agent->companies_id > 0
+            ? Companies::find($this->agent->companies_id)
+            : null;
+        if ($company === null) {
+            return null;
+        }
+
+        $people = PeoplesRepository::getByPhoneNumber(
+            app: $this->agent->app,
+            company: $company,
+            phoneNumbers: $this->phoneVariants(),
+        )->get();
+        if ($people->isEmpty()) {
+            return null;
+        }
+
+        // Prefer a person with an active lead; else the first person's last lead.
+        foreach ($people as $person) {
+            $lead = LeadsRepository::getPeopleActiveLead($person);
+            if ($lead !== null) {
+                return $lead;
+            }
+        }
+
+        return LeadsRepository::getPeopleLastLead($people->first());
+    }
+
+    /**
+     * Digit-only variants to match stored contacts (getByPhoneNumber compares on
+     * digits). A US-style 11-digit "1XXXXXXXXXX" also matches the 10-digit local.
+     *
+     * @return array<int, string>
+     */
+    private function phoneVariants(): array
+    {
+        $digits = preg_replace('/\D+/', '', $this->phone) ?? '';
+        $variants = array_filter([$digits]);
+
+        if (strlen($digits) === 11 && str_starts_with($digits, '1')) {
+            $variants[] = substr($digits, 1);
+        }
+
+        return array_values(array_unique($variants));
+    }
+
+    /**
+     * @param array<string, mixed> $c
+     */
+    private function summarize(array $c): string
+    {
+        $lines = [];
+        $lines[] = $c['name'] !== null
+            ? "Estás llamando a {$c['name']}."
+            : 'Estás llamando a un cliente.';
+
+        $state = trim(($c['status'] ?? '') . ' / ' . ($c['stage'] ?? ''), ' /');
+        if ($state !== '') {
+            $lines[] = "Estado: {$state}.";
+        }
+        if ($c['owner'] !== null) {
+            $lines[] = "Vendedor asignado: {$c['owner']}.";
+        }
+        if ($c['vehicle_interest'] !== null) {
+            $lines[] = "Interés: {$c['vehicle_interest']}.";
+        }
+        if ($c['context_info'] !== null) {
+            $lines[] = "Contexto del lead: {$c['context_info']}";
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/src/Domains/Intelligence/Agents/Actions/Voice/BuildVoiceAgentLeadContextAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/BuildVoiceAgentLeadContextAction.php
@@ -7,6 +7,7 @@ namespace Kanvas\Intelligence\Agents\Actions\Voice;
 use Baka\Support\Str;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\SalesAssist\Enums\LeadCustomFieldEnum;
+use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Repositories\LeadsRepository;
@@ -46,48 +47,36 @@ class BuildVoiceAgentLeadContextAction
     public function execute(): ?array
     {
         try {
-            $lead = $this->resolveLead();
-            if ($lead === null) {
-                return null;
+            [$person, $lead] = $this->resolve();
+            if ($person === null) {
+                return null; // truly unknown number — nothing to recognize
             }
 
-            $name = trim(($lead->firstname ?? '') . ' ' . ($lead->lastname ?? ''));
-            if ($name === '') {
-                $name = (string) ($lead->title ?? '');
-            }
-
-            $vehicle = trim((string) $lead->get(LeadCustomFieldEnum::VEHICLE_OF_INTEREST->value));
-            $contextInfo = trim((string) $lead->get(ConfigurationEnum::LEAD_CONTEXT_INFO->value));
-            if ($contextInfo !== '') {
-                $contextInfo = mb_substr($contextInfo, 0, self::CONTEXT_INFO_MAX);
-            }
-
-            $context = [
-                'lead_id' => $lead->getId(),
-                'name' => $name !== '' ? $name : null,
-                'status' => $lead->status?->name,
-                'stage' => $lead->stage?->name,
-                'owner' => $lead->owner?->displayname,
-                'vehicle_interest' => $vehicle !== '' ? $vehicle : null,
-                'context_info' => $contextInfo !== '' ? $contextInfo : null,
-            ];
-            $context['summary'] = $this->summarize($context);
-
-            return $context;
+            // Known lead -> full context. Known contact with no lead -> a lighter
+            // "returning caller" context (recognition without pretending we have a
+            // lead). Both set is_returning so callers can tailor the greeting.
+            return $lead !== null
+                ? $this->leadContext($lead)
+                : $this->contactContext($person);
         } catch (Throwable $e) {
             captureException($e);
 
-            return null; // never block placing the call over a context miss
+            return null; // never block the call over a context miss
         }
     }
 
-    private function resolveLead(): ?Lead
+    /**
+     * Resolve the person behind the number and their current lead (if any).
+     *
+     * @return array{0: People|null, 1: Lead|null}
+     */
+    private function resolve(): array
     {
         $company = $this->agent->companies_id > 0
             ? Companies::find($this->agent->companies_id)
             : null;
         if ($company === null) {
-            return null;
+            return [null, null];
         }
 
         $people = PeoplesRepository::getByPhoneNumber(
@@ -96,18 +85,89 @@ class BuildVoiceAgentLeadContextAction
             phoneNumbers: $this->phoneVariants(),
         )->get();
         if ($people->isEmpty()) {
-            return null;
+            return [null, null];
         }
 
         // Prefer a person with an active lead; else the first person's last lead.
         foreach ($people as $person) {
             $lead = LeadsRepository::getPeopleActiveLead($person);
             if ($lead !== null) {
-                return $lead;
+                return [$person, $lead];
             }
         }
 
-        return LeadsRepository::getPeopleLastLead($people->first());
+        $first = $people->first();
+
+        return [$first, LeadsRepository::getPeopleLastLead($first)];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function leadContext(Lead $lead): array
+    {
+        $name = trim(($lead->firstname ?? '') . ' ' . ($lead->lastname ?? ''));
+        if ($name === '') {
+            $name = (string) ($lead->title ?? '');
+        }
+
+        $vehicle = trim((string) $lead->get(LeadCustomFieldEnum::VEHICLE_OF_INTEREST->value));
+        $contextInfo = trim((string) $lead->get(ConfigurationEnum::LEAD_CONTEXT_INFO->value));
+        if ($contextInfo !== '') {
+            $contextInfo = mb_substr($contextInfo, 0, self::CONTEXT_INFO_MAX);
+        }
+
+        $context = [
+            'lead_id' => $lead->getId(),
+            'name' => $name !== '' ? $name : null,
+            'status' => $lead->status?->name,
+            'stage' => $lead->stage?->name,
+            'owner' => $lead->owner?->displayname,
+            'vehicle_interest' => $vehicle !== '' ? $vehicle : null,
+            'context_info' => $contextInfo !== '' ? $contextInfo : null,
+            'is_returning' => true,
+        ];
+        $context['summary'] = $this->summarize($context);
+
+        return $context;
+    }
+
+    /**
+     * A known contact with no lead yet — recognized, but not (yet) a lead.
+     *
+     * @return array<string, mixed>
+     */
+    private function contactContext(People $person): array
+    {
+        $name = $this->peopleName($person);
+
+        return [
+            'lead_id' => null,
+            'name' => $name,
+            'status' => null,
+            'stage' => null,
+            'owner' => null,
+            'vehicle_interest' => null,
+            'context_info' => null,
+            'is_returning' => true,
+            'summary' => $name !== null
+                ? "Ya conocemos a este contacto: {$name}. Aún no hay un lead abierto; ya ha contactado antes."
+                : 'Este número ya ha contactado antes, pero todavía no tenemos su nombre.',
+        ];
+    }
+
+    /**
+     * A real name for the person, or null. createPeopleFromPhone stores the phone
+     * number as firstname, so a phone-only "name" is treated as unknown.
+     */
+    private function peopleName(People $person): ?string
+    {
+        $name = trim(($person->firstname ?? '') . ' ' . ($person->lastname ?? ''));
+        if ($name === '' || preg_match('/^[\d\s+()\-]+$/', $name) === 1) {
+            return null;
+        }
+
+        return $name;
     }
 
     /**


### PR DESCRIPTION
Resolves the **person behind a phone number** into a compact context the voice runtime injects into a call — powering **both** directions: outbound ("who we're calling" + history) and inbound ("who's calling us"). One shared resolver; `@guardByAppKey`, cross-app aware.

## Query
`voiceAgentLeadContext(agent_uuid: String!, phone: String!): VoiceAgentLeadContext` (nullable) →
`{ lead_id, name, status, stage, owner, vehicle_interest, context_info, is_returning, summary }`.
`summary` is a short, English, LLM-ready block.

## Recognition tiers
- **Known lead** → full context (status, stage, owner, vehicle of interest, `LEAD_CONTEXT_INFO` history).
- **Returning contact** (a People with no active lead) → lighter "we already know this contact" + name. The phone-as-name placeholder from `createPeopleFromPhone` is treated as unknown.
- **Unknown number** → `null` (fresh caller).

## Reuses Kanvas primitives (no reinvention)
- `PeoplesRepository::getByPhoneNumber` + `LeadsRepository::getPeopleActiveLead` / `getPeopleLastLead` to resolve person → current lead.
- `LEAD_CONTEXT_INFO` (`lead_ai_agent_context_info`) as the history blob, bounded to 800 chars to fit the Twilio `<Stream>` payload. `BuildVoiceAgentLeadContextAction` reads the same field the runtime writes — closes the loop.
- Phone variants via the shared `Str::normalizePhoneNumber` + country-code form (mirrors `ProcessTwilioWebhookJob`) — no hand-rolled normalization (addresses the dedup review).

## Files
- `src/Domains/Intelligence/Agents/Actions/Voice/BuildVoiceAgentLeadContextAction.php` — the resolver (person → [lead | returning-contact | none]).
- `app/GraphQL/Intelligence/Queries/Agent/VoiceAgentLeadContextQuery.php` — resolver, cross-app aware via `getByUuidForVoiceRuntime`.
- `graphql/schemas/Intelligence/voiceAgent.graphql` — `VoiceAgentLeadContext` type + query.

## Serves both runtime PRs
- Outbound context → kanvas-voice-agents **#12**.
- Inbound recognition → kanvas-voice-agents **#13**.

## Scope / behavior
- **Recognition only — read-only.** No People/Lead is created here; capture-on-first-call + promote-to-lead (repeat/intent) is a separate later slice.
- **Best-effort:** returns `null` on any miss/error; never blocks a call.

Verified: `php -l` clean; all agent-context summary strings are English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)