### PR TITLE
feat(approvals): attach invoice PDF as a real Slack file on approval requests

### DIFF
--- a/src/Domains/Connectors/Slack/Client.php
+++ b/src/Domains/Connectors/Slack/Client.php
@@ -217,6 +217,46 @@ class Client
     }
 
     /**
+     * Uploads a file into a channel/DM as a real Slack attachment, via the current 3-step external
+     * upload flow (the old one-shot files.upload was deprecated): reserve an upload URL, PUT the
+     * bytes to it, then complete the upload against the destination channel.
+     */
+    public function uploadFile(
+        string $channel,
+        string $filename,
+        string $contents,
+        ?string $initialComment = null,
+        ?string $threadTs = null,
+    ): void {
+        $reservation = $this->call('files.getUploadURLExternal', [
+            'filename' => $filename,
+            'length' => (string) strlen($contents),
+        ]);
+
+        $uploadUrl = (string) ($reservation['upload_url'] ?? '');
+        $fileId = (string) ($reservation['file_id'] ?? '');
+
+        if ($uploadUrl === '' || $fileId === '') {
+            throw new ValidationException('Slack files.getUploadURLExternal did not return an upload_url/file_id.');
+        }
+
+        $response = Http::timeout(30)
+            ->withBody($contents, 'application/octet-stream')
+            ->post($uploadUrl);
+
+        if (! $response->successful()) {
+            throw new ValidationException('Slack file upload failed with HTTP ' . $response->status() . '.');
+        }
+
+        $this->call('files.completeUploadExternal', array_filter([
+            'files' => json_encode([['id' => $fileId, 'title' => $filename]]),
+            'channel_id' => $channel,
+            'initial_comment' => $initialComment,
+            'thread_ts' => $threadTs,
+        ]));
+    }
+
+    /**
      * Download a Slack-hosted file (url_private / url_private_download). These require the bot token as
      * a bearer header — a plain GET (e.g. SafeUrlFetcher, which sends no auth) gets Slack's HTML login
      * page instead of the bytes.

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -247,6 +247,8 @@ class CreateApBillTool extends Tool
                     . ($subaccount !== null && trim($subaccount) !== '' ? " / Subaccount: {$subaccount}" : '')
                     . "\nMemo: {$memo}\nBill ID (Kanvas): {$bill->getId()}\n\nReply \"approve bill "
                     . "{$bill->getId()}\" to approve it and push it to Acumatica.",
+                $source_attachment_url,
+                $source_attachment_filename,
             )->execute();
 
             return [

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
@@ -199,6 +199,8 @@ class CreateArInvoiceTool extends Tool
                 "You have an AR invoice pending approval:\nCustomer: {$customer->name}\nAmount: {$currency} "
                     . "{$amount}\nMemo: {$memo}\nInvoice ID (Kanvas): {$invoice->getId()}\n\nReply "
                     . "\"approve invoice {$invoice->getId()}\" to approve it and push it to Acumatica.",
+                $source_attachment_url,
+                $source_attachment_filename,
             )->execute();
 
             return [

--- a/src/Domains/Scribe/Approvals/Actions/NotifyApproverAction.php
+++ b/src/Domains/Scribe/Approvals/Actions/NotifyApproverAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Scribe\Approvals\Actions;
 
+use Illuminate\Support\Facades\Http;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\Slack\Client as SlackClient;
 use Kanvas\Intelligence\Agents\Models\Agent;
@@ -20,6 +21,8 @@ class NotifyApproverAction
     public function __construct(
         protected readonly Apps $app,
         protected readonly string $text,
+        protected readonly ?string $attachmentUrl = null,
+        protected readonly ?string $attachmentFilename = null,
     ) {
     }
 
@@ -41,9 +44,37 @@ class NotifyApproverAction
 
             $client = SlackClient::getInstanceByAgent($agent);
             $dmChannel = $client->openDirectMessageChannel($slackUserId);
+
+            if ($this->tryUploadAttachment($client, $dmChannel)) {
+                return;
+            }
+
             $client->postMessage($dmChannel, $this->text);
         } catch (Throwable $e) {
             report($e);
+        }
+    }
+
+    /** Uploads the invoice PDF as a real Slack attachment, with $this->text as its caption. Returns false (never throws) so execute() falls back to a plain text message on any failure. */
+    private function tryUploadAttachment(SlackClient $client, string $dmChannel): bool
+    {
+        if ($this->attachmentUrl === null || trim($this->attachmentUrl) === '') {
+            return false;
+        }
+
+        try {
+            $contents = Http::timeout(30)->get($this->attachmentUrl)->throw()->body();
+            $filename = $this->attachmentFilename !== null && trim($this->attachmentFilename) !== ''
+                ? $this->attachmentFilename
+                : basename(parse_url($this->attachmentUrl, PHP_URL_PATH) ?: 'invoice.pdf');
+
+            $client->uploadFile($dmChannel, $filename, $contents, $this->text);
+
+            return true;
+        } catch (Throwable $e) {
+            report($e);
+
+            return false;
         }
     }
 }

