### PR TITLE
fix(voice): align Bouncer scope to the agent's app on capture

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Agents\Actions\Voice;
 
 use Baka\Support\Str;
+use Bouncer;
+use Kanvas\AccessControlList\Enums\RolesEnums;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Guild\Customers\Actions\CreatePeopleAction;
@@ -68,6 +70,14 @@ class CaptureVoiceCallerAction
         // rest of the request (same pattern as TenantAware*Searchable jobs).
         $previousApp = app(Apps::class);
         app()->instance(Apps::class, $this->agent->app);
+
+        // Same reason, for RBAC: Role is a Bouncer model with a global scope that
+        // filters by the ACTIVE scope, which is the runtime's app-key app. Lead
+        // creation fires LeadObserver -> CreateChannelAction, which looks up the
+        // "Admin" role for the agent's app; under the wrong scope that role is
+        // hidden and firstOrFail throws. Point Bouncer at the agent's app scope.
+        $previousScope = Bouncer::scope()->get();
+        Bouncer::scope()->to(RolesEnums::getScope($this->agent->app));
 
         try {
             $company = $this->agent->companies_id > 0
@@ -134,6 +144,7 @@ class CaptureVoiceCallerAction
 
             return ['status' => 'error', 'message' => "I couldn't save the caller details just now."];
         } finally {
+            Bouncer::scope()->to($previousScope);
             app()->instance(Apps::class, $previousApp);
         }
     }


### PR DESCRIPTION
Follow-up to #10993 (which is already merged). That PR fixed the cross-app **People** resolution (app scope); this one fixes the next layer — **RBAC**.

## Symptom
After #10993 deployed, cross-app capture advanced into lead creation and threw `ModelNotFoundException [Role]` from `CreateChannelAction` (fired by `LeadObserver::created`) looking up the "Admin" role — Sentry [KANVAS-ECOSYSTEM-69F](https://mctekk.sentry.io/issues/KANVAS-ECOSYSTEM-69F).

## Root cause
`Role` is a Bouncer model whose **global scope filters by the active scope**. During the capture request the active scope is the runtime's app-key app, not the agent's — so the agent-app "Admin" role is hidden and `firstOrFail()` throws, even though the role exists.

Confirmed via tinker: the `app_176_company_0` Admin (id 4399) is present in `kanvas_ecosystem`, but only visible once `Bouncer::scope()->to(getScope($agentApp))` is set. No data seeding required.

## Fix
In `CaptureVoiceCallerAction::execute()`, point the Bouncer scope at the agent's app for the duration of capture (restored in `finally`), mirroring the `app()` rebind already in place from #10993.

## Test
Cross-app outbound call, interested caller, no existing lead → lead + channel now create without the Role error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)