### PR TITLE
fix(voice): create lead in the agent's app on cross-app capture

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Agents\Actions\Voice;
 
 use Baka\Support\Str;
+use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Guild\Customers\Actions\CreatePeopleAction;
 use Kanvas\Guild\Customers\DataTransferObject\Address;
@@ -59,6 +60,15 @@ class CaptureVoiceCallerAction
      */
     public function execute(): array
     {
+        // Cross-app: the agent may live in a different app than the app-key the
+        // voice runtime authenticated with. Bind the agent's app as the current
+        // app so downstream app-scoped queries resolve against it — notably
+        // CreateLeadAction re-resolving the People by id, whose getById scopes
+        // fromApp(app(Apps::class)). Restore afterward so nothing leaks into the
+        // rest of the request (same pattern as TenantAware*Searchable jobs).
+        $previousApp = app(Apps::class);
+        app()->instance(Apps::class, $this->agent->app);
+
         try {
             $company = $this->agent->companies_id > 0
                 ? Companies::find($this->agent->companies_id)
@@ -123,6 +133,8 @@ class CaptureVoiceCallerAction
             ]);
 
             return ['status' => 'error', 'message' => "I couldn't save the caller details just now."];
+        } finally {
+            app()->instance(Apps::class, $previousApp);
         }
     }
 


### PR DESCRIPTION
Stacked on #10993 (error logging).

## Bug

`captureVoiceLead` threw `ModelNotFoundException: No query results for model [People]` during **lead creation**, but only in **cross-app** mode (agent lives in a different app than the app-key the voice runtime authenticates with).

## Root cause

```
CaptureVoiceCallerAction::createLeadFromPeople
  -> CreateLeadAction::execute
    -> CreatePeopleAction::execute          (nested People DTO carries the id)
      -> PeoplesRepository::getById($id, $company)   // $app = null
        -> ...->fromApp(null)               // scopeFromApp defaults to app(Apps::class)
```

The People is created in the **agent's** app (`peopleData->app`), but the re-resolution scopes `fromApp()` to `app(Apps::class)` — the **runtime's** app-key app. Cross-app, those differ, so the People isn't found. (Recognition and People-creation worked because they pass the agent's app explicitly.)

## Fix

Bind the agent's app as the current app for the duration of `execute()` (restored in a `finally`), so every downstream app-scoped query resolves against the agent's app. Same pattern the `TenantAware*Searchable` jobs use.

## Test

Cross-app outbound call, interested caller, no existing lead → lead now created under the agent's app instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)