### PR TITLE
feat(voice): populate the captured lead's description

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
@@ -267,6 +267,7 @@ class CaptureVoiceCallerAction
             type_id: $leadType->getId(),
             source_id: $leadSource->getId(),
             receiver_id: $leadReceiver->getId(),
+            description: $this->leadDescription(),
         );
 
         $lead = new CreateLeadAction($leadData)->execute();
@@ -297,5 +298,20 @@ class CaptureVoiceCallerAction
         ]);
 
         return implode(' — ', $parts);
+    }
+
+    /**
+     * Human-facing lead description for the CRM: how the lead came in plus the
+     * interest the agent captured (when any).
+     */
+    private function leadDescription(): string
+    {
+        $direction = $this->direction === 'outbound' ? 'Outbound' : 'Inbound';
+        $parts = ["{$direction} voice call captured by the AI agent."];
+        if ($this->interest !== null && trim($this->interest) !== '') {
+            $parts[] = 'Interest: ' . trim($this->interest);
+        }
+
+        return implode(' ', $parts);
     }
 }


### PR DESCRIPTION
Follow-up to #11006 (already merged) — the title change landed there; this adds the **description**, which was still null on captured leads.

## What
`LeadData` supports `description` but capture never set it, so voice-captured leads had a null description. Populate it with how the lead came in plus the captured interest:

```
Outbound voice call captured by the AI agent. Interest: interested in a 2024 Camry.
```

The interest clause is omitted when none was captured. Extracted into a small `leadDescription()` helper; no other behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)