### PR TITLE
feat(connectors): add Slack notification, Trello and Jira integrations

### DIFF
--- a/database/migrations/Workflow/2026_08_28_120000_add_slack_notification_integration.php
+++ b/database/migrations/Workflow/2026_08_28_120000_add_slack_notification_integration.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Registers the generic "send a Slack notification" integration against the shared integration
+ * mechanism. The `integrationCompany` mutation reads `handler` from this row and calls
+ * SlackNotificationHandler::setup(), which validates and stores a webhook URL and/or bot token on
+ * the company. This is separate from the Slack agent/listener install flow (manifest-driven,
+ * receiver-backed) — it only supports one-way notifications for workflow rules.
+ */
+return new class () extends Migration {
+    protected $connection = 'workflow';
+
+    public function up(): void
+    {
+        if (DB::connection('workflow')->table('integrations')->where('name', 'slack')->where('apps_id', 0)->exists()) {
+            return;
+        }
+
+        $config = [
+            'webhook_url' => ['type' => 'text', 'required' => false],
+            'bot_token' => ['type' => 'text', 'required' => false],
+            'default_channel' => ['type' => 'text', 'required' => false],
+        ];
+
+        DB::connection('workflow')->table('integrations')->insert([
+            'uuid' => (string) Str::uuid(),
+            'name' => 'slack',
+            'handler' => 'Kanvas\\Connectors\\Slack\\Handlers\\SlackNotificationHandler',
+            'apps_id' => 0,
+            'config' => json_encode($config),
+            'is_deleted' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::connection('workflow')->table('integrations')
+            ->where('name', 'slack')
+            ->where('apps_id', 0)
+            ->delete();
+    }
+};

--- a/database/migrations/Workflow/2026_08_28_130000_add_trello_integration.php
+++ b/database/migrations/Workflow/2026_08_28_130000_add_trello_integration.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Registers Trello against the generic integration mechanism. Without this row the shared
+ * `integrationCompany` mutation has no `handler` to resolve, so TrelloHandler::setup() is
+ * unreachable and there is no way to store the key/token pair a company connects with.
+ */
+return new class () extends Migration {
+    protected $connection = 'workflow';
+
+    public function up(): void
+    {
+        if (DB::connection('workflow')->table('integrations')->where('name', 'trello')->where('apps_id', 0)->exists()) {
+            return;
+        }
+
+        $config = [
+            'api_key' => ['type' => 'text', 'required' => true],
+            'api_token' => ['type' => 'text', 'required' => true],
+        ];
+
+        DB::connection('workflow')->table('integrations')->insert([
+            'uuid' => (string) Str::uuid(),
+            'name' => 'trello',
+            'handler' => 'Kanvas\\Connectors\\Trello\\Handlers\\TrelloHandler',
+            'apps_id' => 0,
+            'config' => json_encode($config),
+            'is_deleted' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::connection('workflow')->table('integrations')
+            ->where('name', 'trello')
+            ->where('apps_id', 0)
+            ->delete();
+    }
+};

--- a/database/migrations/Workflow/2026_08_28_140000_add_jira_integration.php
+++ b/database/migrations/Workflow/2026_08_28_140000_add_jira_integration.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Registers Jira against the generic integration mechanism. Without this row the shared
+ * `integrationCompany` mutation has no `handler` to resolve, so JiraHandler::setup() is
+ * unreachable and there is no way to store the instance URL / email / API token a company
+ * connects with.
+ */
+return new class () extends Migration {
+    protected $connection = 'workflow';
+
+    public function up(): void
+    {
+        if (DB::connection('workflow')->table('integrations')->where('name', 'jira')->where('apps_id', 0)->exists()) {
+            return;
+        }
+
+        $config = [
+            'instance_url' => ['type' => 'text', 'required' => true],
+            'email' => ['type' => 'text', 'required' => true],
+            'api_token' => ['type' => 'text', 'required' => true],
+            'default_project_key' => ['type' => 'text', 'required' => false],
+            'default_issue_type' => ['type' => 'text', 'required' => false],
+        ];
+
+        DB::connection('workflow')->table('integrations')->insert([
+            'uuid' => (string) Str::uuid(),
+            'name' => 'jira',
+            'handler' => 'Kanvas\\Connectors\\Jira\\Handlers\\JiraHandler',
+            'apps_id' => 0,
+            'config' => json_encode($config),
+            'is_deleted' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::connection('workflow')->table('integrations')
+            ->where('name', 'jira')
+            ->where('apps_id', 0)
+            ->delete();
+    }
+};

--- a/docs/integrations_slack_trello_jira.md
+++ b/docs/integrations_slack_trello_jira.md
@@ -1,0 +1,260 @@
+# Slack, Trello & Jira Integrations
+
+This document explains how the Slack, Trello and Jira connectors are wired into Kanvas, how to
+enable/configure each one per company, and how to use them from workflow rules to automate
+notifications and team synchronization.
+
+All three follow the same [connector pattern](../src/Domains/Connectors/CLAUDE.md) used across the
+codebase (Shopify, Stripe, WordPress, Salesforce, pi.dev, ...):
+
+```
+src/Domains/Connectors/{Slack,Trello,Jira}/
+├── Client.php                 # Thin REST client (Trello/Jira) — Slack reuses the existing bot-token Client
+├── Handlers/*Handler.php      # Extends BaseIntegration; validates + stores credentials
+├── Services/*.php             # Business logic on top of the Client
+├── Activities/*.php           # #[WorkflowAction] steps a rule can run
+└── Enums/ConfigurationEnum.php, CustomFieldEnum.php
+```
+
+Each connector is registered as a row in the generic `integrations` table (see
+`database/migrations/Workflow/2026_08_28_*_integration.php`), which means credentials are connected,
+configured and tested through the **same GraphQL mutation every other connector uses** —
+`integrationCompany` — no bespoke GraphQL was added for setup. Removing/disabling a connection also
+reuses the generic `removeIntegrationCompany` / `integrationCompanyIsActive` mutations.
+
+Once connected, each integration exposes one or more workflow actions
+(`#[Kanvas\Workflow\Attributes\WorkflowAction]`) that are auto-discovered by
+`php artisan kanvas:workflow-sync-actions` and become selectable steps in the Workflow Rules UI /
+`actions` GraphQL query — no manual registration needed.
+
+---
+
+## 1. Slack — send notifications
+
+Kanvas already ships a full Slack **agent** integration (two-way conversational channel, see
+`src/Domains/Connectors/Slack/Actions/ConnectSlackAgentAction.php`). The pieces documented here are
+a separate, much smaller capability: **posting one-way notifications** to a Slack channel from any
+workflow rule (new order, failed sync, escalated lead, etc.) — either via an **Incoming Webhook** or
+a **Bot User OAuth Token**.
+
+* Handler: `Kanvas\Connectors\Slack\Handlers\SlackNotificationHandler`
+* Service: `Kanvas\Connectors\Slack\Services\SlackNotificationService`
+* Workflow action: `Kanvas\Connectors\Slack\Activities\SendSlackNotificationActivity`
+* Config keys: `Kanvas\Connectors\Slack\Enums\NotificationConfigurationEnum`
+* Integration name: `slack` (`Kanvas\Workflow\Enums\IntegrationsEnum::SLACK`)
+
+### Configure
+
+At least one of `webhook_url` / `bot_token` is required. Both may be set — a rule can then choose a
+channel per call via the bot token while the webhook stays a fallback for its own single channel.
+
+```graphql
+mutation {
+  integrationCompany(input: {
+    integration: { name: "slack" }
+    region: { id: "<region id>" }
+    company_id: "<company id>"
+    config: {
+      webhook_url: "https://hooks.slack.com/services/T000/B000/XXXXXXXXXXXX"
+      bot_token: "xoxb-your-bot-token"
+      default_channel: "#alerts"
+    }
+  }) { id }
+}
+```
+
+* `webhook_url` — from Slack: **Apps → Incoming Webhooks → Add New Webhook to Workspace**.
+* `bot_token` — from a Slack app's **OAuth & Permissions** page (needs the `chat:write` scope), a
+  Bot User OAuth Token (`xoxb-...`).
+* `default_channel` — used when a rule doesn't pass one explicitly (only consulted for the bot-token
+  path — a webhook is already bound to a single channel on Slack's side).
+
+`SlackNotificationHandler::setup()` posts a canned test message (webhook) and/or calls
+`auth.test` (bot token) before storing anything, so a bad credential fails the mutation instead of
+the first real alert.
+
+### Use from a workflow rule
+
+Attach the **"Send Slack Notification"** action to a rule. Params:
+
+| param | required | description |
+|---|---|---|
+| `text` | yes | Message body to post |
+| `channel` | no | Channel id/name; only used with a bot token, falls back to `default_channel` |
+
+### Send it directly (no rule)
+
+```php
+use Kanvas\Connectors\Slack\Services\SlackNotificationService;
+
+$service = new SlackNotificationService($app, $company);
+$service->send('Deploy finished ✅', '#deploys');
+```
+
+---
+
+## 2. Trello — cards, lists & boards
+
+* Client: `Kanvas\Connectors\Trello\Client`
+* Handler: `Kanvas\Connectors\Trello\Handlers\TrelloHandler`
+* Service: `Kanvas\Connectors\Trello\Services\TrelloBoardService`
+* Workflow action: `Kanvas\Connectors\Trello\Activities\CreateTrelloCardActivity`
+* Config keys: `Kanvas\Connectors\Trello\Enums\ConfigurationEnum`
+* Entity linkage: `Kanvas\Connectors\Trello\Enums\CustomFieldEnum::TRELLO_CARD_ID`
+* Integration name: `trello`
+
+### Configure
+
+```graphql
+mutation {
+  integrationCompany(input: {
+    integration: { name: "trello" }
+    region: { id: "<region id>" }
+    company_id: "<company id>"
+    config: {
+      api_key: "<Trello developer API key>"
+      api_token: "<Trello user token>"
+    }
+  }) { id }
+}
+```
+
+* `api_key` — from https://trello.com/app-key (per Trello Power-Up/app).
+* `api_token` — the user token generated on the same page (or via the OAuth authorize link Trello
+  gives you), scoped to whatever boards that member can see.
+
+`TrelloHandler::setup()` calls `GET /1/members/me` with the pair before storing it.
+
+### Use from a workflow rule
+
+Attach **"Create Trello Card"**. Params:
+
+| param | required | description |
+|---|---|---|
+| `list_id` | yes | Trello list id (`idList`) the card is created under |
+| `name` | yes | Card title |
+| `description` | no | Card description (Markdown) |
+| `due` | no | ISO-8601 due date |
+
+If the entity already has a card linked (`TRELLO_CARD_ID` custom field, set on the first run), the
+activity **updates that card** instead of creating a duplicate — so re-running the rule (a retry, a
+second webhook delivery, ...) is safe.
+
+### Use the service directly
+
+```php
+use Kanvas\Connectors\Trello\Services\TrelloBoardService;
+
+$trello = TrelloBoardService::forApp($app, $company);
+$boards = $trello->boards();
+$lists = $trello->lists($boards[0]['id']);
+$card = $trello->createCard($lists[0]['id'], 'Investigate outage', 'Customer reported downtime');
+$trello->addComment($card['id'], 'Looking into this now.');
+```
+
+---
+
+## 3. Jira — issues, transitions & worklogs
+
+* Client: `Kanvas\Connectors\Jira\Client`
+* Handler: `Kanvas\Connectors\Jira\Handlers\JiraHandler`
+* Service: `Kanvas\Connectors\Jira\Services\JiraIssueService`
+* Workflow action: `Kanvas\Connectors\Jira\Activities\CreateJiraIssueActivity`
+* Config keys: `Kanvas\Connectors\Jira\Enums\ConfigurationEnum`
+* Entity linkage: `Kanvas\Connectors\Jira\Enums\CustomFieldEnum::JIRA_ISSUE_KEY`
+* Integration name: `jira`
+
+### Configure
+
+```graphql
+mutation {
+  integrationCompany(input: {
+    integration: { name: "jira" }
+    region: { id: "<region id>" }
+    company_id: "<company id>"
+    config: {
+      instance_url: "https://your-domain.atlassian.net"
+      email: "agent@yourcompany.com"
+      api_token: "<Jira API token>"
+      default_project_key: "OPS"
+      default_issue_type: "Task"
+    }
+  }) { id }
+}
+```
+
+* `instance_url` — your Jira Cloud site, e.g. `https://your-domain.atlassian.net`.
+* `email` — the Atlassian account email the token belongs to.
+* `api_token` — from https://id.atlassian.com/manage-profile/security/api-tokens. Jira Cloud
+  authenticates with HTTP Basic auth (`email:api_token`) — there is no OAuth refresh to manage.
+* `default_project_key` / `default_issue_type` — optional, stored for future use by callers that
+  don't want to pass them on every request.
+
+`JiraHandler::setup()` calls `GET /rest/api/3/myself` before storing anything.
+
+### Use from a workflow rule
+
+Attach **"Create Jira Issue"**. Params:
+
+| param | required | description |
+|---|---|---|
+| `project_key` | yes | Jira project key, e.g. `OPS` |
+| `summary` | yes | Issue summary/title |
+| `description` | no | Plain text — automatically wrapped into Jira's Atlassian Document Format |
+| `issue_type` | no | Issue type name (`Task`, `Bug`, `Story`, ...). Defaults to `Task` |
+
+Same idempotency shape as Trello: a re-run updates the linked issue (`JIRA_ISSUE_KEY` custom field)
+instead of filing a duplicate.
+
+### Use the service directly
+
+```php
+use Kanvas\Connectors\Jira\Services\JiraIssueService;
+
+$jira = JiraIssueService::forApp($app, $company);
+$issue = $jira->createIssue('OPS', 'Investigate outage', 'Customer reported downtime');
+$jira->transitionIssue($issue['key'], 'In Progress');
+$jira->addWorklog($issue['key'], '2h', 'Investigated root cause');
+$jira->transitionIssue($issue['key'], 'Done', 'Resolved — see comments.');
+```
+
+`transitionIssue()` takes the target status by **name** (e.g. `"In Progress"`, `"Done"`) rather than
+Jira's numeric transition id, since transition ids are workflow-specific per Jira project and a rule
+author can't be expected to know them; it looks the id up via `GET /issue/{key}/transitions` and
+raises a clear error if that status isn't reachable from the issue's current one.
+
+---
+
+## Removing / testing a connection
+
+These reuse the generic mutations already used by every connector:
+
+```graphql
+mutation { removeIntegrationCompany(id: "<integration_companies.id>") }
+
+mutation {
+  integrationCompanyIsActive(input: { id: "<integration_companies.id>", is_active: false })
+}
+```
+
+There is no separate "test connection" mutation: `integrationCompany` **is** the test — the handler
+validates the credentials against the real API before the row is marked `ACTIVE` (or `FAILED` if
+validation throws).
+
+## Tests
+
+* `tests/Connectors/Slack/SlackNotificationServiceTest.php`,
+  `SlackNotificationHandlerTest.php` — unit tests for the notification service and handler
+  (webhook + bot token paths), using `Http::fake()`.
+* `tests/Connectors/Trello/ClientTest.php`, `TrelloBoardServiceTest.php`, `TrelloHandlerTest.php`
+* `tests/Connectors/Jira/ClientTest.php`, `JiraIssueServiceTest.php`, `JiraHandlerTest.php`
+* `tests/Connectors/Integration/{Slack,Trello,Jira}/*ActivityTest.php` — end-to-end through
+  `executeIntegration()` (registers a real `integrations` / `integration_companies` row via the
+  `HasIntegrationCompany` test trait, then runs the `KanvasActivity`).
+
+## Adding another operation
+
+Follow the existing `Services/*.php` classes as the extension point — e.g. add
+`JiraIssueService::assignIssue()` or `TrelloBoardService::addMemberToCard()`, then wrap it in a new
+`#[WorkflowAction]`-tagged class under `Activities/` if it should be callable from a rule. See
+`.claude/skills/kanvas-connector/SKILL.md` for the full scaffold checklist.

--- a/src/Domains/Connectors/Jira/Activities/CreateJiraIssueActivity.php
+++ b/src/Domains/Connectors/Jira/Activities/CreateJiraIssueActivity.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Jira\Activities;
+
+use Illuminate\Database\Eloquent\Model;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Jira\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Jira\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Jira\Services\JiraIssueService;
+use Kanvas\Workflow\Attributes\WorkflowAction;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\KanvasActivity;
+
+/**
+ * Files (or, on a re-run, updates) a Jira issue from any Kanvas entity. The entity keeps the
+ * created issue key in its custom fields (`CustomFieldEnum::JIRA_ISSUE_KEY`), the same
+ * idempotency shape `Trello\Activities\CreateTrelloCardActivity` uses for its card id.
+ */
+#[WorkflowAction(
+    name: 'Create Jira Issue',
+    description: 'Creates a Jira issue in the given project from a Kanvas entity. If the entity '
+        . 'already has an issue linked (from a previous run), updates the summary/description on '
+        . 'that issue instead of filing a duplicate.',
+    integration: IntegrationsEnum::JIRA,
+    requiresConfig: [
+        ConfigurationEnum::INSTANCE_URL,
+        ConfigurationEnum::EMAIL,
+        ConfigurationEnum::API_TOKEN,
+    ],
+    requiredParams: ['project_key', 'summary'],
+    params: [
+        'project_key' => 'Jira project key the issue is filed under (e.g. "OPS"). Required.',
+        'summary' => 'Issue summary/title. Required.',
+        'description' => 'Issue description (plain text — wrapped into Jira\'s document format).',
+        'issue_type' => 'Issue type name: Task, Bug, Story... Defaults to "Task".',
+    ],
+)]
+class CreateJiraIssueActivity extends KanvasActivity
+{
+    public function execute(Model $entity, Apps $app, array $params): array
+    {
+        $this->overwriteAppService($app);
+
+        $projectKey = trim((string) ($params['project_key'] ?? ''));
+        $summary = trim((string) ($params['summary'] ?? ''));
+
+        if ($projectKey === '' || $summary === '') {
+            return $this->failWorkflow([
+                'message' => 'Missing required params "project_key" and/or "summary"',
+                'entity' => [get_class($entity), $entity->getId()],
+            ]);
+        }
+
+        $company = $entity->company;
+
+        return $this->executeIntegration(
+            entity: $entity,
+            app: $app,
+            integration: IntegrationsEnum::JIRA,
+            additionalParams: $params,
+            integrationOperation: function (Model $entity, Apps $app, mixed $integrationCompany, array $additionalParams) use ($projectKey, $summary, $company): array {
+                $service = JiraIssueService::forApp($app, $company);
+
+                $description = isset($additionalParams['description']) ? (string) $additionalParams['description'] : null;
+                $issueType = trim((string) ($additionalParams['issue_type'] ?? '')) ?: 'Task';
+
+                $existingIssueKey = $this->existingIssueKey($entity);
+
+                if ($existingIssueKey !== null) {
+                    $service->updateIssue($existingIssueKey, array_filter([
+                        'summary' => $summary,
+                        'description' => $description,
+                    ]));
+
+                    return ['issue_key' => $existingIssueKey, 'created' => false];
+                }
+
+                $issue = $service->createIssue($projectKey, $summary, $description, $issueType);
+
+                if (isset($issue['key']) && method_exists($entity, 'set')) {
+                    $entity->set(CustomFieldEnum::JIRA_ISSUE_KEY->value, (string) $issue['key']);
+                    $entity->set(CustomFieldEnum::JIRA_ISSUE_ID->value, (string) ($issue['id'] ?? ''));
+                }
+
+                return ['issue' => $issue, 'created' => true];
+            },
+            company: $company,
+        );
+    }
+
+    private function existingIssueKey(Model $entity): ?string
+    {
+        if (! method_exists($entity, 'get')) {
+            return null;
+        }
+
+        $issueKey = $entity->get(CustomFieldEnum::JIRA_ISSUE_KEY->value);
+
+        return empty($issueKey) ? null : (string) $issueKey;
+    }
+}

--- a/src/Domains/Connectors/Jira/Client.php
+++ b/src/Domains/Connectors/Jira/Client.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Jira;
+
+use Baka\Contracts\AppInterface;
+use Baka\Contracts\CompanyInterface;
+use Baka\Http\SafeUrl;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Connectors\Jira\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Jira\Exceptions\JiraException;
+use Kanvas\Exceptions\ValidationException;
+
+/**
+ * Thin REST client for Jira Cloud's `/rest/api/3` (https://developer.atlassian.com/cloud/jira/platform/rest/v3/).
+ *
+ * Jira Cloud authenticates with HTTP Basic auth using the account email + an API token
+ * (https://id.atlassian.com/manage-profile/security/api-tokens) — not OAuth, so there is no token
+ * refresh to manage.
+ */
+class Client
+{
+    protected const string API_PATH = '/rest/api/3/';
+
+    protected string $instanceUrl;
+    protected string $email;
+    protected string $apiToken;
+
+    public function __construct(
+        protected AppInterface $app,
+        protected CompanyInterface $company,
+    ) {
+        $this->instanceUrl = rtrim((string) ($company->get(ConfigurationEnum::INSTANCE_URL->value)
+            ?? $app->get(ConfigurationEnum::INSTANCE_URL->value) ?? ''), '/');
+        $this->email = (string) ($company->get(ConfigurationEnum::EMAIL->value)
+            ?? $app->get(ConfigurationEnum::EMAIL->value) ?? '');
+        $this->apiToken = (string) ($company->get(ConfigurationEnum::API_TOKEN->value)
+            ?? $app->get(ConfigurationEnum::API_TOKEN->value) ?? '');
+
+        if ($this->instanceUrl === '' || $this->email === '' || $this->apiToken === '') {
+            throw new ValidationException('Jira instance URL, email and API token are required.');
+        }
+
+        // Tenant-supplied at setup, so it counts as user input for SSRF purposes.
+        SafeUrl::assertSafe($this->instanceUrl);
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @return array<array-key, mixed>
+     */
+    public function get(string $endpoint, array $query = []): array
+    {
+        return $this->handle($this->request()->get($this->url($endpoint), $query), $endpoint);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return array<array-key, mixed>
+     */
+    public function post(string $endpoint, array $payload = []): array
+    {
+        return $this->handle($this->request()->post($this->url($endpoint), $payload), $endpoint);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return array<array-key, mixed>
+     */
+    public function put(string $endpoint, array $payload = []): array
+    {
+        return $this->handle($this->request()->put($this->url($endpoint), $payload), $endpoint);
+    }
+
+    protected function request(): PendingRequest
+    {
+        return Http::withBasicAuth($this->email, $this->apiToken)
+            ->acceptJson()
+            ->timeout(30);
+    }
+
+    protected function url(string $endpoint): string
+    {
+        return $this->instanceUrl . self::API_PATH . ltrim($endpoint, '/');
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function handle(Response $response, string $endpoint): array
+    {
+        if (! $response->successful()) {
+            $errors = $response->json('errorMessages') ?? $response->json('errors') ?? $response->body();
+
+            throw new JiraException(
+                'Jira request to ' . $endpoint . ' failed (HTTP ' . $response->status() . '): '
+                    . (is_string($errors) ? $errors : (string) json_encode($errors)),
+                $response->status()
+            );
+        }
+
+        $body = $response->body();
+
+        return $body === '' ? [] : (json_decode($body, true) ?? []);
+    }
+
+    /**
+     * `/myself` is Jira's cheapest authenticated endpoint — confirms the email/token pair
+     * authenticates before it is stored.
+     */
+    public static function validateCredentials(string $instanceUrl, string $email, string $apiToken): bool
+    {
+        $instanceUrl = rtrim($instanceUrl, '/');
+
+        if ($instanceUrl === '' || $email === '' || $apiToken === '') {
+            throw new ValidationException('Jira instance URL, email and API token are required.');
+        }
+
+        SafeUrl::assertSafe($instanceUrl);
+
+        $response = Http::withBasicAuth($email, $apiToken)
+            ->acceptJson()
+            ->timeout(15)
+            ->get($instanceUrl . self::API_PATH . 'myself');
+
+        if ($response->status() === 401) {
+            throw new ValidationException('Jira rejected the provided email/API token.');
+        }
+
+        if (! $response->successful()) {
+            throw new ValidationException('Jira validation failed with HTTP ' . $response->status() . '.');
+        }
+
+        return true;
+    }
+}

--- a/src/Domains/Connectors/Jira/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/Jira/Enums/ConfigurationEnum.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Jira\Enums;
+
+enum ConfigurationEnum: string
+{
+    case INSTANCE_URL = 'jira_instance_url';
+    case EMAIL = 'jira_email';
+    case API_TOKEN = 'jira_api_token';
+
+    // Optional defaults so a rule can omit them on every call.
+    case DEFAULT_PROJECT_KEY = 'jira_default_project_key';
+    case DEFAULT_ISSUE_TYPE = 'jira_default_issue_type';
+}

--- a/src/Domains/Connectors/Jira/Enums/CustomFieldEnum.php
+++ b/src/Domains/Connectors/Jira/Enums/CustomFieldEnum.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Jira\Enums;
+
+/**
+ * Entity-level linkage back to Jira, mirroring `Trello\Enums\CustomFieldEnum` — set on whatever
+ * Kanvas entity a rule filed the issue for, so a re-run updates the existing issue instead of
+ * filing a duplicate.
+ */
+enum CustomFieldEnum: string
+{
+    case JIRA_ISSUE_KEY = 'JIRA_ISSUE_KEY';
+    case JIRA_ISSUE_ID = 'JIRA_ISSUE_ID';
+}

--- a/src/Domains/Connectors/Jira/Exceptions/JiraException.php
+++ b/src/Domains/Connectors/Jira/Exceptions/JiraException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Jira\Exceptions;
+
+use Kanvas\Exceptions\ValidationException;
+
+class JiraException extends ValidationException
+{
+    public function __construct(string $message = '', int $code = 0)
+    {
+        parent::__construct($message, $code);
+    }
+}

--- a/src/Domains/Connectors/Jira/Handlers/JiraHandler.php
+++ b/src/Domains/Connectors/Jira/Handlers/JiraHandler.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Jira\Handlers;
+
+use Kanvas\Connectors\Contracts\BaseIntegration;
+use Kanvas\Connectors\Jira\Client;
+use Kanvas\Connectors\Jira\Enums\ConfigurationEnum;
+use Kanvas\Exceptions\ValidationException;
+use Override;
+
+/**
+ * Connects Jira through the generic `integrationCompany` mutation. Credentials are the tenant's
+ * Jira Cloud instance URL, the account email, and an API token — all company-scoped, since two
+ * companies in the same app are almost always different Jira tenants.
+ */
+class JiraHandler extends BaseIntegration
+{
+    #[Override]
+    public function setup(): bool
+    {
+        $instanceUrl = rtrim(trim((string) ($this->data['instance_url'] ?? '')), '/');
+        $email = trim((string) ($this->data['email'] ?? ''));
+        $apiToken = trim((string) ($this->data['api_token'] ?? ''));
+        $defaultProjectKey = trim((string) ($this->data['default_project_key'] ?? ''));
+        $defaultIssueType = trim((string) ($this->data['default_issue_type'] ?? ''));
+
+        if ($instanceUrl === '' || $email === '' || $apiToken === '') {
+            throw new ValidationException('Jira instance URL, email and API token are required.');
+        }
+
+        if (! Client::validateCredentials($instanceUrl, $email, $apiToken)) {
+            throw new ValidationException('Failed to validate the Jira connection.');
+        }
+
+        $this->company->set(ConfigurationEnum::INSTANCE_URL->value, $instanceUrl);
+        $this->company->set(ConfigurationEnum::EMAIL->value, $email);
+        $this->company->set(ConfigurationEnum::API_TOKEN->value, $apiToken);
+
+        if ($defaultProjectKey !== '') {
+            $this->company->set(ConfigurationEnum::DEFAULT_PROJECT_KEY->value, $defaultProjectKey);
+        }
+
+        if ($defaultIssueType !== '') {
+            $this->company->set(ConfigurationEnum::DEFAULT_ISSUE_TYPE->value, $defaultIssueType);
+        }
+
+        return true;
+    }
+}

--- a/src/Domains/Connectors/Jira/Services/JiraIssueService.php
+++ b/src/Domains/Connectors/Jira/Services/JiraIssueService.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Jira\Services;
+
+use Baka\Contracts\AppInterface;
+use Baka\Contracts\CompanyInterface;
+use Kanvas\Connectors\Jira\Client;
+use Kanvas\Connectors\Jira\Exceptions\JiraException;
+
+/**
+ * High-level Jira issue operations built on top of the raw `Client` — create/update, status
+ * transitions, and work logging. Everything a "sync this to Jira" workflow rule needs.
+ */
+class JiraIssueService
+{
+    public function __construct(protected Client $client)
+    {
+    }
+
+    public static function forApp(AppInterface $app, CompanyInterface $company): self
+    {
+        return new self(new Client($app, $company));
+    }
+
+    /**
+     * @param array<string, mixed> $fields Extra Jira fields merged in verbatim (labels, priority,
+     *                                     assignee, custom fields...).
+     * @return array<string, mixed> The created issue (id, key, self)
+     */
+    public function createIssue(
+        string $projectKey,
+        string $summary,
+        ?string $description = null,
+        string $issueType = 'Task',
+        array $fields = []
+    ): array {
+        $payload = [
+            'fields' => array_merge($fields, array_filter([
+                'project' => ['key' => $projectKey],
+                'summary' => $summary,
+                'issuetype' => ['name' => $issueType],
+                'description' => $description !== null ? self::toDocumentFormat($description) : null,
+            ])),
+        ];
+
+        return $this->client->post('issue', $payload);
+    }
+
+    /**
+     * Jira's PUT /issue returns an empty 204 body on success — the caller only needs to know it
+     * didn't throw.
+     *
+     * @param array<string, mixed> $fields
+     */
+    public function updateIssue(string $issueIdOrKey, array $fields): void
+    {
+        $payload = array_filter([
+            'summary' => $fields['summary'] ?? null,
+            'description' => isset($fields['description']) ? self::toDocumentFormat((string) $fields['description']) : null,
+        ]);
+
+        unset($fields['summary'], $fields['description']);
+
+        $this->client->put('issue/' . $issueIdOrKey, ['fields' => array_merge($fields, $payload)]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getIssue(string $issueIdOrKey): array
+    {
+        return $this->client->get('issue/' . $issueIdOrKey);
+    }
+
+    /**
+     * Available transitions from the issue's current status — the ids `transitionIssue()` needs.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getTransitions(string $issueIdOrKey): array
+    {
+        return (array) ($this->client->get('issue/' . $issueIdOrKey . '/transitions')['transitions'] ?? []);
+    }
+
+    /**
+     * Moves an issue to a new status by NAME (e.g. "In Progress", "Done") rather than by id,
+     * since transition ids are workflow-specific and a rule author can't be expected to know them.
+     */
+    public function transitionIssue(string $issueIdOrKey, string $transitionName, ?string $comment = null): void
+    {
+        $transitionId = $this->resolveTransitionId($issueIdOrKey, $transitionName);
+
+        $payload = ['transition' => ['id' => $transitionId]];
+
+        if ($comment !== null && $comment !== '') {
+            $payload['update'] = [
+                'comment' => [
+                    ['add' => ['body' => self::toDocumentFormat($comment)]],
+                ],
+            ];
+        }
+
+        $this->client->post('issue/' . $issueIdOrKey . '/transitions', $payload);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function addWorklog(string $issueIdOrKey, string $timeSpent, ?string $comment = null): array
+    {
+        return $this->client->post('issue/' . $issueIdOrKey . '/worklog', array_filter([
+            'timeSpent' => $timeSpent,
+            'comment' => $comment !== null ? self::toDocumentFormat($comment) : null,
+        ]));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function addComment(string $issueIdOrKey, string $comment): array
+    {
+        return $this->client->post('issue/' . $issueIdOrKey . '/comment', [
+            'body' => self::toDocumentFormat($comment),
+        ]);
+    }
+
+    protected function resolveTransitionId(string $issueIdOrKey, string $transitionName): string
+    {
+        foreach ($this->getTransitions($issueIdOrKey) as $transition) {
+            $name = (string) ($transition['name'] ?? '');
+
+            if (strcasecmp($name, $transitionName) === 0) {
+                return (string) $transition['id'];
+            }
+        }
+
+        throw new JiraException(
+            'Jira issue ' . $issueIdOrKey . ' has no transition named "' . $transitionName . '" available from its current status.'
+        );
+    }
+
+    /**
+     * Jira Cloud API v3 requires rich-text fields (description, comment body...) in Atlassian
+     * Document Format rather than plain strings. A single paragraph is enough for anything a
+     * workflow rule composes — nobody is authoring rich text in a rule param.
+     *
+     * @return array<string, mixed>
+     */
+    public static function toDocumentFormat(string $text): array
+    {
+        return [
+            'type' => 'doc',
+            'version' => 1,
+            'content' => [
+                [
+                    'type' => 'paragraph',
+                    'content' => [
+                        ['type' => 'text', 'text' => $text],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Domains/Connectors/Slack/Activities/SendSlackNotificationActivity.php
+++ b/src/Domains/Connectors/Slack/Activities/SendSlackNotificationActivity.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Slack\Activities;
+
+use Illuminate\Database\Eloquent\Model;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Slack\Enums\NotificationConfigurationEnum;
+use Kanvas\Connectors\Slack\Services\SlackNotificationService;
+use Kanvas\Workflow\Attributes\WorkflowAction;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\KanvasActivity;
+
+/**
+ * Wire this to any rule — the entity is only used to resolve which company/region the Slack
+ * notification credentials belong to, the same way `PushMessageToWordPressActivity` uses the
+ * message purely to find its company.
+ */
+#[WorkflowAction(
+    name: 'Send Slack Notification',
+    description: 'Posts a text notification to Slack using the company\'s configured Incoming Webhook '
+        . 'URL or Bot User OAuth Token. Use it to alert a channel from any workflow rule — new order, '
+        . 'failed sync, escalated lead, etc.',
+    integration: IntegrationsEnum::SLACK,
+    requiresConfig: [
+        NotificationConfigurationEnum::WEBHOOK_URL,
+        NotificationConfigurationEnum::BOT_TOKEN,
+    ],
+    requiredParams: ['text'],
+    params: [
+        'text' => 'The message body to post to Slack. Required.',
+        'channel' => 'Channel id (C0123456789) or name (#alerts). Only consulted when sending via bot '
+            . 'token — a webhook is already bound to a single channel on Slack\'s side. Falls back to '
+            . 'the connector\'s configured default_channel.',
+    ],
+)]
+class SendSlackNotificationActivity extends KanvasActivity
+{
+    public function execute(Model $entity, Apps $app, array $params): array
+    {
+        $this->overwriteAppService($app);
+
+        $text = trim((string) ($params['text'] ?? ''));
+
+        if ($text === '') {
+            return $this->failWorkflow([
+                'message' => 'Missing required param "text"',
+                'entity' => [get_class($entity), $entity->getId()],
+            ]);
+        }
+
+        $company = $entity->company;
+        $channel = isset($params['channel']) && trim((string) $params['channel']) !== ''
+            ? trim((string) $params['channel'])
+            : null;
+
+        return $this->executeIntegration(
+            entity: $entity,
+            app: $app,
+            integration: IntegrationsEnum::SLACK,
+            additionalParams: $params,
+            integrationOperation: function (Model $entity, Apps $app, mixed $integrationCompany, array $additionalParams) use ($text, $channel, $company): array {
+                $service = new SlackNotificationService($app, $company);
+
+                if (! $service->isConfigured()) {
+                    return $this->failWorkflow([
+                        'message' => 'Slack notifications are not configured for this company',
+                        'entity' => [get_class($entity), $entity->getId()],
+                    ]);
+                }
+
+                return $service->send($text, $channel);
+            },
+            company: $company,
+        );
+    }
+}

--- a/src/Domains/Connectors/Slack/Enums/NotificationConfigurationEnum.php
+++ b/src/Domains/Connectors/Slack/Enums/NotificationConfigurationEnum.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Slack\Enums;
+
+/**
+ * Config keys for the generic "send a notification to Slack" integration
+ * (`Kanvas\Connectors\Slack\Handlers\SlackNotificationHandler`).
+ *
+ * Kept separate from `ConfigurationEnum` — that one holds the agent/listener install state
+ * (signing secret, bot user id, joined channels...); this one is the small, company-scoped
+ * set of credentials a tenant pastes in through the generic `integrationCompany` mutation to
+ * push plain notifications (workflow rules, alerts) into a Slack channel.
+ */
+enum NotificationConfigurationEnum: string
+{
+    // An Incoming Webhook URL. Simplest path — no bot install required, posts to the single
+    // channel the webhook was created for.
+    case WEBHOOK_URL = 'slack_notification_webhook_url';
+
+    // A Bot User OAuth Token (xoxb-...), used with `chat.postMessage` when the tenant wants to
+    // choose the destination channel per call instead of being pinned to one webhook.
+    case BOT_TOKEN = 'slack_notification_bot_token';
+
+    // Fallback channel (id like `C0123456789` or name like `#general`) used when a caller does
+    // not pass one explicitly. Only meaningful with BOT_TOKEN — a webhook is already bound to a
+    // channel on Slack's side.
+    case DEFAULT_CHANNEL = 'slack_notification_default_channel';
+}

--- a/src/Domains/Connectors/Slack/Handlers/SlackNotificationHandler.php
+++ b/src/Domains/Connectors/Slack/Handlers/SlackNotificationHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Slack\Handlers;
+
+use Kanvas\Connectors\Contracts\BaseIntegration;
+use Kanvas\Connectors\Slack\Enums\NotificationConfigurationEnum;
+use Kanvas\Connectors\Slack\Services\SlackNotificationService;
+use Kanvas\Exceptions\ValidationException;
+use Override;
+
+/**
+ * Connects the generic "send a Slack notification" integration through the shared
+ * `integrationCompany` mutation. Distinct from the Slack agent/listener install flow
+ * (`Actions\ConnectSlackAgentAction` / `ConnectSlackListenerAction`), which provisions a full
+ * two-way conversational channel — this only needs enough to push one-way alerts.
+ *
+ * At least one of `webhook_url` / `bot_token` is required; both may be set so a rule can choose
+ * per call. Credentials are company-scoped: each tenant configures its own destination.
+ */
+class SlackNotificationHandler extends BaseIntegration
+{
+    #[Override]
+    public function setup(): bool
+    {
+        $webhookUrl = trim((string) ($this->data['webhook_url'] ?? ''));
+        $botToken = trim((string) ($this->data['bot_token'] ?? ''));
+        $defaultChannel = trim((string) ($this->data['default_channel'] ?? ''));
+
+        if ($webhookUrl === '' && $botToken === '') {
+            throw new ValidationException(
+                'Provide a Slack Incoming Webhook URL or a Bot User OAuth Token to connect Slack notifications.'
+            );
+        }
+
+        if ($webhookUrl !== '') {
+            SlackNotificationService::validateWebhook($webhookUrl);
+            $this->company->set(NotificationConfigurationEnum::WEBHOOK_URL->value, $webhookUrl);
+        }
+
+        if ($botToken !== '') {
+            SlackNotificationService::validateBotToken($botToken);
+            $this->company->set(NotificationConfigurationEnum::BOT_TOKEN->value, $botToken);
+        }
+
+        if ($defaultChannel !== '') {
+            $this->company->set(NotificationConfigurationEnum::DEFAULT_CHANNEL->value, $defaultChannel);
+        }
+
+        return true;
+    }
+}

--- a/src/Domains/Connectors/Slack/Services/SlackNotificationService.php
+++ b/src/Domains/Connectors/Slack/Services/SlackNotificationService.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Slack\Services;
+
+use Baka\Contracts\AppInterface;
+use Baka\Contracts\CompanyInterface;
+use Baka\Http\SafeUrl;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Connectors\Slack\Client;
+use Kanvas\Connectors\Slack\Enums\NotificationConfigurationEnum;
+use Kanvas\Exceptions\ValidationException;
+use Throwable;
+
+/**
+ * Sends plain notifications to Slack for workflow rules / alerts — deliberately independent of the
+ * agent install flow (`Client::getInstanceByAgent`), which needs an Agent to hang its bot token on.
+ * This reads company-scoped credentials set up through the generic `integrationCompany` mutation
+ * (see `Handlers\SlackNotificationHandler`), the same mechanism every other connector uses.
+ *
+ * A webhook URL is tried first when both are configured: it is the simpler credential (nothing to
+ * scope beyond the single channel it was created for) and needs no channel argument.
+ */
+class SlackNotificationService
+{
+    public function __construct(
+        protected AppInterface $app,
+        protected CompanyInterface $company,
+    ) {
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->webhookUrl() !== '' || $this->botToken() !== '';
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks Slack Block Kit blocks, optional.
+     * @return array{channel: ?string, ts: ?string, via: string}
+     */
+    public function send(string $text, ?string $channel = null, array $blocks = []): array
+    {
+        $webhookUrl = $this->webhookUrl();
+        if ($webhookUrl !== '') {
+            $this->sendViaWebhook($webhookUrl, $text, $blocks);
+
+            return [
+                'channel' => $channel ?? ($this->defaultChannel() ?: null),
+                'ts' => null,
+                'via' => 'webhook',
+            ];
+        }
+
+        $botToken = $this->botToken();
+        if ($botToken !== '') {
+            $resolvedChannel = $channel ?? $this->defaultChannel();
+
+            if ($resolvedChannel === '') {
+                throw new ValidationException(
+                    'A Slack channel is required: pass one explicitly or configure default_channel.'
+                );
+            }
+
+            $ts = new Client($botToken)->postMessage($resolvedChannel, $text);
+
+            return ['channel' => $resolvedChannel, 'ts' => $ts, 'via' => 'bot_token'];
+        }
+
+        throw new ValidationException('Slack notifications are not configured for this company.');
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $blocks
+     */
+    protected function sendViaWebhook(string $webhookUrl, string $text, array $blocks): void
+    {
+        SafeUrl::assertSafe($webhookUrl);
+
+        /** @var Response $response */
+        $response = Http::timeout(15)
+            ->acceptJson()
+            ->post($webhookUrl, array_filter([
+                'text' => $text,
+                'blocks' => $blocks !== [] ? $blocks : null,
+            ]));
+
+        if (! $response->successful()) {
+            throw new ValidationException(
+                'Slack webhook notification failed with HTTP ' . $response->status() . ': ' . $response->body()
+            );
+        }
+    }
+
+    public function webhookUrl(): string
+    {
+        return trim((string) ($this->company->get(NotificationConfigurationEnum::WEBHOOK_URL->value) ?? ''));
+    }
+
+    public function botToken(): string
+    {
+        return trim((string) ($this->company->get(NotificationConfigurationEnum::BOT_TOKEN->value) ?? ''));
+    }
+
+    public function defaultChannel(): string
+    {
+        return trim((string) ($this->company->get(NotificationConfigurationEnum::DEFAULT_CHANNEL->value) ?? ''));
+    }
+
+    /**
+     * Posts a canned test message and requires Slack to accept it — used by the handler at
+     * setup time so a typo'd webhook URL fails loudly instead of silently at the first real alert.
+     */
+    public static function validateWebhook(string $webhookUrl): bool
+    {
+        SafeUrl::assertSafe($webhookUrl);
+
+        try {
+            /** @var Response $response */
+            $response = Http::timeout(10)
+                ->acceptJson()
+                ->post($webhookUrl, ['text' => 'Kanvas is now connected to this Slack channel.']);
+        } catch (Throwable $e) {
+            throw new ValidationException('Failed to reach the Slack webhook URL: ' . $e->getMessage());
+        }
+
+        if (! $response->successful()) {
+            throw new ValidationException(
+                'Slack rejected the webhook test message (HTTP ' . $response->status() . ').'
+            );
+        }
+
+        return true;
+    }
+
+    public static function validateBotToken(string $botToken): bool
+    {
+        try {
+            new Client($botToken)->authTest();
+        } catch (Throwable $e) {
+            throw new ValidationException('Failed to validate the Slack bot token: ' . $e->getMessage());
+        }
+
+        return true;
+    }
+}

--- a/src/Domains/Connectors/Trello/Activities/CreateTrelloCardActivity.php
+++ b/src/Domains/Connectors/Trello/Activities/CreateTrelloCardActivity.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Trello\Activities;
+
+use Illuminate\Database\Eloquent\Model;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Trello\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Trello\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Trello\Services\TrelloBoardService;
+use Kanvas\Workflow\Attributes\WorkflowAction;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\KanvasActivity;
+
+/**
+ * Creates (or, on a re-run, updates) a Trello card from any Kanvas entity — a new Lead, a support
+ * message, a task, whatever the rule is wired to. The entity keeps the created card id in its
+ * custom fields (`CustomFieldEnum::TRELLO_CARD_ID`) so retrying the rule edits the same card
+ * instead of creating a duplicate every time — the same idempotency shape
+ * `PushMessageToWordPressActivity` uses for its WordPress post id.
+ */
+#[WorkflowAction(
+    name: 'Create Trello Card',
+    description: 'Creates a Trello card under the given list from a Kanvas entity. If the entity '
+        . 'already has a card linked (from a previous run), updates that card instead of creating a '
+        . 'duplicate.',
+    integration: IntegrationsEnum::TRELLO,
+    requiresConfig: [
+        ConfigurationEnum::API_KEY,
+        ConfigurationEnum::API_TOKEN,
+    ],
+    requiredParams: ['list_id', 'name'],
+    params: [
+        'list_id' => 'Trello list id (idList) the card is created under. Required.',
+        'name' => 'Card title. Required.',
+        'description' => 'Card description (Trello supports Markdown).',
+        'due' => 'ISO-8601 due date, e.g. 2026-01-31T12:00:00.000Z.',
+    ],
+)]
+class CreateTrelloCardActivity extends KanvasActivity
+{
+    public function execute(Model $entity, Apps $app, array $params): array
+    {
+        $this->overwriteAppService($app);
+
+        $listId = trim((string) ($params['list_id'] ?? ''));
+        $name = trim((string) ($params['name'] ?? ''));
+
+        if ($listId === '' || $name === '') {
+            return $this->failWorkflow([
+                'message' => 'Missing required params "list_id" and/or "name"',
+                'entity' => [get_class($entity), $entity->getId()],
+            ]);
+        }
+
+        $company = $entity->company;
+
+        return $this->executeIntegration(
+            entity: $entity,
+            app: $app,
+            integration: IntegrationsEnum::TRELLO,
+            additionalParams: $params,
+            integrationOperation: function (Model $entity, Apps $app, mixed $integrationCompany, array $additionalParams) use ($listId, $name, $company): array {
+                $service = TrelloBoardService::forApp($app, $company);
+
+                $description = isset($additionalParams['description']) ? (string) $additionalParams['description'] : null;
+                $due = isset($additionalParams['due']) ? (string) $additionalParams['due'] : null;
+
+                $existingCardId = $this->existingCardId($entity);
+
+                if ($existingCardId !== null) {
+                    $card = $service->updateCard($existingCardId, array_filter([
+                        'name' => $name,
+                        'desc' => $description,
+                        'due' => $due,
+                    ]));
+
+                    return ['card' => $card, 'created' => false];
+                }
+
+                $card = $service->createCard($listId, $name, $description, array_filter(['due' => $due]));
+
+                if (isset($card['id']) && method_exists($entity, 'set')) {
+                    $entity->set(CustomFieldEnum::TRELLO_CARD_ID->value, (string) $card['id']);
+                    $entity->set(CustomFieldEnum::TRELLO_LIST_ID->value, $listId);
+                }
+
+                return ['card' => $card, 'created' => true];
+            },
+            company: $company,
+        );
+    }
+
+    private function existingCardId(Model $entity): ?string
+    {
+        if (! method_exists($entity, 'get')) {
+            return null;
+        }
+
+        $cardId = $entity->get(CustomFieldEnum::TRELLO_CARD_ID->value);
+
+        return empty($cardId) ? null : (string) $cardId;
+    }
+}

--- a/src/Domains/Connectors/Trello/Client.php
+++ b/src/Domains/Connectors/Trello/Client.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Trello;
+
+use Baka\Contracts\AppInterface;
+use Baka\Contracts\CompanyInterface;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Connectors\Trello\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Trello\Exceptions\TrelloException;
+use Kanvas\Exceptions\ValidationException;
+
+/**
+ * Thin REST client for the Trello API (https://developer.atlassian.com/cloud/trello/rest/).
+ *
+ * Trello authenticates every request with `key` + `token` parameters rather than a header —
+ * `withAuth()` merges them into whatever the caller passed (query string for GET, form body for
+ * POST/PUT/DELETE, both of which Trello accepts).
+ */
+class Client
+{
+    public const string BASE_URL = 'https://api.trello.com/1/';
+
+    protected string $apiKey;
+    protected string $apiToken;
+
+    public function __construct(
+        protected AppInterface $app,
+        protected CompanyInterface $company,
+    ) {
+        $this->apiKey = (string) ($company->get(ConfigurationEnum::API_KEY->value)
+            ?? $app->get(ConfigurationEnum::API_KEY->value) ?? '');
+        $this->apiToken = (string) ($company->get(ConfigurationEnum::API_TOKEN->value)
+            ?? $app->get(ConfigurationEnum::API_TOKEN->value) ?? '');
+
+        if ($this->apiKey === '' || $this->apiToken === '') {
+            throw new ValidationException('Trello API key and token are missing for this company.');
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $query
+     * @return array<array-key, mixed>
+     */
+    public function get(string $endpoint, array $query = []): array
+    {
+        $response = $this->request()->get($this->url($endpoint), $this->withAuth($query));
+
+        return $this->handle($response, $endpoint);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array<array-key, mixed>
+     */
+    public function post(string $endpoint, array $data = []): array
+    {
+        $response = $this->request()->asForm()->post($this->url($endpoint), $this->withAuth($data));
+
+        return $this->handle($response, $endpoint);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array<array-key, mixed>
+     */
+    public function put(string $endpoint, array $data = []): array
+    {
+        $response = $this->request()->asForm()->put($this->url($endpoint), $this->withAuth($data));
+
+        return $this->handle($response, $endpoint);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @return array<array-key, mixed>
+     */
+    public function delete(string $endpoint, array $data = []): array
+    {
+        $response = $this->request()->asForm()->delete($this->url($endpoint), $this->withAuth($data));
+
+        return $this->handle($response, $endpoint);
+    }
+
+    protected function request(): PendingRequest
+    {
+        return Http::acceptJson()->timeout(20);
+    }
+
+    protected function url(string $endpoint): string
+    {
+        return self::BASE_URL . ltrim($endpoint, '/');
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     * @return array<string, mixed>
+     */
+    protected function withAuth(array $params): array
+    {
+        return array_filter(
+            array_merge($params, ['key' => $this->apiKey, 'token' => $this->apiToken]),
+            static fn (mixed $value): bool => $value !== null
+        );
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    protected function handle(Response $response, string $endpoint): array
+    {
+        if (! $response->successful()) {
+            $message = $response->json('message') ?? $response->body();
+
+            throw new TrelloException(
+                'Trello request to ' . $endpoint . ' failed (HTTP ' . $response->status() . '): '
+                    . (is_string($message) ? $message : (string) json_encode($message)),
+                $response->status()
+            );
+        }
+
+        $body = $response->body();
+
+        return $body === '' ? [] : (json_decode($body, true) ?? []);
+    }
+
+    /**
+     * `members/me` is the cheapest authenticated endpoint Trello offers — used to confirm a
+     * key/token pair actually works before it is stored.
+     */
+    public static function validateCredentials(string $apiKey, string $apiToken): bool
+    {
+        if ($apiKey === '' || $apiToken === '') {
+            throw new ValidationException('Trello API key and token are required.');
+        }
+
+        $response = Http::acceptJson()
+            ->timeout(15)
+            ->get(self::BASE_URL . 'members/me', ['key' => $apiKey, 'token' => $apiToken]);
+
+        if ($response->status() === 401) {
+            throw new ValidationException('Trello rejected the provided API key/token.');
+        }
+
+        if (! $response->successful()) {
+            throw new ValidationException('Trello validation failed with HTTP ' . $response->status() . '.');
+        }
+
+        return true;
+    }
+}

--- a/src/Domains/Connectors/Trello/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/Trello/Enums/ConfigurationEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Trello\Enums;
+
+enum ConfigurationEnum: string
+{
+    case API_KEY = 'trello_api_key';
+    case API_TOKEN = 'trello_api_token';
+}

--- a/src/Domains/Connectors/Trello/Enums/CustomFieldEnum.php
+++ b/src/Domains/Connectors/Trello/Enums/CustomFieldEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Trello\Enums;
+
+/**
+ * Entity-level linkage back to Trello. Set on whatever Kanvas entity a rule created the card for,
+ * so a re-run of the activity updates the existing card instead of creating a duplicate — the same
+ * idempotency shape `PushMessageToWordPressAction` uses for its WordPress post id.
+ */
+enum CustomFieldEnum: string
+{
+    case TRELLO_CARD_ID = 'TRELLO_CARD_ID';
+    case TRELLO_BOARD_ID = 'TRELLO_BOARD_ID';
+    case TRELLO_LIST_ID = 'TRELLO_LIST_ID';
+}

--- a/src/Domains/Connectors/Trello/Exceptions/TrelloException.php
+++ b/src/Domains/Connectors/Trello/Exceptions/TrelloException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Trello\Exceptions;
+
+use Kanvas\Exceptions\ValidationException;
+
+class TrelloException extends ValidationException
+{
+    public function __construct(string $message = '', int $code = 0)
+    {
+        parent::__construct($message, $code);
+    }
+}

--- a/src/Domains/Connectors/Trello/Handlers/TrelloHandler.php
+++ b/src/Domains/Connectors/Trello/Handlers/TrelloHandler.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Trello\Handlers;
+
+use Kanvas\Connectors\Contracts\BaseIntegration;
+use Kanvas\Connectors\Trello\Client;
+use Kanvas\Connectors\Trello\Enums\ConfigurationEnum;
+use Kanvas\Exceptions\ValidationException;
+use Override;
+
+/**
+ * Connects Trello through the generic `integrationCompany` mutation. Credentials are a Developer
+ * API Key (per Trello "Power-Up"/app) plus a user Token (https://trello.com/app-key) — both are
+ * company-scoped since a card should be created under whichever member authorized the token.
+ */
+class TrelloHandler extends BaseIntegration
+{
+    #[Override]
+    public function setup(): bool
+    {
+        $apiKey = trim((string) ($this->data['api_key'] ?? ''));
+        $apiToken = trim((string) ($this->data['api_token'] ?? ''));
+
+        if ($apiKey === '' || $apiToken === '') {
+            throw new ValidationException('Trello API key and token are required.');
+        }
+
+        if (! Client::validateCredentials($apiKey, $apiToken)) {
+            throw new ValidationException('Failed to validate the Trello connection.');
+        }
+
+        $this->company->set(ConfigurationEnum::API_KEY->value, $apiKey);
+        $this->company->set(ConfigurationEnum::API_TOKEN->value, $apiToken);
+
+        return true;
+    }
+}

--- a/src/Domains/Connectors/Trello/Services/TrelloBoardService.php
+++ b/src/Domains/Connectors/Trello/Services/TrelloBoardService.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Trello\Services;
+
+use Baka\Contracts\AppInterface;
+use Baka\Contracts\CompanyInterface;
+use Kanvas\Connectors\Trello\Client;
+
+/**
+ * High-level Trello operations built on top of the raw `Client` — boards/lists lookups and card
+ * create/update, which is all a workflow rule or a "sync a task to Trello" action needs.
+ */
+class TrelloBoardService
+{
+    public function __construct(protected Client $client)
+    {
+    }
+
+    public static function forApp(AppInterface $app, CompanyInterface $company): self
+    {
+        return new self(new Client($app, $company));
+    }
+
+    /**
+     * Boards the token's member belongs to.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function boards(): array
+    {
+        return $this->client->get('members/me/boards', ['fields' => 'name,id,url,closed']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function board(string $boardId): array
+    {
+        return $this->client->get('boards/' . $boardId);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function lists(string $boardId, bool $includeClosed = false): array
+    {
+        return $this->client->get('boards/' . $boardId . '/lists', [
+            'filter' => $includeClosed ? 'all' : 'open',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function card(string $cardId): array
+    {
+        return $this->client->get('cards/' . $cardId);
+    }
+
+    /**
+     * @param array<string, mixed> $options Extra Trello card fields: due, idMembers, idLabels, pos...
+     * @return array<string, mixed>
+     */
+    public function createCard(
+        string $listId,
+        string $name,
+        ?string $description = null,
+        array $options = []
+    ): array {
+        return $this->client->post('cards', array_merge($options, array_filter([
+            'idList' => $listId,
+            'name' => $name,
+            'desc' => $description,
+        ])));
+    }
+
+    /**
+     * @param array<string, mixed> $fields Any Trello card field: name, desc, due, idList, closed...
+     * @return array<string, mixed>
+     */
+    public function updateCard(string $cardId, array $fields): array
+    {
+        return $this->client->put('cards/' . $cardId, $fields);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function moveCardToList(string $cardId, string $listId): array
+    {
+        return $this->updateCard($cardId, ['idList' => $listId]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function archiveCard(string $cardId): array
+    {
+        return $this->updateCard($cardId, ['closed' => 'true']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function addComment(string $cardId, string $text): array
+    {
+        return $this->client->post('cards/' . $cardId . '/actions/comments', ['text' => $text]);
+    }
+}

--- a/src/Domains/Workflow/Enums/IntegrationsEnum.php
+++ b/src/Domains/Workflow/Enums/IntegrationsEnum.php
@@ -65,4 +65,7 @@ enum IntegrationsEnum: string
     case WORDPRESS = 'wordpress';
     case UNIVERSAL_SEGUROS = 'universal_seguros';
     case YUSEN = 'yusen';
+    case SLACK = 'slack';
+    case TRELLO = 'trello';
+    case JIRA = 'jira';
 }

--- a/tests/Connectors/Integration/Jira/CreateJiraIssueActivityTest.php
+++ b/tests/Connectors/Integration/Jira/CreateJiraIssueActivityTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Integration\Jira;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Jira\Activities\CreateJiraIssueActivity;
+use Kanvas\Connectors\Jira\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Jira\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Jira\Handlers\JiraHandler;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\Models\StoredWorkflow;
+use Tests\Connectors\Traits\HasIntegrationCompany;
+use Tests\TestCase;
+
+final class CreateJiraIssueActivityTest extends TestCase
+{
+    use HasIntegrationCompany;
+
+    private const string INSTANCE_URL = 'https://kanvas.atlassian.net';
+
+    public function testCreatesAnIssueAndLinksItToTheEntity(): void
+    {
+        $this->registerIntegration();
+        $this->configureJira();
+
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/issue' => Http::response(['id' => '10001', 'key' => 'OPS-1']),
+        ]);
+
+        $message = $this->makeMessage();
+
+        $result = $this->activity()->execute($message, app(Apps::class), [
+            'project_key' => 'OPS',
+            'summary' => 'Customer reported an outage',
+        ]);
+
+        $this->assertTrue($result['created']);
+        $this->assertSame('OPS-1', $result['issue']['key']);
+        $this->assertSame('OPS-1', $message->get(CustomFieldEnum::JIRA_ISSUE_KEY->value));
+    }
+
+    public function testUpdatesTheLinkedIssueInsteadOfFilingADuplicate(): void
+    {
+        $this->registerIntegration();
+        $this->configureJira();
+
+        $message = $this->makeMessage();
+        $message->set(CustomFieldEnum::JIRA_ISSUE_KEY->value, 'OPS-1');
+
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/issue/OPS-1' => Http::response('', 204),
+        ]);
+
+        $result = $this->activity()->execute($message, app(Apps::class), [
+            'project_key' => 'OPS',
+            'summary' => 'Updated summary',
+        ]);
+
+        $this->assertFalse($result['created']);
+        $this->assertSame('OPS-1', $result['issue_key']);
+        Http::assertSent(fn (Request $request): bool => $request->method() === 'PUT');
+    }
+
+    public function testFailsTheWorkflowWhenRequiredParamsAreMissing(): void
+    {
+        $result = $this->activity()->execute($this->makeMessage(), app(Apps::class), []);
+
+        $this->assertStringContainsString('project_key', $result['message']);
+    }
+
+    private function activity(): CreateJiraIssueActivity
+    {
+        return new CreateJiraIssueActivity(0, now()->toDateTimeString(), StoredWorkflow::make(), []);
+    }
+
+    private function registerIntegration(): void
+    {
+        $user = auth()->user();
+
+        $this->setIntegration(
+            app(Apps::class),
+            IntegrationsEnum::JIRA,
+            JiraHandler::class,
+            $user->getCurrentCompany(),
+            $user
+        );
+    }
+
+    private function configureJira(): void
+    {
+        $this->company()->set(ConfigurationEnum::INSTANCE_URL->value, self::INSTANCE_URL);
+        $this->company()->set(ConfigurationEnum::EMAIL->value, 'agent@kanvas.test');
+        $this->company()->set(ConfigurationEnum::API_TOKEN->value, 'test-api-token');
+    }
+
+    private function company(): Companies
+    {
+        return auth()->user()->getCurrentCompany();
+    }
+
+    private function makeMessage(): Message
+    {
+        return Message::factory()
+            ->withAppId(app(Apps::class)->getId())
+            ->withCompanyId($this->company()->getId())
+            ->create(['message' => ['content' => 'Customer reported an outage.']]);
+    }
+}

--- a/tests/Connectors/Integration/Slack/SendSlackNotificationActivityTest.php
+++ b/tests/Connectors/Integration/Slack/SendSlackNotificationActivityTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Integration\Slack;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Slack\Activities\SendSlackNotificationActivity;
+use Kanvas\Connectors\Slack\Enums\NotificationConfigurationEnum;
+use Kanvas\Connectors\Slack\Handlers\SlackNotificationHandler;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\Models\StoredWorkflow;
+use Tests\Connectors\Traits\HasIntegrationCompany;
+use Tests\TestCase;
+
+final class SendSlackNotificationActivityTest extends TestCase
+{
+    use HasIntegrationCompany;
+
+    private const string WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/XXXXXXXXXXXX';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The cached test company/user is shared across test classes in this suite; clear any
+        // credential a previous test may have left configured.
+        foreach (NotificationConfigurationEnum::cases() as $case) {
+            $this->company()->del($case->value);
+        }
+    }
+
+    public function testSendsThroughTheConfiguredWebhook(): void
+    {
+        $this->registerIntegration();
+        $this->company()->set(NotificationConfigurationEnum::WEBHOOK_URL->value, self::WEBHOOK_URL);
+
+        Http::fake([self::WEBHOOK_URL => Http::response('ok')]);
+
+        $result = $this->activity()->execute(
+            $this->makeMessage(),
+            app(Apps::class),
+            ['text' => 'New order received']
+        );
+
+        $this->assertSame('webhook', $result['via']);
+        Http::assertSent(fn (Request $request): bool => $request['text'] === 'New order received');
+    }
+
+    public function testFailsTheWorkflowWhenTextParamIsMissing(): void
+    {
+        $result = $this->activity()->execute($this->makeMessage(), app(Apps::class), []);
+
+        $this->assertStringContainsString('text', $result['message']);
+    }
+
+    public function testFailsTheWorkflowWhenSlackIsNotConfigured(): void
+    {
+        $this->registerIntegration();
+
+        $result = $this->activity()->execute(
+            $this->makeMessage(),
+            app(Apps::class),
+            ['text' => 'New order received']
+        );
+
+        $this->assertStringContainsString('not configured', $result['message']);
+    }
+
+    private function activity(): SendSlackNotificationActivity
+    {
+        return new SendSlackNotificationActivity(0, now()->toDateTimeString(), StoredWorkflow::make(), []);
+    }
+
+    private function registerIntegration(): void
+    {
+        $user = auth()->user();
+
+        $this->setIntegration(
+            app(Apps::class),
+            IntegrationsEnum::SLACK,
+            SlackNotificationHandler::class,
+            $user->getCurrentCompany(),
+            $user
+        );
+    }
+
+    private function company(): Companies
+    {
+        return auth()->user()->getCurrentCompany();
+    }
+
+    private function makeMessage(): Message
+    {
+        return Message::factory()
+            ->withAppId(app(Apps::class)->getId())
+            ->withCompanyId($this->company()->getId())
+            ->create(['message' => ['content' => 'A new order came in.']]);
+    }
+}

--- a/tests/Connectors/Integration/Trello/CreateTrelloCardActivityTest.php
+++ b/tests/Connectors/Integration/Trello/CreateTrelloCardActivityTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Integration\Trello;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Trello\Activities\CreateTrelloCardActivity;
+use Kanvas\Connectors\Trello\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Trello\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Trello\Handlers\TrelloHandler;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Workflow\Enums\IntegrationsEnum;
+use Kanvas\Workflow\Models\StoredWorkflow;
+use Tests\Connectors\Traits\HasIntegrationCompany;
+use Tests\TestCase;
+
+final class CreateTrelloCardActivityTest extends TestCase
+{
+    use HasIntegrationCompany;
+
+    public function testCreatesACardAndLinksItToTheEntity(): void
+    {
+        $this->registerIntegration();
+        $this->company()->set(ConfigurationEnum::API_KEY->value, 'test-key');
+        $this->company()->set(ConfigurationEnum::API_TOKEN->value, 'test-token');
+
+        Http::fake([
+            'api.trello.com/1/cards*' => Http::response(['id' => 'card1', 'name' => 'New Lead']),
+        ]);
+
+        $message = $this->makeMessage();
+
+        $result = $this->activity()->execute($message, app(Apps::class), [
+            'list_id' => 'list1',
+            'name' => 'New Lead',
+        ]);
+
+        $this->assertTrue($result['created']);
+        $this->assertSame('card1', $result['card']['id']);
+        $this->assertSame('card1', $message->get(CustomFieldEnum::TRELLO_CARD_ID->value));
+    }
+
+    public function testUpdatesTheLinkedCardInsteadOfCreatingADuplicate(): void
+    {
+        $this->registerIntegration();
+        $this->company()->set(ConfigurationEnum::API_KEY->value, 'test-key');
+        $this->company()->set(ConfigurationEnum::API_TOKEN->value, 'test-token');
+
+        $message = $this->makeMessage();
+        $message->set(CustomFieldEnum::TRELLO_CARD_ID->value, 'card1');
+
+        Http::fake([
+            'api.trello.com/1/cards/card1*' => Http::response(['id' => 'card1', 'name' => 'Updated title']),
+        ]);
+
+        $result = $this->activity()->execute($message, app(Apps::class), [
+            'list_id' => 'list1',
+            'name' => 'Updated title',
+        ]);
+
+        $this->assertFalse($result['created']);
+        Http::assertSent(fn (Request $request): bool => $request->method() === 'PUT');
+    }
+
+    public function testFailsTheWorkflowWhenRequiredParamsAreMissing(): void
+    {
+        $result = $this->activity()->execute($this->makeMessage(), app(Apps::class), []);
+
+        $this->assertStringContainsString('list_id', $result['message']);
+    }
+
+    private function activity(): CreateTrelloCardActivity
+    {
+        return new CreateTrelloCardActivity(0, now()->toDateTimeString(), StoredWorkflow::make(), []);
+    }
+
+    private function registerIntegration(): void
+    {
+        $user = auth()->user();
+
+        $this->setIntegration(
+            app(Apps::class),
+            IntegrationsEnum::TRELLO,
+            TrelloHandler::class,
+            $user->getCurrentCompany(),
+            $user
+        );
+    }
+
+    private function company(): Companies
+    {
+        return auth()->user()->getCurrentCompany();
+    }
+
+    private function makeMessage(): Message
+    {
+        return Message::factory()
+            ->withAppId(app(Apps::class)->getId())
+            ->withCompanyId($this->company()->getId())
+            ->create(['message' => ['content' => 'A new lead came in.']]);
+    }
+}

--- a/tests/Connectors/Jira/ClientTest.php
+++ b/tests/Connectors/Jira/ClientTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Jira;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Jira\Client;
+use Kanvas\Connectors\Jira\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Jira\Exceptions\JiraException;
+use Kanvas\Exceptions\ValidationException;
+use Tests\TestCase;
+
+final class ClientTest extends TestCase
+{
+    private const string INSTANCE_URL = 'https://kanvas.atlassian.net';
+
+    private Apps $currentApp;
+    private Companies $currentCompany;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->currentApp = app(Apps::class);
+        $this->currentCompany = static::$cachedUser->getCurrentCompany();
+
+        $this->currentCompany->set(ConfigurationEnum::INSTANCE_URL->value, self::INSTANCE_URL);
+        $this->currentCompany->set(ConfigurationEnum::EMAIL->value, 'agent@kanvas.test');
+        $this->currentCompany->set(ConfigurationEnum::API_TOKEN->value, 'test-api-token');
+    }
+
+    public function testConstructorThrowsWhenConfigurationIsMissing(): void
+    {
+        $company = static::$cachedUser->getCurrentCompany();
+        $company->set(ConfigurationEnum::INSTANCE_URL->value, '');
+        $company->set(ConfigurationEnum::EMAIL->value, '');
+        $company->set(ConfigurationEnum::API_TOKEN->value, '');
+
+        $this->expectException(ValidationException::class);
+
+        new Client($this->currentApp, $company);
+    }
+
+    public function testGetSendsBasicAuthAndReturnsDecodedJson(): void
+    {
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/issue/OPS-1' => Http::response(['id' => '10001', 'key' => 'OPS-1']),
+        ]);
+
+        $client = new Client($this->currentApp, $this->currentCompany);
+        $issue = $client->get('issue/OPS-1');
+
+        $this->assertSame('OPS-1', $issue['key']);
+
+        Http::assertSent(function (Request $request): bool {
+            $header = $request->header('Authorization')[0] ?? '';
+
+            return str_starts_with($header, 'Basic ')
+                && base64_decode(substr($header, 6)) === 'agent@kanvas.test:test-api-token';
+        });
+    }
+
+    public function testFailedResponseIsWrappedInJiraException(): void
+    {
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/issue' => Http::response([
+                'errorMessages' => ['summary is required'],
+            ], 400),
+        ]);
+
+        $client = new Client($this->currentApp, $this->currentCompany);
+
+        $this->expectException(JiraException::class);
+        $this->expectExceptionMessage('summary is required');
+
+        $client->post('issue', ['fields' => []]);
+    }
+
+    public function testValidateCredentialsReturnsTrueOnSuccess(): void
+    {
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/myself' => Http::response(['accountId' => 'abc123']),
+        ]);
+
+        $this->assertTrue(Client::validateCredentials(self::INSTANCE_URL, 'agent@kanvas.test', 'test-api-token'));
+    }
+
+    public function testValidateCredentialsRejectsUnauthorized(): void
+    {
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/myself' => Http::response('', 401),
+        ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Jira rejected');
+
+        Client::validateCredentials(self::INSTANCE_URL, 'agent@kanvas.test', 'bad-token');
+    }
+
+    public function testValidateCredentialsRejectsEmptyInput(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        Client::validateCredentials('', '', '');
+    }
+}

--- a/tests/Connectors/Jira/JiraHandlerTest.php
+++ b/tests/Connectors/Jira/JiraHandlerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Jira;
+
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Jira\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Jira\Handlers\JiraHandler;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Regions\Models\Regions;
+use Tests\TestCase;
+
+final class JiraHandlerTest extends TestCase
+{
+    private const string INSTANCE_URL = 'https://kanvas.atlassian.net';
+
+    private Apps $currentApp;
+    private Companies $currentCompany;
+    private Regions $currentRegion;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->currentApp = app(Apps::class);
+        $this->currentCompany = static::$cachedUser->getCurrentCompany();
+        $this->currentRegion = Regions::getDefault($this->currentCompany, $this->currentApp);
+    }
+
+    public function testSetupThrowsWhenCredentialsAreMissing(): void
+    {
+        $handler = new JiraHandler(
+            $this->currentApp,
+            $this->currentCompany,
+            $this->currentRegion,
+            ['instance_url' => '', 'email' => '', 'api_token' => '']
+        );
+
+        $this->expectException(ValidationException::class);
+
+        $handler->setup();
+    }
+
+    public function testSetupStoresConfigurationWhenJiraAcceptsIt(): void
+    {
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/myself' => Http::response(['accountId' => 'abc123']),
+        ]);
+
+        $handler = new JiraHandler(
+            $this->currentApp,
+            $this->currentCompany,
+            $this->currentRegion,
+            [
+                'instance_url' => self::INSTANCE_URL . '/',
+                'email' => 'agent@kanvas.test',
+                'api_token' => 'test-api-token',
+                'default_project_key' => 'OPS',
+                'default_issue_type' => 'Bug',
+            ]
+        );
+
+        $this->assertTrue($handler->setup());
+        $this->assertSame(self::INSTANCE_URL, $this->currentCompany->get(ConfigurationEnum::INSTANCE_URL->value));
+        $this->assertSame('agent@kanvas.test', $this->currentCompany->get(ConfigurationEnum::EMAIL->value));
+        $this->assertSame('test-api-token', $this->currentCompany->get(ConfigurationEnum::API_TOKEN->value));
+        $this->assertSame('OPS', $this->currentCompany->get(ConfigurationEnum::DEFAULT_PROJECT_KEY->value));
+        $this->assertSame('Bug', $this->currentCompany->get(ConfigurationEnum::DEFAULT_ISSUE_TYPE->value));
+    }
+
+    public function testSetupThrowsWhenJiraRejectsTheCredentials(): void
+    {
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/myself' => Http::response('', 401),
+        ]);
+
+        $handler = new JiraHandler(
+            $this->currentApp,
+            $this->currentCompany,
+            $this->currentRegion,
+            [
+                'instance_url' => self::INSTANCE_URL,
+                'email' => 'agent@kanvas.test',
+                'api_token' => 'bad-token',
+            ]
+        );
+
+        $this->expectException(ValidationException::class);
+
+        $handler->setup();
+    }
+}

--- a/tests/Connectors/Jira/JiraIssueServiceTest.php
+++ b/tests/Connectors/Jira/JiraIssueServiceTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Jira;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Jira\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Jira\Exceptions\JiraException;
+use Kanvas\Connectors\Jira\Services\JiraIssueService;
+use Tests\TestCase;
+
+final class JiraIssueServiceTest extends TestCase
+{
+    private const string INSTANCE_URL = 'https://kanvas.atlassian.net';
+
+    private JiraIssueService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Apps $app */
+        $app = app(Apps::class);
+        /** @var Companies $company */
+        $company = static::$cachedUser->getCurrentCompany();
+
+        $company->set(ConfigurationEnum::INSTANCE_URL->value, self::INSTANCE_URL);
+        $company->set(ConfigurationEnum::EMAIL->value, 'agent@kanvas.test');
+        $company->set(ConfigurationEnum::API_TOKEN->value, 'test-api-token');
+
+        $this->service = JiraIssueService::forApp($app, $company);
+    }
+
+    public function testToDocumentFormatWrapsPlainTextInAtlassianDocumentFormat(): void
+    {
+        $document = JiraIssueService::toDocumentFormat('Hello Jira');
+
+        $this->assertSame('doc', $document['type']);
+        $this->assertSame(1, $document['version']);
+        $this->assertSame('paragraph', $document['content'][0]['type']);
+        $this->assertSame('Hello Jira', $document['content'][0]['content'][0]['text']);
+    }
+
+    public function testCreateIssueSendsProjectSummaryAndDescription(): void
+    {
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/issue' => Http::response(['id' => '10001', 'key' => 'OPS-1']),
+        ]);
+
+        $issue = $this->service->createIssue('OPS', 'Investigate outage', 'Customer reported downtime');
+
+        $this->assertSame('OPS-1', $issue['key']);
+
+        Http::assertSent(function (Request $request): bool {
+            $body = $request->data();
+
+            return $body['fields']['project']['key'] === 'OPS'
+                && $body['fields']['summary'] === 'Investigate outage'
+                && $body['fields']['issuetype']['name'] === 'Task'
+                && $body['fields']['description']['content'][0]['content'][0]['text'] === 'Customer reported downtime';
+        });
+    }
+
+    public function testGetTransitionsReturnsTheTransitionsArray(): void
+    {
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/issue/OPS-1/transitions' => Http::response([
+                'transitions' => [
+                    ['id' => '11', 'name' => 'In Progress'],
+                    ['id' => '31', 'name' => 'Done'],
+                ],
+            ]),
+        ]);
+
+        $transitions = $this->service->getTransitions('OPS-1');
+
+        $this->assertCount(2, $transitions);
+        $this->assertSame('Done', $transitions[1]['name']);
+    }
+
+    public function testTransitionIssueResolvesTransitionIdByName(): void
+    {
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/issue/OPS-1/transitions' => Http::sequence()
+                ->push([
+                    'transitions' => [
+                        ['id' => '11', 'name' => 'In Progress'],
+                        ['id' => '31', 'name' => 'Done'],
+                    ],
+                ])
+                ->push([], 204),
+        ]);
+
+        $this->service->transitionIssue('OPS-1', 'done');
+
+        Http::assertSent(
+            fn (Request $request): bool => $request->method() === 'POST'
+                && ($request->data()['transition']['id'] ?? null) === '31'
+        );
+    }
+
+    public function testTransitionIssueThrowsWhenTheNamedTransitionDoesNotExist(): void
+    {
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/issue/OPS-1/transitions' => Http::response([
+                'transitions' => [
+                    ['id' => '11', 'name' => 'In Progress'],
+                ],
+            ]),
+        ]);
+
+        $this->expectException(JiraException::class);
+        $this->expectExceptionMessage('no transition named "Done"');
+
+        $this->service->transitionIssue('OPS-1', 'Done');
+    }
+
+    public function testAddWorklogSendsTimeSpentAndComment(): void
+    {
+        Http::fake([
+            self::INSTANCE_URL . '/rest/api/3/issue/OPS-1/worklog' => Http::response(['id' => 'wl-1']),
+        ]);
+
+        $worklog = $this->service->addWorklog('OPS-1', '2h', 'Investigated root cause');
+
+        $this->assertSame('wl-1', $worklog['id']);
+        Http::assertSent(
+            fn (Request $request): bool => $request->data()['timeSpent'] === '2h'
+                && ($request->data()['comment']['content'][0]['content'][0]['text'] ?? null) === 'Investigated root cause'
+        );
+    }
+}

