### PR TITLE
Index people addresses by deletion status

### DIFF
--- a/database/migrations/Guild/2026_08_26_000001_add_people_deleted_index_to_peoples_address.php
+++ b/database/migrations/Guild/2026_08_26_000001_add_people_deleted_index_to_peoples_address.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    private const string INDEX_NAME = 'peoples_address_peoples_id_is_deleted_idx';
+
+    public function up(): void
+    {
+        Schema::connection('crm')->table('peoples_address', function (Blueprint $table) {
+            $table->index(['peoples_id', 'is_deleted'], self::INDEX_NAME);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection('crm')->table('peoples_address', function (Blueprint $table) {
+            $table->dropIndex(self::INDEX_NAME);
+        });
+    }
+};


### PR DESCRIPTION
Summary:
- add a composite index on peoples_address(peoples_id, is_deleted)
- use the CRM database connection
- add a reversible down migration with an explicit index name

Validation:
- PHP syntax check passed
- git diff --check passed