### PR TITLE
feat(approvals): attach the invoice PDF as a real Slack file on appro…

### DIFF
--- a/src/Domains/ActionEngine/Engagements/Actions/CreateEngagementAction.php
+++ b/src/Domains/ActionEngine/Engagements/Actions/CreateEngagementAction.php
@@ -302,6 +302,10 @@ class CreateEngagementAction
             'form_type' => $this->engagementData->formType,
         ];
 
+        if ($this->company->get('hide_millage')) {
+            $params['welcome'] = 'false';
+        }
+
         $extraField = $this->engagementData->extraField;
         if (is_array($extraField)) {
             $extraField = implode('&', $extraField);

--- a/src/Domains/Connectors/Mailgun/Actions/AttachEmailAttachmentsToLeadAction.php
+++ b/src/Domains/Connectors/Mailgun/Actions/AttachEmailAttachmentsToLeadAction.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\Mailgun\Actions;
 
-use Kanvas\Filesystem\Models\Filesystem;
+use Kanvas\Connectors\Mailgun\Services\MailgunAttachmentService;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Workflow\Models\ReceiverWebhookCall;
-use Throwable;
 
 class AttachEmailAttachmentsToLeadAction
 {
@@ -22,96 +21,6 @@ class AttachEmailAttachmentsToLeadAction
      */
     public function execute(): array
     {
-        $files = $this->capturedFiles();
-
-        if ($files === []) {
-            return [];
-        }
-
-        $inlineFields = $this->inlineFields();
-        $attached = [];
-
-        foreach ($files as $file) {
-            $field = is_string($file['field'] ?? null) ? $file['field'] : '';
-
-            if ($field !== '' && in_array($field, $inlineFields, true)) {
-                continue;
-            }
-
-            $filesystemId = (int) ($file['filesystem_id'] ?? 0);
-
-            if ($filesystemId === 0) {
-                continue;
-            }
-
-            $name = is_string($file['name'] ?? null) && $file['name'] !== '' ? $file['name'] : 'attachment';
-
-            if ($this->attach($filesystemId, $name)) {
-                $attached[] = $name;
-            }
-        }
-
-        return $attached;
-    }
-
-    /**
-     * @return array<int, array<array-key, mixed>>
-     */
-    protected function capturedFiles(): array
-    {
-        $payload = $this->webhookRequest->payload;
-        $files = is_array($payload) ? ($payload['uploaded_files'] ?? null) : null;
-
-        if (! is_array($files)) {
-            return [];
-        }
-
-        return array_values(array_filter($files, 'is_array'));
-    }
-
-    /**
-     * Multipart field names of inline attachments. `content-id-map` maps each content-id
-     * referenced in the email body to its field name (e.g. `attachment-1`).
-     *
-     * @return array<int, string>
-     */
-    protected function inlineFields(): array
-    {
-        $payload = $this->webhookRequest->payload;
-        $map = is_array($payload) ? ($payload['content-id-map'] ?? null) : null;
-
-        if (is_string($map)) {
-            $decoded = json_decode($map, true);
-            $map = is_array($decoded) ? $decoded : [];
-        }
-
-        if (! is_array($map)) {
-            return [];
-        }
-
-        $fields = [];
-
-        foreach ($map as $value) {
-            if (is_string($value) && $value !== '') {
-                $fields[] = $value;
-            }
-        }
-
-        return $fields;
-    }
-
-    protected function attach(int $filesystemId, string $name): bool
-    {
-        try {
-            /** @var Filesystem $filesystem */
-            $filesystem = Filesystem::getById($filesystemId, $this->lead->app);
-            $this->lead->addFile($filesystem, $name);
-
-            return true;
-        } catch (Throwable $e) {
-            report($e);
-
-            return false;
-        }
+        return new MailgunAttachmentService($this->webhookRequest)->attachTo($this->lead);
     }
 }

--- a/src/Domains/Connectors/Mailgun/Actions/CreateMessageFromAgentInboxAction.php
+++ b/src/Domains/Connectors/Mailgun/Actions/CreateMessageFromAgentInboxAction.php
@@ -6,8 +6,8 @@ namespace Kanvas\Connectors\Mailgun\Actions;
 
 use Illuminate\Database\Eloquent\Model;
 use Kanvas\Connectors\Mailgun\Enums\ReceiverConfigurationEnum;
+use Kanvas\Connectors\Mailgun\Services\MailgunAttachmentService;
 use Kanvas\Connectors\Mailgun\Services\MailgunPayloadService;
-use Kanvas\Filesystem\Models\Filesystem;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
@@ -23,7 +23,6 @@ use Kanvas\Social\MessagesTypes\Services\MessageTypeService;
 use Kanvas\SystemModules\Repositories\SystemModulesRepository;
 use Kanvas\Users\Models\Users;
 use Kanvas\Workflow\Models\ReceiverWebhookCall;
-use Throwable;
 
 /**
  * Turns one email delivered to an agent's own mailbox into a Message on a per-sender channel.
@@ -95,7 +94,7 @@ class CreateMessageFromAgentInboxAction
             $company
         );
 
-        $this->attachCapturedFiles($message, $payload);
+        new MailgunAttachmentService($this->webhookRequest)->attachTo($message);
 
         return $message;
     }
@@ -122,46 +121,5 @@ class CreateMessageFromAgentInboxAction
         $channel->set(ReceiverConfigurationEnum::AGENT_ID->value, $this->agent->getId());
 
         return $channel;
-    }
-
-    /**
-     * ProcessWebhookAttemptAction already uploaded the email's attachments into Filesystem (the
-     * receiver sets capture_files) — the multipart request is gone by the time this job runs, so
-     * this is the only chance to hang them off the message for the kernel to read.
-     */
-    private function attachCapturedFiles(Message $message, MailgunPayloadService $payload): void
-    {
-        $rawPayload = $this->webhookRequest->payload;
-        $files = is_array($rawPayload) ? ($rawPayload['uploaded_files'] ?? null) : null;
-
-        if (! is_array($files)) {
-            return;
-        }
-
-        $inlineFields = $payload->inlineAttachmentFields();
-
-        foreach ($files as $file) {
-            $filesystemId = is_array($file) ? (int) ($file['filesystem_id'] ?? 0) : 0;
-
-            if ($filesystemId === 0) {
-                continue;
-            }
-
-            $field = is_string($file['field'] ?? null) ? $file['field'] : '';
-
-            if ($field !== '' && in_array($field, $inlineFields, true)) {
-                continue;
-            }
-
-            try {
-                $filesystem = Filesystem::getById($filesystemId, $message->app);
-                $message->addFile(
-                    $filesystem,
-                    (string) ($file['name'] ?? $filesystem->name)
-                );
-            } catch (Throwable $e) {
-                report($e);
-            }
-        }
     }
 }

