### PR TITLE
fix(voice): lead recognition crash on unset status/stage/owner

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/Voice/BuildVoiceAgentLeadContextAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/BuildVoiceAgentLeadContextAction.php
@@ -120,9 +120,12 @@ class BuildVoiceAgentLeadContextAction
         $context = [
             'lead_id' => $lead->getId(),
             'name' => $name !== '' ? $name : null,
-            'status' => $lead->status?->name,
-            'stage' => $lead->stage?->name,
-            'owner' => $lead->owner?->displayname,
+            // Guard with is_object: these relations resolve to the raw FK int
+            // (e.g. 0) when unset — a voice-captured lead has status/stage/owner
+            // of 0 — and ?-> only guards null, so ?->name on an int throws.
+            'status' => is_object($lead->status) ? $lead->status->name : null,
+            'stage' => is_object($lead->stage) ? $lead->stage->name : null,
+            'owner' => is_object($lead->owner) ? $lead->owner->displayname : null,
             'vehicle_interest' => $vehicle !== '' ? $vehicle : null,
             'context_info' => $contextInfo !== '' ? $contextInfo : null,
             'is_returning' => true,


### PR DESCRIPTION
## Symptom
Lead history didn't work — the agent didn't recognize a returning caller on an outbound call, even though the lead exists.

## Root cause
`BuildVoiceAgentLeadContextAction::leadContext()` builds the context with:
```php
'status' => $lead->status?->name,
'stage'  => $lead->stage?->name,
'owner'  => $lead->owner?->displayname,
```
The null-safe `?->` only guards **null**. A **voice-captured** lead is created with `status_id`/`pipeline_stage_id`/`leads_owner_id` = `0`, so these relations resolve to the raw FK **int `0`**, and `->name` on an int throws `ErrorException: Attempt to read property "name" on int` (Sentry [KANVAS-ECOSYSTEM-69K](https://mctekk.sentry.io/issues/KANVAS-ECOSYSTEM-69K), event at 15:18:13 via `VoiceAgentLeadContextQuery`).

That exception killed the `voiceAgentLeadContext` query → the runtime received no context → the agent couldn't recognize the caller.

## Fix
Guard each with `is_object()` so an unset (int `0`) relation yields `null` instead of throwing. `summarize()` reads the resulting array, so it's unaffected.

## Test
Outbound (or inbound) call from a number with an existing voice-captured lead → recognition now returns context and the agent greets by name.

`Fixes KANVAS-ECOSYSTEM-69K`

🤖 Generated with [Claude Code](https://claude.com/claude-code)