### PR TITLE
Store workflow input in entity integration history

### DIFF
--- a/database/migrations/Workflow/2026_08_26_000002_add_input_to_entity_integration_history.php
+++ b/database/migrations/Workflow/2026_08_26_000002_add_input_to_entity_integration_history.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::connection('workflow')->table('entity_integration_history', function (Blueprint $table) {
+            $table->longText('input')->nullable()->after('rules_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection('workflow')->table('entity_integration_history', function (Blueprint $table) {
+            $table->dropColumn('input');
+        });
+    }
+};

--- a/graphql/schemas/WorkFlow/integrations.graphql
+++ b/graphql/schemas/WorkFlow/integrations.graphql
@@ -43,6 +43,7 @@ type WorkflowIntegrationsHistory {
     integrationCompany: IntegrationsCompanies
     status: Status
     workflow: Workflow
+    input: Mixed
     response: Mixed
     exception: Mixed
     trigger: String @method(name: "getTrigger")

--- a/src/Domains/Connectors/Shopify/Workflows/Activities/DeleteVariantFromShopifyActivity.php
+++ b/src/Domains/Connectors/Shopify/Workflows/Activities/DeleteVariantFromShopifyActivity.php
@@ -73,6 +73,7 @@ class DeleteVariantFromShopifyActivity extends KanvasActivity
                     integrationCompany: $integrationCompany,
                     status: $status,
                     entity: $variant,
+                    input: $this->buildIntegrationHistoryInput($variant, $params),
                     response: $historyResponse ?? null,
                     exception: $exception,
                     workflowId: $this->workflowId(),

--- a/src/Domains/Connectors/Shopify/Workflows/Activities/SyncProductWithShopifyWithIntegrationActivity.php
+++ b/src/Domains/Connectors/Shopify/Workflows/Activities/SyncProductWithShopifyWithIntegrationActivity.php
@@ -76,6 +76,7 @@ class SyncProductWithShopifyWithIntegrationActivity extends KanvasActivity
                         integrationCompany: $integrationCompany,
                         status: $status,
                         entity: $product,
+                        input: $this->buildIntegrationHistoryInput($product, $params),
                         response: $historyResponse ?? null,
                         exception: $exception,
                         workflowId: $this->workflowId(),

--- a/src/Domains/Workflow/Integrations/Actions/AddEntityIntegrationHistoryAction.php
+++ b/src/Domains/Workflow/Integrations/Actions/AddEntityIntegrationHistoryAction.php
@@ -28,6 +28,7 @@ class AddEntityIntegrationHistoryAction
         $integrationHistory->companies_id = $this->dto->integrationCompany->company->getId();
         $integrationHistory->integrations_id = $this->dto->integrationCompany->integration->getId();
         $integrationHistory->status_id = $this->dto->status->getId();
+        $integrationHistory->input = $this->dto->input;
         $integrationHistory->response = $this->dto->response;
         $integrationHistory->exception = $this->dto->exception;
         $integrationHistory->workflow_id = $this->dto->workflowId;

--- a/src/Domains/Workflow/Integrations/DataTransferObject/EntityIntegrationHistory.php
+++ b/src/Domains/Workflow/Integrations/DataTransferObject/EntityIntegrationHistory.php
@@ -20,6 +20,7 @@ class EntityIntegrationHistory extends Data
         public Status $status,
         public EntityIntegrationInterface|Model $entity,
         public ?Rule $rule,
+        public mixed $input = null,
         public mixed $response = null,
         public mixed $exception = null,
         public ?int $workflowId = null

--- a/src/Domains/Workflow/Integrations/Models/EntityIntegrationHistory.php
+++ b/src/Domains/Workflow/Integrations/Models/EntityIntegrationHistory.php
@@ -22,6 +22,7 @@ class EntityIntegrationHistory extends BaseModel
         'integrations_company_id',
         'integrations_id',
         'status_id',
+        'input',
         'response',
         'exception',
         'workflow_id',
@@ -29,6 +30,7 @@ class EntityIntegrationHistory extends BaseModel
     ];
 
     protected $casts = [
+        'input' => Json::class,
         'response' => Json::class,
         'exception' => Json::class,
         'is_deleted' => 'boolean',

--- a/src/Domains/Workflow/Traits/ActivityIntegrationTrait.php
+++ b/src/Domains/Workflow/Traits/ActivityIntegrationTrait.php
@@ -78,13 +78,15 @@ trait ActivityIntegrationTrait
         Model $entity,
         mixed $historyResponse = null,
         ?Throwable $exception = null,
-        ?Rule $rule = null
+        ?Rule $rule = null,
+        mixed $input = null
     ): ModelsEntityIntegrationHistory {
         $dto = new EntityIntegrationHistory(
             app: $app,
             integrationCompany: $integrationCompany,
             status: $status,
             entity: $entity,
+            input: $input,
             response: $historyResponse ?? null,
             exception: $exception,
             workflowId: $this->workflowId(),
@@ -98,6 +100,14 @@ trait ActivityIntegrationTrait
         )->execute();
 
         return $this->lastIntegrationHistory;
+    }
+
+    protected function buildIntegrationHistoryInput(Model $entity, array $params): array
+    {
+        return [
+            'entity' => $entity->toArray(),
+            'params' => $params,
+        ];
     }
 
     public function executeIntegration(
@@ -174,7 +184,8 @@ trait ActivityIntegrationTrait
             $entity,
             $response ?? null,
             $exception,
-            rule: $additionalParams['rule'] ?? null
+            rule: $additionalParams['rule'] ?? null,
+            input: $this->buildIntegrationHistoryInput($entity, $additionalParams)
         );
 
         if ($throwException && $exception) {

--- a/tests/Workflow/Integration/ActivityIntegrationTraitTest.php
+++ b/tests/Workflow/Integration/ActivityIntegrationTraitTest.php
@@ -11,6 +11,7 @@ use Kanvas\Regions\Models\Regions;
 use Kanvas\Workflow\Enums\IntegrationsEnum;
 use Kanvas\Workflow\Enums\StatusEnum;
 use Kanvas\Workflow\Integrations\Models\IntegrationsCompany;
+use Kanvas\Workflow\Integrations\Models\EntityIntegrationHistory;
 use Kanvas\Workflow\Integrations\Models\Status;
 use Kanvas\Workflow\Models\Integrations;
 use Kanvas\Workflow\Traits\ActivityIntegrationTrait;
@@ -118,6 +119,37 @@ final class ActivityIntegrationTraitTest extends TestCase
         $this->assertNull($resolved);
     }
 
