### PR TITLE
feat(souk): expose a company-wide order audit log

### DIFF
--- a/app/GraphQL/Souk/Queries/Orders/OrderActivityLogQuery.php
+++ b/app/GraphQL/Souk/Queries/Orders/OrderActivityLogQuery.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\GraphQL\Souk\Queries\Orders;
 
 use Illuminate\Database\Eloquent\Builder;
+use Kanvas\Activities\Models\Activity;
+use Kanvas\Apps\Models\Apps;
 use Kanvas\Souk\Orders\Models\Order;
-use Spatie\Activitylog\Models\Activity;
 
 class OrderActivityLogQuery
 {
@@ -15,5 +16,29 @@ class OrderActivityLogQuery
         return Activity::query()
             ->where('subject_type', Order::class)
             ->where('subject_id', $root->getKey());
+    }
+
+    public function getCompanyBuilder(mixed $root, array $args): Builder
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        $query = Activity::query()
+            ->where('subject_type', Order::class)
+            ->forAppAndCompany($app, $company);
+
+        if (! empty($args['order_number'])) {
+            // activity_log and orders sit on different connections, so the ids are resolved
+            // in PHP rather than as a subquery
+            $orderIds = Order::query()
+                ->fromApp($app)
+                ->fromCompany($company)
+                ->where('order_number', $args['order_number'])
+                ->pluck('id');
+
+            $query->whereIn('subject_id', $orderIds);
+        }
+
+        return $query;
     }
 }

--- a/graphql/schemas/Souk/order-corrections.graphql
+++ b/graphql/schemas/Souk/order-corrections.graphql
@@ -10,6 +10,18 @@ extend type Query @guard {
         )
 }
 
