### PR TITLE
feat(voice): outbound capture requires intent to create a lead

### DIFF
--- a/app/GraphQL/Intelligence/Mutations/VoiceAgentCallerMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/VoiceAgentCallerMutation.php
@@ -17,7 +17,7 @@ use Kanvas\Intelligence\Agents\Repositories\AgentsRepository;
 class VoiceAgentCallerMutation
 {
     /**
-     * @param array{agent_uuid: string, phone: string, name?: string|null, interest?: string|null, interested?: bool|null} $args
+     * @param array{agent_uuid: string, phone: string, name?: string|null, interest?: string|null, interested?: bool|null, direction?: string|null} $args
      *
      * @return array<string, mixed>
      */
@@ -32,6 +32,7 @@ class VoiceAgentCallerMutation
             $args['name'] ?? null,
             $args['interest'] ?? null,
             (bool) ($args['interested'] ?? false),
+            $args['direction'] ?? null,
         )->execute();
     }
 }

--- a/graphql/schemas/Intelligence/voiceAgent.graphql
+++ b/graphql/schemas/Intelligence/voiceAgent.graphql
@@ -117,8 +117,8 @@ extend type Mutation @guardByAppKey {
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Mutations\\VoiceAgentToolMutation@run"
         )
-    "Data plane: capture the caller behind a phone as a contact, promoting to a lead on repeat or clear intent. Phone comes from the runtime, not the LLM."
-    captureVoiceLead(agent_uuid: String!, phone: String!, name: String, interest: String, interested: Boolean): Mixed
+    "Data plane: capture the caller behind a phone as a contact, promoting to a lead on repeat or clear intent (outbound requires intent). Phone/direction come from the runtime, not the LLM."
+    captureVoiceLead(agent_uuid: String!, phone: String!, name: String, interest: String, interested: Boolean, direction: String): Mixed
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Mutations\\VoiceAgentCallerMutation@capture"
         )

--- a/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
@@ -50,6 +50,7 @@ class CaptureVoiceCallerAction
         private readonly ?string $name = null,
         private readonly ?string $interest = null,
         private readonly bool $interested = false,
+        private readonly ?string $direction = null,
     ) {
     }
 
@@ -82,10 +83,16 @@ class CaptureVoiceCallerAction
                 $people->set('voice_interest', $this->interest);
             }
 
-            // Promote on repeat OR clear intent; reuse an active lead if present.
+            // Promote to a lead when there's no active lead yet. OUTBOUND (we
+            // dialed them) requires clear intent — placing the call isn't itself
+            // a qualifying signal. INBOUND keeps the "repeat OR intent" rule: a
+            // second call counts even without stated intent.
             $lead = LeadsRepository::getPeopleActiveLead($people);
             $createdLead = false;
-            if ($lead === null && ($isReturning || $this->interested)) {
+            $qualifies = $this->direction === 'outbound'
+                ? $this->interested
+                : ($isReturning || $this->interested);
+            if ($lead === null && $qualifies) {
                 $lead = $this->createLeadFromPeople($people, $user);
                 $createdLead = true;
             }


### PR DESCRIPTION
## What

`captureVoiceLead` now accepts a `direction` (`inbound` | `outbound`), supplied by the voice runtime from call context (never the LLM), and applies a direction-aware promotion policy in `CaptureVoiceCallerAction`.

## Promotion policy

| Direction | Creates a lead when… |
|---|---|
| **outbound** (we dialed them) | `interested = true` **and** no active lead exists. Placing the call is **not** itself a qualifying signal. |
| **inbound** (unchanged) | no active lead **and** (`isReturning` **or** `interested`) — a repeat call still counts. |

A People contact is still upserted in all cases; only the lead-promotion condition changes. `direction` is nullable and defaults to the inbound rule, so it's backward compatible.

## Requires

Runtime change that sends `direction` — mctekk/kanvas-voice-agents PR (stacked on #17). **Merge/deploy this first**; the runtime only ever sends a value this schema now accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)