### PR TITLE
fix(inventory): gift framing invalidates blurbs, exclude gift-wrap categories

### DIFF
--- a/config/inventory-discovery.php
+++ b/config/inventory-discovery.php
@@ -70,6 +70,14 @@ return [
      * luxurious") and no explicit number. A tenant with a different price band
      * overrides both on the app.
      */
+    /*
+     * Categories a shopper never means, however well they match. Gift wrapping is
+     * the canonical case: it scores highly on a gift query and is not a gift.
+     * Matched on the category name, case-insensitively; a tenant overrides with
+     * the `product_discovery_excluded_categories` app setting.
+     */
+    'excluded_categories' => [],
+
     'premium_min_price' => 10000.0,
     'cheap_max_price' => 50.0,
 ];

--- a/src/Domains/Connectors/ProductEnrichment/Actions/EnrichProductAction.php
+++ b/src/Domains/Connectors/ProductEnrichment/Actions/EnrichProductAction.php
@@ -10,6 +10,8 @@ use Kanvas\Connectors\ProductEnrichment\Enums\AttributeEnum;
 use Kanvas\Connectors\ProductEnrichment\Enums\CustomFieldEnum;
 use Kanvas\Connectors\ProductEnrichment\Services\ProductEnrichmentAgentService;
 use Kanvas\Inventory\Products\Models\Products;
+use Kanvas\Inventory\Recommendations\Enums\ConfigurationEnum as RecommendationConfigurationEnum;
+use Kanvas\Inventory\Recommendations\Enums\SemanticProfileStrategyEnum;
 use Laravel\Ai\Responses\StructuredAgentResponse;
 
 /**
@@ -81,6 +83,8 @@ class EnrichProductAction
     /**
      * Fingerprints everything the prompt is built from — attributes included, or a
      * product whose body type changed keeps a blurb describing the old one forever.
+     * The framing strategy is in here too: flipping an app from generic to gift
+     * rewrites the prompt, so every blurb written under the old one is stale.
      */
     private function contentHash(): string
     {
@@ -89,6 +93,9 @@ class EnrichProductAction
             $this->product->description,
             $this->product->categories->pluck('name')->implode(','),
             $this->promptAttributes(),
+            SemanticProfileStrategyEnum::fromApp(
+                $this->product->app?->get(RecommendationConfigurationEnum::SEMANTIC_PROFILE_STRATEGY->value),
+            )->value,
         ]));
     }
 

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/ConfigureProductDiscoveryTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/ConfigureProductDiscoveryTool.php
@@ -10,6 +10,7 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use Kanvas\Inventory\Recommendations\Enums\ConfigurationEnum;
 use Kanvas\Inventory\Recommendations\Enums\SemanticProfileStrategyEnum;
 use Kanvas\Inventory\Recommendations\Services\ProductDiscoveryStatusService;
+use NeuronAI\Tools\ArrayProperty;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
@@ -78,14 +79,14 @@ class ConfigureProductDiscoveryTool extends Tool
                     . 'which runs inside Typesense and needs no API key. Pass "none" to stay keyword-only.',
                 required: false,
             ),
