### PR TITLE
fix(voice): self-provision the Warm lead type in captureVoiceLead

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
@@ -173,10 +173,21 @@ class CaptureVoiceCallerAction
 
     private function createLeadFromPeople(People $people, mixed $user): Lead
     {
-        $leadType = LeadType::fromApp($people->app)
-            ->fromCompany($people->company)
-            ->where('name', 'Warm')
-            ->firstOrFail();
+        // Self-provision the "Warm" type if the company lacks it (it's a seeded
+        // default, but older/incomplete companies may not have it) — same
+        // create-if-missing pattern the Reynolds/Elead connectors use, so capture
+        // never hard-fails on a missing lead type.
+        $leadType = LeadType::firstOrCreate(
+            [
+                'apps_id' => $people->app->getId(),
+                'companies_id' => $people->company->getId(),
+                'name' => 'Warm',
+            ],
+            [
+                'description' => 'Warm',
+                'is_active' => 1,
+            ],
+        );
 
         $leadSource = new CreateLeadSourceAction(
             new LeadSource($people->app, $people->company, $leadType->getId(), 'voice', true, 'voice')


### PR DESCRIPTION
Follow-up to #10981 (already merged). That PR's `CaptureVoiceCallerAction` used `LeadType::…->where('name','Warm')->firstOrFail()`, copied from the ElevenLabs path — so capturing a caller **hard-fails** for any company that lacks a "Warm" lead type (it's a seeded default, but older/incomplete companies may not have it). The action's try/catch turns that into a silent "couldn't save" with no lead created.

## Change
Create-if-missing instead, scoped to the agent's app + company — the same pattern the Reynolds/Elead connectors already use:
```php
$leadType = LeadType::firstOrCreate(
    ['apps_id' => $people->app->getId(), 'companies_id' => $people->company->getId(), 'name' => 'Warm'],
    ['description' => 'Warm', 'is_active' => 1],
);
```

So capture no longer depends on onboarding having seeded "Warm" — it's provisioned on demand, then the lead is created.

Note: uses a bare `firstOrCreate` (like Reynolds/Elead) rather than `CreateLeadTypeAction` (Facebook/Calendly) — lighter; easy to swap if the team prefers the action.

`php -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)