--- a/tests/Connectors/Slack/SlackNotificationHandlerTest.php
+++ b/tests/Connectors/Slack/SlackNotificationHandlerTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Slack;
+
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Slack\Enums\NotificationConfigurationEnum;
+use Kanvas\Connectors\Slack\Handlers\SlackNotificationHandler;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Regions\Models\Regions;
+use Tests\TestCase;
+
+final class SlackNotificationHandlerTest extends TestCase
+{
+    private const string WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/XXXXXXXXXXXX';
+
+    private Apps $currentApp;
+    private Companies $currentCompany;
+    private Regions $currentRegion;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->currentApp = app(Apps::class);
+        $this->currentCompany = static::$cachedUser->getCurrentCompany();
+        $this->currentRegion = Regions::getDefault($this->currentCompany, $this->currentApp);
+    }
+
+    public function testSetupThrowsWhenNeitherCredentialIsProvided(): void
+    {
+        $handler = new SlackNotificationHandler(
+            $this->currentApp,
+            $this->currentCompany,
+            $this->currentRegion,
+            []
+        );
+
+        $this->expectException(ValidationException::class);
+
+        $handler->setup();
+    }
+
+    public function testSetupStoresAValidatedWebhookUrl(): void
+    {
+        Http::fake([self::WEBHOOK_URL => Http::response('ok')]);
+
+        $handler = new SlackNotificationHandler(
+            $this->currentApp,
+            $this->currentCompany,
+            $this->currentRegion,
+            ['webhook_url' => self::WEBHOOK_URL, 'default_channel' => '#alerts']
+        );
+
+        $this->assertTrue($handler->setup());
+        $this->assertSame(self::WEBHOOK_URL, $this->currentCompany->get(NotificationConfigurationEnum::WEBHOOK_URL->value));
+        $this->assertSame('#alerts', $this->currentCompany->get(NotificationConfigurationEnum::DEFAULT_CHANNEL->value));
+    }
+
+    public function testSetupStoresAValidatedBotToken(): void
+    {
+        Http::fake([
+            'slack.com/api/auth.test' => Http::response(['ok' => true, 'user_id' => 'UBOT1', 'team_id' => 'T1', 'team' => 'Acme']),
+        ]);
+
+        $handler = new SlackNotificationHandler(
+            $this->currentApp,
+            $this->currentCompany,
+            $this->currentRegion,
+            ['bot_token' => 'xoxb-real-token']
+        );
+
+        $this->assertTrue($handler->setup());
+        $this->assertSame('xoxb-real-token', $this->currentCompany->get(NotificationConfigurationEnum::BOT_TOKEN->value));
+    }
+
+    public function testSetupThrowsWhenSlackRejectsTheWebhook(): void
+    {
+        Http::fake([self::WEBHOOK_URL => Http::response('invalid_payload', 400)]);
+
+        $handler = new SlackNotificationHandler(
+            $this->currentApp,
+            $this->currentCompany,
+            $this->currentRegion,
+            ['webhook_url' => self::WEBHOOK_URL]
+        );
+
+        $this->expectException(ValidationException::class);
+
+        $handler->setup();
+    }
+}