+    public function testExecuteIntegrationStoresWorkflowInputInHistory(): void
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+        $region = $this->createRegion($app, companiesId: $company->getId());
+        $this->registerIntegration($company->getId(), $region);
+        $input = [
+            'message_id' => 123,
+            'payload' => ['source' => 'workflow-test'],
+        ];
+
+        $this->activity()->executeIntegration(
+            entity: $company,
+            app: $app,
+            integration: IntegrationsEnum::INTERNAL,
+            integrationOperation: fn ($entity, $app, $integrationCompany, $params) => $params,
+            additionalParams: $input,
+            region: $region,
+            company: $company,
+        );
+
+        $history = EntityIntegrationHistory::query()
+            ->where('entity_namespace', $company::class)
+            ->where('entity_id', $company->getId())
+            ->latest('id')
+            ->firstOrFail();
+
+        $this->assertSame($company->toArray(), $history->input['entity']);
+        $this->assertSame($input, $history->input['params']);
+    }
+
     private function createRegion(Apps $app, int $companiesId): Regions
     {
         return Regions::create([
@@ -153,6 +185,11 @@ final class ActivityIntegrationTraitTest extends TestCase
     {
         return new class () {
             use ActivityIntegrationTrait;
+
+            public function workflowId(): ?int
+            {
+                return null;
+            }
         };
     }
 }


### PR DESCRIPTION
Summary:
- add a nullable input column to entity_integration_history
- store an entity snapshot and workflow/rule parameters for each integration execution
- capture the same input structure in direct Shopify integration history writes
- expose input through GraphQL
- add integration coverage for persisted entity and params

Input shape:
- entity: entity.toArray() at execution time
- params: parameters delivered to the workflow activity

Validation:
- PHP syntax checks passed
- git diff --check passed