### PR TITLE
fix(action-engine): preserve share code action slug

### DIFF
--- a/src/Domains/ActionEngine/Engagements/Actions/CreateEngagementAction.php
+++ b/src/Domains/ActionEngine/Engagements/Actions/CreateEngagementAction.php
@@ -598,7 +598,7 @@ class CreateEngagementAction
         return match ($type) {
             'creditApp' => ActionEnum::CREDIT_APP->value,
             'cosigner' => ActionEnum::CO_SIGNER->value,
-            'codeShare' => ActionEnum::SHARE_BLUELINK->value,
+            'codeShare' => $actionSlug,
             'messageVideos' => ActionEnum::MESSAGE_VIDEO->value,
             default => $actionSlug,
         };

--- a/tests/ActionEngine/Unit/CreateEngagementActionResolutionTest.php
+++ b/tests/ActionEngine/Unit/CreateEngagementActionResolutionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\ActionEngine\Unit;
+
+use Kanvas\ActionEngine\Actions\Enums\ActionEnum;
+use Kanvas\ActionEngine\Engagements\Actions\CreateEngagementAction;
+use ReflectionClass;
+use ReflectionMethod;
+use Tests\TestCaseUnit;
+
+final class CreateEngagementActionResolutionTest extends TestCaseUnit
+{
+    private CreateEngagementAction $action;
+    private ReflectionMethod $getBaseAction;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->action = (new ReflectionClass(CreateEngagementAction::class))->newInstanceWithoutConstructor();
+        $this->getBaseAction = new ReflectionMethod(CreateEngagementAction::class, 'getBaseAction');
+    }
+
+    public function testBlueLinkShareCodeResolvesToItsOwnAction(): void
+    {
+        $this->assertSame(
+            ActionEnum::SHARE_BLUELINK->value,
+            $this->getBaseAction->invoke($this->action, 'codeShare', ActionEnum::SHARE_BLUELINK->value)
+        );
+    }
+
+    public function testElectrifyAmericaShareCodeResolvesToItsOwnAction(): void
+    {
+        $this->assertSame(
+            ActionEnum::SHARE_ELECTRIFY_AMERICA->value,
+            $this->getBaseAction->invoke($this->action, 'codeShare', ActionEnum::SHARE_ELECTRIFY_AMERICA->value)
+        );
+    }
+
+    public function testCreditAppAndCosignerMappingsStillResolveToTheirBaseActions(): void
+    {
+        $this->assertSame(
+            ActionEnum::CREDIT_APP->value,
+            $this->getBaseAction->invoke($this->action, 'creditApp', ActionEnum::CREDIT_APP_2->value)
+        );
+
+        $this->assertSame(
+            ActionEnum::CO_SIGNER->value,
+            $this->getBaseAction->invoke($this->action, 'cosigner', ActionEnum::CO_SIGNER_2->value)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- keep Hyundai share-code slugs resolving to their own Action/CompanyAction instead of collapsing all codeShare actions to BlueLink
- add focused regression coverage for BlueLink, Electrify America, credit-app, and cosigner mappings

## Tests
- Not run locally: this machine has no PHP/composer runtime available; `php` command is not installed.
