### PR TITLE
feat(movipass): activate free-tier parking reservations without payment

### DIFF
--- a/src/Domains/Connectors/Movipass/Actions/ApplyFreeParkingTierAction.php
+++ b/src/Domains/Connectors/Movipass/Actions/ApplyFreeParkingTierAction.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Movipass\Actions;
+
+use Illuminate\Support\Carbon;
+use Kanvas\Connectors\Movipass\Enums\ProductAttributeEnum;
+use Kanvas\Souk\Orders\Models\Order;
+
+class ApplyFreeParkingTierAction
+{
+    public function __construct(
+        protected readonly Order $order,
+    ) {
+    }
+
+    public function execute(): bool
+    {
+        if ($this->order->parent_id) {
+            return false;
+        }
+
+        $freeMinutes = $this->resolveFreeMinutes();
+
+        if ($freeMinutes === null) {
+            return false;
+        }
+
+        $startAt = Carbon::parse($this->order->metadata['data']['start_at'] ?? 'now');
+
+        $this->order->metadata = [
+            ...$this->order->metadata ?? [],
+            'data' => [
+                ...$this->order->metadata['data'] ?? [],
+                'start_at' => $startAt->toDateTimeString(),
+                // Derived here, never taken from the payload: the client controls the order total,
+                // so a client-supplied duration would hand out unlimited free parking.
+                'end_at' => $startAt->copy()->addMinutes($freeMinutes)->toDateTimeString(),
+                'free_tier' => true,
+                'free_minutes' => $freeMinutes,
+            ],
+        ];
+
+        $this->zeroOutAmounts();
+
+        $this->order->saveQuietly();
+
+        return true;
+    }
+
+    private function resolveFreeMinutes(): ?int
+    {
+        foreach ($this->order->items as $item) {
+            $attribute = $item->variant?->product?->getAttributeByName(ProductAttributeEnum::PARKING_FREE_MINUTES->value);
+
+            if ((int) $attribute?->value > 0) {
+                return (int) $attribute->value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Items are zeroed alongside the order totals so Order::calculateTotal(), which sums
+     * unit_price_net_amount × quantity, cannot resurrect a charge on a free reservation.
+     */
+    private function zeroOutAmounts(): void
+    {
+        $this->order->items()->update([
+            'unit_price_net_amount' => 0,
+            'unit_price_gross_amount' => 0,
+        ]);
+
+        $this->order->total_gross_amount = 0;
+        $this->order->total_net_amount = 0;
+        $this->order->discount_amount = 0;
+        $this->order->tax_amount = 0;
+    }
+}

--- a/src/Domains/Connectors/Movipass/Enums/ProductAttributeEnum.php
+++ b/src/Domains/Connectors/Movipass/Enums/ProductAttributeEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Movipass\Enums;
+
+enum ProductAttributeEnum: string
+{
+    case PARKING_FREE_MINUTES = 'parking_free_minutes';
+}

--- a/src/Domains/Connectors/Movipass/Workflows/Activities/SyncMovipassActivity.php
+++ b/src/Domains/Connectors/Movipass/Workflows/Activities/SyncMovipassActivity.php
@@ -9,6 +9,7 @@ use Baka\Helpers\GenerateQrCode;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\UploadedFile;
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Movipass\Actions\ApplyFreeParkingTierAction;
 use Kanvas\Connectors\Movipass\Enums\ConfigurationEnum;
 use Kanvas\Connectors\Movipass\Enums\MovipassOrderStatusEnum;
 use Kanvas\Connectors\Movipass\Enums\OrderTypeEnum;
@@ -74,7 +75,11 @@ class SyncMovipassActivity extends KanvasActivity implements WorkflowActivityInt
                         ],
                     ];
 
-                    if ($order->metadata['data']['is_manual'] ?? false) {
+                    // Applied before the transition: GetSlotAvailabilityAction filters on end_at,
+                    // so the STATUS_TRANSITION recalculation needs the free window already persisted.
+                    $isFreeTier = new ApplyFreeParkingTierAction($order)->execute();
+
+                    if ($isFreeTier || ($order->metadata['data']['is_manual'] ?? false)) {
                         $order->transitionToStatus(
                             $order->user,
                             MovipassOrderStatusEnum::ACTIVE->value

--- a/tests/Connectors/Integration/Movipass/ApplyFreeParkingTierActionTest.php
+++ b/tests/Connectors/Integration/Movipass/ApplyFreeParkingTierActionTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Integration\Movipass;
+
+use Illuminate\Support\Carbon;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Movipass\Actions\ApplyFreeParkingTierAction;
+use Kanvas\Connectors\Movipass\Enums\ProductAttributeEnum;
+use Tests\Connectors\Traits\CreatesMovipassParkingOrder;
+use Tests\Connectors\Traits\HasIntegrationCompany;
+use Tests\GraphQL\Inventory\Traits\InventoryCases;
+use Tests\GraphQL\Souk\Traits\PaymentCases;
+use Tests\TestCase;
+
+final class ApplyFreeParkingTierActionTest extends TestCase
+{
+    use CreatesMovipassParkingOrder;
+    use HasIntegrationCompany;
+    use InventoryCases;
+    use PaymentCases;
+
+    public function testAppliesFreeWindowAndZeroesTheOrder(): void
+    {
+        $app = app(Apps::class);
+
+        $order = $this->createMovipassOrder($app, [], [$this->freeMinutesAttribute(150)]);
+
+        $applied = new ApplyFreeParkingTierAction($order)->execute();
+
+        $order->refresh();
+
+        $this->assertTrue($applied);
+        $this->assertTrue($order->metadata['data']['free_tier']);
+        $this->assertEquals(150, $order->metadata['data']['free_minutes']);
+        $this->assertEquals(
+            Carbon::parse($order->metadata['data']['start_at'])->addMinutes(150)->toDateTimeString(),
+            $order->metadata['data']['end_at']
+        );
+        $this->assertEquals(0.0, (float) $order->total_gross_amount);
+        $this->assertEquals(0.0, (float) $order->total_net_amount);
+        $this->assertEquals(0.0, (float) $order->items->first()->unit_price_net_amount);
+    }
+
+    public function testEndAtFromThePayloadIsIgnored(): void
+    {
+        $app = app(Apps::class);
+        $startAt = now()->toDateTimeString();
+
+        $order = $this->createMovipassOrder(
+            $app,
+            [
+                'start_at' => $startAt,
+                'end_at' => now()->addHours(8)->toDateTimeString(),
+            ],
+            [$this->freeMinutesAttribute(150)]
+        );
+
+        new ApplyFreeParkingTierAction($order)->execute();
+
+        $order->refresh();
+
+        $this->assertEquals(
+            Carbon::parse($startAt)->addMinutes(150)->toDateTimeString(),
+            $order->metadata['data']['end_at']
+        );
+    }
+
+    public function testExtensionOrderIsNeverFree(): void
+    {
+        $app = app(Apps::class);
+
+        $reservation = $this->createMovipassOrder($app, [], [$this->freeMinutesAttribute(150)]);
+        $extension = $this->createMovipassOrder($app, [], [$this->freeMinutesAttribute(150)]);
+        $extension->parent_id = $reservation->getId();
+        $extension->saveQuietly();
+
+        $applied = new ApplyFreeParkingTierAction($extension)->execute();
+
+        $extension->refresh();
+
+        $this->assertFalse($applied);
+        $this->assertArrayNotHasKey('free_tier', $extension->metadata['data']);
+        $this->assertGreaterThan(0.0, (float) $extension->total_gross_amount);
+    }
+
+    public function testOrderWithoutTheAttributeIsUntouched(): void
+    {
+        $app = app(Apps::class);
+
+        $order = $this->createMovipassOrder($app);
+
+        $applied = new ApplyFreeParkingTierAction($order)->execute();
+
+        $order->refresh();
+
+        $this->assertFalse($applied);
+        $this->assertArrayNotHasKey('free_tier', $order->metadata['data']);
+        $this->assertArrayNotHasKey('end_at', $order->metadata['data']);
+        $this->assertGreaterThan(0.0, (float) $order->total_gross_amount);
+    }
+
+    private function freeMinutesAttribute(int $minutes): array
+    {
+        return [
+            'name' => ProductAttributeEnum::PARKING_FREE_MINUTES->value,
+            'value' => $minutes,
+        ];
+    }
+}

--- a/tests/Connectors/Integration/Movipass/SyncMovipassActivityTest.php
+++ b/tests/Connectors/Integration/Movipass/SyncMovipassActivityTest.php
@@ -6,17 +6,14 @@ namespace Tests\Connectors\Integration\Movipass;
 
 use Illuminate\Support\Facades\Auth;
 use Kanvas\Apps\Models\Apps;
-use Kanvas\Connectors\Movipass\Enums\OrderTypeEnum;
-use Kanvas\Connectors\Movipass\Handlers\MovipassHandler;
+use Kanvas\Connectors\Movipass\Enums\MovipassOrderStatusEnum;
+use Kanvas\Connectors\Movipass\Enums\ProductAttributeEnum;
 use Kanvas\Connectors\Movipass\Workflows\Activities\SyncMovipassActivity;
-use Kanvas\Inventory\Products\Models\Products;
-use Kanvas\Regions\Models\Regions;
 use Kanvas\Souk\Discounts\Models\Discount;
 use Kanvas\Souk\Discounts\Models\DiscountType;
-use Kanvas\Souk\Orders\Models\Order;
-use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Kanvas\Workflow\Enums\WorkflowEnum;
 use Kanvas\Workflow\Models\StoredWorkflow;
+use Tests\Connectors\Traits\CreatesMovipassParkingOrder;
 use Tests\Connectors\Traits\HasIntegrationCompany;
 use Tests\GraphQL\Inventory\Traits\InventoryCases;
 use Tests\GraphQL\Souk\Traits\PaymentCases;
@@ -24,6 +21,7 @@ use Tests\TestCase;
 
 final class SyncMovipassActivityTest extends TestCase
 {
+    use CreatesMovipassParkingOrder;
     use HasIntegrationCompany;
     use InventoryCases;
     use PaymentCases;
@@ -34,90 +32,6 @@ final class SyncMovipassActivityTest extends TestCase
         if (getenv('GITHUB_ACTIONS')) {
             $this->markTestSkipped('Movipass integration tests are skipped in CI');
         }
-    }
-
-    private function createMovipassOrder(Apps $app, array $metadataData = []): Order
-    {
-        $user = Auth::user();
-        $company = $user->getCurrentCompany();
-        $region = Regions::getDefault($company, $app);
-
-        $this->setIntegration(
-            $app,
-            IntegrationsEnum::MOVIPASS,
-            MovipassHandler::class,
-            $company,
-            $user
-        );
-
-        $this->setAllowNoPaymentStatus(true, $app);
-
-        $warehouseResponse = $this->createWarehouses((string) $region->getId())->json()['data']['createWarehouse'];
-        $productResponse = $this->createProduct(attributes: [
-            [
-                'name' => 'slots',
-                'value' => 100,
-            ],
-        ])->json()['data']['createProduct'];
-
-        $product = Products::fromApp($app)->find($productResponse['id']);
-
-        $channelResponse = $this->createChannel()->json()['data']['createChannel'];
-
-        $this->addVariantToChannel(
-            variantId: (string) $product->variants->first()->id,
-            channelId: $channelResponse['id'],
-            warehouseData: ['id' => $warehouseResponse['id']]
-        );
-
-        $this->addVariantToWarehouse(
-            variantId: (string) $product->variants->first()->id,
-            warehouseId: $warehouseResponse['id'],
-            amount: 100
-        );
-
-        $data = [
-            'cartId' => 0,
-            'customer' => [
-                'email' => fake()->email(),
-            ],
-            'order_type' => OrderTypeEnum::MOVIPASS->value,
-            'metadata' => [
-                'data' => array_merge([
-                    'vehiclePlate' => 'T000001',
-                    'vehicleBrand' => 'Toyota',
-                    'vehicleColor' => 'red',
-                    'is_manual' => false,
-                ], $metadataData),
-            ],
-            'items' => [
-                [
-                    'variant_id' => (string) $product->variants->first()->id,
-                    'quantity' => 1,
-                    'price' => 100,
-                ],
-            ],
-            'reference' => 'Movipass parking test',
-        ];
-
-        $response = $this->graphQL('
-            mutation createOrderFromCart($input: OrderCartInput!) {
-                createOrderFromCart(input: $input) {
-                    order {
-                        id
-                    }
-                }
-            }
-        ', [
-            'input' => $data,
-        ], [], [
-            'X-Kanvas-Location' => $company->branch->uuid,
-            'X-Kanvas-App' => $app->key,
-        ]);
-
-        $orderId = $response->json('data.createOrderFromCart.order.id');
-
-        return Order::fromApp($app)->find($orderId);
     }
 
     private function createActiveDiscount(Apps $app, int $companiesId): Discount
@@ -263,5 +177,38 @@ final class SyncMovipassActivityTest extends TestCase
 
         $this->assertEquals('success', $result['status']);
         $this->assertSame('Movipass parking test #' . $order->order_number, $order->reference);
+    }
+
+    public function testFreeTierOrderActivatesWithoutPayment(): void
+    {
+        $app = app(Apps::class);
+
+        $order = $this->createMovipassOrder($app, [], [$this->freeMinutesAttribute(150)]);
+
+        $activity = new SyncMovipassActivity(
+            0,
+            now()->toDateTimeString(),
+            new StoredWorkflow(),
+            []
+        );
+
+        $result = $activity->execute($order, $app, [
+            'currentEventTypeName' => WorkflowEnum::CREATED->value,
+        ]);
+
+        $order->refresh();
+
+        $this->assertEquals('success', $result['status']);
+        $this->assertTrue($order->metadata['data']['free_tier']);
+        $this->assertEquals(MovipassOrderStatusEnum::ACTIVE->slug(), $order->orderStatus?->slug);
+        $this->assertNotEquals('paid', $order->payment_status);
+    }
+
+    private function freeMinutesAttribute(int $minutes): array
+    {
+        return [
+            'name' => ProductAttributeEnum::PARKING_FREE_MINUTES->value,
+            'value' => $minutes,
+        ];
     }
 }

--- a/tests/Connectors/Traits/CreatesMovipassParkingOrder.php
+++ b/tests/Connectors/Traits/CreatesMovipassParkingOrder.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Traits;
+
+use Illuminate\Support\Facades\Auth;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Movipass\Enums\OrderTypeEnum;
+use Kanvas\Connectors\Movipass\Handlers\MovipassHandler;
+use Kanvas\Inventory\Products\Models\Products;
+use Kanvas\Regions\Models\Regions;
+use Kanvas\Souk\Orders\Models\Order;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+
+/**
+ * Requires HasIntegrationCompany, InventoryCases and PaymentCases on the consuming test case.
+ */
+trait CreatesMovipassParkingOrder
+{
+    protected function createMovipassOrder(
+        Apps $app,
+        array $metadataData = [],
+        array $productAttributes = []
+    ): Order {
+        $user = Auth::user();
+        $company = $user->getCurrentCompany();
+        $region = Regions::getDefault($company, $app);
+
+        $this->setIntegration(
+            $app,
+            IntegrationsEnum::MOVIPASS,
+            MovipassHandler::class,
+            $company,
+            $user
+        );
+
+        $this->setAllowNoPaymentStatus(true, $app);
+
+        $warehouseResponse = $this->createWarehouses((string) $region->getId())->json()['data']['createWarehouse'];
+        $productResponse = $this->createProduct(attributes: [
+            [
+                'name' => 'slots',
+                'value' => 100,
+            ],
+            ...$productAttributes,
+        ])->json()['data']['createProduct'];
+
+        $product = Products::fromApp($app)->find($productResponse['id']);
+
+        $channelResponse = $this->createChannel()->json()['data']['createChannel'];
+
+        $this->addVariantToChannel(
+            variantId: (string) $product->variants->first()->id,
+            channelId: $channelResponse['id'],
+            warehouseData: ['id' => $warehouseResponse['id']]
+        );
+
+        $this->addVariantToWarehouse(
+            variantId: (string) $product->variants->first()->id,
+            warehouseId: $warehouseResponse['id'],
+            amount: 100
+        );
+
+        $data = [
+            'cartId' => 0,
+            'customer' => [
+                'email' => fake()->email(),
+            ],
+            'order_type' => OrderTypeEnum::MOVIPASS->value,
+            'metadata' => [
+                'data' => array_merge([
+                    'vehiclePlate' => 'T000001',
+                    'vehicleBrand' => 'Toyota',
+                    'vehicleColor' => 'red',
+                    'is_manual' => false,
+                ], $metadataData),
+            ],
+            'items' => [
+                [
+                    'variant_id' => (string) $product->variants->first()->id,
+                    'quantity' => 1,
+                    'price' => 100,
+                ],
+            ],
+            'reference' => 'Movipass parking test',
+        ];
+
+        $response = $this->graphQL('
+            mutation createOrderFromCart($input: OrderCartInput!) {
+                createOrderFromCart(input: $input) {
+                    order {
+                        id
+                    }
+                }
+            }
+        ', [
+            'input' => $data,
+        ], [], [
+            'X-Kanvas-Location' => $company->branch->uuid,
+            'X-Kanvas-App' => $app->key,
+        ]);
+
+        $orderId = $response->json('data.createOrderFromCart.order.id');
+
+        return Order::fromApp($app)->find($orderId);
+    }
+}


