### PR TITLE
feat(credit700): send prior residence and prior employment history to RouteOne

### DIFF
--- a/src/Domains/Connectors/Credit700/DataTransferObject/CreditApplication.php
+++ b/src/Domains/Connectors/Credit700/DataTransferObject/CreditApplication.php
@@ -24,12 +24,17 @@ class CreditApplication extends Data
         public readonly ?string $dob = null,
         public readonly ?string $email = null,
         public readonly ?string $phone = null,
+        public readonly ?string $mobileNumber = null,
         public readonly ?string $employer = null,
         public readonly ?string $employmentStatus = null,
         public readonly ?string $position = null,
         public readonly ?int $employmentYears = null,
         public readonly ?int $employmentMonths = null,
         public readonly ?string $workPhone = null,
+        public readonly ?string $previousEmployer = null,
+        public readonly ?int $previousEmploymentYears = null,
+        public readonly ?string $previousEmploymentTitle = null,
+        public readonly ?string $previousWorkPhone = null,
         public readonly ?float $monthlyIncome = null,
         public readonly ?float $otherIncome = null,
         public readonly ?string $otherIncomeExplanation = null,
@@ -37,6 +42,12 @@ class CreditApplication extends Data
         public readonly ?float $housingPayment = null,
         public readonly ?string $driversLicenseNumber = null,
         public readonly ?string $driversLicenseState = null,
+        public readonly ?int $currentAddressPeriod = null,
+        public readonly ?string $previousAddress = null,
+        public readonly ?string $previousCity = null,
+        public readonly ?string $previousState = null,
+        public readonly ?string $previousZip = null,
+        public readonly ?int $previousAddressPeriod = null,
     ) {
     }
 
@@ -52,8 +63,10 @@ class CreditApplication extends Data
         $financial = $formData['financial'] ?? [];
 
         $employmentDuration = DateHelper::parseDuration($financial['years_at_current_employment'] ?? '');
+        $previousEmploymentDuration = DateHelper::parseDuration($financial['years_at_previous_employment'] ?? '');
 
         $peopleLicense = $people->getDriverLicense();
+        $hasPreviousAddress = ! empty($housing['previous_address'] ?? null);
 
         $name = trim(($personal['first_name'] ?? '') . ' ' . ($personal['last_name'] ?? ''));
 
@@ -66,13 +79,18 @@ class CreditApplication extends Data
             zip: self::normalizeZip($housing['zip_code'] ?? ''),
             dob: self::normalizeDob($personal['dob'] ?? null),
             email: self::nullableString($personal['email'] ?? null),
-            phone: self::nullableString($personal['mobile_number'] ?? null),
+            phone: self::nullableString($personal['home_number'] ?? null),
+            mobileNumber: self::nullableString($personal['mobile_number'] ?? null),
             employer: self::nullableString($financial['current_employer'] ?? null),
             employmentStatus: self::nullableString($financial['employment_status'] ?? null),
             position: self::nullableString($financial['current_employment_title'] ?? null),
             employmentYears: $employmentDuration['years'],
             employmentMonths: $employmentDuration['months'],
             workPhone: self::nullableString($financial['current_employer_phone'] ?? null),
+            previousEmployer: self::nullableString($financial['previous_employer'] ?? null),
+            previousEmploymentYears: $previousEmploymentDuration['years'],
+            previousEmploymentTitle: self::nullableString($financial['previous_employment_title'] ?? null),
+            previousWorkPhone: self::nullableString($financial['previous_employer_phone'] ?? null),
             monthlyIncome: self::nullableFloat($financial['gross_income'] ?? null),
             otherIncome: self::nullableFloat($financial['other_income'] ?? null),
             otherIncomeExplanation: self::nullableString($financial['other_income_source'] ?? null),
@@ -82,7 +100,31 @@ class CreditApplication extends Data
                 ?? $peopleLicense?->number,
             driversLicenseState: self::normalizeState($personal['drivers_license_state'] ?? null)
                 ?: $peopleLicense?->state,
