### PR TITLE
fix(voice): cross-app lead creation (app + Bouncer scope) + capture logging

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
@@ -112,6 +112,15 @@ class CaptureVoiceCallerAction
             ];
         } catch (Throwable $e) {
             captureException($e);
+            // Log the real reason — the spoken message below is deliberately
+            // generic, so without this the actual failure is only in Sentry.
+            logger()->error('captureVoiceLead failed', [
+                'phone' => $this->phone,
+                'agent_id' => $this->agent->getId(),
+                'direction' => $this->direction,
+                'exception' => $e->getMessage(),
+                'at' => $e->getFile() . ':' . $e->getLine(),
+            ]);
 
             return ['status' => 'error', 'message' => "I couldn't save the caller details just now."];
         }

--- a/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Agents\Actions\Voice;
 
 use Baka\Support\Str;
+use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Guild\Customers\Actions\CreatePeopleAction;
 use Kanvas\Guild\Customers\DataTransferObject\Address;
@@ -59,6 +60,15 @@ class CaptureVoiceCallerAction
      */
     public function execute(): array
     {
+        // Cross-app: the agent may live in a different app than the app-key the
+        // voice runtime authenticated with. Bind the agent's app as the current
+        // app so downstream app-scoped queries resolve against it — notably
+        // CreateLeadAction re-resolving the People by id, whose getById scopes
+        // fromApp(app(Apps::class)). Restore afterward so nothing leaks into the
+        // rest of the request (same pattern as TenantAware*Searchable jobs).
+        $previousApp = app(Apps::class);
+        app()->instance(Apps::class, $this->agent->app);
+
         try {
             $company = $this->agent->companies_id > 0
                 ? Companies::find($this->agent->companies_id)
@@ -123,6 +133,8 @@ class CaptureVoiceCallerAction
             ]);
 
             return ['status' => 'error', 'message' => "I couldn't save the caller details just now."];
+        } finally {
+            app()->instance(Apps::class, $previousApp);
         }
     }
 


### PR DESCRIPTION
> **Merge this to land the full fix on `development`.** Bundles the three commits that make cross-app voice capture work end to end.

## 1. Cross-app People resolution (app scope)
`captureVoiceLead` threw `ModelNotFoundException [People]`: People is created in the agent's app, but `CreateLeadAction → CreatePeopleAction → getById` scopes `fromApp()` to `app(Apps::class)` (the runtime's app-key app). Fix: bind the agent's app as current app for the capture (restored in `finally`).

## 2. Cross-app RBAC (Bouncer scope)  ← clears the current blocker
After #1, lead creation advanced and threw `ModelNotFoundException [Role]` from `CreateChannelAction` (fired by `LeadObserver::created`) looking up the "Admin" role. `Role` is a Bouncer model whose **global scope filters by the active scope** — during the request that's the runtime's app-key app, so the agent-app role is hidden. Confirmed via tinker: `app_176_company_0` Admin (id 4399) is present in `kanvas_ecosystem` but only visible once `Bouncer::scope()->to(getScope($agentApp))` is set. Fix: align the Bouncer scope to the agent's app for the capture (restored in `finally`).

## 3. Capture failure logging
Catch block now `logger()->error('captureVoiceLead failed', [...])` with exception message + `file:line` + phone/agent/direction, so failures hit the app log, not just Sentry.

Sentry: [KANVAS-ECOSYSTEM-61R](https://mctekk.sentry.io/issues/KANVAS-ECOSYSTEM-61R) (People) and [KANVAS-ECOSYSTEM-69F](https://mctekk.sentry.io/issues/KANVAS-ECOSYSTEM-69F) (Role). Not auto-closing 61R (broad grouping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)