### PR TITLE
Add RAG processing and Typesense variant indexing

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/BaseRagAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/BaseRagAgent.php
@@ -24,4 +24,9 @@ class BaseRagAgent extends RAG implements BehavesAsKanvasAgent
             ? $this->knowledgeRagNodes()
             : [];
     }
+
+    protected function usesOrganizationWideKnowledge(): bool
+    {
+        return false;
+    }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/RAG/Retrieval/KnowledgeRetrieval.php
+++ b/src/Domains/Intelligence/Agents/Neuron/RAG/Retrieval/KnowledgeRetrieval.php
@@ -19,7 +19,8 @@ use Override;
 /**
  * Native Neuron retrieval over the shared knowledge store. Retrieves the agent's
  * own uploaded docs plus, for a customer-facing agent, the lead in scope — each
- * scoped to its entity so knowledge never leaks between agents (or prospects).
+ * scoped to its entity so knowledge never leaks between prospects. Explicitly
+ * internal agents can instead retrieve across their app/company boundary.
  * No-ops when the app hasn't enabled knowledge.
  */
 class KnowledgeRetrieval implements RetrievalInterface
@@ -29,6 +30,7 @@ class KnowledgeRetrieval implements RetrievalInterface
         private readonly ?Companies $company,
         private readonly ?Model $agent = null,
         private readonly ?Model $entity = null,
+        private readonly bool $organizationWide = false,
     ) {
     }
 
@@ -48,6 +50,17 @@ class KnowledgeRetrieval implements RetrievalInterface
         $topK = KnowledgeComponents::resultLimit($this->app);
         $minScore = KnowledgeComponents::minScore($this->app);
         $embedding = KnowledgeComponents::embedder($this->app)->embed((string) $query->getContent());
+
+        if ($this->organizationWide) {
+            $hits = $store->search(
+                $embedding,
+                KnowledgeScope::forOrganization($this->app->getId(), $this->company->getId()),
+                $topK,
+                $minScore,
+            );
+
+            return $this->toDocuments($hits, $topK);
+        }
 
         // The agent's own docs, plus the record in scope (a Lead). A global row like
         // a Users (apps_id/companies_id = 0) can't form a KnowledgeEntity, so it's skipped.

--- a/src/Domains/Intelligence/Agents/Neuron/SystemUserAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/SystemUserAgent.php
@@ -56,6 +56,12 @@ class SystemUserAgent extends BaseRagAgent implements ConversesWithUser
 
     private ?Channel $mentionChannel = null;
 
+    #[Override]
+    protected function usesOrganizationWideKnowledge(): bool
+    {
+        return true;
+    }
+
     /**
      * Answering an @mention: read the WHOLE channel this turn, not the per-session store.
      */

--- a/src/Domains/Intelligence/Agents/Neuron/Traits/HasKnowledgeRag.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Traits/HasKnowledgeRag.php
@@ -12,6 +12,9 @@ use NeuronAI\RAG\Nodes\InstructionsNode;
 use NeuronAI\RAG\Nodes\PostProcessNode;
 use NeuronAI\RAG\Nodes\PreProcessNode;
 use NeuronAI\RAG\Nodes\RetrievalNode;
+use NeuronAI\RAG\PostProcessor\AdaptiveThresholdPostProcessor;
+use NeuronAI\RAG\PreProcessor\QueryTransformationPreProcessor;
+use NeuronAI\RAG\PreProcessor\QueryTransformationType;
 use NeuronAI\RAG\Retrieval\RetrievalInterface;
 use NeuronAI\RAG\VectorStore\MemoryVectorStore;
 use NeuronAI\RAG\VectorStore\VectorStoreInterface;
@@ -46,7 +49,8 @@ trait HasKnowledgeRag
             $this->app,
             $this->company,
             $this->agent,
-            $this->resolveEntityForTurn()
+            $this->resolveEntityForTurn(),
+            organizationWide: $this->usesOrganizationWideKnowledge(),
         );
     }
 
@@ -68,5 +72,22 @@ trait HasKnowledgeRag
     protected function vectorStore(): VectorStoreInterface
     {
         return new MemoryVectorStore();
+    }
+
+    protected function preProcessors(): array
+    {
+        return [
+            new QueryTransformationPreProcessor(
+                provider: $this->resolveProvider(),
+                transformation: QueryTransformationType::REWRITING,
+            ),
+        ];
+    }
+
+    protected function postProcessors(): array
+    {
+        return [
+            new AdaptiveThresholdPostProcessor(multiplier: 0.6),
+        ];
     }
 }

--- a/src/Domains/Intelligence/Agents/Services/AgentProviderService.php
+++ b/src/Domains/Intelligence/Agents/Services/AgentProviderService.php
@@ -63,6 +63,7 @@ class AgentProviderService
             return new Gemini(
                 key: self::requireKey($source, $agent, $provider),
                 model: $model,
+                parameters: $parameters,
                 httpClient: $httpClient,
             );
         }