--- a/tests/Connectors/Slack/SlackNotificationServiceTest.php
+++ b/tests/Connectors/Slack/SlackNotificationServiceTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Slack;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Slack\Enums\NotificationConfigurationEnum;
+use Kanvas\Connectors\Slack\Services\SlackNotificationService;
+use Kanvas\Exceptions\ValidationException;
+use Tests\TestCase;
+
+final class SlackNotificationServiceTest extends TestCase
+{
+    private const string WEBHOOK_URL = 'https://hooks.slack.com/services/T000/B000/XXXXXXXXXXXX';
+
+    private Apps $currentApp;
+    private Companies $currentCompany;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->currentApp = app(Apps::class);
+        $this->currentCompany = static::$cachedUser->getCurrentCompany();
+
+        // The cached test company/user is shared across test classes in this suite; clear any
+        // credential a previous test may have left configured so "not configured yet" is actually
+        // exercised regardless of run order.
+        foreach (NotificationConfigurationEnum::cases() as $case) {
+            $this->currentCompany->del($case->value);
+        }
+    }
+
+    public function testIsConfiguredIsFalseUntilACredentialIsStored(): void
+    {
+        $service = new SlackNotificationService($this->currentApp, $this->currentCompany);
+
+        $this->assertFalse($service->isConfigured());
+    }
+
+    public function testSendThrowsWhenNothingIsConfigured(): void
+    {
+        $service = new SlackNotificationService($this->currentApp, $this->currentCompany);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('not configured');
+
+        $service->send('hello');
+    }
+
+    public function testSendPrefersTheWebhookWhenBothCredentialsAreConfigured(): void
+    {
+        $this->currentCompany->set(NotificationConfigurationEnum::WEBHOOK_URL->value, self::WEBHOOK_URL);
+        $this->currentCompany->set(NotificationConfigurationEnum::BOT_TOKEN->value, 'xoxb-should-not-be-used');
+
+        Http::fake([self::WEBHOOK_URL => Http::response('ok')]);
+
+        $service = new SlackNotificationService($this->currentApp, $this->currentCompany);
+        $result = $service->send('Deploy finished');
+
+        $this->assertSame('webhook', $result['via']);
+        Http::assertSent(
+            fn (Request $request): bool => $request->url() === self::WEBHOOK_URL
+                && $request['text'] === 'Deploy finished'
+        );
+    }
+
+    public function testSendViaWebhookThrowsWhenSlackRejectsIt(): void
+    {
+        $this->currentCompany->set(NotificationConfigurationEnum::WEBHOOK_URL->value, self::WEBHOOK_URL);
+
+        Http::fake([self::WEBHOOK_URL => Http::response('invalid_payload', 400)]);
+
+        $service = new SlackNotificationService($this->currentApp, $this->currentCompany);
+
+        $this->expectException(ValidationException::class);
+
+        $service->send('Deploy finished');
+    }
+
+    public function testSendViaBotTokenUsesTheExplicitChannelOverTheDefault(): void
+    {
+        $this->currentCompany->set(NotificationConfigurationEnum::BOT_TOKEN->value, 'xoxb-real-token');
+        $this->currentCompany->set(NotificationConfigurationEnum::DEFAULT_CHANNEL->value, '#general');
+
+        Http::fake([
+            'slack.com/api/chat.postMessage' => Http::response(['ok' => true, 'ts' => '123.456']),
+        ]);
+
+        $service = new SlackNotificationService($this->currentApp, $this->currentCompany);
+        $result = $service->send('Deploy finished', '#alerts');
+
+        $this->assertSame('#alerts', $result['channel']);
+        $this->assertSame('123.456', $result['ts']);
+        $this->assertSame('bot_token', $result['via']);
+        Http::assertSent(fn (Request $request): bool => $request['channel'] === '#alerts');
+    }
+
+    public function testSendViaBotTokenFallsBackToTheDefaultChannel(): void
+    {
+        $this->currentCompany->set(NotificationConfigurationEnum::BOT_TOKEN->value, 'xoxb-real-token');
+        $this->currentCompany->set(NotificationConfigurationEnum::DEFAULT_CHANNEL->value, '#general');
+
+        Http::fake([
+            'slack.com/api/chat.postMessage' => Http::response(['ok' => true, 'ts' => '123.456']),
+        ]);
+
+        $service = new SlackNotificationService($this->currentApp, $this->currentCompany);
+        $result = $service->send('Deploy finished');
+
+        $this->assertSame('#general', $result['channel']);
+        Http::assertSent(fn (Request $request): bool => $request['channel'] === '#general');
+    }
+
+    public function testSendViaBotTokenThrowsWhenNoChannelIsAvailable(): void
+    {
+        $this->currentCompany->set(NotificationConfigurationEnum::BOT_TOKEN->value, 'xoxb-real-token');
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('channel is required');
+
+        new SlackNotificationService($this->currentApp, $this->currentCompany)->send('Deploy finished');
+    }
+
+    public function testValidateWebhookReturnsTrueWhenSlackAccepts(): void
+    {
+        Http::fake([self::WEBHOOK_URL => Http::response('ok')]);
+
+        $this->assertTrue(SlackNotificationService::validateWebhook(self::WEBHOOK_URL));
+    }
+
+    public function testValidateWebhookThrowsWhenSlackRejects(): void
+    {
+        Http::fake([self::WEBHOOK_URL => Http::response('invalid_payload', 400)]);
+
+        $this->expectException(ValidationException::class);
+
+        SlackNotificationService::validateWebhook(self::WEBHOOK_URL);
+    }
+
+    public function testValidateBotTokenReturnsTrueWhenSlackAccepts(): void
+    {
+        Http::fake([
+            'slack.com/api/auth.test' => Http::response(['ok' => true, 'user_id' => 'UBOT1', 'team_id' => 'T1', 'team' => 'Acme']),
+        ]);
+
+        $this->assertTrue(SlackNotificationService::validateBotToken('xoxb-real-token'));
+    }
+
+    public function testValidateBotTokenThrowsWhenSlackRejects(): void
+    {
+        Http::fake([
+            'slack.com/api/auth.test' => Http::response(['ok' => false, 'error' => 'invalid_auth']),
+        ]);
+
+        $this->expectException(ValidationException::class);
+
+        SlackNotificationService::validateBotToken('xoxb-bad-token');
+    }
+}