--- a/src/Domains/Connectors/Mailgun/Services/MailgunAttachmentService.php
+++ b/src/Domains/Connectors/Mailgun/Services/MailgunAttachmentService.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Mailgun\Services;
+
+use Illuminate\Database\Eloquent\Model;
+use Kanvas\Filesystem\Models\Filesystem;
+use Kanvas\Workflow\Models\ReceiverWebhookCall;
+use Throwable;
+
+/**
+ * Hangs an inbound email's attachments off whatever entity the receiver files it against — a Lead on
+ * the shared inbox, a Message on an agent mailbox.
+ *
+ * ProcessWebhookAttemptAction already uploaded them into Filesystem and left the ids at
+ * `payload.uploaded_files`; the multipart request is gone by the time any job runs, so this is the
+ * last chance to keep them.
+ */
+class MailgunAttachmentService
+{
+    public function __construct(
+        private readonly ReceiverWebhookCall $webhookRequest,
+    ) {
+    }
+
+    /**
+     * @return array<int, string> names of the files attached
+     */
+    public function attachTo(Model $entity): array
+    {
+        $payload = $this->webhookRequest->payload;
+        $files = is_array($payload) ? ($payload['uploaded_files'] ?? null) : null;
+
+        if (! is_array($files)) {
+            return [];
+        }
+
+        $inlineFields = new MailgunPayloadService($payload)->inlineAttachmentFields();
+        $attached = [];
+
+        foreach ($files as $file) {
+            if (! is_array($file) || in_array($file['field'] ?? '', $inlineFields, true)) {
+                continue;
+            }
+
+            $filesystemId = (int) ($file['filesystem_id'] ?? 0);
+            $name = is_string($file['name'] ?? null) && $file['name'] !== '' ? $file['name'] : 'attachment';
+
+            if ($filesystemId > 0 && $this->attach($entity, $filesystemId, $name)) {
+                $attached[] = $name;
+            }
+        }
+
+        return $attached;
+    }
+
+    private function attach(Model $entity, int $filesystemId, string $name): bool
+    {
+        try {
+            /** @var Filesystem $filesystem */
+            $filesystem = Filesystem::getById($filesystemId, $entity->app);
+            $entity->addFile($filesystem, $name);
+
+            return true;
+        } catch (Throwable $e) {
+            report($e);
+
+            return false;
+        }
+    }
+}

--- a/src/Domains/Connectors/Mailgun/Services/MailgunPayloadService.php
+++ b/src/Domains/Connectors/Mailgun/Services/MailgunPayloadService.php
@@ -62,10 +62,11 @@ class MailgunPayloadService
     }
 
     /**
-     * Multipart field names of inline attachments — `content-id-map` maps each content-id referenced
-     * in the body to its field name (e.g. `attachment-1`). These are the signature logos and embedded
-     * images of the mail itself, not things the sender attached: treating them as attachments buries
-     * a real PDF under three corporate logos on every reply.
+     * Multipart field names of images embedded in the body — signature logos and the like, not files
+     * the sender attached. Treating those as attachments buries a real PDF under corporate logos.
+     *
+     * Being in `content-id-map` is not enough: Gmail stamps a Content-ID on every attachment it sends,
+     * embedded or not. Only a `cid:` reference in the HTML body makes one part of the layout.
      *
      * @return array<int, string>
      */
@@ -74,18 +75,30 @@ class MailgunPayloadService
         $map = $this->payload['content-id-map'] ?? null;
 
         if (is_string($map)) {
-            $decoded = json_decode($map, true);
-            $map = is_array($decoded) ? $decoded : [];
+            $map = json_decode($map, true);
         }
 
-        if (! is_array($map)) {
+        $html = (string) ($this->payload['body-html'] ?? '');
+
+        if (! is_array($map) || $html === '') {
             return [];
         }
 
-        return array_values(array_filter(
-            $map,
-            fn (mixed $field): bool => is_string($field) && $field !== ''
-        ));
+        $fields = [];
+
+        foreach ($map as $contentId => $field) {
+            $contentId = is_string($contentId) ? trim($contentId, '<> ') : '';
+
+            if ($contentId !== ''
+                && is_string($field)
+                && $field !== ''
+                && stripos($html, 'cid:' . $contentId) !== false
+            ) {
+                $fields[] = $field;
+            }
+        }
+
+        return array_values(array_unique($fields));
     }
 
     public function inReplyTo(): string

--- a/src/Domains/Connectors/Mailgun/Webhooks/AgentInboxWebhookJob.php
+++ b/src/Domains/Connectors/Mailgun/Webhooks/AgentInboxWebhookJob.php
@@ -46,6 +46,15 @@ use Override;
         . 'rather than becoming a lead. Use the company lead inbox receiver instead for a shared '
         . 'address where the agent is chosen by a workflow rule.',
     integration: IntegrationsEnum::MAILGUN,
+    params: [
+        'agent_id' => 'REQUIRED. Id of the agent that owns this mailbox. Without it nothing is '
+            . 'processed — every delivery answers "Receiver has no agent configured".',
+        'mailbox_address' => 'The address the Mailgun route forwards here, e.g. sofia@mail.example.com.',
+        'capture_files' => 'Stores the email\'s attachments and hangs them off the message, which is '
+            . 'what lets a photo or PDF reach anything downstream. Already on for this receiver; set '
+            . 'it to false only to discard attachments on purpose. There is no backfill — the files '
+            . 'are unrecoverable once the delivery is over.',
+    ],
 )]
 class AgentInboxWebhookJob extends ProcessWebhookJob
 {
@@ -120,6 +129,12 @@ class AgentInboxWebhookJob extends ProcessWebhookJob
             // empty turn. Reporting it would bury the real faults in the same feed.
             return ['message' => $e->getMessage()];
         }
+    }
+
+    #[Override]
+    public static function capturesFiles(): bool
+    {
+        return true;
     }
 
     #[Override]

--- a/src/Domains/Connectors/Mailgun/Webhooks/AgentProcessEmailWebhookJob.php
+++ b/src/Domains/Connectors/Mailgun/Webhooks/AgentProcessEmailWebhookJob.php
@@ -24,6 +24,11 @@ use function Sentry\captureMessage;
         . 'against the lead it belongs to. It records the mail; it does not reply — the reply is a '
         . 'separate email-responder step attached to the message.',
     integration: IntegrationsEnum::MAILGUN,
