### PR TITLE
fix: key create_ap_bill/create_ar_invoice/create_ar_credit_memo run budget by inputs (1.x)

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -24,19 +24,22 @@ use Kanvas\Scribe\Bills\DataTransferObject\Bill as BillData;
 use Kanvas\Scribe\Bills\DataTransferObject\BillLine as BillLineData;
 use Kanvas\Scribe\Ledger\Models\Account;
 use Kanvas\Scribe\Ledger\Models\Subaccount;
+use NeuronAI\Tools\HasRunKey;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
+use NeuronAI\Tools\TrackByInputs;
 use Override;
 use Spatie\LaravelData\DataCollection;
 use Throwable;
 
 /** Creates a one-line AP bill and, by default, auto-approves it and pushes it to Acumatica in one step. */
 #[AgentTool(name: 'Create AP Bill', category: 'accounting')]
-class CreateApBillTool extends Tool
+class CreateApBillTool extends Tool implements HasRunKey
 {
     use HasKanvasContext;
     use StoresApprovalSourceFields;
+    use TrackByInputs;
 
     public function __construct()
     {

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArCreditMemoTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArCreditMemoTool.php
@@ -22,20 +22,23 @@ use Kanvas\Scribe\Invoices\DataTransferObject\InvoiceLine as InvoiceLineData;
 use Kanvas\Scribe\Invoices\Enums\ConfigurationEnum;
 use Kanvas\Scribe\Ledger\Models\Account;
 use NeuronAI\Tools\ArrayProperty;
+use NeuronAI\Tools\HasRunKey;
 use NeuronAI\Tools\ObjectProperty;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
 use NeuronAI\Tools\ToolPropertyInterface;
+use NeuronAI\Tools\TrackByInputs;
 use Override;
 use Spatie\LaravelData\DataCollection;
 use Throwable;
 
 /** Issues a standalone AR credit memo (e.g. a back-end rebate) not tied to any specific invoice, and pushes it to Acumatica. */
 #[AgentTool(name: 'Create AR Credit Memo', category: 'accounting')]
-class CreateArCreditMemoTool extends Tool
+class CreateArCreditMemoTool extends Tool implements HasRunKey
 {
     use HasKanvasContext;
+    use TrackByInputs;
 
     public function __construct()
     {

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
@@ -20,20 +20,23 @@ use Kanvas\Scribe\Invoices\Actions\CreateInvoiceAction;
 use Kanvas\Scribe\Invoices\Actions\IssueInvoiceAction;
 use Kanvas\Scribe\Invoices\DataTransferObject\Invoice as InvoiceData;
 use Kanvas\Scribe\Invoices\DataTransferObject\InvoiceLine as InvoiceLineData;
+use NeuronAI\Tools\HasRunKey;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
+use NeuronAI\Tools\TrackByInputs;
 use Override;
 use Spatie\LaravelData\DataCollection;
 use Throwable;
 
 /** Creates a one-line AR invoice and, by default, issues it and pushes it to Acumatica — the AR mirror of CreateApBillTool. Stays open; use apply_ar_payment to record a payment against it separately. */
 #[AgentTool(name: 'Create AR Invoice', category: 'accounting')]
-class CreateArInvoiceTool extends Tool
+class CreateArInvoiceTool extends Tool implements HasRunKey
 {
     use HasKanvasContext;
     use PushesInvoiceWithCreditHoldRetry;
     use StoresApprovalSourceFields;
+    use TrackByInputs;
 
     public function __construct()
     {

--- a/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
@@ -568,6 +568,7 @@ class AccountsPayableAgentToolsTest extends ScribeTestCase
             new FindBillTool(),
             new FindPurchaseOrderTool(),
             new MatchBillsForPaymentTool(),
+            new CreateApBillTool(),
         ];
 
         foreach ($tools as $tool) {

--- a/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php
@@ -574,6 +574,8 @@ class AccountsReceivableAgentToolsTest extends ScribeTestCase
             new FindCustomerTool(),
             new FindInvoiceTool(),
             new MatchInvoicesForPaymentTool(),
+            new CreateArInvoiceTool(),
+            new CreateArCreditMemoTool(),
         ];
 
         foreach ($tools as $tool) {


### PR DESCRIPTION
## Summary
1.x mirror of #11083. Cherry-picked cleanly, no conflicts.

- Production incident: `create_ap_bill has been executed too many times - 10 - with arguments: {...}` aborted an AP agent turn.
- Root cause: NeuronAI caps every tool at 10 runs per turn, keyed by tool **name** by default — so a batch of more than 10 distinct bills/invoices in one turn shares a single budget and the 11th trips `ToolRunsExceededException`, killing the whole turn. Same root cause already documented and fixed on `find_vendor`/`find_bill`/`find_customer`/etc. (Sentry KANVAS-ECOSYSTEM-621/64Q) — `create_ap_bill`, `create_ar_invoice`, and `create_ar_credit_memo` were the remaining gap.
- Added `HasRunKey` + `TrackByInputs` to all three, so the budget is now keyed per distinct bill/invoice/credit-memo instead of per tool name.

## Test plan
- [x] `tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php` — passes
- [x] `tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php` — passes