--- a/tests/Connectors/Trello/ClientTest.php
+++ b/tests/Connectors/Trello/ClientTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Trello;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Trello\Client;
+use Kanvas\Connectors\Trello\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Trello\Exceptions\TrelloException;
+use Kanvas\Exceptions\ValidationException;
+use Tests\TestCase;
+
+final class ClientTest extends TestCase
+{
+    private Apps $currentApp;
+    private Companies $currentCompany;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->currentApp = app(Apps::class);
+        $this->currentCompany = static::$cachedUser->getCurrentCompany();
+
+        $this->currentCompany->set(ConfigurationEnum::API_KEY->value, 'test-key');
+        $this->currentCompany->set(ConfigurationEnum::API_TOKEN->value, 'test-token');
+    }
+
+    public function testConstructorThrowsWhenCredentialsAreMissing(): void
+    {
+        $company = static::$cachedUser->getCurrentCompany();
+        $company->set(ConfigurationEnum::API_KEY->value, '');
+        $company->set(ConfigurationEnum::API_TOKEN->value, '');
+
+        $this->expectException(ValidationException::class);
+
+        new Client($this->currentApp, $company);
+    }
+
+    public function testGetAppendsKeyAndTokenAndReturnsDecodedJson(): void
+    {
+        Http::fake([
+            'api.trello.com/1/boards/board1*' => Http::response(['id' => 'board1', 'name' => 'Roadmap']),
+        ]);
+
+        $client = new Client($this->currentApp, $this->currentCompany);
+        $board = $client->get('boards/board1');
+
+        $this->assertSame('Roadmap', $board['name']);
+
+        Http::assertSent(
+            fn (Request $request): bool => str_contains($request->url(), 'boards/board1')
+                && $request['key'] === 'test-key'
+                && $request['token'] === 'test-token'
+        );
+    }
+
+    public function testCreateCardPostsFormWithAuth(): void
+    {
+        Http::fake([
+            'api.trello.com/1/cards*' => Http::response(['id' => 'card1', 'name' => 'New Card']),
+        ]);
+
+        $client = new Client($this->currentApp, $this->currentCompany);
+        $card = $client->post('cards', ['idList' => 'list1', 'name' => 'New Card']);
+
+        $this->assertSame('card1', $card['id']);
+
+        Http::assertSent(
+            fn (Request $request): bool => $request->method() === 'POST'
+                && $request['idList'] === 'list1'
+                && $request['name'] === 'New Card'
+                && $request['key'] === 'test-key'
+                && $request['token'] === 'test-token'
+        );
+    }
+
+    public function testClientErrorIsWrappedInTrelloException(): void
+    {
+        Http::fake([
+            'api.trello.com/1/members/me*' => Http::response(['message' => 'invalid key'], 401),
+        ]);
+
+        $client = new Client($this->currentApp, $this->currentCompany);
+
+        $this->expectException(TrelloException::class);
+        $this->expectExceptionMessage('invalid key');
+
+        $client->get('members/me');
+    }
+
+    public function testValidateCredentialsReturnsTrueOnSuccess(): void
+    {
+        Http::fake([
+            'api.trello.com/1/members/me*' => Http::response(['id' => 'me']),
+        ]);
+
+        $this->assertTrue(Client::validateCredentials('key', 'token'));
+    }
+
+    public function testValidateCredentialsRejectsBadToken(): void
+    {
+        Http::fake([
+            'api.trello.com/1/members/me*' => Http::response(['message' => 'invalid token'], 401),
+        ]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Trello rejected');
+
+        Client::validateCredentials('key', 'token');
+    }
+
+    public function testValidateCredentialsRejectsEmptyInput(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        Client::validateCredentials('', '');
+    }
+}

