### PR TITLE
feat: notify a default email whenever an AR credit memo pushes to Acumatica (1.x)

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArCreditMemoTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArCreditMemoTool.php
@@ -14,10 +14,12 @@ use Kanvas\Guild\Organizations\Models\Organization;
 use Kanvas\Guild\Organizations\Services\OrganizationVendorMatcherService;
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Scribe\Approvals\Actions\NotifyApproverAction;
 use Kanvas\Scribe\Approvals\Enums\OrganizationApproverCustomFieldEnum;
 use Kanvas\Scribe\Invoices\Actions\IssueCreditNoteAction;
 use Kanvas\Scribe\Invoices\DataTransferObject\Invoice as InvoiceData;
 use Kanvas\Scribe\Invoices\DataTransferObject\InvoiceLine as InvoiceLineData;
+use Kanvas\Scribe\Invoices\Enums\ConfigurationEnum;
 use Kanvas\Scribe\Ledger\Models\Account;
 use NeuronAI\Tools\ArrayProperty;
 use NeuronAI\Tools\ObjectProperty;
@@ -222,6 +224,12 @@ class CreateArCreditMemoTool extends Tool
         try {
             $reference = new PushInvoiceToAcumaticaAction($creditNote)->execute();
         } catch (AcumaticaWriteException|Throwable $e) {
+            $this->notifyCreditMemoOutcome(
+                $app,
+                "AR credit memo pushed to Acumatica FAILED:\nCustomer: {$customerDisplayName}\nReference: "
+                    . "{$invoice_number}\nKanvas credit_memo_id: {$creditNote->getId()}\nError: " . $e->getMessage(),
+            );
+
             return [
                 'created' => true,
                 'pushed' => false,
@@ -234,6 +242,13 @@ class CreateArCreditMemoTool extends Tool
                     . $e->getMessage() . '. It needs manual attention — it will not auto-retry.',
             ];
         }
+
+        $this->notifyCreditMemoOutcome(
+            $app,
+            "AR credit memo pushed to Acumatica:\nCustomer: {$customerDisplayName}\nAmount: {$currency} "
+                . number_format((float) $creditNote->total_native, 2) . "\nReference: {$invoice_number}\nKanvas "
+                . "credit_memo_id: {$creditNote->getId()}\nAcumatica ref: {$reference}",
+        );
 
         return [
             'created' => true,
@@ -251,6 +266,18 @@ class CreateArCreditMemoTool extends Tool
                 . 'timestamp yourself. Use add_invoice_note / attach_invoice_file if you need to attach the '
                 . 'request form or manager approval.',
         ];
+    }
+
+    // Until per-customer notification routing is decided, everything goes to one fixed default address (CREDIT_MEMO_NOTIFICATION_EMAIL) — silently skipped when unset.
+    private function notifyCreditMemoOutcome(Apps $app, string $text): void
+    {
+        $email = trim((string) $app->get(ConfigurationEnum::CREDIT_MEMO_NOTIFICATION_EMAIL->value, ''));
+
+        if ($email === '') {
+            return;
+        }
+
+        new NotifyApproverAction(app: $app, text: $text, approverEmail: $email)->execute();
     }
 
     private function resolveAccount(string $accountNumber, Apps $app, Companies $company): ?Account

--- a/src/Domains/Scribe/Invoices/Enums/ConfigurationEnum.php
+++ b/src/Domains/Scribe/Invoices/Enums/ConfigurationEnum.php
@@ -8,4 +8,7 @@ enum ConfigurationEnum: string
 {
     // App-level config naming which client's Credit Request Form layout to parse (a CreditRequestFormClientEnum value). Defaults to NZXT when unset.
     case CREDIT_REQUEST_FORM_CLIENT = 'credit-request-form-client';
+
+    // App-level default recipient email for "a credit memo was pushed to Acumatica" notifications, until per-customer routing is decided. No notification sent when unset.
+    case CREDIT_MEMO_NOTIFICATION_EMAIL = 'credit-memo-notification-email';
 }

--- a/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Scribe\Intelligence;
 
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
+use Kanvas\Intelligence\AgentRuntime\Enums\AgentChannelTokenEnum;
 use Kanvas\Intelligence\Agents\Enums\ToolOutcomeEnum;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Models\AgentType;
@@ -20,7 +23,9 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\ApplyArPaymentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AttachInvoiceFileTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArCreditMemoTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateArInvoiceTool;
+use Kanvas\Scribe\Approvals\Enums\ApprovalConfigurationEnum;
 use Kanvas\Scribe\Approvals\Enums\OrganizationApproverCustomFieldEnum;
+use Kanvas\Scribe\Invoices\Enums\ConfigurationEnum as InvoicesConfigurationEnum;
 use Kanvas\Scribe\Invoices\Enums\DocumentTypeEnum;
 use Kanvas\Scribe\Invoices\Enums\InvoiceDocumentStatusEnum;
 use Kanvas\Scribe\Invoices\Models\Invoice;
@@ -474,6 +479,56 @@ class AccountsReceivableAgentToolsTest extends ScribeTestCase
 
         $line = $creditNote->lines->first();
         $this->assertSame($controlAccount->getId(), $line->account_id);