### PR DESCRIPTION
Parking lots can now grant a free window (2.5h on the case that opened this): the parent reservation is created at zero and goes ACTIVE without ever passing through the payment flow. Overstay is billed by the existing extension flow (child order), so no new charging code.

Until now nothing could activate a zero-priced reservation. payment_status is only written by the real charge path (ProcessPaymentAction, CapturePaymentAction, CreatePaymentAction), and SyncPayablePaymentStatusAction cannot stand in for it: it returns early with no payment rows, and computeStatus() requires netPaid > 0, so even a zero-amount payment would not mark it paid. Without payment_status = paid the UPDATED branch never moves the order out of `created`.

The free window is derived in the backend, never taken from the payload. The order total comes from the client, and the payment gate was in practice what validated it: sending total 0 bought nothing while activation still required a captured payment. Activating without a charge removes that gate, so end_at is computed as start_at + parking_free_minutes and the requested duration is ignored. Otherwise a client asks for 8 free hours.

- parking_free_minutes lives on the product, matching the existing parking attribute convention. Absent or 0 leaves paid parking untouched.
- payment_status stays null on purpose: a free reservation is active without payment, not paid. No zero-amount payment row is created.
- Extensions are never free (parent_id orders are skipped).
- Items are zeroed alongside the order totals so Order::calculateTotal() cannot resurrect a charge.
- The tier is applied before the ACTIVE transition because GetSlotAvailabilityAction filters on end_at and the slot recalculation needs the window persisted.

The order-creation helper moves out of SyncMovipassActivityTest into a shared trait so the new action test can reuse it.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