--- a/tests/Connectors/Trello/TrelloBoardServiceTest.php
+++ b/tests/Connectors/Trello/TrelloBoardServiceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Trello;
+
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Trello\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Trello\Services\TrelloBoardService;
+use Tests\TestCase;
+
+final class TrelloBoardServiceTest extends TestCase
+{
+    private TrelloBoardService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var Apps $app */
+        $app = app(Apps::class);
+        /** @var Companies $company */
+        $company = static::$cachedUser->getCurrentCompany();
+
+        $company->set(ConfigurationEnum::API_KEY->value, 'test-key');
+        $company->set(ConfigurationEnum::API_TOKEN->value, 'test-token');
+
+        $this->service = TrelloBoardService::forApp($app, $company);
+    }
+
+    public function testBoardsRequestsMemberBoards(): void
+    {
+        Http::fake([
+            'api.trello.com/1/members/me/boards*' => Http::response([
+                ['id' => 'board1', 'name' => 'Roadmap'],
+            ]),
+        ]);
+
+        $boards = $this->service->boards();
+
+        $this->assertSame('Roadmap', $boards[0]['name']);
+        Http::assertSent(fn (Request $request): bool => str_contains($request->url(), 'members/me/boards'));
+    }
+
+    public function testListsFiltersToOpenByDefault(): void
+    {
+        Http::fake([
+            'api.trello.com/1/boards/board1/lists*' => Http::response([
+                ['id' => 'list1', 'name' => 'To Do'],
+            ]),
+        ]);
+
+        $lists = $this->service->lists('board1');
+
+        $this->assertSame('To Do', $lists[0]['name']);
+        Http::assertSent(fn (Request $request): bool => $request['filter'] === 'open');
+    }
+
+    public function testCreateCardSendsListNameAndDescription(): void
+    {
+        Http::fake([
+            'api.trello.com/1/cards*' => Http::response(['id' => 'card1', 'name' => 'Investigate outage']),
+        ]);
+
+        $card = $this->service->createCard('list1', 'Investigate outage', 'Customer reported downtime');
+
+        $this->assertSame('card1', $card['id']);
+        Http::assertSent(
+            fn (Request $request): bool => $request['idList'] === 'list1'
+                && $request['name'] === 'Investigate outage'
+                && $request['desc'] === 'Customer reported downtime'
+        );
+    }
+
+    public function testUpdateCardMovesListWhenRequested(): void
+    {
+        Http::fake([
+            'api.trello.com/1/cards/card1*' => Http::response(['id' => 'card1', 'idList' => 'list2']),
+        ]);
+
+        $card = $this->service->moveCardToList('card1', 'list2');
+
+        $this->assertSame('list2', $card['idList']);
+        Http::assertSent(
+            fn (Request $request): bool => $request->method() === 'PUT' && $request['idList'] === 'list2'
+        );
+    }
+
+    public function testArchiveCardSendsClosedTrue(): void
+    {
+        Http::fake([
+            'api.trello.com/1/cards/card1*' => Http::response(['id' => 'card1', 'closed' => true]),
+        ]);
+
+        $this->service->archiveCard('card1');
+
+        Http::assertSent(fn (Request $request): bool => $request['closed'] === 'true');
+    }
+
+    public function testAddCommentPostsToActionsComments(): void
+    {
+        Http::fake([
+            'api.trello.com/1/cards/card1/actions/comments*' => Http::response(['id' => 'comment1']),
+        ]);
+
+        $this->service->addComment('card1', 'Looking into this now.');
+
+        Http::assertSent(
+            fn (Request $request): bool => str_contains($request->url(), 'actions/comments')
+                && $request['text'] === 'Looking into this now.'
+        );
+    }
+}