-            new ToolProperty(
+            new ArrayProperty(
                 name: 'excluded_categories',
-                type: PropertyType::ARRAY,
                 description: 'Category names never worth recommending, however well they match — gift wrap, '
                     . 'gift cards, shipping fees, warranties. On a gift catalog "Envoltura" scores highly on '
                     . 'every gift query and is never the gift. Names are matched case- and accent-insensitively. '
                     . 'Pass an empty array to clear.',
                 required: false,
+                items: new ToolProperty(name: 'category', type: PropertyType::STRING, description: 'A category name.'),
             ),
             new ToolProperty(
                 name: 'typesense_api_key',

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/ConfigureProductDiscoveryTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/ConfigureProductDiscoveryTool.php
@@ -79,6 +79,15 @@ class ConfigureProductDiscoveryTool extends Tool
                 required: false,
             ),
             new ToolProperty(
+                name: 'excluded_categories',
+                type: PropertyType::ARRAY,
+                description: 'Category names never worth recommending, however well they match — gift wrap, '
+                    . 'gift cards, shipping fees, warranties. On a gift catalog "Envoltura" scores highly on '
+                    . 'every gift query and is never the gift. Names are matched case- and accent-insensitively. '
+                    . 'Pass an empty array to clear.',
+                required: false,
+            ),
+            new ToolProperty(
                 name: 'typesense_api_key',
                 type: PropertyType::STRING,
                 description: 'Typesense API key, if this app needs its own rather than the platform default.',
@@ -100,6 +109,7 @@ class ConfigureProductDiscoveryTool extends Tool
         ?string $catalog_type = null,
         ?string $index_name = null,
         ?string $embedding_model = null,
+        ?array $excluded_categories = null,
         ?string $typesense_api_key = null,
         ?string $typesense_host = null,
     ): array {
@@ -112,7 +122,14 @@ class ConfigureProductDiscoveryTool extends Tool
         }
 
         try {
-            $applied = $this->apply($catalog_type, $index_name, $embedding_model, $typesense_api_key, $typesense_host);
+            $applied = $this->apply(
+                $catalog_type,
+                $index_name,
+                $embedding_model,
+                $excluded_categories,
+                $typesense_api_key,
+                $typesense_host,
+            );
             $report = new ProductDiscoveryStatusService($this->app, $this->company)->report();
         } catch (Throwable $e) {
             report($e);
@@ -136,9 +153,8 @@ class ConfigureProductDiscoveryTool extends Tool
                 . 'vectors from product names alone and the results look broken. If the collection already '
                 . 'exists without an embedding field it must be dropped and rebuilt; the embed field is '
                 . 'fixed when the collection is created. Then add a workflow rule on Products '
-                . 'created + updated so new products stay enriched. If products were already enriched '
-                . 'under a different catalog_type, their blurbs are written for the wrong reader — clear '
-                . 'their search_enrichment_hash and re-run the backfill.',
+                . 'created + updated so new products stay enriched. Changing catalog_type invalidates every '
+                . 'existing blurb on its own — re-running the backfill rewrites them, no hash clearing needed.',
         ];
     }
 
@@ -149,6 +165,7 @@ class ConfigureProductDiscoveryTool extends Tool
         ?string $catalogType,
         ?string $indexName,
         ?string $embeddingModel,
