### PR TITLE
feat(google-sheets): support domain-wide delegation as an alternative to direct sharing

### DIFF
--- a/src/Domains/Connectors/GoogleSheets/CLAUDE.md
+++ b/src/Domains/Connectors/GoogleSheets/CLAUDE.md
@@ -113,13 +113,32 @@ The service account can only touch a spreadsheet that has been explicitly shared
 Without this, every call fails with a permission error from the Sheets API — the credentials
 being configured correctly is not enough on its own.
 
-### Alternative: domain-wide delegation (when the tenant's Workspace blocks external sharing)
+### Diagnosing a blocked share
 
-Some Workspace tenants block sharing files with any account outside the org (Trust Rules, or a
-plan that doesn't support adding new Trust Rules) — the service account's email is external, so
-the share in the section above fails there no matter what. The fix is **domain-wide
-delegation**: the service account impersonates a real internal user instead of acting as itself,
-so no external share is ever needed.
+If sharing the sheet with the service account's email fails with something like *"Policy set by
+the administrators of [org] prohibits the sharing of items with [service account], because it is
+not a Google Account in a compatible allowlisted domain"* — the tenant's Workspace has one of two
+sharing restrictions in play. Check **Admin Console → Apps → Google Workspace → Drive and Docs →
+Sharing settings**:
+
+- **"Sharing outside of [org]" is set to `Off`, or set to `Allowlisted domains` but the service
+  account's domain (`....iam.gserviceaccount.com`) isn't in that list** — a super-admin adds it
+  there. This alone sometimes isn't enough if the org has also adopted Trust Rules (next point).
+- **The domain shows an "Incompatible with allowlisted domains" warning even after being added**
+  — this means the org has migrated Drive sharing enforcement to **Trust Rules**
+  (`Admin Console → Rules → Trust rules`), which override the classic domain allowlist entirely.
+  The fix is a Trust Rule (scoped to the relevant Org Unit) that allows sharing with anyone in
+  allowlisted domains — not just adding the domain to the old list, which no longer has any
+  effect once Trust Rules govern that org.
+- **"Create rule" for a new Trust Rule is greyed out even for a super-admin** — Trust Rule
+  *creation* is gated behind the Workspace edition/add-on, separate from being able to view
+  existing rules. If upgrading the plan isn't an option, domain-wide delegation below sidesteps
+  the whole sharing-policy question, since it never shares anything externally in the first place.
+
+### Alternative: domain-wide delegation (when direct sharing can't be unblocked)
+
+The fix for any of the above is **domain-wide delegation**: the service account impersonates a
+real internal user instead of acting as itself, so no external share is ever needed.
 
 1. In [Google Cloud Console](https://console.cloud.google.com/) → **IAM & Admin → Service
    Accounts** → open the service account → copy its **OAuth2 Client ID** (a numeric id, distinct
@@ -196,7 +215,7 @@ column A (ID invoice) — column **D** (Status) → `"Approved"`, column **E** (
 | 3 | `gmail-refresh-token` (scope `gmail.modify` — covers reading AND sending) | Settings → Key Configurations | Gmail |
 | 4 | `google-sheets-credentials` | Settings → Key Configurations | GoogleSheets |
 | 5 | `google-sheets-default-invoice-tracker` | Settings → Key Configurations | GoogleSheets |
-| 6 | Sheet shared as Editor with the service account's `client_email` | Google Sheets UI, per-sheet | GoogleSheets |
+| 6 | Sheet shared as Editor with the service account's `client_email` — **or**, if the tenant's Workspace blocks that, `google-sheets-impersonate-user` set + domain-wide delegation authorized (see below) | Google Sheets UI, per-sheet — or Settings → Key Configurations | GoogleSheets |
 | 7 | Sheet has columns A–F as ID invoice / vendor / total / Status / Approved Date / Approved By | Google Sheets UI, per-sheet | GoogleSheets |
 | 8–10 | The 3 approval-queue keys (who can approve, their Slack id, the notifier agent's id) | Settings → Key Configurations | see `Scribe/Approvals/CLAUDE.md` |
 | 11 | Acumatica credentials (see that connector's own docs) | Settings → Key Configurations | Acumatica |

--- a/src/Domains/Connectors/GoogleSheets/CLAUDE.md
+++ b/src/Domains/Connectors/GoogleSheets/CLAUDE.md
@@ -102,7 +102,7 @@ The sheet still needs the service account shared as Editor on it (see below) —
 saves the agent from needing the URL repeated in every message. Without this key set, the agent
 falls back to asking for a sheet link when it needs to log something.
 
-### Per-sheet sharing (always required, cannot be automated)
+### Per-sheet sharing (default path)
 
 The service account can only touch a spreadsheet that has been explicitly shared with it. For
 **every** sheet an agent needs to read or write:
@@ -112,6 +112,30 @@ The service account can only touch a spreadsheet that has been explicitly shared
 
 Without this, every call fails with a permission error from the Sheets API — the credentials
 being configured correctly is not enough on its own.
+
+### Alternative: domain-wide delegation (when the tenant's Workspace blocks external sharing)
+
+Some Workspace tenants block sharing files with any account outside the org (Trust Rules, or a
+plan that doesn't support adding new Trust Rules) — the service account's email is external, so
+the share in the section above fails there no matter what. The fix is **domain-wide
+delegation**: the service account impersonates a real internal user instead of acting as itself,
+so no external share is ever needed.
+
+1. In [Google Cloud Console](https://console.cloud.google.com/) → **IAM & Admin → Service
+   Accounts** → open the service account → copy its **OAuth2 Client ID** (a numeric id, distinct
+   from its email).
+2. A Workspace super-admin goes to `admin.google.com` → **Security → Access and data control →
+   API Controls → Domain-wide Delegation → Add new** → paste that Client ID → scope
+   `https://www.googleapis.com/auth/spreadsheets` → **Authorize**.
+3. Set `google-sheets-impersonate-user` (`ConfigurationEnum::IMPERSONATE_USER`) to a real
+   Workspace email that already has normal (internal) access to the target sheet(s) — `Client`
+   calls `Google\Client::setSubject()` with it, so every API call is made *as that person*, not
+   as the service account.
+4. The sheet itself is **not** shared with the service account at all under this path — it only
+   needs to be a sheet the impersonated user can already open normally.
+
+This key is optional and additive — leave it unset and the connector behaves exactly as before
+(the direct-share model above).
 
 ## Security note
 

--- a/src/Domains/Connectors/GoogleSheets/Client.php
+++ b/src/Domains/Connectors/GoogleSheets/Client.php
@@ -41,6 +41,11 @@ class Client
             $googleClient->setAuthConfig($decoded);
             $googleClient->addScope(GoogleSheetsService::SPREADSHEETS);
 
+            $impersonateUser = trim((string) ($app->get(ConfigurationEnum::IMPERSONATE_USER->value) ?? ''));
+            if ($impersonateUser !== '') {
+                $googleClient->setSubject($impersonateUser);
+            }
+
             return new GoogleSheetsService($googleClient);
         } catch (Throwable $e) {
             throw new ValidationException('Could not authenticate with Google Sheets: ' . $e->getMessage());

--- a/src/Domains/Connectors/GoogleSheets/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/GoogleSheets/Enums/ConfigurationEnum.php
@@ -11,4 +11,13 @@ enum ConfigurationEnum: string
 
     /** The sheet URL/id the AP/AR agents log invoices to when a tool call doesn't specify one. */
     case DEFAULT_INVOICE_SHEET = 'google-sheets-default-invoice-tracker';
+
+    /**
+     * Optional: a real Workspace user's email to impersonate via domain-wide delegation, instead of
+     * sharing every sheet with the service account directly. Requires a Workspace admin to authorize
+     * the service account's OAuth Client ID for the Sheets scope under Admin Console > Security >
+     * API Controls > Domain-wide Delegation. Use this when the tenant's Workspace blocks external
+     * sharing (e.g. Trust Rules) and the impersonated user already has normal internal access.
+     */
+    case IMPERSONATE_USER = 'google-sheets-impersonate-user';
 }

--- a/tests/Connectors/GoogleSheets/ClientTest.php
+++ b/tests/Connectors/GoogleSheets/ClientTest.php
@@ -23,17 +23,20 @@ class ClientTest extends TestCase
      * clobbers a real credential.
      */
     private mixed $originalCredentials = null;
+    private mixed $originalImpersonateUser = null;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->originalCredentials = app(Apps::class)->get(ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value);
+        $this->originalImpersonateUser = app(Apps::class)->get(ConfigurationEnum::IMPERSONATE_USER->value);
     }
 
     protected function tearDown(): void
     {
         app(Apps::class)->set(ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value, $this->originalCredentials);
+        app(Apps::class)->set(ConfigurationEnum::IMPERSONATE_USER->value, $this->originalImpersonateUser);
 
         parent::tearDown();
     }
@@ -74,6 +77,28 @@ class ClientTest extends TestCase
         $service = Client::getInstance($app);
 
         $this->assertNotNull($service->spreadsheets_values);
+    }
+
+    public function test_impersonates_the_configured_user_via_domain_wide_delegation(): void
+    {
+        $app = app(Apps::class);
+        $app->set(ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value, $this->fakeServiceAccountJson());
+        $app->set(ConfigurationEnum::IMPERSONATE_USER->value, 'apex@nzxt.com');
+
+        $service = Client::getInstance($app);
+
+        $this->assertSame('apex@nzxt.com', $service->getClient()->getConfig('subject'));
+    }
+
+    public function test_does_not_impersonate_anyone_when_the_key_is_left_unset(): void
+    {
+        $app = app(Apps::class);
+        $app->set(ConfigurationEnum::GOOGLE_SHEETS_CREDENTIALS->value, $this->fakeServiceAccountJson());
+        $app->set(ConfigurationEnum::IMPERSONATE_USER->value, '');
+
+        $service = Client::getInstance($app);
+
+        $this->assertNull($service->getClient()->getConfig('subject'));
     }
 
     public function test_throws_a_clear_error_when_nothing_is_configured(): void


### PR DESCRIPTION
1.x mirror of #11012.

## Summary
- Adds an optional `google-sheets-impersonate-user` config key — when set, `Client` impersonates that real Workspace user via domain-wide delegation instead of acting as the service account directly, so no external file share is needed.
- Unblocks tenants whose Workspace blocks external sharing (Trust Rules with no room to add new ones).
- Fully optional, backward-compatible.

## Test plan
- [x] Same as #11012 — 21/21 GoogleSheets tests green in this branch too.