### PR TITLE
feat(notifications): include branch_id in lead push notification payloads

### DIFF
--- a/src/Domains/Connectors/Elead/Actions/AddOutBoundPhoneCallActivityToLeadAction.php
+++ b/src/Domains/Connectors/Elead/Actions/AddOutBoundPhoneCallActivityToLeadAction.php
@@ -126,6 +126,7 @@ class AddOutBoundPhoneCallActivityToLeadAction
                 'lead_name' => $this->lead->people->name,
                 'lead_id' => $this->lead->getId(),
                 'people_id' => $this->lead->people->getId(),
+                'branch_id' => $this->lead->companies_branches_id,
             ],
             via: ['sms', 'push', 'expo', 'mail', 'database'],
             entity: $this->lead

--- a/src/Domains/Guild/Leads/Services/NotifyLeadStakeholdersService.php
+++ b/src/Domains/Guild/Leads/Services/NotifyLeadStakeholdersService.php
@@ -147,6 +147,7 @@ class NotifyLeadStakeholdersService
                 'lead_name' => $this->lead->people->name,
                 'lead_id' => $this->lead->getId(),
                 'people_id' => $this->lead->people->getId(),
+                'branch_id' => $this->lead->companies_branches_id,
             ],
             via: $channels,
             entity: $this->lead
@@ -223,6 +224,7 @@ class NotifyLeadStakeholdersService
                 'lead_name' => $this->lead->people->name,
                 'lead_id' => $this->lead->getId(),
                 'people_id' => $this->lead->people->getId(),
+                'branch_id' => $this->lead->companies_branches_id,
             ],
             via: $channels,
             entity: $this->lead

--- a/src/Domains/Intelligence/Actions/HandOffAction.php
+++ b/src/Domains/Intelligence/Actions/HandOffAction.php
@@ -169,6 +169,7 @@ class HandOffAction
                 'lead_name' => $this->lead->people->name,
                 'lead_id' => $this->lead->getId(),
                 'people_id' => $this->lead->people->getId(),
+                'branch_id' => $this->lead->companies_branches_id,
                 ...$this->params,
             ]
         );


### PR DESCRIPTION
## Summary
- Adds `branch_id` (`companies_branches_id`) alongside `people_id`/`lead_id` in the Expo push notification data payload for the three lead-related notifications that carry those keys:
  - `HandOffAction::createHandOffNotification()`
  - `NotifyLeadStakeholdersService::onCustomerEngagement()` / `onAgentReply()`
  - `AddOutBoundPhoneCallActivityToLeadAction::notifyManagers()`
- Lets recipients identify which branch the notification originated from.

## Test plan
- [ ] No automated test coverage exists yet for these notification data payloads (confirmed: `HandOffActionTest` fakes notifications but doesn't assert payload content; `NotifyLeadStakeholdersService` and `AddOutBoundPhoneCallActivityToLeadAction` have no tests).
- [ ] Manual: trigger a hand-off / customer-engagement / stop-the-clock notification and confirm `branch_id` appears in the Expo push data payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)