--- a/src/Domains/Scribe/Approvals/CLAUDE.md
+++ b/src/Domains/Scribe/Approvals/CLAUDE.md
@@ -41,7 +41,10 @@ the tool, the Slack notification, and the queue never change.
    `RequestApprovalAction` explicitly (`action_type: 'approve_invoice'`) since a draft invoice has no
    built-in approval-queue side effect of its own.
 3. `NotifyApproverAction` fires automatically — DMs the configured approver on Slack with the
-   record's details and its Kanvas id.
+   record's details and its Kanvas id, and uploads the invoice PDF (`source_attachment_url`) as a
+   real Slack attachment when one was captured, so the approver can open the actual document
+   before deciding. If the upload fails for any reason, it falls back to the plain text DM instead
+   of losing the notification entirely.
 4. Logged to the tracking sheet as "Pending".
 
 **Approval** (the human, then Apex/Arc again):

--- a/tests/Connectors/Slack/ClientTest.php
+++ b/tests/Connectors/Slack/ClientTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Slack;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Connectors\Slack\Client;
+use Kanvas\Exceptions\ValidationException;
+use Tests\TestCase;
+
+class ClientTest extends TestCase
+{
+    public function test_upload_file_reserves_a_url_uploads_the_bytes_then_completes_the_upload(): void
+    {
+        Http::fake([
+            'slack.com/api/files.getUploadURLExternal' => Http::response([
+                'ok' => true,
+                'upload_url' => 'https://files.slack.com/upload/v1/abc123',
+                'file_id' => 'F123',
+            ]),
+            'files.slack.com/upload/v1/abc123' => Http::response('', 200),
+            'slack.com/api/files.completeUploadExternal' => Http::response(['ok' => true]),
+        ]);
+
+        new Client('xoxb-test-token')->uploadFile('D123', 'invoice.pdf', '%PDF-1.4 fake bytes', 'Here is the invoice');
+
+        Http::assertSent(
+            fn (Request $request): bool => str_contains($request->url(), 'files.getUploadURLExternal')
+                && $request['filename'] === 'invoice.pdf'
+                && $request['length'] === '19'
+        );
+        Http::assertSent(
+            fn (Request $request): bool => $request->url() === 'https://files.slack.com/upload/v1/abc123'
+                && $request->body() === '%PDF-1.4 fake bytes'
+        );
+        Http::assertSent(
+            fn (Request $request): bool => str_contains($request->url(), 'files.completeUploadExternal')
+                && $request['channel_id'] === 'D123'
+                && $request['initial_comment'] === 'Here is the invoice'
+        );
+    }
+
+    public function test_upload_file_throws_when_slack_does_not_return_an_upload_url(): void
+    {
+        Http::fake([
+            'slack.com/api/files.getUploadURLExternal' => Http::response(['ok' => true]),
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        new Client('xoxb-test-token')->uploadFile('D123', 'invoice.pdf', 'bytes');
+    }
+
+    public function test_upload_file_throws_when_the_upload_put_fails(): void
+    {
+        Http::fake([
+            'slack.com/api/files.getUploadURLExternal' => Http::response([
+                'ok' => true,
+                'upload_url' => 'https://files.slack.com/upload/v1/abc123',
+                'file_id' => 'F123',
+            ]),
+            'files.slack.com/upload/v1/abc123' => Http::response('', 500),
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        new Client('xoxb-test-token')->uploadFile('D123', 'invoice.pdf', 'bytes');
+    }
+}

--- a/tests/Scribe/Approvals/NotifyApproverActionTest.php
+++ b/tests/Scribe/Approvals/NotifyApproverActionTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Scribe\Approvals;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Intelligence\AgentRuntime\Enums\AgentChannelTokenEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Scribe\Approvals\Actions\NotifyApproverAction;
+use Kanvas\Scribe\Approvals\Enums\ApprovalConfigurationEnum;
+use Kanvas\Users\Models\Users;
+use Tests\TestCase;
+
+class NotifyApproverActionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private Apps $kanvasApp;
+    private Companies $company;
+    private Users $user;
+    private mixed $originalSlackUserId = null;
+    private mixed $originalNotifierAgentId = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->kanvasApp = app(Apps::class);
+        $this->user = auth()->user();
+        $this->company = $this->user->getCurrentCompany();
+
+        // HasCustomFields writes through Redis, which DatabaseTransactions never rolls back —
+        // save/restore explicitly so a value set here can't leak into the next test in the run.
+        $this->originalSlackUserId = $this->kanvasApp->get(ApprovalConfigurationEnum::APPROVER_SLACK_USER_ID->value);
+        $this->originalNotifierAgentId = $this->kanvasApp->get(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value);
+        $this->kanvasApp->set(ApprovalConfigurationEnum::APPROVER_SLACK_USER_ID->value, '');
+        $this->kanvasApp->set(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value, '');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->kanvasApp->set(ApprovalConfigurationEnum::APPROVER_SLACK_USER_ID->value, $this->originalSlackUserId);
+        $this->kanvasApp->set(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value, $this->originalNotifierAgentId);
+
+        parent::tearDown();
+    }
+
+    public function test_it_uploads_the_pdf_as_a_real_attachment_when_a_url_is_present(): void
+    {
+        $this->configureApprover();
+        $this->fakeSlackAndAttachment();
+
+        new NotifyApproverAction(
+            $this->kanvasApp,
+            'You have an AP bill pending approval',
+            'https://cdn.example.test/invoice-4521.pdf',
+            'invoice-4521.pdf',
+        )->execute();
+
+        Http::assertSent(fn (Request $request): bool => str_contains($request->url(), 'files.getUploadURLExternal'));
+        Http::assertSent(fn (Request $request): bool => str_contains($request->url(), 'files.completeUploadExternal'));
+        Http::assertNotSent(fn (Request $request): bool => str_contains($request->url(), 'chat.postMessage'));
+    }
+
+    public function test_it_sends_a_plain_message_when_there_is_no_attachment(): void
+    {
+        $this->configureApprover();
+        $this->fakeSlackAndAttachment();
+
+        new NotifyApproverAction($this->kanvasApp, 'You have an AP bill pending approval')->execute();
+
+        Http::assertSent(
+            fn (Request $request): bool => str_contains($request->url(), 'chat.postMessage')
+                && $request['text'] === 'You have an AP bill pending approval'
+        );
+        Http::assertNotSent(fn (Request $request): bool => str_contains($request->url(), 'files.getUploadURLExternal'));
+    }
+
+    public function test_it_falls_back_to_a_plain_message_when_the_upload_fails(): void
+    {
+        $this->configureApprover();
+        Http::fake([
+            'slack.com/api/conversations.open' => Http::response(['ok' => true, 'channel' => ['id' => 'D123']]),
+            'cdn.example.test/*' => Http::response('', 404),
+            'slack.com/api/chat.postMessage' => Http::response(['ok' => true, 'ts' => '1700000000.000100']),
+        ]);
+
+        new NotifyApproverAction(
+            $this->kanvasApp,
+            'You have an AP bill pending approval',
+            'https://cdn.example.test/invoice-4521.pdf',
+        )->execute();
+
+        Http::assertSent(
+            fn (Request $request): bool => str_contains($request->url(), 'chat.postMessage')
+                && $request['text'] === 'You have an AP bill pending approval'
+        );
+    }
+
+    public function test_it_does_nothing_when_slack_is_not_configured(): void
+    {
+        Http::fake();
+
+        new NotifyApproverAction($this->kanvasApp, 'You have an AP bill pending approval')->execute();
+
+        Http::assertNothingSent();
+    }
+
+    private function configureApprover(): void
+    {
+        $agent = Agent::factory()
+            ->withAppId($this->kanvasApp->getId())
+            ->withCompanyId($this->company->getId())
+            ->create(['name' => 'Apex', 'user_id' => $this->user->getId()]);
+        $agent->set(AgentChannelTokenEnum::SLACK_BOT_TOKEN->value, 'xoxb-test-token');
+
+        $this->kanvasApp->set(ApprovalConfigurationEnum::APPROVER_SLACK_USER_ID->value, 'U123');
+        $this->kanvasApp->set(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value, (string) $agent->getId());
+    }
+
+    private function fakeSlackAndAttachment(): void
+    {
+        Http::fake([
+            'slack.com/api/conversations.open' => Http::response(['ok' => true, 'channel' => ['id' => 'D123']]),
+            'cdn.example.test/*' => Http::response('%PDF-1.4 fake bytes', 200),
+            'slack.com/api/files.getUploadURLExternal' => Http::response([
+                'ok' => true,
+                'upload_url' => 'https://files.slack.com/upload/v1/abc123',
+                'file_id' => 'F123',
+            ]),
+            'files.slack.com/upload/v1/abc123' => Http::response('', 200),
+            'slack.com/api/files.completeUploadExternal' => Http::response(['ok' => true]),
+            'slack.com/api/chat.postMessage' => Http::response(['ok' => true, 'ts' => '1700000000.000100']),
+        ]);
+    }
+}


### PR DESCRIPTION
1.x mirror of #10924.

## Summary
- The Slack DM Apex/Arc sends when a bill/invoice needs approval now uploads the invoice PDF as a real Slack file attachment (via Slack's external upload flow), instead of nothing.
- If the upload fails for any reason, falls back to the original plain-text message so the notification is never lost.
- No new configuration needed — reuses the `source_attachment_url`/`source_attachment_filename` already captured when the bill/invoice was created.

## Test plan
- [x] `tests/Connectors/Slack/ClientTest.php` — new: covers `Client::uploadFile()` success and failure paths against faked Slack HTTP responses.
- [x] `tests/Scribe/Approvals/NotifyApproverActionTest.php` — new: covers attachment upload, plain-text fallback (no attachment / upload fails), and the existing "Slack not configured" no-op.
- [x] `tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php` / `AccountsReceivableAgentToolsTest.php` — full regression pass.
- [x] All 50 tests green locally in Docker on this branch.