### PR TITLE
fix: active_leads_count was based on a lead status column nothing ever writes

### DIFF
--- a/app/Console/Commands/Guild/RecalculateActiveLeadsCountCommand.php
+++ b/app/Console/Commands/Guild/RecalculateActiveLeadsCountCommand.php
@@ -27,7 +27,7 @@ class RecalculateActiveLeadsCountCommand extends Command
                             {--chunk=500 : People per chunk}
                             {--dry-run : Report what would change without writing}';
 
-    protected $description = 'Recompute peoples.active_leads_count from leads (status < 2, not deleted)';
+    protected $description = 'Recompute peoples.active_leads_count from leads (leads_status_id IN (1, 2), not deleted)';
 
     public function handle(): int
     {
@@ -68,7 +68,7 @@ class RecalculateActiveLeadsCountCommand extends Command
 
             $actualCounts = Lead::query()
                 ->whereIn('people_id', $people->pluck('id'))
-                ->isOpen()
+                ->hasOpenLeadStatus()
                 ->where('is_deleted', 0)
                 ->selectRaw('people_id, COUNT(*) as total')
                 ->groupBy('people_id')

--- a/database/migrations/Guild/2026_08_25_000002_add_active_leads_count_to_peoples_table.php
+++ b/database/migrations/Guild/2026_08_25_000002_add_active_leads_count_to_peoples_table.php
@@ -13,9 +13,9 @@ use Illuminate\Support\Facades\Schema;
  * maintained by LeadObserver::syncActiveLeadsCount() on Lead create/status-
  * change/soft-delete/reassign/hard-delete.
  *
- * "Open" mirrors Lead::isOpen() (the `status` column, status < 2) — not
- * leads_status_id, which the frontend and other Lead helpers define
- * inconsistently.
+ * "Open" mirrors Lead::hasOpenLeadStatus() (leads_status_id IN (1, 2), the
+ * two SalesAssist-active statuses) — NOT the `status` int column, which no
+ * app code ever writes.
  */
 return new class () extends Migration {
     public function up(): void
@@ -29,7 +29,7 @@ return new class () extends Migration {
             SET active_leads_count = (
                 SELECT COUNT(*) FROM leads l
                 WHERE l.people_id = p.id
-                  AND l.status < 2
+                  AND l.leads_status_id IN (1, 2)
                   AND l.is_deleted = 0
             )
         ');

--- a/src/Domains/Guild/Leads/Models/Lead.php
+++ b/src/Domains/Guild/Leads/Models/Lead.php
@@ -321,6 +321,22 @@ class Lead extends BaseModel implements EventResourceInterface
         return $query->where('status', '<', 2);
     }
 
+    /**
+     * TODO: `leads_status` has no `category`/`is_closed` column, so there is
+     * no reliable way to know per-tenant which custom statuses mean "open".
+     * This hardcodes the known global seed ids as a stopgap — replace with a
+     * real category lookup once `leads_status` gets that column.
+     */
+    public function hasOpenLeadStatus(): bool
+    {
+        return in_array((int) $this->getAttributeValue('leads_status_id'), [1, 2], true);
+    }
+
+    public function scopeHasOpenLeadStatus(Builder $query): Builder
+    {
+        return $query->whereIn('leads_status_id', [1, 2]);
+    }
+
     public function isActive(): bool
     {
         $statusName = strtolower($this->status()->firstOrFail()->name);

--- a/src/Domains/Guild/Leads/Observers/LeadObserver.php
+++ b/src/Domains/Guild/Leads/Observers/LeadObserver.php
@@ -218,9 +218,9 @@ class LeadObserver
 
     /**
      * Maintains the active_leads_count counter cache on People. "Counted"
-     * mirrors Lead::isOpen() (status < 2) — not leads_status_id, which the
-     * frontend and other Lead helpers (isActive(), close()/open()) define
-     * inconsistently.
+     * mirrors Lead::hasOpenLeadStatus() (leads_status_id IN (1, 2), the two
+     * SalesAssist-active statuses) — NOT Lead::isOpen()'s `status` int
+     * column, which no app code writes and is stuck at its DB default.
      */
     private function syncActiveLeadsCount(Lead $lead): void
     {
@@ -252,12 +252,12 @@ class LeadObserver
 
     private function isCounted(Lead $lead): bool
     {
-        return $lead->isOpen() && ! (bool) $lead->is_deleted;
+        return $lead->hasOpenLeadStatus() && ! (bool) $lead->is_deleted;
     }
 
     private function wasCounted(Lead $lead): bool
     {
-        return (int) ($lead->getOriginal('status') ?? 0) < 2
+        return in_array((int) $lead->getOriginal('leads_status_id'), [1, 2], true)
             && ! (bool) $lead->getOriginal('is_deleted');
     }
 

--- a/tests/Guild/LeadActiveLeadsCounterObserverTest.php
+++ b/tests/Guild/LeadActiveLeadsCounterObserverTest.php
@@ -18,20 +18,29 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
 
     protected $connectionsToTransact = [null, 'crm'];
 
-    public function testCreatingOpenLeadIncrementsCounter(): void
+    public function testCreatingLeadWithOpenStatus1IncrementsCounter(): void
     {
         $person = $this->createPerson();
 
-        $this->createLead($person, status: 0);
+        $this->createLead($person, leadsStatusId: 1);
 
         $this->assertSame(1, $this->activeLeadsCount($person));
     }
 
-    public function testCreatingClosedLeadDoesNotIncrementCounter(): void
+    public function testCreatingLeadWithOpenStatus2IncrementsCounter(): void
     {
         $person = $this->createPerson();
 
-        $this->createLead($person, status: 5);
+        $this->createLead($person, leadsStatusId: 2);
+
+        $this->assertSame(1, $this->activeLeadsCount($person));
+    }
+
+    public function testCreatingLeadWithClosedStatusDoesNotIncrementCounter(): void
+    {
+        $person = $this->createPerson();
+
+        $this->createLead($person, leadsStatusId: 3);
 
         $this->assertSame(0, $this->activeLeadsCount($person));
     }
@@ -39,10 +48,10 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
     public function testStatusChangeFromOpenToClosedDecrementsCounter(): void
     {
         $person = $this->createPerson();
-        $lead = $this->createLead($person, status: 0);
+        $lead = $this->createLead($person, leadsStatusId: 1);
         $this->assertSame(1, $this->activeLeadsCount($person));
 
-        $lead->status = 5;
+        $lead->leads_status_id = 3;
         $lead->saveOrFail();
 
         $this->assertSame(0, $this->activeLeadsCount($person));
@@ -51,10 +60,10 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
     public function testStatusChangeFromClosedToOpenIncrementsCounter(): void
     {
         $person = $this->createPerson();
-        $lead = $this->createLead($person, status: 5);
+        $lead = $this->createLead($person, leadsStatusId: 3);
         $this->assertSame(0, $this->activeLeadsCount($person));
 
-        $lead->status = 0;
+        $lead->leads_status_id = 2;
         $lead->saveOrFail();
 
         $this->assertSame(1, $this->activeLeadsCount($person));
@@ -63,7 +72,7 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
     public function testSoftDeletingOpenLeadDecrementsCounterExactlyOnce(): void
     {
         $person = $this->createPerson();
-        $lead = $this->createLead($person, status: 0);
+        $lead = $this->createLead($person, leadsStatusId: 1);
         $this->assertSame(1, $this->activeLeadsCount($person));
 
         $lead->softDelete();
@@ -78,7 +87,7 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
     public function testHardDeletingOpenLeadDecrementsCounter(): void
     {
         $person = $this->createPerson();
-        $lead = $this->createLead($person, status: 0);
+        $lead = $this->createLead($person, leadsStatusId: 1);
         $this->assertSame(1, $this->activeLeadsCount($person));
 
         try {
@@ -94,7 +103,7 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
     {
         $personA = $this->createPerson();
         $personB = $this->createPerson();
-        $lead = $this->createLead($personA, status: 0);
+        $lead = $this->createLead($personA, leadsStatusId: 1);
         $this->assertSame(1, $this->activeLeadsCount($personA));
         $this->assertSame(0, $this->activeLeadsCount($personB));
 
@@ -109,8 +118,8 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
     {
         $marker = $this->marker();
         $person = $this->createPerson($marker);
-        $this->createLead($person, status: 0, ownerId: 51);
-        $this->createLead($person, status: 5, ownerId: 52);
+        $this->createLead($person, leadsStatusId: 1, ownerId: 51);
+        $this->createLead($person, leadsStatusId: 3, ownerId: 52);
 
         $this->assertSame(1, $this->activeLeadsCount($person));
 
@@ -147,8 +156,8 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
     {
         $marker = $this->marker();
         $person = $this->createPerson($marker);
-        $this->createLead($person, status: 0, ownerId: 53);
-        $this->createLead($person, status: 5, ownerId: 53);
+        $this->createLead($person, leadsStatusId: 1, ownerId: 53);
+        $this->createLead($person, leadsStatusId: 3, ownerId: 53);
 
         $raw = $this->graphQL(
             'query($marker: Mixed) {
@@ -180,6 +189,113 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
         $this->assertSame([$person->getId()], $ids);
     }
 
+    public function testCurrentCustomersQueryReturnsOnlyPeopleWithAnOpenLead(): void
+    {
+        $marker = $this->marker();
+        $current = $this->createPerson($marker . '-current');
+        $past = $this->createPerson($marker . '-past');
+        $this->createLead($current, leadsStatusId: 1);
+        $this->createLead($past, leadsStatusId: 3);
+
+        $raw = $this->graphQL(
+            'query($marker: Mixed!) {
+                peoples(
+                    where: {
+                        AND: [
+                            { column: FIRSTNAME, operator: LIKE, value: $marker }
+                            { column: ACTIVE_LEADS_COUNT, operator: GT, value: 0 }
+                        ]
+                    }
+                ) {
+                    data { id }
+                }
+            }',
+            ['marker' => $marker . '%'],
+        )->assertOk()->json();
+
+        $ids = array_map(
+            fn (array $row) => (int) $row['id'],
+            $raw['data']['peoples']['data'] ?? [],
+        );
+
+        $this->assertSame([$current->getId()], $ids);
+    }
+
+    public function testPastCustomersQueryReturnsOnlyPeopleWithoutAnOpenLead(): void
+    {
+        $marker = $this->marker();
+        $current = $this->createPerson($marker . '-current');
+        $past = $this->createPerson($marker . '-past');
+        $this->createLead($current, leadsStatusId: 2);
+        $this->createLead($past, leadsStatusId: 3);
+
+        $raw = $this->graphQL(
+            'query($marker: Mixed!) {
+                peoples(
+                    where: {
+                        AND: [
+                            { column: FIRSTNAME, operator: LIKE, value: $marker }
+                            { column: ACTIVE_LEADS_COUNT, operator: EQ, value: 0 }
+                        ]
+                    }
+                ) {
+                    data { id }
+                }
+            }',
+            ['marker' => $marker . '%'],
+        )->assertOk()->json();
+
+        $ids = array_map(
+            fn (array $row) => (int) $row['id'],
+            $raw['data']['peoples']['data'] ?? [],
+        );
+
+        $this->assertSame([$past->getId()], $ids);
+    }
+
+    public function testPersonWithOnlyClosedLeadsMovesFromCurrentToPastAfterStatusChange(): void
+    {
+        $marker = $this->marker();
+        $person = $this->createPerson($marker);
+        $lead = $this->createLead($person, leadsStatusId: 1);
+
+        $currentIds = $this->fetchIdsByActiveLeadsCount($marker, isCurrent: true);
+        $this->assertSame([$person->getId()], $currentIds);
+        $this->assertSame([], $this->fetchIdsByActiveLeadsCount($marker, isCurrent: false));
+
+        $lead->leads_status_id = 3;
+        $lead->saveOrFail();
+
+        $this->assertSame([], $this->fetchIdsByActiveLeadsCount($marker, isCurrent: true));
+        $this->assertSame([$person->getId()], $this->fetchIdsByActiveLeadsCount($marker, isCurrent: false));
+    }
+
+    private function fetchIdsByActiveLeadsCount(string $marker, bool $isCurrent): array
+    {
+        $operator = $isCurrent ? 'GT' : 'EQ';
+
+        $raw = $this->graphQL(
+            'query($marker: Mixed!) {
+                peoples(
+                    where: {
+                        AND: [
+                            { column: FIRSTNAME, operator: LIKE, value: $marker }
+                            { column: ACTIVE_LEADS_COUNT, operator: ' . $operator . ', value: 0 }
+                        ]
+                    }
+                ) {
+                    data { id }
+                }
+            }',
+            ['marker' => $marker . '%'],
+        )->assertOk()->json();
+
+        return array_map(
+            fn (array $row) => (int) $row['id'],
+            $raw['data']['peoples']['data'] ?? [],
+        );
+    }
+
     private function activeLeadsCount(People $person): int
     {
         return (int) People::query()->find($person->getId())->active_leads_count;
@@ -202,7 +318,7 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
         return $people->fresh();
     }
 
-    private function createLead(People $people, int $status, int $ownerId = 50): Lead
+    private function createLead(People $people, int $leadsStatusId, int $ownerId = 50): Lead
     {
         $app = app(Apps::class);
         $user = auth()->user();
@@ -214,7 +330,7 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
             ->withPeopleId($people->getId())
             ->create([
                 'leads_owner_id' => $ownerId,
-                'status' => $status,
+                'leads_status_id' => $leadsStatusId,
             ]);
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #10996. `Lead::isOpen()` defines "open" as `status < 2`, and `LeadObserver` used that to maintain `peoples.active_leads_count`. Turns out the `status` int column is **never written anywhere in the app** — `UpdateLeadAction`, `SetLeadStatusTool`, `leadWonOrLost`, and `Lead::close()`/`open()` all only ever set `leads_status_id`. So `status` stays frozen at its DB default (`0`) forever, `isOpen()` always evaluates `true`, and `active_leads_count` was effectively counting "has any non-deleted lead" instead of "has an open lead" — confirmed in production with people whose leads were `leads_status_id` → "Sold"/"Bad" still showing up as Current.

- Added `Lead::hasOpenLeadStatus()` / `scopeHasOpenLeadStatus()` — checks `leads_status_id IN (1, 2)`, the two SalesAssist-active statuses, with a `TODO` to replace this once `leads_status` gets a real `category`/`is_closed` column (it's currently a free-form per-company list with no such semantic field, so a generic solution isn't possible yet).
- Swapped `LeadObserver::isCounted()`/`wasCounted()` and `RecalculateActiveLeadsCountCommand` off `isOpen()`/`scopeIsOpen()` onto the new methods.
- Updated the `active_leads_count` migration's backfill SQL to match (does not affect prod — that migration already ran there).
- Left `Lead::isOpen()`/`scopeIsOpen()` in place (unused now) rather than deleting, since they're a faithful, correct implementation of the `status` column definition — just not the one we want here.

## Post-deploy step required

The migration in #10996 already ran in production and backfilled `active_leads_count` using the old (always-true) definition. This PR does not fix that data — after this merges, run:

```bash
php artisan kanvas-guild:recalculate-active-leads-count --dry-run   # check scope first
php artisan kanvas-guild:recalculate-active-leads-count             # then for real
```

## Test plan

- [x] `tests/Guild/LeadActiveLeadsCounterObserverTest.php` — 13/13 passing, rewritten to build leads via `leads_status_id` (1 and 2 both exercised as open, 3 as closed), plus 3 new tests specifically for Current/Past classification
- [x] `tests/Guild/` full suite — 219/219 passing, no regressions
- [x] `tests/GraphQL/Guild/PeopleTest.php` — same pre-existing unrelated flaky failure (`updatePeoplePhoto`) as on `development`, not caused by this change
- [x] `phpstan analyse` on all touched files — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)