### PR TITLE
fix(universal-seguros): leer quote_number/premium de data.* en toQuot…

### DIFF
--- a/src/Domains/Connectors/UniversalSeguros/Providers/UniversalSegurosProvider.php
+++ b/src/Domains/Connectors/UniversalSeguros/Providers/UniversalSegurosProvider.php
@@ -337,7 +337,7 @@ class UniversalSegurosProvider implements
      */
     protected function toQuoteResult(array $response): QuoteResult
     {
-        $quoteNumber = (string) ($response['numeroCotizacion'] ?? '');
+        $quoteNumber = (string) ($response['data']['numeroCotizacion'] ?? $response['numeroCotizacion'] ?? '');
         $terms = is_array($response['data']['terminos'] ?? null) ? $response['data']['terminos'] : [];
 
         $fixedPremium = $this->toFloat($terms['primaFija'] ?? null);
@@ -346,7 +346,7 @@ class UniversalSegurosProvider implements
             success: $quoteNumber !== '',
             message: $quoteNumber !== '' ? 'Quote created' : 'Universal Seguros did not return a quote number',
             quoteNumber: $quoteNumber,
-            premium: $fixedPremium ?? $this->toFloat($terms['prima'] ?? null),
+            premium: ($fixedPremium !== null && $fixedPremium > 0) ? $fixedPremium : $this->toFloat($terms['prima'] ?? null),
             ratePerKm: $fixedPremium !== null ? $this->toFloat($terms['primaKm'] ?? null) : null,
             tax: $this->toFloat($terms['impuesto'] ?? null),
             total: $this->toFloat($terms['totalCobro'] ?? null),


### PR DESCRIPTION
- numeroCotizacion viene anidado en response.data, no en la raiz; leerlo de la raiz dejaba quote_number vacio y marcaba cotizaciones A-PA validas como success:false ("did not return a quote number").
- premium quedaba en 0 cuando primaFija venia presente-pero-cero; ahora cae a prima para A-PA sin romper A-KM (que si usa primaFija).


## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
