### PR TITLE
hotfix: zoho type

### DIFF
--- a/src/Domains/Connectors/Zoho/Actions/SyncLeadToZohoAction.php
+++ b/src/Domains/Connectors/Zoho/Actions/SyncLeadToZohoAction.php
@@ -11,6 +11,7 @@ use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\Zoho\Client;
 use Kanvas\Connectors\Zoho\DataTransferObject\ZohoLead;
 use Kanvas\Connectors\Zoho\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Zoho\Services\ZohoFieldTypeService;
 use Kanvas\Connectors\Zoho\ZohoService;
 use Kanvas\Guild\Agents\Models\Agent;
 use Kanvas\Guild\Leads\Models\Lead;
@@ -68,7 +69,7 @@ class SyncLeadToZohoAction
                 }
 
                 try {
-                    $zohoLead = $leadModule->create($zohoData);
+                    $zohoLead = $this->createLeadRecord($leadModule, $zohoData);
                     $zohoLeadId = $zohoLead->getId();
 
                     $lead->set(
@@ -90,7 +91,8 @@ class SyncLeadToZohoAction
             } else {
                 $zohoLeadInfo = $leadModule->get((string) $zohoLeadId)->getData();
                 if (! empty($zohoLeadInfo)) {
-                    $zohoLead = $leadModule->update(
+                    $zohoLead = $this->updateLeadRecord(
+                        $leadModule,
                         (string) $zohoLeadId,
                         $zohoData
                     );
@@ -103,6 +105,57 @@ class SyncLeadToZohoAction
 
             return $zohoData;
         });
+    }
+
+    /**
+     * Zoho rejects the whole lead when a single value doesn't match its field type — the lead form
+     * hands us "$50,000" for a currency field, and 24 leads never reached the CRM because of it. We
+     * can't know each tenant's field types up front (the map is per-company config), so we let Zoho
+     * be the judge: on INVALID_DATA, coerce exactly the fields it named into the types it asked for
+     * and retry once, dropping any value we can't make fit rather than losing the lead over it.
+     */
+    protected function createLeadRecord(ZohoRecordsModule $leadModule, array &$zohoData): object
+    {
+        try {
+            return $leadModule->create($zohoData);
+        } catch (ApiError $e) {
+            $retryData = $this->coerceRejectedPayload($e, $zohoData);
+
+            if ($retryData === null) {
+                throw $e;
+            }
+
+            $zohoData = $retryData;
+
+            return $leadModule->create($zohoData);
+        }
+    }
+
+    protected function updateLeadRecord(
+        ZohoRecordsModule $leadModule,
+        string $zohoLeadId,
+        array &$zohoData
+    ): object {
+        try {
+            return $leadModule->update($zohoLeadId, $zohoData);
+        } catch (ApiError $e) {
+            $retryData = $this->coerceRejectedPayload($e, $zohoData);
+
+            if ($retryData === null) {
+                throw $e;
+            }
+
+            $zohoData = $retryData;
+
+            return $leadModule->update($zohoLeadId, $zohoData);
+        }
+    }
+
+    protected function coerceRejectedPayload(ApiError $e, array $zohoData): ?array
+    {
+        $body = json_decode((string) $e->response()->getBody(), true);
+
+        return ZohoFieldTypeService::coercePayload($zohoData, is_array($body) ? $body : null);
     }
 
     /**

--- a/src/Domains/Connectors/Zoho/DataTransferObject/ZohoLead.php
+++ b/src/Domains/Connectors/Zoho/DataTransferObject/ZohoLead.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\Zoho\DataTransferObject;
 
-use Carbon\Carbon;
-use Exception;
 use Illuminate\Support\Str;
 use Kanvas\Connectors\Zoho\Enums\CustomFieldEnum;
+use Kanvas\Connectors\Zoho\Services\ZohoFieldTypeService;
 use Kanvas\Guild\Leads\Models\Lead;
 use Override;
 use Spatie\LaravelData\Data;
@@ -89,16 +88,15 @@ class ZohoLead extends Data
         foreach ($map as $key => $name) {
             $value = $entity[$key] ?? null;
             if (is_array($name)) {
-                if ($name['type'] !== 'date') {
-                    settype($value, $name['type']);
-                } else {
-                    try {
-                        $date = Carbon::parse($value);
-                        $value = $date->format('Y-m-d');
-                    } catch (Exception $e) {
-                        $value = null;
-                    }
-                }
+                $type = (string) $name['type'];
+
+                // settype('$50,000', 'double') is 0.0 and Carbon::parse(null) is today — both send
+                // Zoho a value that is wrong rather than absent, so numbers and dates go through the
+                // caster, which yields null when the value can't be trusted and the field is skipped.
+                $value = $type === 'date' || ZohoFieldTypeService::isNumericType($type)
+                    ? ZohoFieldTypeService::cast($value, $type)
+                    : self::castScalar($value, $type);
+
                 $name = $name['name'];
             }
             if (strtolower($key) == 'credit_score' && $value != null) {
@@ -126,6 +124,13 @@ class ZohoLead extends Data
                 $data[$name] = $value;
             }
         }
+    }
+
+    private static function castScalar(mixed $value, string $type): mixed
+    {
+        settype($value, $type);
+
+        return $value;
     }
 
     public function hasMemberNumber(): bool

--- a/src/Domains/Connectors/Zoho/Services/ZohoFieldTypeService.php
+++ b/src/Domains/Connectors/Zoho/Services/ZohoFieldTypeService.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Zoho\Services;
+
+use Carbon\Carbon;
+use Throwable;
+
+/**
+ * Zoho validates every value against the column type of its own field and rejects the whole record
+ * with INVALID_DATA when it doesn't parse — a currency field will not take "$50,000", a date field
+ * will not take "08/28/2026". Lead payloads are assembled from receiver form input plus a per-company
+ * field map, so formatted strings reach the API constantly and cost us the entire lead.
+ *
+ * Zoho names the offending field and the type it wanted (api_name + expected_data_type), which is
+ * enough to coerce the value and retry. Everything here is pure so it can be unit tested without the
+ * API. See Sentry KANVAS-ECOSYSTEM InvalidDataType on Amount_Requested.
+ */
+final class ZohoFieldTypeService
+{
+    private const DECIMAL_TYPES = ['currency', 'double', 'decimal', 'float'];
+    private const INTEGER_TYPES = ['integer', 'bigint', 'long'];
+
+    public static function isNumericType(string $expectedType): bool
+    {
+        $type = strtolower(trim($expectedType));
+
+        return in_array($type, self::DECIMAL_TYPES, true) || in_array($type, self::INTEGER_TYPES, true);
+    }
+
+    public static function canCast(string $expectedType): bool
+    {
+        $type = strtolower(trim($expectedType));
+
+        return self::isNumericType($type) || in_array($type, ['boolean', 'date', 'datetime'], true);
+    }
+
+    /**
+     * Null means "we can't make this value fit that type" — the caller drops the field.
+     */
+    public static function cast(mixed $value, string $expectedType): mixed
+    {
+        if ($value === null || is_array($value) || is_object($value)) {
+            return null;
+        }
+
+        $type = strtolower(trim($expectedType));
+        $raw = trim((string) $value);
+
+        if (in_array($type, self::DECIMAL_TYPES, true)) {
+            return self::toNumber($raw);
+        }
+
+        if (in_array($type, self::INTEGER_TYPES, true)) {
+            $number = self::toNumber($raw);
+
+            return $number === null ? null : (int) $number;
+        }
+
+        return match ($type) {
+            'boolean' => filter_var($raw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE),
+            'date' => self::toDate($raw, 'Y-m-d'),
+            'datetime' => self::toDate($raw, 'c'),
+            default => null,
+        };
+    }
+
+    /**
+     * Rebuild a rejected payload with the types Zoho asked for. Returns null when nothing changed,
+     * so the caller knows a retry would just be the same call again.
+     */
+    public static function coercePayload(array $data, ?array $body): ?array
+    {
+        $changed = false;
+
+        foreach (self::invalidTypeFields($body) as $apiName => $expectedType) {
+            $key = self::resolveKey($data, $apiName);
+
+            if ($key === null) {
+                continue;
+            }
+
+            $cast = self::cast($data[$key], $expectedType);
+
+            if ($cast === $data[$key]) {
+                continue;
+            }
+
+            if ($cast === null) {
+                unset($data[$key]);
+            } else {
+                $data[$key] = $cast;
+            }
+
+            $changed = true;
+        }
+
+        return $changed ? $data : null;
+    }
+
+    /**
+     * Reads the raw decoded response body (keys preserved) rather than the SDK's details(), which
+     * flattens the api_name/expected_data_type pair into a positional list.
+     *
+     * @return array<string, string> api_name => expected_data_type
+     */
+    public static function invalidTypeFields(?array $body): array
+    {
+        $rows = $body['data'] ?? [$body];
+        $fields = [];
+
+        foreach ($rows as $row) {
+            if (! is_array($row) || ($row['code'] ?? null) !== 'INVALID_DATA') {
+                continue;
+            }
+
+            $apiName = $row['details']['api_name'] ?? null;
+
+            if (! is_string($apiName) || $apiName === '') {
+                continue;
+            }
+
+            $fields[$apiName] = (string) ($row['details']['expected_data_type'] ?? '');
+        }
+
+        return $fields;
+    }
+
+    private static function resolveKey(array $data, string $apiName): ?string
+    {
+        if (array_key_exists($apiName, $data)) {
+            return $apiName;
+        }
+
+        foreach (array_keys($data) as $key) {
+            if (strcasecmp((string) $key, $apiName) === 0) {
+                return (string) $key;
+            }
+        }
+
+        return null;
+    }
+
+    private static function toNumber(string $value): ?float
+    {
+        $number = preg_replace('/[^0-9.\-]/', '', $value);
+
+        return is_numeric($number) ? (float) $number : null;
+    }
+
+    private static function toDate(string $value, string $format): ?string
+    {
+        try {
+            return Carbon::parse($value)->format($format);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Domains/Connectors/Zoho/Workflows/ZohoLeadActivity.php
+++ b/src/Domains/Connectors/Zoho/Workflows/ZohoLeadActivity.php
@@ -52,12 +52,22 @@ class ZohoLeadActivity extends KanvasActivity implements WorkflowActivityInterfa
                 $syncLeadWithZoho = new SyncLeadToZohoAction($app, $lead);
                 $zohoLead = $syncLeadWithZoho->execute();
 
-                return [
-                    'zohoLeadId' => $lead->get(CustomFieldEnum::ZOHO_LEAD_ID->value),
+                $zohoLeadId = $lead->get(CustomFieldEnum::ZOHO_LEAD_ID->value);
+
+                $result = [
+                    'zohoLeadId' => $zohoLeadId,
                     'zohoRequest' => $zohoLead,
                     'leadId' => $lead->getId(),
                     'status' => $lead->status()->first()->name,
                 ];
+
+                if (empty($zohoLeadId)) {
+                    return $this->failWorkflow([
+                        'message' => 'Lead was not created in Zoho, no Zoho lead id was returned',
+                    ] + $result);
+                }
+
+                return $result;
             },
             company: $lead->company,
         );

--- a/tests/Unit/Connectors/Zoho/ZohoFieldTypeServiceTest.php
+++ b/tests/Unit/Connectors/Zoho/ZohoFieldTypeServiceTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Connectors\Zoho;
+
+use Kanvas\Connectors\Zoho\Services\ZohoFieldTypeService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the INVALID_DATA recovery behind the InvalidDataType Sentry issue: Zoho rejected a whole
+ * lead because the form sent "$50,000" to a currency field. We coerce the fields Zoho names and
+ * retry, dropping the ones we can't make fit instead of losing the lead.
+ */
+final class ZohoFieldTypeServiceTest extends TestCase
+{
+    private const REJECTION_BODY = [
+        'data' => [
+            [
+                'code' => 'INVALID_DATA',
+                'details' => [
+                    'expected_data_type' => 'currency',
+                    'api_name' => 'Amount_Requested',
+                ],
+                'message' => 'invalid data',
+                'status' => 'error',
+            ],
+        ],
+    ];
+
+    public function testCurrencyStripsFormattingIntoANumber(): void
+    {
+        $this->assertSame(50000.0, ZohoFieldTypeService::cast('$50,000', 'currency'));
+        $this->assertSame(1234.56, ZohoFieldTypeService::cast('$1,234.56 USD', 'double'));
+        $this->assertSame(-50.0, ZohoFieldTypeService::cast('-$50', 'decimal'));
+    }
+
+    public function testIntegerTypesDropTheDecimals(): void
+    {
+        $this->assertSame(1234, ZohoFieldTypeService::cast('1,234.90', 'integer'));
+        $this->assertSame(99999, ZohoFieldTypeService::cast('99999', 'bigint'));
+    }
+
+    public function testNumericCastReturnsNullWhenThereIsNoNumberToRecover(): void
+    {
+        $this->assertNull(ZohoFieldTypeService::cast('N/A', 'currency'));
+        $this->assertNull(ZohoFieldTypeService::cast('', 'currency'));
+        $this->assertNull(ZohoFieldTypeService::cast(null, 'currency'));
+    }
+
+    public function testBooleanCast(): void
+    {
+        $this->assertTrue(ZohoFieldTypeService::cast('yes', 'boolean'));
+        $this->assertFalse(ZohoFieldTypeService::cast('false', 'boolean'));
+        $this->assertNull(ZohoFieldTypeService::cast('maybe', 'boolean'));
+    }
+
+    public function testDateCastNormalizesAndRefusesToInventOne(): void
+    {
+        $this->assertSame('2026-08-28', ZohoFieldTypeService::cast('08/28/2026', 'date'));
+        $this->assertNull(ZohoFieldTypeService::cast(null, 'date'));
+        $this->assertNull(ZohoFieldTypeService::cast('not a date', 'date'));
+    }
+
+    public function testUnknownTypeIsNotCastable(): void
+    {
+        $this->assertFalse(ZohoFieldTypeService::canCast('picklist'));
+        $this->assertNull(ZohoFieldTypeService::cast('Excellent (720+)', 'picklist'));
+    }
+
+    public function testInvalidTypeFieldsReadsApiNameAndExpectedType(): void
+    {
+        $this->assertSame(
+            ['Amount_Requested' => 'currency'],
+            ZohoFieldTypeService::invalidTypeFields(self::REJECTION_BODY)
+        );
+    }
+
+    public function testInvalidTypeFieldsIgnoresOtherErrorCodes(): void
+    {
+        $body = [
+            'data' => [
+                [
+                    'code' => 'MANDATORY_NOT_FOUND',
+                    'details' => ['api_name' => 'Last_Name'],
+                    'status' => 'error',
+                ],
+            ],
+        ];
+
+        $this->assertSame([], ZohoFieldTypeService::invalidTypeFields($body));
+        $this->assertSame([], ZohoFieldTypeService::invalidTypeFields(null));
+    }
+
+    public function testCoercePayloadFixesOnlyTheRejectedField(): void
+    {
+        $payload = [
+            'Last_Name' => 'D BARNES',
+            'Amount_Requested' => '$50,000',
+            'Annual_Revenue' => 360000,
+        ];
+
+        $this->assertSame(
+            [
+                'Last_Name' => 'D BARNES',
+                'Amount_Requested' => 50000.0,
+                'Annual_Revenue' => 360000,
+            ],
+            ZohoFieldTypeService::coercePayload($payload, self::REJECTION_BODY)
+        );
+    }
+
+    public function testCoercePayloadMatchesTheFieldCaseInsensitively(): void
+    {
+        $coerced = ZohoFieldTypeService::coercePayload(['amount_requested' => '$50,000'], self::REJECTION_BODY);
+
+        $this->assertSame(['amount_requested' => 50000.0], $coerced);
+    }
+
+    public function testCoercePayloadDropsAValueItCannotFix(): void
+    {
+        $coerced = ZohoFieldTypeService::coercePayload(
+            ['Last_Name' => 'D BARNES', 'Amount_Requested' => 'to be defined'],
+            self::REJECTION_BODY
+        );
+
+        $this->assertSame(['Last_Name' => 'D BARNES'], $coerced);
+    }
+
+    public function testCoercePayloadReturnsNullWhenARetryWouldSendTheSamePayload(): void
+    {
+        $this->assertNull(
+            ZohoFieldTypeService::coercePayload(['Amount_Requested' => 50000.0], self::REJECTION_BODY)
+        );
+
+        $this->assertNull(
+            ZohoFieldTypeService::coercePayload(['Amount_Requested' => '$50,000'], null)
+        );
+
+        $this->assertNull(
+            ZohoFieldTypeService::coercePayload(['Last_Name' => 'D BARNES'], self::REJECTION_BODY)
+        );
+    }
+}


### PR DESCRIPTION
Sales emails a Credit Request Form (CNR) per credit memo, already manager-approved in the email itself — a fixed-layout Excel template, not a free-form document, verified against two real NZXT samples (Proshop back-end rebates).
