### PR TITLE
feat: add welcome flag to engagement url params (1.x)

### DIFF
--- a/src/Domains/ActionEngine/Engagements/Actions/CreateEngagementAction.php
+++ b/src/Domains/ActionEngine/Engagements/Actions/CreateEngagementAction.php
@@ -300,8 +300,11 @@ class CreateEngagementAction
             'cid' => $this->lead->company->uuid,
             'bcid' => $this->lead->branch ? $this->lead->branch->uuid : null,
             'form_type' => $this->engagementData->formType,
-            'welcome' => ! $this->company->get('hide_millage'),
         ];
+
+        if ($this->company->get('hide_millage')) {
+            $params['welcome'] = 'false';
+        }
 
         $extraField = $this->engagementData->extraField;
         if (is_array($extraField)) {

--- a/src/Domains/ActionEngine/Engagements/Actions/CreateEngagementAction.php
+++ b/src/Domains/ActionEngine/Engagements/Actions/CreateEngagementAction.php
@@ -300,6 +300,7 @@ class CreateEngagementAction
             'cid' => $this->lead->company->uuid,
             'bcid' => $this->lead->branch ? $this->lead->branch->uuid : null,
             'form_type' => $this->engagementData->formType,
+            'welcome' => ! $this->company->get('hide_millage'),
         ];
 
         $extraField = $this->engagementData->extraField;


### PR DESCRIPTION
Adds a `welcome` param to the engagement URL query string, derived from the company's `hide_millage` setting.

- `welcome=true` when the company does **not** have `hide_millage` enabled
- `welcome=false` when `hide_millage` is enabled

Follow-up to #10903.