+            currentAddressPeriod: self::normalizePeriod($housing['time_at_address'] ?? null),
+            previousAddress: $hasPreviousAddress ? self::normalizeStreet($housing['previous_address']) : null,
+            previousCity: $hasPreviousAddress ? self::normalizeCity($housing['previous_city'] ?? null) : null,
+            previousState: $hasPreviousAddress ? self::normalizeState($housing['previous_state'] ?? null) : null,
+            previousZip: $hasPreviousAddress ? self::normalizeZip($housing['previous_zip_code'] ?? '') : null,
+            previousAddressPeriod: $hasPreviousAddress
+                ? self::normalizePeriod($housing['previous_time_at_address'] ?? null)
+                : null,
         );
+    }
+
+    /**
+     * 700Credit/RouteOne expects a single integer: whole years when the duration has no
+     * month remainder (e.g. "3.0" -> 3 years), otherwise the total in months (e.g. "1.4"
+     * -> 16 months). Never send decimals or "years.months" text.
+     */
+    private static function normalizePeriod(mixed $duration): ?int
+    {
+        if (empty($duration)) {
+            return null;
+        }
+
+        $parsed = DateHelper::parseDuration($duration);
+
+        return $parsed['months'] === 0 ? $parsed['years'] : ($parsed['years'] * 12) + $parsed['months'];
     }
 
     /**

--- a/src/Domains/Connectors/Credit700/Services/CreditApplicationService.php
+++ b/src/Domains/Connectors/Credit700/Services/CreditApplicationService.php
@@ -79,17 +79,34 @@ class CreditApplicationService
             'DOB' => $application->dob,
             'EMAIL' => $application->email,
             'PHONE' => $application->phone,
+            'MOBILE' => $application->mobileNumber,
+
             'EMPLOYER' => $application->employer,
             'EMPLOYMENTSTATUS' => $application->employmentStatus,
             'POSITION' => $application->position,
             'YEARS' => $application->employmentYears,
             'MONTHS' => $application->employmentMonths,
             'WPHONE' => $application->workPhone,
+
+            'PREVEMPLOYER' => $application->previousEmployer,
+            'PREVEMPLOYMENTYEARS' => $application->previousEmploymentYears,
+            'PREVOCCUPATION' => $application->previousEmploymentTitle,
+            'PREVWORKPHONE' => $application->previousWorkPhone,
+
             'MINCOME' => $application->monthlyIncome,
             'OTHERINCOME' => $application->otherIncome,
             'OTHERINCOMEEXPLN' => $application->otherIncomeExplanation,
+
             'HOUSING' => $application->housingType,
             'HOUSINGPAY' => $application->housingPayment,
+
+            'CURRENTADDRESSPERIOD' => $application->currentAddressPeriod,
+            'PREVADDRESS' => $application->previousAddress,
+            'PREVCITY' => $application->previousCity,
+            'PREVSTATE' => $application->previousState,
+            'PREVZIP' => $application->previousZip,
+            'PREVADDRESSPERIOD' => $application->previousAddressPeriod,
+
             'DRIVERSLICENSENO' => $application->driversLicenseNumber,
             'DLSTATE' => $application->driversLicenseState,
         ];

--- a/tests/Connectors/Integration/Credit700/SubmitCreditApplicationTest.php
+++ b/tests/Connectors/Integration/Credit700/SubmitCreditApplicationTest.php
@@ -11,6 +11,7 @@ use Kanvas\Connectors\Credit700\Enums\ConfigurationEnum;
 use Kanvas\Connectors\Credit700\Services\CreditApplicationService;
 use Kanvas\Guild\Customers\Models\People;
 use Mockery;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 /**
@@ -29,6 +30,7 @@ final class SubmitCreditApplicationTest extends TestCase
                 'dob' => '14-April-1965',
                 'email' => 'john@example.com',
                 'mobile_number' => '312-555-1234',
+                'home_number' => '312-555-0000',
                 'drivers_license' => 'D1234567',
                 'drivers_license_state' => 'il',
             ],
@@ -39,7 +41,12 @@ final class SubmitCreditApplicationTest extends TestCase
                 'zip_code' => '60601',
                 'residence_type' => 'Rent',
                 'rent' => 1800,
-                'time_at_address' => '3.6',
+                'time_at_address' => '1.2',
+                'previous_address' => '4605 riverbend Ct.',
+                'previous_city' => 'Tifton',
+                'previous_state' => ['code' => 'GA'],
+                'previous_zip_code' => '31794',
+                'previous_time_at_address' => '7.4',
             ],
             'financial' => [
                 'current_employer' => 'ABC Motors',
@@ -49,6 +56,10 @@ final class SubmitCreditApplicationTest extends TestCase
                 'income_interval' => 'monthly',
                 'current_employer_phone' => '312-555-9999',
                 'years_at_current_employment' => '3.6',
+                'previous_employer' => 'XYZ Corp',
+                'previous_employment_title' => 'Assistant Manager',
+                'previous_employer_phone' => '312-555-8888',
+                'years_at_previous_employment' => '2.9',
                 'other_income' => 400,
                 'other_income_source' => 'Freelance',
             ],
@@ -77,6 +88,69 @@ final class SubmitCreditApplicationTest extends TestCase
         $this->assertSame(6500.0, $application->monthlyIncome);
         $this->assertSame('Rent', $application->housingType);
         $this->assertSame('IL', $application->driversLicenseState);
+        $this->assertSame(14, $application->currentAddressPeriod);
+        $this->assertSame('4605 riverbend Ct.', $application->previousAddress);
+        $this->assertSame('Tifton', $application->previousCity);
+        $this->assertSame('GA', $application->previousState);
+        $this->assertSame('31794', $application->previousZip);
+        $this->assertSame(88, $application->previousAddressPeriod);
+        $this->assertSame('312-555-0000', $application->phone);
+        $this->assertSame('312-555-1234', $application->mobileNumber);
+        $this->assertSame('XYZ Corp', $application->previousEmployer);
+        $this->assertSame(2, $application->previousEmploymentYears);
+        $this->assertSame('Assistant Manager', $application->previousEmploymentTitle);
+        $this->assertSame('312-555-8888', $application->previousWorkPhone);
+    }
+
+    #[DataProvider('addressPeriodProvider')]
+    public function testFromFormNormalizesAddressPeriod(string $timeAtAddress, ?int $expectedPeriod): void
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        $people = People::factory()->withAppId($app->getId())->withCompanyId($company->getId())->create();
+
+        $formData = $this->formData();
+        $formData['housing']['time_at_address'] = $timeAtAddress;
+
+        $this->assertSame(
+            $expectedPeriod,
+            CreditApplication::from($formData, $people)->currentAddressPeriod
+        );
+    }
+
+    public static function addressPeriodProvider(): array
+    {
+        return [
+            'whole years, no month remainder' => ['3.0', 3],
+            'years and months, converts to total months' => ['1.4', 16],
+            'empty duration' => ['', null],
+        ];
+    }
+
+    public function testFromFormOmitsPreviousAddressWhenNotProvided(): void
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        $people = People::factory()->withAppId($app->getId())->withCompanyId($company->getId())->create();
+
+        $formData = $this->formData();
+        unset(
+            $formData['housing']['previous_address'],
+            $formData['housing']['previous_city'],
+            $formData['housing']['previous_state'],
+            $formData['housing']['previous_zip_code'],
+            $formData['housing']['previous_time_at_address'],
+        );
+
+        $application = CreditApplication::from($formData, $people);
+
+        $this->assertNull($application->previousAddress);
+        $this->assertNull($application->previousCity);
+        $this->assertNull($application->previousState);
+        $this->assertNull($application->previousZip);
+        $this->assertNull($application->previousAddressPeriod);
     }
 
     /**
@@ -141,7 +215,68 @@ final class SubmitCreditApplicationTest extends TestCase
         $this->assertSame('test_account', $capturedPayload['ACCOUNT']);
         $this->assertSame('123-45-6789', $capturedPayload['SSN']);
         $this->assertSame('6500', $capturedPayload['MINCOME']);
+        $this->assertSame('14', $capturedPayload['CURRENTADDRESSPERIOD']);
+        $this->assertSame('4605 riverbend Ct.', $capturedPayload['PREVADDRESS']);
+        $this->assertSame('Tifton', $capturedPayload['PREVCITY']);
+        $this->assertSame('GA', $capturedPayload['PREVSTATE']);
+        $this->assertSame('31794', $capturedPayload['PREVZIP']);
+        $this->assertSame('88', $capturedPayload['PREVADDRESSPERIOD']);
+        $this->assertSame('312-555-0000', $capturedPayload['PHONE']);
+        $this->assertSame('312-555-1234', $capturedPayload['MOBILE']);
+        $this->assertSame('XYZ Corp', $capturedPayload['PREVEMPLOYER']);
+        $this->assertSame('2', $capturedPayload['PREVEMPLOYMENTYEARS']);
+        $this->assertSame('Assistant Manager', $capturedPayload['PREVOCCUPATION']);
+        $this->assertSame('312-555-8888', $capturedPayload['PREVWORKPHONE']);
         $this->assertArrayNotHasKey('PURCHASEPRICE', $capturedPayload);
+    }
+
+    public function testSubmitToRouteOneOmitsPreviousAddressWhenNotProvided(): void
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        $app->set(ConfigurationEnum::ACCOUNT->value, 'test_account');
+        $app->set(ConfigurationEnum::PASSWORD->value, 'test_password');
+        $app->set(ConfigurationEnum::CLIENT_ID->value, 'test_client_id');
+        $app->set(ConfigurationEnum::CLIENT_SECRET->value, 'test_client_secret');
+
+        $capturedPayload = null;
+
+        $mockClient = Mockery::mock('overload:' . Client::class);
+        $mockClient->shouldReceive('post')
+            ->with('/Request', Mockery::type('array'))
+            ->andReturnUsing(function (string $path, array $data) use (&$capturedPayload): array {
+                $capturedPayload = $data;
+
+                return [
+                    'XML_Version' => 'Iframe 2.0',
+                    'XML_Report' => [
+                        'Transid' => '700DSO-198906135',
+                        'Token' => '700DSO-04f4c5c0-1858-4c9a-b4f6-3ac7ababb5cc',
+                    ],
+                ];
+            });
+
+        $people = People::factory()->withAppId($app->getId())->withCompanyId($company->getId())->create();
+
+        $formData = $this->formData();
+        unset(
+            $formData['housing']['previous_address'],
+            $formData['housing']['previous_city'],
+            $formData['housing']['previous_state'],
+            $formData['housing']['previous_zip_code'],
+            $formData['housing']['previous_time_at_address'],
+        );
+
+        $application = CreditApplication::from($formData, $people);
+
+        new CreditApplicationService($app)->submitToRouteOne($application);
+
+        $this->assertArrayNotHasKey('PREVADDRESS', $capturedPayload);
+        $this->assertArrayNotHasKey('PREVCITY', $capturedPayload);
+        $this->assertArrayNotHasKey('PREVSTATE', $capturedPayload);
+        $this->assertArrayNotHasKey('PREVZIP', $capturedPayload);
+        $this->assertArrayNotHasKey('PREVADDRESSPERIOD', $capturedPayload);
     }
 
     public function testSubmitToRouteOneFlagsGatewayError(): void


### PR DESCRIPTION
## Summary
- RouteOne needs current/previous address duration and previous employer data to complete residence and employment history on the credit application — the form already captures this, but the Credit700 connector never forwarded it.
- Added `currentAddressPeriod`, `previousAddress`/`previousCity`/`previousState`/`previousZip`/`previousAddressPeriod`, `mobileNumber`, and `previousEmployer`/`previousEmploymentYears`/`previousEmploymentTitle`/`previousWorkPhone` to the `CreditApplication` DTO, with a `normalizePeriod()` helper (whole years when there's no month remainder, otherwise total months).
- **Behavior change:** `PHONE` now comes from `personal.home_number` instead of `personal.mobile_number`; the new `MOBILE` field carries `mobile_number`.
- Mapped all new fields onto the RouteOne payload in `CreditApplicationService::buildPayload()`.

## Test plan
- [x] `php vendor/bin/phpunit tests/Connectors/Integration/Credit700/` — 10 tests, 65 assertions, all green.
- [x] Verified DTO mapping (form → DTO) and payload mapping (DTO → RouteOne keys) independently, including the "no previous address/employment provided" omission path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)