+extend type Query @guard {
+    orderActivityLogs(
+        order_number: String
+        where: _ @whereConditions(columns: ["description", "event", "causer_id", "created_at"])
+        orderBy: _ @orderBy(columns: ["id", "created_at"])
+    ): [ActivityLog!]!
+        @paginate(
+            defaultCount: 25
+            builder: "App\\GraphQL\\Souk\\Queries\\Orders\\OrderActivityLogQuery@getCompanyBuilder"
+        )
+}
+
 extend type Mutation @guard {
     amendOrder(
         order_id: ID!

--- a/src/Domains/Souk/Orders/Actions/Corrections/BaseOrderCorrectionAction.php
+++ b/src/Domains/Souk/Orders/Actions/Corrections/BaseOrderCorrectionAction.php
@@ -54,6 +54,7 @@ abstract class BaseOrderCorrectionAction
         array $evidenceUrls = []
     ): void {
         activity()
+            ->useLog($this->order->getActivityLogName())
             ->causedBy($this->user)
             ->performedOn($this->order)
             ->withProperties([

--- a/src/Domains/Souk/Orders/Models/Order.php
+++ b/src/Domains/Souk/Orders/Models/Order.php
@@ -934,6 +934,12 @@ class Order extends BaseModel implements PayableInterface
             ->first();
     }
 
+    // the -company-app suffix is what Activity::scopeForAppAndCompany matches on
+    public function getActivityLogName(): string
+    {
+        return 'order-' . $this->companies_id . '-' . $this->apps_id;
+    }
+
     public function calculateTotal(bool $autoSave = true): void
     {
         $total = OrderItem::query()->where(['order_id' => $this->id])

--- a/tests/GraphQL/Souk/OrderActivityLogsTest.php
+++ b/tests/GraphQL/Souk/OrderActivityLogsTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\GraphQL\Souk;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Auth;
+use Kanvas\Activities\Models\Activity;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Movipass\Actions\Corrections\CorrectVehiclePlateAction;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Regions\Models\Regions;
+use Kanvas\Souk\Orders\Models\Order;
+use Kanvas\Users\Models\Users;
+use Tests\TestCase;
+
+final class OrderActivityLogsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private const QUERY = '
+        query orderActivityLogs($order_number: String) {
+            orderActivityLogs(
+                order_number: $order_number
+                orderBy: [{ column: CREATED_AT, order: DESC }]
+                first: 50
+            ) {
+                data {
+                    id
+                    log_name
+                    description
+                    entity_id
+                    properties
+                }
+                paginatorInfo { total }
+            }
+        }
+    ';
+
+    private function createTestOrder(Apps $app, Users $user, array $overrides = []): Order
+    {
+        $company = $user->getCurrentCompany();
+        $region = Regions::getDefault($company, $app);
+
+        $person = People::withoutSyncingToSearch(
+            fn () => People::factory()
+                ->withAppId($app->getId())
+                ->withCompanyId($company->getId())
+                ->create()
+        );
+
+        return Order::withoutSyncingToSearch(
+            fn () => Order::factory()
+                ->withAppId($app->getId())
+                ->withCompanyId($company->getId())
+                ->withUserId($user->getId())
+                ->create(array_merge([
+                    'region_id' => $region->getId(),
+                    'people_id' => $person->id,
+                ], $overrides))
+        );
+    }
+
+    private function correctPlate(Order $order, Users $user, string $newPlate): void
+    {
+        Order::withoutSyncingToSearch(
+            fn () => new CorrectVehiclePlateAction($order, $user, $newPlate, 'audit view test')->execute()
+        );
+    }
+
+    public function testItListsCorrectionsWithoutAskingForAnOrder(): void
+    {
+        $app = app(Apps::class);
+        $user = Auth::user();
+
+        $order = $this->createTestOrder($app, $user, [
+            'order_number' => 91001,
+            'metadata' => ['data' => ['vehiclePlate' => 'AUD001', 'vehicleBrand' => 'Toyota']],
+            'reference' => 'Toyota / AUD001 - #91001',
+        ]);
+
+        $this->correctPlate($order, $user, 'AUD999');
+
+        $response = $this->graphQL(self::QUERY);
+
+        $response->assertSuccessful();
+
+        $entries = collect($response->json('data.orderActivityLogs.data'))
+            ->where('entity_id', $order->id);
+
+        $this->assertCount(1, $entries);
+        $this->assertEquals('correct-plate', $entries->first()['description']);
+        $this->assertEquals($order->getActivityLogName(), $entries->first()['log_name']);
+        $this->assertEquals('audit view test', $entries->first()['properties']['reason']);
+    }
+
+    public function testItFiltersByOrderNumber(): void
+    {
+        $app = app(Apps::class);
+        $user = Auth::user();
+
+        $wanted = $this->createTestOrder($app, $user, [
+            'order_number' => 91002,
+            'metadata' => ['data' => ['vehiclePlate' => 'WNT001', 'vehicleBrand' => 'Kia']],
+            'reference' => 'Kia / WNT001 - #91002',
+        ]);
+
+        $other = $this->createTestOrder($app, $user, [
+            'order_number' => 91003,
+            'metadata' => ['data' => ['vehiclePlate' => 'OTH001', 'vehicleBrand' => 'Honda']],
+            'reference' => 'Honda / OTH001 - #91003',
+        ]);
+
+        $this->correctPlate($wanted, $user, 'WNT999');
+        $this->correctPlate($other, $user, 'OTH999');
+
+        $response = $this->graphQL(self::QUERY, ['order_number' => '91002']);
+
+        $response->assertSuccessful();
+
+        $ids = collect($response->json('data.orderActivityLogs.data'))->pluck('entity_id');
+
+        $this->assertContains($wanted->id, $ids);
+        $this->assertNotContains($other->id, $ids);
+    }
+
+    public function testItHidesLogsFromOtherTenants(): void
+    {
+        $app = app(Apps::class);
+        $user = Auth::user();
+
+        $order = $this->createTestOrder($app, $user, [
+            'order_number' => 91004,
+            'metadata' => ['data' => ['vehiclePlate' => 'TEN001', 'vehicleBrand' => 'Ford']],
+            'reference' => 'Ford / TEN001 - #91004',
+        ]);
+
+        $this->correctPlate($order, $user, 'TEN999');
+
+        $foreign = Activity::query()->where('subject_id', $order->id)->firstOrFail()->replicate();
+        $foreign->log_name = 'order-999999-999999';
+        $foreign->save();
+
+        $response = $this->graphQL(self::QUERY);
+
+        $response->assertSuccessful();
+
+        $logNames = collect($response->json('data.orderActivityLogs.data'))->pluck('log_name')->unique();
+
+        $this->assertNotContains('order-999999-999999', $logNames);
+        $this->assertContains($order->getActivityLogName(), $logNames);
+    }
+}


### PR DESCRIPTION
Matrix V2 item 3: consult what changed without opening one plate at a time.

The existing getAllAppCompanyActivityLogs resolver was never wired to a schema, and it would not have worked: it scopes through Activity::forAppAndCompany, which matches a `log_name` suffix that only Products and Variants write. Order corrections logged through the bare activity() helper, so they landed on the default log name and fell outside every tenant scope.

Scoping by the order instead was not an option either — activity_log lives on the default connection and orders on commerce, which are configured with separate hosts, so a cross-database subquery would break the day they are split.

So corrections now write the same log name convention Products already uses, `order-{company}-{app}`, which makes the tenant scope indexable and keeps the query on one connection. The order_number filter resolves ids in PHP for the same reason.

Corrections made before this change keep `log_name = 'default'` and stay out of the view. Including them would mean matching 'default', which would pull other tenants' logs — a leak, not a trade-off. Recovering them needs a targeted update.

Tests: OrderActivityLogs 3/3, corrections 13/13, order items + status 12/12.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