+    params: [
+        'capture_files' => 'Stores the email\'s attachments and attaches them to the message and the '
+            . 'lead. Already on for this receiver; set it to false only to discard attachments on '
+            . 'purpose. There is no backfill — the files are unrecoverable once the delivery is over.',
+    ],
 )]
 class AgentProcessEmailWebhookJob extends ProcessWebhookJob
 {
@@ -57,6 +62,12 @@ class AgentProcessEmailWebhookJob extends ProcessWebhookJob
         $this->assertAttachmentsCaptured();
 
         return $message->toArray();
+    }
+
+    #[Override]
+    public static function capturesFiles(): bool
+    {
+        return true;
     }
 
     #[Override]

--- a/src/Domains/Connectors/Mailgun/Webhooks/ScribePdfInboundWebhookJob.php
+++ b/src/Domains/Connectors/Mailgun/Webhooks/ScribePdfInboundWebhookJob.php
@@ -57,6 +57,12 @@ use Override;
 )]
 class ScribePdfInboundWebhookJob extends ProcessWebhookJob
 {
+    #[Override]
+    public static function capturesFiles(): bool
+    {
+        return true;
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/src/Domains/Connectors/Slack/Client.php
+++ b/src/Domains/Connectors/Slack/Client.php
@@ -217,6 +217,46 @@ class Client
     }
 
     /**
+     * Uploads a file into a channel/DM as a real Slack attachment, via the current 3-step external
+     * upload flow (the old one-shot files.upload was deprecated): reserve an upload URL, PUT the
+     * bytes to it, then complete the upload against the destination channel.
+     */
+    public function uploadFile(
+        string $channel,
+        string $filename,
+        string $contents,
+        ?string $initialComment = null,
+        ?string $threadTs = null,
+    ): void {
+        $reservation = $this->call('files.getUploadURLExternal', [
+            'filename' => $filename,
+            'length' => (string) strlen($contents),
+        ]);
+
+        $uploadUrl = (string) ($reservation['upload_url'] ?? '');
+        $fileId = (string) ($reservation['file_id'] ?? '');
+
+        if ($uploadUrl === '' || $fileId === '') {
+            throw new ValidationException('Slack files.getUploadURLExternal did not return an upload_url/file_id.');
+        }
+
+        $response = Http::timeout(30)
+            ->withBody($contents, 'application/octet-stream')
+            ->post($uploadUrl);
+
+        if (! $response->successful()) {
+            throw new ValidationException('Slack file upload failed with HTTP ' . $response->status() . '.');
+        }
+
+        $this->call('files.completeUploadExternal', array_filter([
+            'files' => json_encode([['id' => $fileId, 'title' => $filename]]),
+            'channel_id' => $channel,
+            'initial_comment' => $initialComment,
+            'thread_ts' => $threadTs,
+        ]));
+    }
+
+    /**
      * Download a Slack-hosted file (url_private / url_private_download). These require the bot token as
      * a bearer header — a plain GET (e.g. SafeUrlFetcher, which sends no auth) gets Slack's HTML login
      * page instead of the bytes.

--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentChannelReplyAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentChannelReplyAction.php
@@ -28,6 +28,7 @@ use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Social\MessagesTypes\Models\MessageType;
 use Kanvas\Social\MessagesTypes\Services\MessageTypeService;
 use Kanvas\Workflow\Enums\WorkflowEnum;
+use Throwable;
 
 /**
  * Shared base for per-connector channel reply actions (WaSender, Mailgun, RespondIO,
@@ -142,6 +143,8 @@ class BaseAgentChannelReplyAction
         $newMessage->set('communicationChannel', $this->communicationChannel);
         $newMessage->set('from_number', $from);
 
+        $this->carryForwardAttachments($message, $newMessage);
+
         $entity = $message->entity();
         if ($entity instanceof Model) {
             $newMessage->addEntity($entity);
@@ -200,6 +203,24 @@ class BaseAgentChannelReplyAction
         }
 
         return $newMessage;
+    }
+
+    /**
+     * The sender's attachments land on the inbound message, but everything downstream reads the reply
+     * — the WordPress publisher skips inbound messages outright, so an emailed-in photo could never
+     * become a post's featured image. Same Filesystem rows, not copies.
+     *
+     * Must stay ahead of fireWorkflow() so the rules the reply triggers already see the files.
+     */
+    private function carryForwardAttachments(Message $inbound, Message $reply): void
+    {
+        foreach ($inbound->files as $file) {
+            try {
+                $reply->addFile($file, (string) $file->name);
+            } catch (Throwable $e) {
+                report($e);
+            }
+        }
     }
 
     protected function companyRequiresHumanApproval(): bool

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -247,6 +247,8 @@ class CreateApBillTool extends Tool
                     . ($subaccount !== null && trim($subaccount) !== '' ? " / Subaccount: {$subaccount}" : '')
                     . "\nMemo: {$memo}\nBill ID (Kanvas): {$bill->getId()}\n\nReply \"approve bill "
                     . "{$bill->getId()}\" to approve it and push it to Acumatica.",
+                $source_attachment_url,
+                $source_attachment_filename,
             )->execute();
 
             return [

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
@@ -199,6 +199,8 @@ class CreateArInvoiceTool extends Tool
                 "You have an AR invoice pending approval:\nCustomer: {$customer->name}\nAmount: {$currency} "
                     . "{$amount}\nMemo: {$memo}\nInvoice ID (Kanvas): {$invoice->getId()}\n\nReply "
                     . "\"approve invoice {$invoice->getId()}\" to approve it and push it to Acumatica.",
+                $source_attachment_url,
+                $source_attachment_filename,
             )->execute();
 
             return [

--- a/src/Domains/Scribe/Approvals/Actions/NotifyApproverAction.php
+++ b/src/Domains/Scribe/Approvals/Actions/NotifyApproverAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kanvas\Scribe\Approvals\Actions;
 
+use Illuminate\Support\Facades\Http;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\Slack\Client as SlackClient;
 use Kanvas\Intelligence\Agents\Models\Agent;
@@ -20,6 +21,8 @@ class NotifyApproverAction
     public function __construct(
         protected readonly Apps $app,
         protected readonly string $text,
+        protected readonly ?string $attachmentUrl = null,
+        protected readonly ?string $attachmentFilename = null,
     ) {
     }
 
@@ -41,9 +44,37 @@ class NotifyApproverAction
 
             $client = SlackClient::getInstanceByAgent($agent);
             $dmChannel = $client->openDirectMessageChannel($slackUserId);
+
+            if ($this->tryUploadAttachment($client, $dmChannel)) {
+                return;
+            }
+
             $client->postMessage($dmChannel, $this->text);
         } catch (Throwable $e) {
             report($e);
+        }
+    }
+
+    /** Uploads the invoice PDF as a real Slack attachment, with $this->text as its caption. Returns false (never throws) so execute() falls back to a plain text message on any failure. */
+    private function tryUploadAttachment(SlackClient $client, string $dmChannel): bool
+    {
+        if ($this->attachmentUrl === null || trim($this->attachmentUrl) === '') {
+            return false;
+        }
+
+        try {
+            $contents = Http::timeout(30)->get($this->attachmentUrl)->throw()->body();
+            $filename = $this->attachmentFilename !== null && trim($this->attachmentFilename) !== ''
+                ? $this->attachmentFilename
+                : basename(parse_url($this->attachmentUrl, PHP_URL_PATH) ?: 'invoice.pdf');
+
+            $client->uploadFile($dmChannel, $filename, $contents, $this->text);
+
+            return true;
+        } catch (Throwable $e) {
+            report($e);
+
+            return false;
         }
     }
 }

