### PR TITLE
feat(voice): richer captured-lead context (summary + appointment intent)

### DIFF
--- a/app/GraphQL/Intelligence/Mutations/VoiceAgentCallerMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/VoiceAgentCallerMutation.php
@@ -33,6 +33,9 @@ class VoiceAgentCallerMutation
             $args['interest'] ?? null,
             (bool) ($args['interested'] ?? false),
             $args['direction'] ?? null,
+            $args['summary'] ?? null,
+            (bool) ($args['wants_appointment'] ?? false),
+            $args['appointment_preference'] ?? null,
         )->execute();
     }
 }

--- a/graphql/schemas/Intelligence/voiceAgent.graphql
+++ b/graphql/schemas/Intelligence/voiceAgent.graphql
@@ -118,7 +118,7 @@ extend type Mutation @guardByAppKey {
             resolver: "App\\GraphQL\\Intelligence\\Mutations\\VoiceAgentToolMutation@run"
         )
     "Data plane: capture the caller behind a phone as a contact, promoting to a lead on repeat or clear intent (outbound requires intent). Phone/direction come from the runtime, not the LLM."
-    captureVoiceLead(agent_uuid: String!, phone: String!, name: String, interest: String, interested: Boolean, direction: String): Mixed
+    captureVoiceLead(agent_uuid: String!, phone: String!, name: String, interest: String, interested: Boolean, direction: String, summary: String, wants_appointment: Boolean, appointment_preference: String): Mixed
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Mutations\\VoiceAgentCallerMutation@capture"
         )

--- a/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/CaptureVoiceCallerAction.php
@@ -54,6 +54,9 @@ class CaptureVoiceCallerAction
         private readonly ?string $interest = null,
         private readonly bool $interested = false,
         private readonly ?string $direction = null,
+        private readonly ?string $summary = null,
+        private readonly bool $wantsAppointment = false,
+        private readonly ?string $appointmentPreference = null,
     ) {
     }
 
@@ -102,6 +105,12 @@ class CaptureVoiceCallerAction
             if ($this->interest !== null && $this->interest !== '') {
                 $people->set('voice_interest', $this->interest);
             }
+            if ($this->wantsAppointment) {
+                $people->set('voice_wants_appointment', '1');
+                if ($this->appointmentPreference !== null && $this->appointmentPreference !== '') {
+                    $people->set('voice_appointment_preference', $this->appointmentPreference);
+                }
+            }
 
             // Promote to a lead when there's no active lead yet. OUTBOUND (we
             // dialed them) requires clear intent — placing the call isn't itself
@@ -116,8 +125,9 @@ class CaptureVoiceCallerAction
                 $lead = $this->createLeadFromPeople($people, $user);
                 $createdLead = true;
             }
-            if ($lead !== null && $this->interest !== null && $this->interest !== '') {
-                $lead->set(ConfigurationEnum::LEAD_CONTEXT_INFO->value, $this->interest);
+            $contextInfo = $this->buildContextInfo();
+            if ($lead !== null && $contextInfo !== '') {
+                $lead->set(ConfigurationEnum::LEAD_CONTEXT_INFO->value, $contextInfo);
             }
 
             return [
@@ -311,7 +321,39 @@ class CaptureVoiceCallerAction
         if ($this->interest !== null && trim($this->interest) !== '') {
             $parts[] = 'Interest: ' . trim($this->interest);
         }
+        if ($this->summary !== null && trim($this->summary) !== '') {
+            $parts[] = trim($this->summary);
+        }
+        if ($this->wantsAppointment) {
+            $parts[] = $this->appointmentNote();
+        }
 
         return implode(' ', $parts);
+    }
+
+    /**
+     * The AI-facing lead context, round-tripped via LEAD_CONTEXT_INFO and read
+     * back on the next call: the caller's interest, the agent's call summary, and
+     * any appointment request. Empty string when nothing was captured.
+     */
+    private function buildContextInfo(): string
+    {
+        $lines = array_filter([
+            ($this->interest !== null && trim($this->interest) !== '') ? 'Interest: ' . trim($this->interest) : null,
+            ($this->summary !== null && trim($this->summary) !== '') ? trim($this->summary) : null,
+            $this->wantsAppointment ? $this->appointmentNote() : null,
+        ]);
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * A one-line appointment note including the caller's time preference, if any.
+     */
+    private function appointmentNote(): string
+    {
+        $pref = trim((string) $this->appointmentPreference);
+
+        return $pref !== '' ? "Wants an appointment: {$pref}." : 'Wants an appointment.';
     }
 }


### PR DESCRIPTION
Adds richer context to captured voice leads — a free-text call **summary** plus **appointment intent** — beyond the short interest.

## New `captureVoiceLead` args
- `summary` — the agent's recap of the call (timeline, vehicle, budget, trade-in, etc.).
- `wants_appointment` (Boolean) + `appointment_preference` (String, e.g. "Saturday morning").

## Stored where
- **`LEAD_CONTEXT_INFO`** (the field read back on the next call) now composes: `Interest: … / <summary> / Wants an appointment: <pref>.`
- Lead **description** gets the same richer content.
- Appointment intent is also saved on the **People** (`voice_wants_appointment`, `voice_appointment_preference`) for follow-up/queries.

Context-only for now — no calendar event/task is created (that's a later step).

Pairs with the runtime PR that sends these new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)