+    }
+
+    public function test_create_ar_credit_memo_notifies_the_configured_default_email(): void
+    {
+        $originalNotificationEmail = $this->kanvasApp->get(InvoicesConfigurationEnum::CREDIT_MEMO_NOTIFICATION_EMAIL->value);
+        $originalNotifierAgentId = $this->kanvasApp->get(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value);
+
+        try {
+            $notifierAgent = Agent::factory()
+                ->withAppId($this->kanvasApp->getId())
+                ->withCompanyId($this->company->getId())
+                ->create(['name' => 'Apex', 'user_id' => static::$cachedUser->getId()]);
+            $notifierAgent->set(AgentChannelTokenEnum::SLACK_BOT_TOKEN->value, 'xoxb-test-token');
+
+            $this->kanvasApp->set(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value, (string) $notifierAgent->getId());
+            $this->kanvasApp->set(InvoicesConfigurationEnum::CREDIT_MEMO_NOTIFICATION_EMAIL->value, 'notify@example.test');
+
+            Http::fake([
+                'slack.com/api/users.lookupByEmail' => Http::response(['ok' => true, 'user' => ['id' => 'U123']]),
+                'slack.com/api/conversations.open' => Http::response(['ok' => true, 'channel' => ['id' => 'D123']]),
+                'slack.com/api/chat.postMessage' => Http::response(['ok' => true, 'ts' => '1700000000.000100']),
+            ]);
+
+            $customer = $this->seedTestOrganization('Notification Test Customer');
+            $controlAccount = Account::query()
+                ->where('apps_id', $this->kanvasApp->getId())
+                ->where('companies_id', $this->company->getId())
+                ->where('account_sub_type', AccountSubTypeEnum::TRAVEL_AND_MEALS->value)
+                ->firstOrFail();
+
+            $result = new CreateArCreditMemoTool()
+                ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+                ->__invoke(
+                    customer_name: 'Notification Test Customer',
+                    invoice_number: 'Notification Test Reference',
+                    lines: [
+                        ['control_account_number' => $controlAccount->account_number, 'amount' => 75.0],
+                    ],
+                );
+
+            $this->assertTrue($result['created']);
+            Http::assertSent(
+                fn (Request $request): bool => str_contains($request->url(), 'chat.postMessage')
+                    && str_contains((string) $request['text'], 'Notification Test Customer')
+                    && str_contains((string) $request['text'], (string) $result['credit_memo_id'])
+            );
+        } finally {
+            $this->kanvasApp->set(InvoicesConfigurationEnum::CREDIT_MEMO_NOTIFICATION_EMAIL->value, $originalNotificationEmail);
+            $this->kanvasApp->set(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value, $originalNotifierAgentId);
+        }
     }
 
     public function test_add_invoice_note_reports_not_found_for_unknown_invoice(): void

--- a/tests/Scribe/Invoices/CreditRequestFormParserFactoryTest.php
+++ b/tests/Scribe/Invoices/CreditRequestFormParserFactoryTest.php
@@ -11,6 +11,24 @@ use Tests\Scribe\ScribeTestCase;
 
 final class CreditRequestFormParserFactoryTest extends ScribeTestCase
 {
+    private mixed $originalClientConfig = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // HasCustomFields writes through Redis, which DatabaseTransactions never rolls back —
+        // save/restore explicitly so a value set here can't leak into the next test in the run.
+        $this->originalClientConfig = $this->kanvasApp->get(ConfigurationEnum::CREDIT_REQUEST_FORM_CLIENT->value);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->kanvasApp->set(ConfigurationEnum::CREDIT_REQUEST_FORM_CLIENT->value, $this->originalClientConfig);
+
+        parent::tearDown();
+    }
+
     public function test_defaults_to_nzxt_when_unconfigured(): void
     {
         $this->kanvasApp->set(ConfigurationEnum::CREDIT_REQUEST_FORM_CLIENT->value, '');


### PR DESCRIPTION
1.x mirror of #11051.

## Summary
- Mirrors AP's approver notification — a credit memo has no approver concept (it pushes straight to Acumatica), so this is a plain FYI to one fixed address until real per-customer/stakeholder routing is decided.
- Added `CREDIT_MEMO_NOTIFICATION_EMAIL` (app-level config, no-op when unset), reusing `NotifyApproverAction`'s existing Slack-DM-by-email mechanism.
- Fires on both success and Acumatica push failure.
- Also fixed a test-pollution bug in `CreditRequestFormParserFactoryTest`: missing save/restore of an app custom field (Redis-backed, not rolled back by `DatabaseTransactions`).

## Test plan
- [x] Same as #11051 — cherry-pick needed one import-order conflict resolved (an unrelated `ToolOutcomeEnum` import already on this branch).
- [x] `php -l` clean on all changed files.
- [x] Full suite green (29 tests).

## Follow-up (operational, not code)
- Set `CREDIT_MEMO_NOTIFICATION_EMAIL` on the relevant Kanvas app to the real default recipient once ready to test live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)