--- a/src/Domains/Scribe/Approvals/CLAUDE.md
+++ b/src/Domains/Scribe/Approvals/CLAUDE.md
@@ -41,7 +41,10 @@ the tool, the Slack notification, and the queue never change.
    `RequestApprovalAction` explicitly (`action_type: 'approve_invoice'`) since a draft invoice has no
    built-in approval-queue side effect of its own.
 3. `NotifyApproverAction` fires automatically — DMs the configured approver on Slack with the
-   record's details and its Kanvas id.
+   record's details and its Kanvas id, and uploads the invoice PDF (`source_attachment_url`) as a
+   real Slack attachment when one was captured, so the approver can open the actual document
+   before deciding. If the upload fails for any reason, it falls back to the plain text DM instead
+   of losing the notification entirely.
 4. Logged to the tracking sheet as "Pending".
 
 **Approval** (the human, then Apex/Arc again):

--- a/src/Domains/Workflow/Actions/ProcessWebhookAttemptAction.php
+++ b/src/Domains/Workflow/Actions/ProcessWebhookAttemptAction.php
@@ -89,17 +89,30 @@ class ProcessWebhookAttemptAction
 
     protected function fileCaptureEnabled(): bool
     {
-        return (bool) ($this->receiver->configuration['capture_files'] ?? false);
+        $jobClass = $this->jobClass();
+
+        return (bool) ($this->receiver->configuration['capture_files'] ?? false)
+            || ($jobClass !== null && $jobClass::capturesFiles());
     }
 
     protected function requestIsAuthentic(): bool
     {
-        $jobClass = $this->receiver->action?->model_name;
+        $jobClass = $this->jobClass();
 
-        if (! is_string($jobClass) || ! is_a($jobClass, ProcessWebhookJob::class, true)) {
+        if ($jobClass === null) {
             return true;
         }
 
         return $jobClass::authenticateRequest($this->request, $this->receiver);
+    }
+
+    /**
+     * @return class-string<ProcessWebhookJob>|null
+     */
+    private function jobClass(): ?string
+    {
+        $jobClass = $this->receiver->action?->model_name;
+
+        return is_string($jobClass) && is_a($jobClass, ProcessWebhookJob::class, true) ? $jobClass : null;
     }
 }

--- a/src/Domains/Workflow/Jobs/ProcessWebhookJob.php
+++ b/src/Domains/Workflow/Jobs/ProcessWebhookJob.php
@@ -96,5 +96,16 @@ abstract class ProcessWebhookJob implements ShouldQueue
         return null;
     }
 
+    /**
+     * Whether the request's uploaded files must be persisted before this job runs. A receiver can
+     * also opt in with `capture_files`, but a job that cannot work without the files declares it
+     * here rather than trusting whoever wired the receiver: the multipart request is gone by the
+     * time the job runs, so a missing flag drops the files with nothing logged anywhere.
+     */
+    public static function capturesFiles(): bool
+    {
+        return false;
+    }
+
     abstract public function execute(): array;
 }

--- a/tests/Connectors/Integration/Mailgun/AgentInboxWebhookJobTest.php
+++ b/tests/Connectors/Integration/Mailgun/AgentInboxWebhookJobTest.php
@@ -213,21 +213,21 @@ final class AgentInboxWebhookJobTest extends TestCase
 
         $this->deliver([
             'sender' => $this->user->email,
-            'subject' => 'noticia presidente',
-            'stripped-text' => 'El presidente reafirmó este viernes que la transformación continuará.',
+            'subject' => 'Press release with photo',
+            'stripped-text' => 'The minister confirmed the reform will continue. Photo attached.',
             // Gmail's `f_…` id for a plain attached file, and a body that never references it.
             'content-id-map' => json_encode(['<f_mt3wwiwb0>' => 'attachment-1']),
-            'body-html' => '<div dir="ltr"><p>El presidente reafirmó este viernes.</p></div>',
+            'body-html' => '<div dir="ltr"><p>The minister confirmed the reform will continue.</p></div>',
             'uploaded_files' => [
                 [
-                    'filesystem_id' => $this->uploadFile(UploadedFile::fake()->image('abinader.jpg')),
-                    'name' => 'abinader.jpg',
+                    'filesystem_id' => $this->uploadFile(UploadedFile::fake()->image('press-photo.jpg')),
+                    'name' => 'press-photo.jpg',
                     'field' => 'attachment-1',
                 ],
             ],
         ]);
 
