### PR TITLE
fix(inventory): stop a missing collection field answering nothing, de…

### DIFF
--- a/config/inventory-discovery.php
+++ b/config/inventory-discovery.php
@@ -102,6 +102,13 @@ return [
     'group_by_tokens' => 2,
 
     /*
+     * Places an unavailable product drops in the ranking. A penalty, not a
+     * partition: sorting all in-stock products first lets a weak match leapfrog a
+     * strong one. 0 disables; a value past the page size is a hard partition.
+     */
+    'unavailable_penalty' => 3,
+
+    /*
      * Gift wrapping is the canonical case: it scores highly on a gift query and is
      * not a gift. Matched on the category name, case-insensitively.
      */

--- a/src/Domains/Connectors/ProductEnrichment/Agents/ProductEnrichmentAgent.php
+++ b/src/Domains/Connectors/ProductEnrichment/Agents/ProductEnrichmentAgent.php
@@ -61,6 +61,15 @@ class ProductEnrichmentAgent extends KanvasLaravelAgent implements HasStructured
           fits everything matches nothing.
         - Banned openings, in any language: "para quienes buscan", "ideal para quienes", "for those
           who want", "perfect for anyone". They introduce an audience you are about to invent.
+        - NEVER open with "Diseñado para" / "Designed for". Almost every blurb defaulted to it, and
+          the search then matched every one of them against the word "diseño" — a shopper asking for
+          design got gaming mice and hair supplements. Lead with the product, not with who it is for.
+        - Vary the opening. Blurbs are matched as text: when they all share a first phrase, that
+          phrase stops carrying meaning and starts adding noise to every query.
+        - Name the DOMAIN, never a generic person-noun. "jugadores" covers tennis players and
+          gamers, "entusiastas" covers everyone — so a query about a tennis fan returned five gaming
+          mice. Write "videojuegos en PlayStation", "tenis", "cafe de especialidad". The product's
+          own vocabulary is what tells it apart from a product in another category entirely.
 
         When the record gives you NOTHING to differentiate on — no description, no attributes, just a
         name — write ONE short factual sentence stating only what the name tells you, and stop.

--- a/src/Domains/Inventory/CLAUDE.md
+++ b/src/Domains/Inventory/CLAUDE.md
@@ -314,20 +314,35 @@ budget phrases, and the filter admits `[<recipient>, unisex, unknown]` — neutr
 along, or a query for a man loses most of a catalog.
 
 **The shipped lexicon is English only.** A Spanish storefront gets nothing from this until it adds
-its own terms to `product_intent_lexicon` (merged, not replacing):
+its own terms to `product_intent_lexicon` (merged, not replacing). Cover friends and coworkers, not
+just family — "para un amigo" is one of the most common gift queries there is:
 
 ```json
 {
-  "audience_female": ["mujer", "novia", "esposa", "mama", "madre", "hermana", "hija", "tia", "para ella"],
-  "audience_male":   ["hombre", "novio", "esposo", "papa", "padre", "hermano", "hijo", "tio", "para el"],
+  "audience_female": ["mujer", "novia", "esposa", "mama", "madre", "hermana", "hija", "tia", "prima", "amiga", "jefa", "companera", "para ella"],
+  "audience_male":   ["hombre", "novio", "esposo", "papa", "padre", "hermano", "hijo", "tio", "primo", "amigo", "jefe", "companero", "para el"],
   "audience_senior": ["abuela", "abuelo", "suegra", "suegro"],
   "audience_kids":   ["nino", "nina", "chico", "chica"]
 }
 ```
 
 Accents are folded before matching, so `mama` covers `mamá`. Longest match wins, so `grandmother`
-is not read as `mother`. Adding `audience` to an existing collection needs a reindex, not a drop —
-it is an ordinary field, not an embed change.
+is not read as `mother`.
+
+⚠️ **Reindexing does NOT add the field to an existing collection.** Scout's
+`getOrCreateCollectionFromModel()` returns early when the collection exists and never applies a
+changed schema, so a collection built before `audience` existed will never gain it — the reindex
+pushes a value Typesense ignores. Patch it in place (no drop, no re-embedding):
+
+```bash
+curl -X PATCH -H "X-TYPESENSE-API-KEY: $KEY" -H 'Content-Type: application/json' \
+  "$HOST/collections/<prefix><index>" \
+  -d '{"fields":[{"name":"audience","type":"string[]","optional":true,"facet":true}]}'
+```
+
+Discovery checks whether the collection declares the field (cached 10 min) and skips the clause when
+it does not, so a missing field costs the feature rather than every result. `check_product_discovery_setup`
+reports it with this command as the fix.
 
 ### Embeddings (required for cross-language and paraphrase matching)
 
@@ -357,7 +372,7 @@ reject **every** search with `Field \`embedding\` does not have a vector query i
 | `product_discovery_vector_alpha` | `0.75` | Vector vs keyword weight in the hybrid search |
 | `product_discovery_max_results_per_group` | `2` | Max results sharing a group key — stops one model in five colours taking the page |
 | `product_discovery_group_by_tokens` | `2` | How many leading name tokens form that group key. The whole name is too fine: "Perfume Premium 31/37/38" are three names and one product. `0` groups on the whole name |
-| `product_discovery_demote_unavailable` | `true` | Sorts unpriced / out-of-stock products below buyable ones. Nothing is dropped, so a thin catalog still fills the page |
+| `product_discovery_unavailable_penalty` | `3` | Places an unpriced / out-of-stock product drops. A penalty, not a partition — sorting all buyable products first lets a weak match leapfrog a strong one. `0` disables; a value past the page size is a hard partition |
 | `product_discovery_excluded_categories` | `[]` | Category names dropped from every result, however well they match. Gift wrap is the canonical case: on a gift catalog "Envoltura" scores highly on every gift query and is never the gift. Matched case- and accent-insensitively |
 | `product_semantic_profile_strategy` | `generic` | Who the blurbs are written for — `gift` (buying for someone else, describe the recipient) or `generic` (buying for themselves, describe the need). Changing it invalidates every existing blurb; see below |
 | `product_discovery_cache_ttl` | `1800` | Seconds a non-empty candidate list is cached |
@@ -462,6 +477,10 @@ Queries come from the impression log, so the set scores what shoppers actually a
   is for things that are never the answer — wrap, shipping, warranties. A gift card IS a gift; it was
   wrong for a *man*, not wrong in general, and excluding it would also break "regalo para mi novia".
   Contextual wrongness is a filter problem, not a denylist problem.
+- **Formulaic blurb openings poison the keyword half.** Nearly every blurb opened "Diseñado
+  para…", so a shopper asking for *diseño* got gaming mice and hair supplements — the stem matched
+  the opening, not the meaning. The prompt now bans that opening and asks for varied ones. When one
+  phrase appears in every blurb it stops carrying meaning and starts adding noise to every query.
 - **A blurb the model invented is worse than no blurb.** Seed rows like "Perfume Premium 38" carry
   no description and no attributes, so the enrichment agent used to invent an audience — "para
   quienes buscan una fragancia sofisticada, ocasiones especiales" — which matches every gift query

--- a/src/Domains/Inventory/Recommendations/Actions/RecommendProductsAction.php
+++ b/src/Domains/Inventory/Recommendations/Actions/RecommendProductsAction.php
@@ -30,6 +30,7 @@ class RecommendProductsAction
     private const int MAX_CANDIDATE_POOL = 60;
     private const int DEFAULT_MAX_PER_GROUP = 2;
     private const int DEFAULT_GROUP_BY_TOKENS = 2;
+    private const int DEFAULT_UNAVAILABLE_PENALTY = 3;
 
     private ?SearchTermTokenizerService $tokenizer = null;
 
@@ -151,8 +152,9 @@ class RecommendProductsAction
     }
 
     /**
-     * A product nobody can buy still answers the question, so it stays — but it
-     * loses its claim on the page to anything actually purchasable.
+     * A rank penalty, NOT a partition: sorting every buyable product above every
+     * unbuyable one lets a weak in-stock match leapfrog a near-perfect one. Sorts
+     * are stable in PHP 8, so equal ranks keep the engine's order.
      *
      * @param array<int, array{product: array, variants: array}> $ranked
      *
@@ -160,24 +162,24 @@ class RecommendProductsAction
      */
     private function demoteUnavailable(array $ranked): array
     {
-        if (! $this->demotesUnavailable()) {
+        $penalty = $this->unavailablePenalty();
+
+        if ($penalty <= 0) {
             return $ranked;
         }
 
-        $available = [];
-        $unavailable = [];
+        $scored = [];
 
-        foreach ($ranked as $result) {
-            if ($this->hasAvailableVariant($result)) {
-                $available[] = $result;
-
-                continue;
-            }
-
-            $unavailable[] = $result;
+        foreach ($ranked as $position => $result) {
+            $scored[] = [
+                'rank' => $position + ($this->hasAvailableVariant($result) ? 0 : $penalty),
+                'result' => $result,
+            ];
         }
 
-        return [...$available, ...$unavailable];
+        usort($scored, static fn (array $a, array $b): int => $a['rank'] <=> $b['rank']);
+
+        return array_column($scored, 'result');
     }
 
     private function hasAvailableVariant(array $result): bool
@@ -266,11 +268,12 @@ class RecommendProductsAction
         return is_numeric($tokens) ? (int) $tokens : self::DEFAULT_GROUP_BY_TOKENS;
     }
 
-    private function demotesUnavailable(): bool
+    private function unavailablePenalty(): int
     {
-        $demote = $this->app->get(ConfigurationEnum::DEMOTE_UNAVAILABLE->value);
+        $penalty = $this->app->get(ConfigurationEnum::UNAVAILABLE_PENALTY->value)
+            ?? config('inventory-discovery.unavailable_penalty');
 
-        return $demote === null ? true : (bool) $demote;
+        return is_numeric($penalty) ? (int) $penalty : self::DEFAULT_UNAVAILABLE_PENALTY;
     }
 
     /**

--- a/src/Domains/Inventory/Recommendations/Enums/ConfigurationEnum.php
+++ b/src/Domains/Inventory/Recommendations/Enums/ConfigurationEnum.php
@@ -22,7 +22,7 @@ enum ConfigurationEnum: string
     case MAX_RESULTS_PER_GROUP = 'product_discovery_max_results_per_group';
     case EXCLUDED_CATEGORIES = 'product_discovery_excluded_categories';
     case GROUP_BY_TOKENS = 'product_discovery_group_by_tokens';
-    case DEMOTE_UNAVAILABLE = 'product_discovery_demote_unavailable';
+    case UNAVAILABLE_PENALTY = 'product_discovery_unavailable_penalty';
 
     /**
      * A list setting comes back as an array from Redis but as a JSON string when a

--- a/src/Domains/Inventory/Recommendations/Services/ProductDiscoveryResolver.php
+++ b/src/Domains/Inventory/Recommendations/Services/ProductDiscoveryResolver.php
@@ -36,6 +36,12 @@ class ProductDiscoveryResolver
         );
     }
 
+    /** The one place the index-name rule lives; mirrors Products::searchableAs(). */
+    public static function collectionName(AppInterface $app): string
+    {
+        return (string) config('scout.prefix') . (string) ($app->get('app_custom_product_index') ?? 'product_index');
+    }
+
     public function isOnTypesense(): bool
     {
         $engine = $this->app->get('products_search_engine')

--- a/src/Domains/Inventory/Recommendations/Services/ProductDiscoveryStatusService.php
+++ b/src/Domains/Inventory/Recommendations/Services/ProductDiscoveryStatusService.php
@@ -107,7 +107,7 @@ class ProductDiscoveryStatusService
      */
     private function collectionCheck(): array
     {
-        $name = (string) config('scout.prefix') . (string) ($this->app->get('app_custom_product_index') ?? 'product_index');
+        $name = ProductDiscoveryResolver::collectionName($this->app);
 
         try {
             $collection = SearchEngineResolver::getTypesenseClient(
@@ -135,6 +135,17 @@ class ProductDiscoveryStatusService
                 false,
                 "'{$name}': {$docs} docs, missing " . implode(', ', $missing),
                 'this collection predates the discovery fields — DROP it and reindex, or every search fails',
+            );
+        }
+
+        // Reindexing alone does NOT add a field to a collection that already exists.
+        if (! in_array(SearchFieldEnum::AUDIENCE->value, $fields, true)) {
+            return $this->check(
+                'collection',
+                false,
+                "'{$name}': {$docs} docs, no audience field — recipient filtering is off",
+                'PATCH the collection to add it (reindexing will NOT): '
+                    . "curl -X PATCH \$HOST/collections/{$name} -d '{\"fields\":[{\"name\":\"audience\",\"type\":\"string[]\",\"optional\":true,\"facet\":true}]}'",
             );
         }
 

--- a/src/Domains/Inventory/Recommendations/Services/TypesenseProductDiscoveryService.php
+++ b/src/Domains/Inventory/Recommendations/Services/TypesenseProductDiscoveryService.php
@@ -7,12 +7,15 @@ namespace Kanvas\Inventory\Recommendations\Services;
 use Baka\Contracts\AppInterface;
 use Baka\Contracts\CompanyInterface;
 use Baka\Search\SearchEngineResolver;
+use Illuminate\Support\Facades\Cache;
 use Kanvas\Inventory\Recommendations\Contracts\ProductDiscoveryInterface;
 use Kanvas\Inventory\Recommendations\DataTransferObject\ProductIntent;
 use Kanvas\Inventory\Recommendations\Enums\AudienceEnum;
 use Kanvas\Inventory\Recommendations\Enums\ConfigurationEnum;
+use Kanvas\Inventory\Recommendations\Enums\SearchFieldEnum;
 use Kanvas\Souk\Enums\ConfigurationEnum as SoukConfigurationEnum;
 use Override;
+use Throwable;
 use Typesense\Client;
 
 /**
@@ -24,6 +27,9 @@ class TypesenseProductDiscoveryService implements ProductDiscoveryInterface
 {
     /** Rank-fusion dampener; stops the top slot dominating everything below. */
     private const int RRF_K = 60;
+
+    /** Long enough that the schema is not re-fetched per search, short enough that a reindex takes effect on its own. */
+    private const int SCHEMA_CACHE_TTL = 600;
 
     private ?Client $client = null;
 
@@ -124,7 +130,7 @@ class TypesenseProductDiscoveryService implements ProductDiscoveryInterface
             $filters[] = sprintf('price:<=%s', $intent->maxPrice);
         }
 
-        if ($intent->audience !== null) {
+        if ($intent->audience !== null && $this->collectionDeclares(SearchFieldEnum::AUDIENCE->value)) {
             $admitted = [$intent->audience, ...AudienceEnum::alwaysIncluded()];
 
             $filters[] = sprintf(
@@ -171,7 +177,32 @@ class TypesenseProductDiscoveryService implements ProductDiscoveryInterface
 
     private function collection(): string
     {
-        return (string) config('scout.prefix') . (string) ($this->app->get('app_custom_product_index') ?? 'product_index');
+        return ProductDiscoveryResolver::collectionName($this->app);
+    }
+
+    /**
+     * Scout creates collections but never migrates them, so a field added to the
+     * model schema is absent from every collection built before it — and Typesense
+     * answers a filter on an undeclared field with NOTHING, not with everything.
+     * Checking first costs the feature instead of every result.
+     */
+    private function collectionDeclares(string $field): bool
+    {
+        $collection = $this->collection();
+
+        return Cache::remember(
+            'product-discovery:fields:' . $collection . ':' . $field,
+            self::SCHEMA_CACHE_TTL,
+            function () use ($collection, $field): bool {
+                try {
+                    $schema = $this->client()->collections[$collection]->retrieve();
+                } catch (Throwable) {
+                    return false;
+                }
+
+                return in_array($field, array_column($schema['fields'] ?? [], 'name'), true);
+            },
+        );
     }
 
     private function queryByFields(): string

--- a/tests/Inventory/Recommendations/RecommendProductsActionTest.php
+++ b/tests/Inventory/Recommendations/RecommendProductsActionTest.php
@@ -253,11 +253,7 @@ class RecommendProductsActionTest extends TestCase
 
     public function testPromotesBuyableProductsOverUnavailableOnes(): void
     {
-        $app = app(Apps::class);
-        /** @var Users $user */
-        $user = auth()->user();
-        $company = $user->getCurrentCompany();
-        new InventorySetup($app, $user, $company)->run();
+        [$app, $company] = $this->tenantWithChannels();
 
         $unpriced = $this->makeProduct($app, $company, 'Perfume Premium 38');
         $buyable = $this->makeProduct($app, $company, 'Delantal Home Chef');
@@ -275,6 +271,34 @@ class RecommendProductsActionTest extends TestCase
             ['Delantal Home Chef', 'Perfume Premium 38'],
             array_column(array_column($result, 'product'), 'name'),
         );
+    }
+
+    public function testAStrongMatchIsDemotedButNotBuriedForBeingUnavailable(): void
+    {
+        [$app, $company] = $this->tenantWithChannels();
+
+        $best = $this->makeProduct($app, $company, 'Kit Barista Morning Ritual');
+        $weaker = [];
+
+        foreach (range(1, 4) as $i) {
+            $product = $this->makeProduct($app, $company, 'Mando Xbox ' . $i);
+            $this->makeBuyable($app, $company, $product);
+            $weaker[] = $product;
+        }
+
+        // The engine ranked the unpriced product first. A partition would drop it
+        // to last behind four weaker matches; a penalty moves it a few places.
+        $ids = [$best->getId(), ...array_map(fn (Products $p): int => $p->getId(), $weaker)];
+
+        $result = new RecommendProductsAction($app, $company, $this->engineReturning($ids))
+            ->execute('un regalo para alguien que ama el cafe', 5);
+
+        $names = array_column(array_column($result, 'product'), 'name');
+        $position = array_search('Kit Barista Morning Ritual', $names, true);
+
+        $this->assertNotFalse($position);
+        $this->assertGreaterThan(0, $position, 'An unavailable product must lose the top slot.');
+        $this->assertLessThan(4, $position, 'It must not be buried behind every buyable product.');
     }
 
     public function testEmptyQueryShortCircuitsWithoutHittingTheEngine(): void
@@ -403,6 +427,24 @@ class RecommendProductsActionTest extends TestCase
                 return $this->ids;
             }
         };
+    }
+
+    /**
+     * A priced variant needs a default channel and a warehouse, and only the Setup
+     * creates them — a factory company has neither.
+     *
+     * @return array{0: Apps, 1: Companies}
+     */
+    private function tenantWithChannels(): array
+    {
+        $app = app(Apps::class);
+        /** @var Users $user */
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        new InventorySetup($app, $user, $company)->run();
+
+        return [$app, $company];
     }
 
     private function makeBuyable(Apps $app, Companies $company, Products $product): void

--- a/tests/Inventory/Recommendations/TypesenseProductDiscoveryServiceTest.php
+++ b/tests/Inventory/Recommendations/TypesenseProductDiscoveryServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Inventory\Recommendations;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Cache;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Inventory\Recommendations\DataTransferObject\ProductIntent;
@@ -14,6 +15,8 @@ use Kanvas\Inventory\Recommendations\Services\TypesenseProductDiscoveryService;
 use Mockery;
 use Tests\TestCase;
 use Typesense\Client;
+use Typesense\Collection;
+use Typesense\Collections;
 use Typesense\MultiSearch;
 
 class TypesenseProductDiscoveryServiceTest extends TestCase
@@ -21,6 +24,15 @@ class TypesenseProductDiscoveryServiceTest extends TestCase
     use DatabaseTransactions;
 
     private array $capturedSearches = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The collection schema is cached per collection+field, so a sibling case
+        // asserting the field is absent would otherwise read this one's answer.
+        Cache::flush();
+    }
 
     public function testSendsEverySearchInOneMultiSearchRoundTrip(): void
     {
@@ -123,6 +135,19 @@ class TypesenseProductDiscoveryServiceTest extends TestCase
         }
     }
 
+    public function testSkipsTheAudienceFilterWhenTheCollectionDoesNotDeclareTheField(): void
+    {
+        // Scout creates collections but never migrates them, so a collection built
+        // before the field exists cannot be filtered on it — and Typesense answers
+        // an undeclared field with NOTHING, not with everything.
+        $service = $this->service($this->response([[10]]), collectionFields: ['search_blurb', 'price']);
+
+        $ids = $service->search($this->intent('a gift for my girlfriend'), 5);
+
+        $this->assertStringNotContainsString('audience:', $this->capturedSearches[0]['searches'][0]['filter_by']);
+        $this->assertSame([10], $ids);
+    }
+
     public function testDoesNotFilterOnAudienceWhenTheSentenceNamesNoOne(): void
     {
         $service = $this->service($this->response([[10]]));
@@ -215,8 +240,15 @@ class TypesenseProductDiscoveryServiceTest extends TestCase
         ];
     }
 
-    private function service(array $response, ?Apps $app = null, ?Companies $company = null): TypesenseProductDiscoveryService
-    {
+    /**
+     * @param list<string> $collectionFields
+     */
+    private function service(
+        array $response,
+        ?Apps $app = null,
+        ?Companies $company = null,
+        array $collectionFields = ['search_blurb', 'price', 'in_stock', 'audience'],
+    ): TypesenseProductDiscoveryService {
         $multiSearch = Mockery::mock(MultiSearch::class);
         $multiSearch->shouldReceive('perform')
             ->andReturnUsing(function (array $body, array $params) use ($response): array {
@@ -226,8 +258,17 @@ class TypesenseProductDiscoveryServiceTest extends TestCase
                 return $response;
             });
 
+        $collection = Mockery::mock(Collection::class);
+        $collection->shouldReceive('retrieve')->andReturn([
+            'fields' => array_map(static fn (string $name): array => ['name' => $name], $collectionFields),
+        ]);
+
+        $collections = Mockery::mock(Collections::class);
+        $collections->shouldReceive('offsetGet')->andReturn($collection);
+
         $client = Mockery::mock(Client::class);
         $client->multiSearch = $multiSearch;
+        $client->collections = $collections;
 
         return new TypesenseProductDiscoveryService(
             $app ?? app(Apps::class),


### PR DESCRIPTION
…mote by penalty

Three problems found testing the recipient filter against Giftea.

MISSING FIELD ANSWERED NOTHING. Scout's getOrCreateCollectionFromModel() returns early when a collection exists and never applies a changed schema, so `audience` was absent from every collection built before it — and Typesense answers a filter on an undeclared field with NOTHING, not by ignoring it. Every recipient query returned zero results and blamed the catalog. Discovery now checks the collection schema first (cached 10 min) and skips the clause when the field is absent, so the cost is the feature rather than every result, and it self-heals once patched. The setup check reports it with the PATCH command; the CLAUDE.md claim that a reindex would add the field was wrong and is corrected.

DEMOTION WAS A PARTITION. Ranking every buyable product above every unbuyable one let a weak in-stock match leapfrog a near-perfect one: the two best answers for "creativo y amante del cafe" fell to #6 and #7 behind an Xbox controller. Now a rank penalty (default 3), so a strong match drops a few places instead of to the back. Replaces product_discovery_demote_unavailable with _unavailable_penalty.

BLURBS DESCRIBED PEOPLE, NOT PRODUCTS. Nearly every one opened "Diseñado para jugadores/entusiastas de…", so the catalog clustered by person-type: "diseño" matched "Diseñado" and returned gaming mice, and "apasionado del tennis" returned five of them because "jugadores" covers both senses. The prompt now bans that opening, asks for varied ones, and requires domain vocabulary over generic person-nouns.

Also folds three copies of the collection-name rule into one resolver method.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
