### PR TITLE
refactor: dedupe open-status ids and Current/Past test queries

### DIFF
--- a/src/Domains/Guild/Leads/Models/Lead.php
+++ b/src/Domains/Guild/Leads/Models/Lead.php
@@ -327,14 +327,16 @@ class Lead extends BaseModel implements EventResourceInterface
      * This hardcodes the known global seed ids as a stopgap — replace with a
      * real category lookup once `leads_status` gets that column.
      */
+    public const array OPEN_LEADS_STATUS_IDS = [1, 2];
+
     public function hasOpenLeadStatus(): bool
     {
-        return in_array((int) $this->getAttributeValue('leads_status_id'), [1, 2], true);
+        return in_array((int) $this->getAttributeValue('leads_status_id'), self::OPEN_LEADS_STATUS_IDS, true);
     }
 
     public function scopeHasOpenLeadStatus(Builder $query): Builder
     {
-        return $query->whereIn('leads_status_id', [1, 2]);
+        return $query->whereIn('leads_status_id', self::OPEN_LEADS_STATUS_IDS);
     }
 
     public function isActive(): bool

--- a/src/Domains/Guild/Leads/Observers/LeadObserver.php
+++ b/src/Domains/Guild/Leads/Observers/LeadObserver.php
@@ -257,7 +257,7 @@ class LeadObserver
 
     private function wasCounted(Lead $lead): bool
     {
-        return in_array((int) $lead->getOriginal('leads_status_id'), [1, 2], true)
+        return in_array((int) $lead->getOriginal('leads_status_id'), Lead::OPEN_LEADS_STATUS_IDS, true)
             && ! (bool) $lead->getOriginal('is_deleted');
     }
 

--- a/tests/Guild/LeadActiveLeadsCounterObserverTest.php
+++ b/tests/Guild/LeadActiveLeadsCounterObserverTest.php
@@ -197,28 +197,10 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
         $this->createLead($current, leadsStatusId: 1);
         $this->createLead($past, leadsStatusId: 3);
 
-        $raw = $this->graphQL(
-            'query($marker: Mixed!) {
-                peoples(
-                    where: {
-                        AND: [
-                            { column: FIRSTNAME, operator: LIKE, value: $marker }
-                            { column: ACTIVE_LEADS_COUNT, operator: GT, value: 0 }
-                        ]
-                    }
-                ) {
-                    data { id }
-                }
-            }',
-            ['marker' => $marker . '%'],
-        )->assertOk()->json();
-
-        $ids = array_map(
-            fn (array $row) => (int) $row['id'],
-            $raw['data']['peoples']['data'] ?? [],
+        $this->assertSame(
+            [$current->getId()],
+            $this->fetchIdsByActiveLeadsCount($marker, isCurrent: true),
         );
-
-        $this->assertSame([$current->getId()], $ids);
     }
 
     public function testPastCustomersQueryReturnsOnlyPeopleWithoutAnOpenLead(): void
@@ -229,28 +211,10 @@ final class LeadActiveLeadsCounterObserverTest extends TestCase
         $this->createLead($current, leadsStatusId: 2);
         $this->createLead($past, leadsStatusId: 3);
 
-        $raw = $this->graphQL(
-            'query($marker: Mixed!) {
-                peoples(
-                    where: {
-                        AND: [
-                            { column: FIRSTNAME, operator: LIKE, value: $marker }
-                            { column: ACTIVE_LEADS_COUNT, operator: EQ, value: 0 }
-                        ]
-                    }
-                ) {
-                    data { id }
-                }
-            }',
-            ['marker' => $marker . '%'],
-        )->assertOk()->json();
-
-        $ids = array_map(
-            fn (array $row) => (int) $row['id'],
-            $raw['data']['peoples']['data'] ?? [],
+        $this->assertSame(
+            [$past->getId()],
+            $this->fetchIdsByActiveLeadsCount($marker, isCurrent: false),
         );
-
-        $this->assertSame([$past->getId()], $ids);
     }
 
     public function testPersonWithOnlyClosedLeadsMovesFromCurrentToPastAfterStatusChange(): void


### PR DESCRIPTION
## Summary

Follow-up cleanup to #11008 (already merged, but this commit was pushed after the merge so it never made it into `development`). Found during a `/kanvas-backend-review` pass on that PR's diff:

- The hardcoded `leads_status_id` list `[1, 2]` was duplicated in 3 places (`Lead::hasOpenLeadStatus()`, `Lead::scopeHasOpenLeadStatus()`, `LeadObserver::wasCounted()`). Extracted into `Lead::OPEN_LEADS_STATUS_IDS` so they can't drift from each other if the active status ids ever change.
- `testCurrentCustomersQueryReturnsOnlyPeopleWithAnOpenLead` / `testPastCustomersQueryReturnsOnlyPeopleWithoutAnOpenLead` were re-inlining the same GraphQL query + id-extraction logic already generalized in the `fetchIdsByActiveLeadsCount()` helper (used by the third new test). Collapsed onto the helper — same behavior, less duplication.

No behavior change — purely mechanical dedup.

## Test plan

- [x] `tests/Guild/LeadActiveLeadsCounterObserverTest.php` — 13/13 passing
- [x] `php -l` on all 3 touched files — no errors
- [x] `phpstan analyse` on all 3 touched files — no errors
- [x] Manually verified against a live GraphiQL session (created custom lead statuses, created leads with open/closed statuses, confirmed Current/Past classification and `active_leads_count` values match expectations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)