-        $this->assertContains('abinader.jpg', $this->inboundMessage()->files->pluck('name')->all());
+        $this->assertContains('press-photo.jpg', $this->inboundMessage()->files->pluck('name')->all());
     }
 
     /**
@@ -242,13 +242,13 @@ final class AgentInboxWebhookJobTest extends TestCase
 
         $this->deliver([
             'sender' => $this->user->email,
-            'subject' => 'noticia presidente',
-            'stripped-text' => 'El presidente reafirmó este viernes que la transformación continuará.',
+            'subject' => 'Press release with photo',
+            'stripped-text' => 'The minister confirmed the reform will continue. Photo attached.',
             'Message-Id' => '<photo-' . Str::random(8) . '@mail.gmail.test>',
             'uploaded_files' => [
                 [
-                    'filesystem_id' => $this->uploadFile(UploadedFile::fake()->image('abinader.jpg')),
-                    'name' => 'abinader.jpg',
+                    'filesystem_id' => $this->uploadFile(UploadedFile::fake()->image('press-photo.jpg')),
+                    'name' => 'press-photo.jpg',
                     'field' => 'attachment-1',
                 ],
             ],
@@ -261,7 +261,7 @@ final class AgentInboxWebhookJobTest extends TestCase
             ->first();
 
         $this->assertNotNull($reply, 'The agent reply must be persisted');
-        $this->assertContains('abinader.jpg', $reply->files->pluck('name')->all());
+        $this->assertContains('press-photo.jpg', $reply->files->pluck('name')->all());
 
         $featured = WordPressPost::fromMessage($reply)->featuredImageUrl;
 

--- a/tests/Connectors/Integration/Mailgun/AgentInboxWebhookJobTest.php
+++ b/tests/Connectors/Integration/Mailgun/AgentInboxWebhookJobTest.php
@@ -18,6 +18,7 @@ use Kanvas\Connectors\Mailgun\Enums\ReceiverConfigurationEnum;
 use Kanvas\Connectors\Mailgun\Webhooks\AgentInboxWebhookJob;
 use Kanvas\Connectors\WordPress\Actions\PushMessageToWordPressAction;
 use Kanvas\Connectors\WordPress\Activities\PushMessageToWordPressActivity;
+use Kanvas\Connectors\WordPress\DataTransferObject\WordPressPost;
 use Kanvas\Connectors\WordPress\Enums\ConfigurationEnum as WordPressConfigurationEnum;
 use Kanvas\Filesystem\Services\FilesystemServices;
 use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
@@ -163,8 +164,11 @@ final class AgentInboxWebhookJobTest extends TestCase
             'sender' => $this->user->email,
             'subject' => 'The signed contract',
             'stripped-text' => 'Here is the contract, can you summarize it?',
-            // Mailgun maps each content-id referenced in the body to its multipart field.
+            // Mailgun maps each content-id to its multipart field; the body referencing that id as
+            // `cid:` is what makes it part of the layout rather than something the sender attached.
             'content-id-map' => json_encode(['<logo@corp>' => 'attachment-2']),
+            'body-html' => '<p>Here is the contract, can you summarize it?</p>'
+                . '<img src="cid:logo@corp" alt="Corp">',
             'uploaded_files' => [
                 [
                     'filesystem_id' => $this->uploadFile(UploadedFile::fake()->create('contract.pdf', 12, 'application/pdf')),
@@ -195,6 +199,74 @@ final class AgentInboxWebhookJobTest extends TestCase
         // Stored as a document, not an image — what any later reader (caption backfill, a tool, the
         // UI) keys off to decide how to open it.
         $this->assertNotEmpty($message->attachmentUrls()['documents']);
+    }
+
+    /**
+     * Gmail stamps a Content-ID on EVERY attachment it sends, so `content-id-map` alone said "inline"
+     * about a photo a newsroom had deliberately attached and the file was dropped on the floor — no
+     * exception, nothing in Sentry, just a post with no image. Only a `cid:` reference in the body
+     * makes one inline.
+     */
+    public function testAnAttachmentGmailGaveAContentIdToIsStillKept(): void
+    {
+        $this->fakeMailgun();
+
+        $this->deliver([
+            'sender' => $this->user->email,
+            'subject' => 'noticia presidente',
+            'stripped-text' => 'El presidente reafirmó este viernes que la transformación continuará.',
+            // Gmail's `f_…` id for a plain attached file, and a body that never references it.
+            'content-id-map' => json_encode(['<f_mt3wwiwb0>' => 'attachment-1']),
+            'body-html' => '<div dir="ltr"><p>El presidente reafirmó este viernes.</p></div>',
+            'uploaded_files' => [
+                [
+                    'filesystem_id' => $this->uploadFile(UploadedFile::fake()->image('abinader.jpg')),
+                    'name' => 'abinader.jpg',
+                    'field' => 'attachment-1',
+                ],
+            ],
+        ]);
+
+        $this->assertContains('abinader.jpg', $this->inboundMessage()->files->pluck('name')->all());
+    }
+
+    /**
+     * The publisher skips inbound messages by design, so the post is built from the agent's reply —
+     * which owned no files at all. The newsroom's photo has to ride across for it to ever become a
+     * featured image.
+     */
+    public function testTheAgentsReplyInheritsTheEmailsPhotoForTheWordPressPost(): void
+    {
+        $this->fakeMailgunAndWordPress();
+        $this->useStructuredAgent();
+
+        $this->deliver([
+            'sender' => $this->user->email,
+            'subject' => 'noticia presidente',
+            'stripped-text' => 'El presidente reafirmó este viernes que la transformación continuará.',
+            'Message-Id' => '<photo-' . Str::random(8) . '@mail.gmail.test>',
+            'uploaded_files' => [
+                [
+                    'filesystem_id' => $this->uploadFile(UploadedFile::fake()->image('abinader.jpg')),
+                    'name' => 'abinader.jpg',
+                    'field' => 'attachment-1',
+                ],
+            ],
+        ]);
+
+        $reply = Message::query()
+            ->where('apps_id', $this->kanvasApp->getId())
+            ->whereJsonContains('message->from_ia', true)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($reply, 'The agent reply must be persisted');
+        $this->assertContains('abinader.jpg', $reply->files->pluck('name')->all());
+
+        $featured = WordPressPost::fromMessage($reply)->featuredImageUrl;
+
+        $this->assertNotNull($featured, 'The carried-forward photo must become the post featured image');
+        $this->assertContains($featured, $reply->attachmentUrls()['images']);
     }
 
     public function testAStrangerIsTurnedAwayWhenTheMailboxIsRestricted(): void
@@ -419,6 +491,15 @@ final class AgentInboxWebhookJobTest extends TestCase
         }
 
         return $result;
+    }
+
+    private function inboundMessage(): Message
+    {
+        return Message::query()
+            ->where('apps_id', $this->kanvasApp->getId())
+            ->whereJsonContains('message->from_email', $this->user->email)
+            ->latest('id')
+            ->firstOrFail();
     }
 
     private function uploadFile(UploadedFile $file): int

--- a/tests/Connectors/Integration/Mailgun/AgentInboxWebhookJobTest.php
+++ b/tests/Connectors/Integration/Mailgun/AgentInboxWebhookJobTest.php
@@ -18,6 +18,7 @@ use Kanvas\Connectors\Mailgun\Enums\ReceiverConfigurationEnum;
 use Kanvas\Connectors\Mailgun\Webhooks\AgentInboxWebhookJob;
 use Kanvas\Connectors\WordPress\Actions\PushMessageToWordPressAction;
 use Kanvas\Connectors\WordPress\Activities\PushMessageToWordPressActivity;
+use Kanvas\Connectors\WordPress\DataTransferObject\WordPressPost;
 use Kanvas\Connectors\WordPress\Enums\ConfigurationEnum as WordPressConfigurationEnum;
 use Kanvas\Filesystem\Services\FilesystemServices;
 use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