--- a/tests/Connectors/Trello/TrelloHandlerTest.php
+++ b/tests/Connectors/Trello/TrelloHandlerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Trello;
+
+use Illuminate\Support\Facades\Http;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Trello\Enums\ConfigurationEnum;
+use Kanvas\Connectors\Trello\Handlers\TrelloHandler;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Regions\Models\Regions;
+use Tests\TestCase;
+
+final class TrelloHandlerTest extends TestCase
+{
+    private Apps $currentApp;
+    private Companies $currentCompany;
+    private Regions $currentRegion;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->currentApp = app(Apps::class);
+        $this->currentCompany = static::$cachedUser->getCurrentCompany();
+        $this->currentRegion = Regions::getDefault($this->currentCompany, $this->currentApp);
+    }
+
+    public function testSetupThrowsWhenCredentialsAreMissing(): void
+    {
+        $handler = new TrelloHandler(
+            $this->currentApp,
+            $this->currentCompany,
+            $this->currentRegion,
+            ['api_key' => '', 'api_token' => '']
+        );
+
+        $this->expectException(ValidationException::class);
+
+        $handler->setup();
+    }
+
+    public function testSetupStoresCredentialsWhenTrelloAcceptsThem(): void
+    {
+        Http::fake([
+            'api.trello.com/1/members/me*' => Http::response(['id' => 'me1', 'username' => 'kanvas']),
+        ]);
+
+        $handler = new TrelloHandler(
+            $this->currentApp,
+            $this->currentCompany,
+            $this->currentRegion,
+            ['api_key' => 'real-key', 'api_token' => 'real-token']
+        );
+
+        $this->assertTrue($handler->setup());
+        $this->assertSame('real-key', $this->currentCompany->get(ConfigurationEnum::API_KEY->value));
+        $this->assertSame('real-token', $this->currentCompany->get(ConfigurationEnum::API_TOKEN->value));
+    }
+
+    public function testSetupThrowsWhenTrelloRejectsTheCredentials(): void
+    {
+        Http::fake([
+            'api.trello.com/1/members/me*' => Http::response(['message' => 'invalid token'], 401),
+        ]);
+
+        $handler = new TrelloHandler(
+            $this->currentApp,
+            $this->currentCompany,
+            $this->currentRegion,
+            ['api_key' => 'bad-key', 'api_token' => 'bad-token']
+        );
+
+        $this->expectException(ValidationException::class);
+
+        $handler->setup();
+    }
+}