+        ?array $excludedCategories,
         ?string $apiKey,
         ?string $host,
     ): array {
@@ -177,6 +194,16 @@ class ConfigureProductDiscoveryTool extends Tool
         } else {
             $this->app->set(ConfigurationEnum::TYPESENSE_QUERY_BY->value, 'search_blurb,name,description');
             $applied[ConfigurationEnum::TYPESENSE_QUERY_BY->value] = 'search_blurb,name,description (keyword only)';
+        }
+
+        if ($excludedCategories !== null) {
+            $names = array_values(array_filter(array_map(
+                static fn (mixed $name): string => is_string($name) ? trim($name) : '',
+                $excludedCategories,
+            )));
+
+            $this->app->set(ConfigurationEnum::EXCLUDED_CATEGORIES->value, $names);
+            $applied[ConfigurationEnum::EXCLUDED_CATEGORIES->value] = $names === [] ? 'cleared' : implode(', ', $names);
         }
 
         if ($apiKey !== null && trim($apiKey) !== '' && $host !== null && trim($host) !== '') {

--- a/src/Domains/Inventory/CLAUDE.md
+++ b/src/Domains/Inventory/CLAUDE.md
@@ -329,6 +329,8 @@ reject **every** search with `Field \`embedding\` does not have a vector query i
 |---|---|---|
 | `product_discovery_vector_alpha` | `0.75` | Vector vs keyword weight in the hybrid search |
 | `product_discovery_max_results_per_group` | `2` | Max results sharing a product name — stops one model in five colours taking the page |
+| `product_discovery_excluded_categories` | `[]` | Category names dropped from every result, however well they match. Gift wrap is the canonical case: on a gift catalog "Envoltura" scores highly on every gift query and is never the gift. Matched case- and accent-insensitively |
+| `product_semantic_profile_strategy` | `generic` | Who the blurbs are written for — `gift` (buying for someone else, describe the recipient) or `generic` (buying for themselves, describe the need). Changing it invalidates every existing blurb; see below |
 | `product_discovery_cache_ttl` | `1800` | Seconds a non-empty candidate list is cached |
 | `product_intent_lexicon` | — | Tenant-language budget phrases, MERGED over the shipped English (§`config/inventory-discovery.php`) |
 | `product_discovery_premium_min_price` / `_cheap_max_price` | config | Price band for vague signals ("de lujo", "barato") |
@@ -338,6 +340,7 @@ reject **every** search with `Field \`embedding\` does not have a vector query i
 ```
 1. set products_search_engine + typesense_search_settings + app_custom_product_index
 2. set the embedding model (if wanted)  ← BEFORE first index
+   set product_semantic_profile_strategy ← BEFORE enrichment
 3. create + configure the enrichment Agent
 4. backfill enrichment                   ← writes search_blurb
 5. reindex                               ← creates the collection, builds vectors
@@ -406,5 +409,12 @@ a blurb that failed to describe what the shopper asked for.
   the ONNX model from disk and answers `Not Ready or Lagging` until it finishes.
 - **A required nested field breaks indexing** when it arrives empty. `categories` / `variants` /
   `attributes` are `optional` in `typesenseCollectionSchema()` for exactly this reason.
+- **`product_semantic_profile_strategy` is part of the enrichment hash.** Flipping an app from
+  `generic` to `gift` reopens the gate on every product, so a plain re-run of the backfill rewrites
+  the blurbs — no clearing `search_enrichment_hash` by hand. Setting it *after* a catalog is already
+  enriched costs a full re-enrichment, so set it before step 4.
+- **Gift wrap outranks the gift.** A "regalo para mi suegra" query matches a gift-wrap blurb almost
+  perfectly, because the blurb genuinely is about giving. Nothing in the ranking can tell the
+  wrapping from the present — put those categories in `product_discovery_excluded_categories`.
 </content>
 </invoke>

--- a/src/Domains/Inventory/Recommendations/Actions/RecommendProductsAction.php
+++ b/src/Domains/Inventory/Recommendations/Actions/RecommendProductsAction.php
@@ -138,6 +138,7 @@ class RecommendProductsAction
             ->sortBy(fn (Products $product): int => $position[$product->getId()] ?? PHP_INT_MAX)
             ->map(fn (Products $product) => $presenter->product($product))
             ->filter()
+            ->filter(fn (array $result): bool => ! $this->isExcludedCategory($result))
             ->filter(fn (array $result): bool => $this->withinBudget($result, $intent))
             ->values()
             ->all();
@@ -192,6 +193,45 @@ class RecommendProductsAction
         $max = $this->app->get(ConfigurationEnum::MAX_RESULTS_PER_GROUP->value);
 
         return is_numeric($max) ? (int) $max : self::DEFAULT_MAX_PER_GROUP;
+    }
+
+    /**
+     * Some categories match well and are never what the shopper meant — gift wrap
+     * on a gift query being the canonical case.
+     */
+    private function isExcludedCategory(array $result): bool
+    {
+        $excluded = $this->excludedCategories();
+
+        if ($excluded === []) {
+            return false;
+        }
+
+        foreach ($result['product']['categories'] ?? [] as $category) {
+            if (in_array(IntentLexiconService::normalize((string) ($category['name'] ?? '')), $excluded, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function excludedCategories(): array
+    {
+        $configured = $this->app->get(ConfigurationEnum::EXCLUDED_CATEGORIES->value)
+            ?? config('inventory-discovery.excluded_categories', []);
+
+        if (is_string($configured)) {
+            $configured = json_decode($configured, true);
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $name): string => is_string($name) ? IntentLexiconService::normalize($name) : '',
+            is_array($configured) ? $configured : [],
+        )));
     }
 
     /**

--- a/src/Domains/Inventory/Recommendations/Enums/ConfigurationEnum.php
+++ b/src/Domains/Inventory/Recommendations/Enums/ConfigurationEnum.php
@@ -18,4 +18,5 @@ enum ConfigurationEnum: string
     case VECTOR_ALPHA = 'product_discovery_vector_alpha';
     case CACHE_TTL = 'product_discovery_cache_ttl';
     case MAX_RESULTS_PER_GROUP = 'product_discovery_max_results_per_group';
+    case EXCLUDED_CATEGORIES = 'product_discovery_excluded_categories';
 }

--- a/tests/Connectors/ProductEnrichment/EnrichProductActionTest.php
+++ b/tests/Connectors/ProductEnrichment/EnrichProductActionTest.php
@@ -15,6 +15,8 @@ use Kanvas\Intelligence\Agents\Models\AgentType;
 use Kanvas\Inventory\Products\Actions\CreateProductAction;
 use Kanvas\Inventory\Products\DataTransferObject\Product;
 use Kanvas\Inventory\Products\Models\Products;
+use Kanvas\Inventory\Recommendations\Enums\ConfigurationEnum;
+use Kanvas\Inventory\Recommendations\Enums\SemanticProfileStrategyEnum;
 use Kanvas\Inventory\Support\Setup as InventorySetup;
 use Kanvas\Social\Tags\Models\Tag;
 use Tests\TestCase;
@@ -28,12 +30,29 @@ class EnrichProductActionTest extends TestCase
     // social separately deadlocks the two connections (lock wait timeout).
     protected array $connectionsToTransact = ['mysql', 'intelligence', 'inventory'];
 
+    private mixed $originalStrategy = null;
+
+    // App settings live in Redis, outside the DB transaction, and set(key, null)
+    // is a no-op there — so an unset strategy is restored as an explicit generic.
+    protected function tearDown(): void
+    {
+        app(Apps::class)->set(
+            ConfigurationEnum::SEMANTIC_PROFILE_STRATEGY->value,
+            is_string($this->originalStrategy) ? $this->originalStrategy : SemanticProfileStrategyEnum::GENERIC->value,
+        );
+
+        parent::tearDown();
+    }
+
     public function testEnrichesProductWritesTagsAndBlurbThenSkipsUnchanged(): void
     {
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
         new InventorySetup($app, $user, $company)->run();
+
+        $this->originalStrategy = $app->get(ConfigurationEnum::SEMANTIC_PROFILE_STRATEGY->value);
+        $app->set(ConfigurationEnum::SEMANTIC_PROFILE_STRATEGY->value, SemanticProfileStrategyEnum::GENERIC->value);
 
         $type = AgentType::factory()
             ->withAppId($app->getId())
@@ -103,5 +122,66 @@ class EnrichProductActionTest extends TestCase
         // Unchanged content → the hash gate skips the LLM on the second run.
         $second = new EnrichProductAction($product)->execute();
         $this->assertSame('unchanged', $second['status']);
+    }
+
+    public function testFlippingTheFramingStrategyReopensTheHashGate(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+        new InventorySetup($app, $user, $company)->run();
+
+        $this->originalStrategy = $app->get(ConfigurationEnum::SEMANTIC_PROFILE_STRATEGY->value);
+        $app->set(ConfigurationEnum::SEMANTIC_PROFILE_STRATEGY->value, SemanticProfileStrategyEnum::GENERIC->value);
+
+        $type = AgentType::factory()
+            ->withAppId($app->getId())
+            ->create(['handler' => ProductEnrichmentAgent::class]);
+        Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create(['agent_type_id' => $type->getId(), 'user_id' => $user->getId()]);
+
+        $product = new CreateProductAction(
+            new Product(
+                app: $app,
+                company: $company,
+                user: $user,
+                name: 'Apron ' . uniqid(),
+                sku: 'AP-' . uniqid(),
+            ),
+            $user,
+        )->execute();
+
+        // No tags on either pass: a tag written through the inventory connection and
+        // then deleted through the social one deadlocks the two transactions.
+        ProductEnrichmentAgent::fake([[
+            'audience' => ['female'],
+            'occasion' => [],
+            'interests' => [],
+            'tags' => [],
+            'blurb_es' => 'Un delantal resistente para cocinar a diario.',
+            'blurb_en' => 'A sturdy apron for everyday cooking.',
+        ]]);
+
+        $this->assertSame('enriched', new EnrichProductAction($product)->execute()['status']);
+
+        // Flipping the framing rewrites the prompt, so every blurb written under the
+        // old one is stale — the gate has to reopen without anyone clearing hashes.
+        $app->set(ConfigurationEnum::SEMANTIC_PROFILE_STRATEGY->value, SemanticProfileStrategyEnum::GIFT->value);
+
+        ProductEnrichmentAgent::fake([[
+            'audience' => ['female'],
+            'occasion' => ['birthday'],
+            'interests' => [],
+            'tags' => [],
+            'blurb_es' => 'Para tu mama, que disfruta cocinar los domingos.',
+            'blurb_en' => 'For your mother, who enjoys cooking on Sundays.',
+        ]]);
+
+        $reframed = new EnrichProductAction($product->refresh())->execute();
+
+        $this->assertSame('enriched', $reframed['status']);
+        $this->assertStringContainsString('your mother', $reframed['blurb']);
     }
 }

--- a/tests/Inventory/Recommendations/EvaluateProductDiscoveryCommandTest.php
+++ b/tests/Inventory/Recommendations/EvaluateProductDiscoveryCommandTest.php
@@ -18,11 +18,30 @@ class EvaluateProductDiscoveryCommandTest extends TestCase
 
     private array $tempFiles = [];
 
+    private mixed $originalEngine = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Recall is asserted against what the SQL path finds. Whichever engine the
+        // app happens to be pointed at otherwise would score a live cluster.
+        $app = app(Apps::class);
+        $this->originalEngine = $app->get('products_search_engine');
+        $app->set('products_search_engine', 'database');
+    }
+
     protected function tearDown(): void
     {
         foreach ($this->tempFiles as $file) {
             @unlink($file);
         }
+
+        $app = app(Apps::class);
+
+        is_string($this->originalEngine)
+            ? $app->set('products_search_engine', $this->originalEngine)
+            : $app->del('products_search_engine');
 
         parent::tearDown();
     }

--- a/tests/Inventory/Recommendations/ProductDiscoveryQueryTest.php
+++ b/tests/Inventory/Recommendations/ProductDiscoveryQueryTest.php
@@ -40,11 +40,31 @@ class ProductDiscoveryQueryTest extends TestCase
         }
     ';
 
+    private mixed $originalEngine = null;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         Cache::flush();
+
+        // These cases assert what the SQL path returns. Whichever engine the app
+        // happens to be pointed at otherwise would send the query to a live
+        // cluster and the assertions would depend on what is indexed there.
+        $app = app(Apps::class);
+        $this->originalEngine = $app->get('products_search_engine');
+        $app->set('products_search_engine', 'database');
+    }
+
+    protected function tearDown(): void
+    {
+        $app = app(Apps::class);
+
+        is_string($this->originalEngine)
+            ? $app->set('products_search_engine', $this->originalEngine)
+            : $app->del('products_search_engine');
+
+        parent::tearDown();
     }
 
     public function testReturnsResultsAndAnAttributionUuid(): void

--- a/tests/Inventory/Recommendations/RecommendProductsActionTest.php
+++ b/tests/Inventory/Recommendations/RecommendProductsActionTest.php
@@ -8,10 +8,14 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Cache;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
+use Kanvas\Inventory\Categories\Actions\CreateCategory;
+use Kanvas\Inventory\Categories\DataTransferObject\Categories as CategoriesDto;
+use Kanvas\Inventory\Categories\Models\Categories;
 use Kanvas\Inventory\Products\Models\Products;
 use Kanvas\Inventory\Recommendations\Actions\RecommendProductsAction;
 use Kanvas\Inventory\Recommendations\Contracts\ProductDiscoveryInterface;
 use Kanvas\Inventory\Recommendations\DataTransferObject\ProductIntent;
+use Kanvas\Inventory\Recommendations\Enums\ConfigurationEnum;
 use Kanvas\Inventory\Recommendations\Services\ProductDiscoveryResolver;
 use Kanvas\Souk\Enums\ConfigurationEnum as SoukConfigurationEnum;
 use RuntimeException;
@@ -165,6 +169,33 @@ class RecommendProductsActionTest extends TestCase
         $this->assertCount(4, $result);
     }
 
+    public function testDropsProductsInAnExcludedCategory(): void
+    {
+        $app = app(Apps::class);
+        $original = $app->get(ConfigurationEnum::EXCLUDED_CATEGORIES->value);
+        $app->set(ConfigurationEnum::EXCLUDED_CATEGORIES->value, ['Envoltura']);
+
+        try {
+            $company = Companies::factory()->create();
+            $wrap = $this->makeProduct($app, $company, 'Envoltura roja');
+            $gift = $this->makeProduct($app, $company, 'Delantal Home Chef');
+
+            // Gift wrap scores highly on a gift query and is never the gift. The
+            // category is matched case-insensitively and accent-folded.
+            $wrap->categories()->attach($this->makeCategory($app, $company, 'ENVOLTURA')->getId());
+
+            $result = new RecommendProductsAction($app, $company, $this->engineReturning([$wrap->getId(), $gift->getId()]))
+                ->execute('regalos para mi suegra');
+
+            $names = array_column(array_column($result, 'product'), 'name');
+
+            $this->assertNotContains('Envoltura roja', $names);
+            $this->assertContains('Delantal Home Chef', $names);
+        } finally {
+            $app->set(ConfigurationEnum::EXCLUDED_CATEGORIES->value, $original);
+        }
+    }
+
     public function testEmptyQueryShortCircuitsWithoutHittingTheEngine(): void
     {
         $app = app(Apps::class);
@@ -291,6 +322,19 @@ class RecommendProductsActionTest extends TestCase
                 return $this->ids;
             }
         };
+    }
+
+    private function makeCategory(Apps $app, Companies $company, string $name): Categories
+    {
+        return new CreateCategory(
+            new CategoriesDto(
+                app: $app,
+                company: $company,
+                user: auth()->user(),
+                name: $name,
+            ),
+            auth()->user(),
+        )->execute();
     }
 
     private function makeProduct(Apps $app, Companies $company, ?string $name = null): Products


### PR DESCRIPTION
Two reasons a Giftea `"regalo para mi suegra"` query returned the wrong things.

## The framing strategy was not in the enrichment hash

`EnrichProductAction::contentHash()` fingerprinted name + description + categories + attributes. `product_semantic_profile_strategy` changes the prompt but was not in it, so setting an app to `gift` after its catalog was already enriched did nothing: every product answered `unchanged` and kept a blurb written for the wrong reader. On Giftea that meant 476 generic-framed blurbs describing what a product is *for*, never who to *give* it to — so a relationship query like "mi suegra" could only match on gender.

The strategy is now part of the hash. Flipping it reopens the gate on every product, so re-running the backfill rewrites the blurbs — no clearing `search_enrichment_hash` by hand.

## Gift wrap outranked the gift

"Envoltura roja" ranked #6 on a gift query. Its blurb genuinely is about giving, so it matches near-perfectly, and nothing in the ranking can tell the wrapping from the present. The old agent prompt excluded these by hand; the storefront path (PR7) never carried that rule across.

New `product_discovery_excluded_categories` app setting, applied at hydrate time, matched case- and accent-insensitively. Also a parameter on `configure_product_discovery` so the PM agent can set it.

## Test fix, not related to the above

`ProductDiscoveryQueryTest` and `EvaluateProductDiscoveryCommandTest` read the ambient `products_search_engine`. On a machine that had run the Typesense setup steps they scored a live cluster instead of the SQL path, and five cases failed for the environment rather than the code. Both now pin the engine in `setUp`/`tearDown`.

## Applying it to Giftea (app 135 / company 3741)

Set `product_discovery_excluded_categories` — takes effect immediately, no re-enrichment — then:

```bash
php artisan kanvas-inventory:backfill-product-enrichment 135 --company_id=3741 --limit=3 --sync
php artisan kanvas-inventory:backfill-product-enrichment 135 --company_id=3741
php artisan kanvas-inventory:scout-product-index-process 135 --action=reindex
```

## Still open

Gift framing does not give the ranker any notion of *appropriateness*. "Suegra" and "novia" both read as female-gift, and nothing encodes what is socially right for whom. That is a taste layer, not a retrieval fix — tracked separately.

## Tests

`Inventory` 178/178, `Recommendations` + `ProductEnrichment` 87/87.