@@ -163,8 +164,11 @@ final class AgentInboxWebhookJobTest extends TestCase
             'sender' => $this->user->email,
             'subject' => 'The signed contract',
             'stripped-text' => 'Here is the contract, can you summarize it?',
-            // Mailgun maps each content-id referenced in the body to its multipart field.
+            // Mailgun maps each content-id to its multipart field; the body referencing that id as
+            // `cid:` is what makes it part of the layout rather than something the sender attached.
             'content-id-map' => json_encode(['<logo@corp>' => 'attachment-2']),
+            'body-html' => '<p>Here is the contract, can you summarize it?</p>'
+                . '<img src="cid:logo@corp" alt="Corp">',
             'uploaded_files' => [
                 [
                     'filesystem_id' => $this->uploadFile(UploadedFile::fake()->create('contract.pdf', 12, 'application/pdf')),
@@ -195,6 +199,74 @@ final class AgentInboxWebhookJobTest extends TestCase
         // Stored as a document, not an image — what any later reader (caption backfill, a tool, the
         // UI) keys off to decide how to open it.
         $this->assertNotEmpty($message->attachmentUrls()['documents']);
+    }
+
+    /**
+     * Gmail stamps a Content-ID on EVERY attachment it sends, so `content-id-map` alone said "inline"
+     * about a photo a newsroom had deliberately attached and the file was dropped on the floor — no
+     * exception, nothing in Sentry, just a post with no image. Only a `cid:` reference in the body
+     * makes one inline.
+     */
+    public function testAnAttachmentGmailGaveAContentIdToIsStillKept(): void
+    {
+        $this->fakeMailgun();
+
+        $this->deliver([
+            'sender' => $this->user->email,
+            'subject' => 'Press release with photo',
+            'stripped-text' => 'The minister confirmed the reform will continue. Photo attached.',
+            // Gmail's `f_…` id for a plain attached file, and a body that never references it.
+            'content-id-map' => json_encode(['<f_mt3wwiwb0>' => 'attachment-1']),
+            'body-html' => '<div dir="ltr"><p>The minister confirmed the reform will continue.</p></div>',
+            'uploaded_files' => [
+                [
+                    'filesystem_id' => $this->uploadFile(UploadedFile::fake()->image('press-photo.jpg')),
+                    'name' => 'press-photo.jpg',
+                    'field' => 'attachment-1',
+                ],
+            ],
+        ]);
+
+        $this->assertContains('press-photo.jpg', $this->inboundMessage()->files->pluck('name')->all());
+    }
+
+    /**
+     * The publisher skips inbound messages by design, so the post is built from the agent's reply —
+     * which owned no files at all. The newsroom's photo has to ride across for it to ever become a
+     * featured image.
+     */
+    public function testTheAgentsReplyInheritsTheEmailsPhotoForTheWordPressPost(): void
+    {
+        $this->fakeMailgunAndWordPress();
+        $this->useStructuredAgent();
+
+        $this->deliver([
+            'sender' => $this->user->email,
+            'subject' => 'Press release with photo',
+            'stripped-text' => 'The minister confirmed the reform will continue. Photo attached.',
+            'Message-Id' => '<photo-' . Str::random(8) . '@mail.gmail.test>',
+            'uploaded_files' => [
+                [
+                    'filesystem_id' => $this->uploadFile(UploadedFile::fake()->image('press-photo.jpg')),
+                    'name' => 'press-photo.jpg',
+                    'field' => 'attachment-1',
+                ],
+            ],
+        ]);
+
+        $reply = Message::query()
+            ->where('apps_id', $this->kanvasApp->getId())
+            ->whereJsonContains('message->from_ia', true)
+            ->latest('id')
+            ->first();
+
+        $this->assertNotNull($reply, 'The agent reply must be persisted');
+        $this->assertContains('press-photo.jpg', $reply->files->pluck('name')->all());
+
+        $featured = WordPressPost::fromMessage($reply)->featuredImageUrl;
+
+        $this->assertNotNull($featured, 'The carried-forward photo must become the post featured image');
+        $this->assertContains($featured, $reply->attachmentUrls()['images']);
     }
 
     public function testAStrangerIsTurnedAwayWhenTheMailboxIsRestricted(): void
@@ -419,6 +491,15 @@ final class AgentInboxWebhookJobTest extends TestCase
         }
 
         return $result;
+    }
+
+    private function inboundMessage(): Message
+    {
+        return Message::query()
+            ->where('apps_id', $this->kanvasApp->getId())
+            ->whereJsonContains('message->from_email', $this->user->email)
+            ->latest('id')
+            ->firstOrFail();
     }
 
     private function uploadFile(UploadedFile $file): int

--- a/tests/Connectors/Integration/Mailgun/AttachEmailAttachmentsToLeadActionTest.php
+++ b/tests/Connectors/Integration/Mailgun/AttachEmailAttachmentsToLeadActionTest.php
@@ -63,7 +63,7 @@ class AttachEmailAttachmentsToLeadActionTest extends TestCase
                 'content-id-map' => json_encode([
                     '<image001.png@01DCE907.D2C23CA0>' => 'attachment-1',
                 ]),
-                'body-html' => '<p>Adjunto la hoja</p>'
+                'body-html' => '<p>Worksheet attached</p>'
                     . '<img src="cid:image001.png@01DCE907.D2C23CA0">',
             ],
             [
@@ -93,14 +93,14 @@ class AttachEmailAttachmentsToLeadActionTest extends TestCase
                 'sender' => 'customer@example.com',
                 'attachment-count' => '1',
                 'content-id-map' => json_encode(['<f_mt3wwiwb0>' => 'attachment-1']),
-                'body-html' => '<div dir="ltr"><p>Aquí va la foto</p></div>',
+                'body-html' => '<div dir="ltr"><p>Here is the photo</p></div>',
             ],
-            ['attachment-1' => UploadedFile::fake()->image('abinader.jpg')]
+            ['attachment-1' => UploadedFile::fake()->image('press-photo.jpg')]
         );
 
         $attached = new AttachEmailAttachmentsToLeadAction($webhookCall, $lead)->execute();
 
-        $this->assertSame(['abinader.jpg'], $attached);
+        $this->assertSame(['press-photo.jpg'], $attached);
         $this->assertCount(1, $lead->getFiles());
     }
 