### PR DESCRIPTION
## Summary

Implements Slack, Trello, and Jira integrations following the repo's standard connector
pattern (`Handler` + `Client` + `Service` + `Activity`, registered against the generic
`integrations` table), so they can be connected/configured/tested through the existing
`integrationCompany` GraphQL mutation and used as steps in Workflow Rules.

- **Slack** (`src/Domains/Connectors/Slack/{Handlers/SlackNotificationHandler.php,Services/SlackNotificationService.php,Activities/SendSlackNotificationActivity.php,Enums/NotificationConfigurationEnum.php}`)
  - Sends notifications to a channel via an **Incoming Webhook URL** or a **Bot User OAuth Token**
    (`chat.postMessage`), both dynamically configurable per company.
  - Kept separate from the existing Slack *agent* integration (`Actions/ConnectSlackAgentAction.php`
    et al.), which provisions a full two-way conversational channel — this is a much smaller,
    one-way "post an alert" capability.
- **Trello** (new connector, `src/Domains/Connectors/Trello/`)
  - `Client` (Developer API Key + Token), `TrelloBoardService` (boards/lists/cards: create, update,
    move, archive, comment), `CreateTrelloCardActivity` workflow step (idempotent — re-running
    updates the linked card instead of duplicating it).
- **Jira** (new connector, `src/Domains/Connectors/Jira/`)
  - `Client` (instance URL + email + API token, HTTP Basic auth against Jira Cloud's `/rest/api/3`),
    `JiraIssueService` (create/update issues, transition status **by name**, add worklogs/comments),
    `CreateJiraIssueActivity` workflow step (same idempotent update-instead-of-duplicate behavior).

### Registration

- `Kanvas\Workflow\Enums\IntegrationsEnum` gained `SLACK`, `TRELLO`, `JIRA`.
- Three new migrations seed each connector's row in the `integrations` table
  (`database/migrations/Workflow/2026_08_28_*_integration.php`), following the same pattern as the
  recent Jina/pi.dev/Yusen migrations.
- Each `Activity` carries `#[Kanvas\Workflow\Attributes\WorkflowAction]`, so
  `kanvas:workflow-sync-actions` picks them up automatically — no manual registration, and the
  existing `WorkflowActionCoverageTest` enforces the attribute is present.

### No new GraphQL surface

Connect/configure/test reuses the **generic** `integrationCompany` / `removeIntegrationCompany` /
`integrationCompanyIsActive` mutations already used by every other connector (Stripe, WordPress,
Salesforce, pi.dev, ...) — `Handler::setup()` validates the credentials against the real API before
the row is marked `ACTIVE`, which *is* the "test connection" step. See
`docs/integrations_slack_trello_jira.md` for GraphQL examples per connector.

## Tests

- Unit tests (`Http::fake()`-based, no live network) for each `Client`/`Service`/`Handler`:
  `tests/Connectors/{Slack,Trello,Jira}/*Test.php`.
- Integration tests exercising the full `executeIntegration()` path through each `Activity`:
  `tests/Connectors/Integration/{Slack,Trello,Jira}/*ActivityTest.php`.

## Docs

`docs/integrations_slack_trello_jira.md` — how to enable, configure (with GraphQL examples) and use
each of the three integrations, plus how to extend them with more operations.

## Notes for reviewers

- This environment had no PHP/Composer/DB available to run the suite locally; tests follow the
  exact conventions of existing connector tests (`tests/Connectors/PiDev/ClientTest.php`,
  `tests/Connectors/Integration/Salesforce/SalesforceHandlerTest.php`,
  `tests/Connectors/Integration/WordPress/PushMessageToWordPressActivityTest.php`) and should run
  under the standard `static-analysis`/`tests` CI workflows unmodified.
- No `.github/workflows/`, `deploy/`, or `.env*` files were touched.