--- a/src/Domains/Intelligence/Knowledge/DataTransferObject/KnowledgeScope.php
+++ b/src/Domains/Intelligence/Knowledge/DataTransferObject/KnowledgeScope.php
@@ -10,17 +10,19 @@ final readonly class KnowledgeScope
 {
     /**
      * A scope filters the shared knowledge collection down to one tenant, and
-     * optionally one entity. Entity-scoped docs (a Lead and its messages) carry
+     * optionally one entity. Organization-wide reads keep only the tenant pair.
+     * Entity-scoped docs (a Lead and its messages) carry
      * a real entity_type/entity_id; tenant-scoped docs (a company's uploaded
      * policy/FAQ files) carry none and are stored with entity_id = 0.
      *
-     * @param class-string|null $entityType FQCN of the owning model; null = tenant-scoped
+     * @param class-string|null $entityType FQCN of the owning model; null = tenant/organization-scoped
      */
     public function __construct(
         public int $appId,
         public int $companyId,
         public ?string $entityType = null,
         public ?int $entityId = null,
+        public bool $organizationWide = false,
     ) {
     }
 
@@ -46,6 +48,15 @@ final readonly class KnowledgeScope
         return new self(appId: $appId, companyId: $companyId);
     }
 
+    public static function forOrganization(int $appId, int $companyId): self
+    {
+        return new self(
+            appId: $appId,
+            companyId: $companyId,
+            organizationWide: true,
+        );
+    }
+
     public function isEntityScoped(): bool
     {
         return $this->entityType !== null && $this->entityId !== null;
@@ -53,12 +64,17 @@ final readonly class KnowledgeScope
 
     /**
      * Typesense filter_by. companies_id is ALWAYS present — this is what closes
-     * the cross-company leak. A tenant-scoped search pins entity_id = 0 so it
-     * returns only company knowledge, never another entity's indexed rows.
+     * the cross-company leak. Organization-wide reads stop at that tenant pair;
+     * tenant-document searches pin entity_id = 0, and entity searches add both
+     * entity_type and entity_id.
      */
     public function filter(): string
     {
         $filter = sprintf('apps_id:=%d && companies_id:=%d', $this->appId, $this->companyId);
+
+        if ($this->organizationWide) {
+            return $filter;
+        }
 
         if ($this->isEntityScoped()) {
             return $filter . sprintf(

--- a/src/Domains/Intelligence/Knowledge/VectorStores/TypesenseKnowledgeStore.php
+++ b/src/Domains/Intelligence/Knowledge/VectorStores/TypesenseKnowledgeStore.php
@@ -15,8 +15,9 @@ use Typesense\Exceptions\ObjectNotFound;
  * — it speaks KnowledgeDocument + KnowledgeScope so both the entity-scoped Lead
  * RAG path and the tenant-scoped company-docs path share one collection shape.
  * Every read/delete is scoped through KnowledgeScope::filter(), which always
- * pins companies_id (closing the cross-company leak) and either an entity or
- * entity_id = 0 (company docs) so the two scopes never see each other's rows.
+ * pins app + company (closing the cross-tenant leak). External agents add an
+ * entity boundary, tenant-document reads pin entity_id = 0, and explicitly
+ * internal organization reads may search every entity inside that company.
  */
 final class TypesenseKnowledgeStore
 {

--- a/src/Domains/Inventory/Variants/Models/Variants.php
+++ b/src/Domains/Inventory/Variants/Models/Variants.php
@@ -495,6 +495,7 @@ class Variants extends BaseModel implements EntityIntegrationInterface, ProductI
             'short_description' => null, //$this->short_description,
             'attributes' => [],
             'apps_id' => $this->apps_id,
+            'created_at' => $this->created_at?->timestamp ?? 0,
             'rating' => (float) $this->rating,
         ];
         $attributes = $this->searchableAttributes();
@@ -758,6 +759,7 @@ class Variants extends BaseModel implements EntityIntegrationInterface, ProductI
                 [
                     'name' => 'files',
                     'type' => 'object[]',
+                    'optional' => true,
                 ],
                 [
                     'name' => 'company',
@@ -780,11 +782,13 @@ class Variants extends BaseModel implements EntityIntegrationInterface, ProductI
                     'name' => 'ean',
                     'type' => 'string',
                     'facet' => true,
+                    'optional' => true,
                 ],
                 [
                     'name' => 'barcode',
                     'type' => 'string',
                     'facet' => true,
+                    'optional' => true,
                 ],
                 [
                     'name' => 'status',
@@ -814,6 +818,7 @@ class Variants extends BaseModel implements EntityIntegrationInterface, ProductI
                 [
                     'name' => 'attributes',
                     'type' => 'object',
+                    'optional' => true,
                 ],
                 [
                     'name' => 'apps_id',
@@ -837,7 +842,7 @@ class Variants extends BaseModel implements EntityIntegrationInterface, ProductI
                 ],
             ],
             'default_sorting_field' => 'created_at',
-            'enable_nested_fields' => true,  // Enable nested fields support for complex objects
+            'enable_nested_fields' => true,
         ];
     }
 

--- a/tests/Intelligence/AgentProviderServiceTest.php
+++ b/tests/Intelligence/AgentProviderServiceTest.php
@@ -205,6 +205,28 @@ final class AgentProviderServiceTest extends TestCase
         $this->assertInstanceOf(Gemini::class, AgentProviderService::resolve($agent));
     }
 
+    public function testPassesConfiguredParametersToGemini(): void
+    {
+        $app = app(Apps::class);
+        $app->set(ConfigurationEnum::GEMINI_KEY->value, 'gemini-key');
+
+        $agent = AgentFactory::new()
+            ->withAppId($app->getId())
+            ->withCompanyId(0)
+            ->create([
+                'config' => [
+                    'llm_provider' => AgentLlmProviderEnum::GEMINI->value,
+                    'model' => 'gemini-model',
+                    'parameters' => ['temperature' => 0.1],
+                ],
+            ]);
+
+        $provider = AgentProviderService::resolve($agent);
+
+        $this->assertInstanceOf(Gemini::class, $provider);
+        $this->assertSame(['temperature' => 0.1], $this->readProp($provider, 'parameters'));
+    }
+
     private function readProp(object $object, string $property): mixed
     {
         return new ReflectionProperty($object, $property)->getValue($object);

--- a/tests/Intelligence/Knowledge/KnowledgeScopeIsolationTest.php
+++ b/tests/Intelligence/Knowledge/KnowledgeScopeIsolationTest.php
@@ -146,6 +146,48 @@ class KnowledgeScopeIsolationTest extends TestCase
         $this->assertFalse($companyB->contains(fn (string $c): bool => str_contains($c, 'Alpha refund')));
     }
 
+    public function testOrganizationScopedSearchIncludesAllCompanyEntitiesButNeverAnotherCompany(): void
+    {
+        $this->requireTypesense();
+
+        $appId = $this->kanvasApp->getId();
+        $store = KnowledgeComponents::store($this->kanvasApp);
+        $records = [];
+
+        foreach ([
+            ['id' => 'company-a-lead-55', 'company' => self::COMPANY_A, 'entity' => 55, 'content' => 'Alpha lead wants a sedan.'],
+            ['id' => 'company-a-lead-56', 'company' => self::COMPANY_A, 'entity' => 56, 'content' => 'Alpha lead wants an SUV.'],
+            ['id' => 'company-b-lead-57', 'company' => self::COMPANY_B, 'entity' => 57, 'content' => 'Beta lead wants a truck.'],
+        ] as $row) {
+            $records[] = new KnowledgeDocument(
+                id: $row['id'],
+                content: $row['content'],
+                metadata: [
+                    'apps_id' => $appId,
+                    'companies_id' => $row['company'],
+                    'entity_type' => 'Kanvas\\Guild\\Leads\\Models\\Lead',
+                    'entity_id' => $row['entity'],
+                    'source_type' => 'lead',
+                    'sourceType' => 'lead',
+                    'sourceName' => 'lead:' . $row['entity'],
+                    'embedding' => [0.1, 0.2, 0.3, 0.4],
+                ],
+            );
+        }
+
+        $store->upsert($records);
+        $vector = KnowledgeComponents::embedder($this->kanvasApp)->embed('vehicle interest');
+        $results = collect($store->search(
+            $vector,
+            KnowledgeScope::forOrganization($appId, self::COMPANY_A),
+            10,
+        ))->pluck('content');
+
+        $this->assertTrue($results->contains('Alpha lead wants a sedan.'));
+        $this->assertTrue($results->contains('Alpha lead wants an SUV.'));
+        $this->assertFalse($results->contains('Beta lead wants a truck.'));
+    }
+
     public function testAgentScopedSearchNeverReturnsAnotherAgentsKnowledge(): void
     {
         $this->requireTypesense();

--- a/tests/Intelligence/Knowledge/LeadRagAgentOptInTest.php
+++ b/tests/Intelligence/Knowledge/LeadRagAgentOptInTest.php
@@ -10,9 +10,16 @@ use Kanvas\Intelligence\Agents\Neuron\BaseRagAgent;
 use Kanvas\Intelligence\Agents\Neuron\CRM\FollowUpAgent;
 use Kanvas\Intelligence\Agents\Neuron\CRM\ReceptionistAgent;
 use Kanvas\Intelligence\Agents\Neuron\CRM\SalesAgent;
+use Kanvas\Intelligence\Agents\Neuron\CRM\SalesManagerAgent;
 use Kanvas\Intelligence\Agents\Neuron\KanvasGenericNeuronAgent;
+use Kanvas\Intelligence\Agents\Neuron\RAG\Retrieval\KnowledgeRetrieval;
 use Kanvas\Intelligence\Agents\Neuron\Traits\HasKnowledgeRag;
+use NeuronAI\Chat\Messages\UserMessage;
+use NeuronAI\RAG\Document;
+use NeuronAI\RAG\PostProcessor\AdaptiveThresholdPostProcessor;
 use NeuronAI\RAG\RAG;
+use ReflectionMethod;
+use ReflectionProperty;
 use Tests\TestCase;
 
 class LeadRagAgentOptInTest extends TestCase
@@ -30,5 +37,54 @@ class LeadRagAgentOptInTest extends TestCase
         $this->assertTrue(is_subclass_of(KanvasGenericNeuronAgent::class, BaseKanvasAgent::class));
         $this->assertFalse(is_subclass_of(KanvasGenericNeuronAgent::class, RAG::class));
         $this->assertNotContains(HasKnowledgeRag::class, class_uses_recursive(KanvasGenericNeuronAgent::class));
+    }
+
+    public function testRagAgentsUseAdaptiveThresholdPostProcessing(): void
+    {
+        $method = new ReflectionMethod(SalesAgent::class, 'postProcessors');
+        $processors = $method->invoke(new SalesAgent());
+
+        $this->assertCount(1, $processors);
+        $this->assertInstanceOf(AdaptiveThresholdPostProcessor::class, $processors[0]);
+    }
+
+    public function testInternalAgentsUseOrganizationWideKnowledgeWhileCustomerAgentsStayEntityScoped(): void
+    {
+        $scopeMethod = new ReflectionMethod(SalesManagerAgent::class, 'usesOrganizationWideKnowledge');
+        $this->assertTrue($scopeMethod->invoke(new SalesManagerAgent()));
+
+        $scopeMethod = new ReflectionMethod(SalesAgent::class, 'usesOrganizationWideKnowledge');
+        $this->assertFalse($scopeMethod->invoke(new SalesAgent()));
+
+        $method = new ReflectionMethod(SalesManagerAgent::class, 'retrieval');
+
+        $internalRetrieval = $method->invoke(new SalesManagerAgent());
+        $customerRetrieval = $method->invoke(new SalesAgent());
+
+        $this->assertInstanceOf(KnowledgeRetrieval::class, $internalRetrieval);
+        $this->assertInstanceOf(KnowledgeRetrieval::class, $customerRetrieval);
+
+        $property = new ReflectionProperty(KnowledgeRetrieval::class, 'organizationWide');
+        $this->assertTrue($property->getValue($internalRetrieval));
+        $this->assertFalse($property->getValue($customerRetrieval));
+    }
+
+    public function testAdaptiveThresholdDropsTheWeakestObservedResult(): void
+    {
+        $documents = array_map(function (float $score): Document {
+            $document = new Document("Document with score {$score}");
+            $document->setScore($score);
+
+            return $document;
+        }, [0.61545687913895, 0.54314804077148, 0.52687251567841]);
+
+        $filtered = new AdaptiveThresholdPostProcessor(multiplier: 0.6)->process(
+            new UserMessage('Test query'),
+            $documents,
+        );
+
+        $this->assertCount(2, $filtered);
+        $this->assertSame(0.61545687913895, $filtered[0]->getScore());
+        $this->assertSame(0.54314804077148, $filtered[1]->getScore());
     }
 }

--- a/tests/Inventory/VariantTypesenseSchemaTest.php
+++ b/tests/Inventory/VariantTypesenseSchemaTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Inventory;
+
+use Kanvas\Inventory\Variants\Models\Variants;
+use Tests\TestCase;
+
+class VariantTypesenseSchemaTest extends TestCase
+{
+    public function testEmptyAndNullableFieldsAreOptional(): void
+    {
+        $schema = new Variants()->typesenseCollectionSchema();
+        $fields = collect($schema['fields'])->keyBy('name');
+
+        foreach (['files', 'ean', 'barcode', 'attributes'] as $field) {
+            $this->assertTrue($fields[$field]['optional']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- rewrite RAG queries before retrieval using Neuron AI query transformation
- filter weak results with adaptive threshold post-processing
- allow internal system-user agents to retrieve organization-wide knowledge while preserving app/company isolation
- pass configured generation parameters to the Gemini provider
- make empty and nullable variant fields compatible with Typesense and include `created_at` in indexed documents

## Tests

- RAG/provider/isolation: 17 tests passed, 63 assertions
- variant Typesense schema and Algolia regression: 6 tests passed, 19 assertions
- `git diff --check`