--- a/tests/Connectors/Integration/Mailgun/AttachEmailAttachmentsToLeadActionTest.php
+++ b/tests/Connectors/Integration/Mailgun/AttachEmailAttachmentsToLeadActionTest.php
@@ -54,7 +54,8 @@ class AttachEmailAttachmentsToLeadActionTest extends TestCase
     {
         $lead = $this->createLead();
 
-        // content-id-map flags attachment-1 as the inline signature image.
+        // content-id-map flags attachment-1, and the body referencing it as `cid:` is what confirms
+        // it is the inline signature image rather than something the sender attached.
         $webhookCall = $this->buildWebhookCall(
             [
                 'sender' => 'customer@example.com',
@@ -62,6 +63,8 @@ class AttachEmailAttachmentsToLeadActionTest extends TestCase
                 'content-id-map' => json_encode([
                     '<image001.png@01DCE907.D2C23CA0>' => 'attachment-1',
                 ]),
+                'body-html' => '<p>Adjunto la hoja</p>'
+                    . '<img src="cid:image001.png@01DCE907.D2C23CA0">',
             ],
             [
                 'attachment-1' => UploadedFile::fake()->image('image001.png'),
@@ -74,6 +77,30 @@ class AttachEmailAttachmentsToLeadActionTest extends TestCase
         $attached = new AttachEmailAttachmentsToLeadAction($webhookCall, $lead)->execute();
 
         $this->assertSame(['worksheet.pdf'], $attached);
+        $this->assertCount(1, $lead->getFiles());
+    }
+
+    /**
+     * Gmail gives every attachment a Content-ID whether it is embedded or not, so the map on its own
+     * threw away files senders had attached on purpose.
+     */
+    public function testAttachesAFileGmailGaveAContentIdButNeverReferencedInTheBody(): void
+    {
+        $lead = $this->createLead();
+
+        $webhookCall = $this->buildWebhookCall(
+            [
+                'sender' => 'customer@example.com',
+                'attachment-count' => '1',
+                'content-id-map' => json_encode(['<f_mt3wwiwb0>' => 'attachment-1']),
+                'body-html' => '<div dir="ltr"><p>Aquí va la foto</p></div>',
+            ],
+            ['attachment-1' => UploadedFile::fake()->image('abinader.jpg')]
+        );
+
+        $attached = new AttachEmailAttachmentsToLeadAction($webhookCall, $lead)->execute();
+
+        $this->assertSame(['abinader.jpg'], $attached);
         $this->assertCount(1, $lead->getFiles());
     }
 

--- a/tests/Connectors/Integration/Mailgun/AttachEmailAttachmentsToLeadActionTest.php
+++ b/tests/Connectors/Integration/Mailgun/AttachEmailAttachmentsToLeadActionTest.php
@@ -54,7 +54,8 @@ class AttachEmailAttachmentsToLeadActionTest extends TestCase
     {
         $lead = $this->createLead();
 
-        // content-id-map flags attachment-1 as the inline signature image.
+        // content-id-map flags attachment-1, and the body referencing it as `cid:` is what confirms
+        // it is the inline signature image rather than something the sender attached.
         $webhookCall = $this->buildWebhookCall(
             [
                 'sender' => 'customer@example.com',
@@ -62,6 +63,8 @@ class AttachEmailAttachmentsToLeadActionTest extends TestCase
                 'content-id-map' => json_encode([
                     '<image001.png@01DCE907.D2C23CA0>' => 'attachment-1',
                 ]),
+                'body-html' => '<p>Worksheet attached</p>'
+                    . '<img src="cid:image001.png@01DCE907.D2C23CA0">',
             ],
             [
                 'attachment-1' => UploadedFile::fake()->image('image001.png'),
@@ -74,6 +77,30 @@ class AttachEmailAttachmentsToLeadActionTest extends TestCase
         $attached = new AttachEmailAttachmentsToLeadAction($webhookCall, $lead)->execute();
 
         $this->assertSame(['worksheet.pdf'], $attached);
+        $this->assertCount(1, $lead->getFiles());
+    }
+
+    /**
+     * Gmail gives every attachment a Content-ID whether it is embedded or not, so the map on its own
+     * threw away files senders had attached on purpose.
+     */
+    public function testAttachesAFileGmailGaveAContentIdButNeverReferencedInTheBody(): void
+    {
+        $lead = $this->createLead();
+
+        $webhookCall = $this->buildWebhookCall(
+            [
+                'sender' => 'customer@example.com',
+                'attachment-count' => '1',
+                'content-id-map' => json_encode(['<f_mt3wwiwb0>' => 'attachment-1']),
+                'body-html' => '<div dir="ltr"><p>Here is the photo</p></div>',
+            ],
+            ['attachment-1' => UploadedFile::fake()->image('press-photo.jpg')]
+        );
+
+        $attached = new AttachEmailAttachmentsToLeadAction($webhookCall, $lead)->execute();
+
+        $this->assertSame(['press-photo.jpg'], $attached);
         $this->assertCount(1, $lead->getFiles());
     }
 

--- a/tests/Connectors/Slack/ClientTest.php
+++ b/tests/Connectors/Slack/ClientTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Slack;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Connectors\Slack\Client;
+use Kanvas\Exceptions\ValidationException;
+use Tests\TestCase;
+
+class ClientTest extends TestCase
+{
+    public function test_upload_file_reserves_a_url_uploads_the_bytes_then_completes_the_upload(): void
+    {
+        Http::fake([
+            'slack.com/api/files.getUploadURLExternal' => Http::response([
+                'ok' => true,
+                'upload_url' => 'https://files.slack.com/upload/v1/abc123',
+                'file_id' => 'F123',
+            ]),
+            'files.slack.com/upload/v1/abc123' => Http::response('', 200),
+            'slack.com/api/files.completeUploadExternal' => Http::response(['ok' => true]),
+        ]);
+
+        new Client('xoxb-test-token')->uploadFile('D123', 'invoice.pdf', '%PDF-1.4 fake bytes', 'Here is the invoice');
+
+        Http::assertSent(
+            fn (Request $request): bool => str_contains($request->url(), 'files.getUploadURLExternal')
+                && $request['filename'] === 'invoice.pdf'
+                && $request['length'] === '19'
+        );
+        Http::assertSent(
+            fn (Request $request): bool => $request->url() === 'https://files.slack.com/upload/v1/abc123'
+                && $request->body() === '%PDF-1.4 fake bytes'
+        );
+        Http::assertSent(
+            fn (Request $request): bool => str_contains($request->url(), 'files.completeUploadExternal')
+                && $request['channel_id'] === 'D123'
+                && $request['initial_comment'] === 'Here is the invoice'
+        );
+    }
+
+    public function test_upload_file_throws_when_slack_does_not_return_an_upload_url(): void
+    {
+        Http::fake([
+            'slack.com/api/files.getUploadURLExternal' => Http::response(['ok' => true]),
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        new Client('xoxb-test-token')->uploadFile('D123', 'invoice.pdf', 'bytes');
+    }
+
+    public function test_upload_file_throws_when_the_upload_put_fails(): void
+    {
+        Http::fake([
+            'slack.com/api/files.getUploadURLExternal' => Http::response([
+                'ok' => true,
+                'upload_url' => 'https://files.slack.com/upload/v1/abc123',
+                'file_id' => 'F123',
+            ]),
+            'files.slack.com/upload/v1/abc123' => Http::response('', 500),
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        new Client('xoxb-test-token')->uploadFile('D123', 'invoice.pdf', 'bytes');
+    }
+}

--- a/tests/Scribe/Approvals/NotifyApproverActionTest.php
+++ b/tests/Scribe/Approvals/NotifyApproverActionTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Scribe\Approvals;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Intelligence\AgentRuntime\Enums\AgentChannelTokenEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Scribe\Approvals\Actions\NotifyApproverAction;
+use Kanvas\Scribe\Approvals\Enums\ApprovalConfigurationEnum;
+use Kanvas\Users\Models\Users;
+use Tests\TestCase;
+
+class NotifyApproverActionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private Apps $kanvasApp;
+    private Companies $company;
+    private Users $user;
+    private mixed $originalSlackUserId = null;
+    private mixed $originalNotifierAgentId = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->kanvasApp = app(Apps::class);
+        $this->user = auth()->user();
+        $this->company = $this->user->getCurrentCompany();
+
+        // HasCustomFields writes through Redis, which DatabaseTransactions never rolls back —
+        // save/restore explicitly so a value set here can't leak into the next test in the run.
+        $this->originalSlackUserId = $this->kanvasApp->get(ApprovalConfigurationEnum::APPROVER_SLACK_USER_ID->value);
+        $this->originalNotifierAgentId = $this->kanvasApp->get(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value);
+        $this->kanvasApp->set(ApprovalConfigurationEnum::APPROVER_SLACK_USER_ID->value, '');
+        $this->kanvasApp->set(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value, '');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->kanvasApp->set(ApprovalConfigurationEnum::APPROVER_SLACK_USER_ID->value, $this->originalSlackUserId);
+        $this->kanvasApp->set(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value, $this->originalNotifierAgentId);
+
+        parent::tearDown();
+    }
+
+    public function test_it_uploads_the_pdf_as_a_real_attachment_when_a_url_is_present(): void
+    {
+        $this->configureApprover();
+        $this->fakeSlackAndAttachment();
+
+        new NotifyApproverAction(
+            $this->kanvasApp,
+            'You have an AP bill pending approval',
+            'https://cdn.example.test/invoice-4521.pdf',
+            'invoice-4521.pdf',
+        )->execute();
+
+        Http::assertSent(fn (Request $request): bool => str_contains($request->url(), 'files.getUploadURLExternal'));
+        Http::assertSent(fn (Request $request): bool => str_contains($request->url(), 'files.completeUploadExternal'));
+        Http::assertNotSent(fn (Request $request): bool => str_contains($request->url(), 'chat.postMessage'));
+    }
+
+    public function test_it_sends_a_plain_message_when_there_is_no_attachment(): void
+    {
+        $this->configureApprover();
+        $this->fakeSlackAndAttachment();
+
+        new NotifyApproverAction($this->kanvasApp, 'You have an AP bill pending approval')->execute();
+
+        Http::assertSent(
+            fn (Request $request): bool => str_contains($request->url(), 'chat.postMessage')
+                && $request['text'] === 'You have an AP bill pending approval'
+        );
+        Http::assertNotSent(fn (Request $request): bool => str_contains($request->url(), 'files.getUploadURLExternal'));
+    }
+
+    public function test_it_falls_back_to_a_plain_message_when_the_upload_fails(): void
+    {
+        $this->configureApprover();
+        Http::fake([
+            'slack.com/api/conversations.open' => Http::response(['ok' => true, 'channel' => ['id' => 'D123']]),
+            'cdn.example.test/*' => Http::response('', 404),
+            'slack.com/api/chat.postMessage' => Http::response(['ok' => true, 'ts' => '1700000000.000100']),
+        ]);
+
+        new NotifyApproverAction(
+            $this->kanvasApp,
+            'You have an AP bill pending approval',
+            'https://cdn.example.test/invoice-4521.pdf',
+        )->execute();
+
+        Http::assertSent(
+            fn (Request $request): bool => str_contains($request->url(), 'chat.postMessage')
+                && $request['text'] === 'You have an AP bill pending approval'
+        );
+    }
+
+    public function test_it_does_nothing_when_slack_is_not_configured(): void
+    {
+        Http::fake();
+
+        new NotifyApproverAction($this->kanvasApp, 'You have an AP bill pending approval')->execute();
+
+        Http::assertNothingSent();
+    }
+
+    private function configureApprover(): void
+    {
+        $agent = Agent::factory()
+            ->withAppId($this->kanvasApp->getId())
+            ->withCompanyId($this->company->getId())
+            ->create(['name' => 'Apex', 'user_id' => $this->user->getId()]);
+        $agent->set(AgentChannelTokenEnum::SLACK_BOT_TOKEN->value, 'xoxb-test-token');
+
+        $this->kanvasApp->set(ApprovalConfigurationEnum::APPROVER_SLACK_USER_ID->value, 'U123');
+        $this->kanvasApp->set(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value, (string) $agent->getId());
+    }
+
+    private function fakeSlackAndAttachment(): void
+    {
+        Http::fake([
+            'slack.com/api/conversations.open' => Http::response(['ok' => true, 'channel' => ['id' => 'D123']]),
+            'cdn.example.test/*' => Http::response('%PDF-1.4 fake bytes', 200),
+            'slack.com/api/files.getUploadURLExternal' => Http::response([
+                'ok' => true,
+                'upload_url' => 'https://files.slack.com/upload/v1/abc123',
+                'file_id' => 'F123',
+            ]),
+            'files.slack.com/upload/v1/abc123' => Http::response('', 200),
+            'slack.com/api/files.completeUploadExternal' => Http::response(['ok' => true]),
+            'slack.com/api/chat.postMessage' => Http::response(['ok' => true, 'ts' => '1700000000.000100']),
+        ]);
+    }
+}


### PR DESCRIPTION
…val requests

Uploads the invoice PDF into the approver's Slack DM via Slack's external
upload flow (getUploadURLExternal -> PUT -> completeUploadExternal) instead
of only sending a text summary, so the approver can open the actual document
before deciding. Falls back to a plain text message if the upload fails for
any reason, so the notification is never lost.## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
