### PR TITLE
fix: attribute lead channel file groups to the participant that submitted the action

### DIFF
--- a/src/Domains/Guild/Leads/Exceptions/MissingParticipantPeopleIdException.php
+++ b/src/Domains/Guild/Leads/Exceptions/MissingParticipantPeopleIdException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Leads\Exceptions;
+
+use Exception;
+
+/**
+ * A leads_participants row whose peoples_id does not resolve. It fails loudly instead of degrading
+ * because the alternative is the participant's files vanishing from the payload with nothing logged.
+ *
+ * @todo emit this to the audit trail (ledger) as well as throwing, so orphan participants can be
+ *       tracked per app/company without waiting for someone to open the lead
+ */
+class MissingParticipantPeopleIdException extends Exception
+{
+}

--- a/src/Domains/Guild/Leads/Services/LeadChannelFilesService.php
+++ b/src/Domains/Guild/Leads/Services/LeadChannelFilesService.php
@@ -142,8 +142,12 @@ class LeadChannelFilesService
     {
         //`?:` and not `??`: engagement.people_id is 0 on legacy rows and 0 would never fall through `??`
         $peopleId = (int) ($engagement?->people_id ?: 0)
-            ?: (int) ($lastMessage->get('people_id') ?: 0)
-            ?: (int) ($message->get('people_id') ?: 0);
+            ?: (int) ($lastMessage->get('people_id') ?: 0);
+
+        //every get() is a custom field lookup, so only reach for the thread parent when it is another row
+        if (! $peopleId && ! $lastMessage->is($message)) {
+            $peopleId = (int) ($message->get('people_id') ?: 0);
+        }
 
         if (! $peopleId || $peopleId === (int) $this->lead->people_id) {
             return null;

--- a/src/Domains/Guild/Leads/Services/LeadChannelFilesService.php
+++ b/src/Domains/Guild/Leads/Services/LeadChannelFilesService.php
@@ -6,7 +6,9 @@ namespace Kanvas\Guild\Leads\Services;
 
 use Baka\Support\Str;
 use Exception;
+use Kanvas\ActionEngine\Engagements\Models\Engagement;
 use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Leads\Exceptions\MissingParticipantPeopleIdException;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Social\Messages\Models\Message;
 use Throwable;
@@ -85,68 +87,79 @@ class LeadChannelFilesService
 
     protected function formatMessageFileGroup(Message $message): array
     {
-        // Get the last submitted message or the latest child
         $lastMessage = $this->getLastSubmittedMessage($message) ?? $message;
 
         $files = $this->getFilesFromMessage($lastMessage);
-        $notificationName = null;
+        $verb = 'message';
+        $action = 'Message Files';
+        $status = 'submitted';
+        $metadata = [];
 
+        //a message with no engagement is a plain conversation message, it keeps the generic labels
         try {
-            // Get engagement information if available
-            $companyAction = null;
-            $stages = null;
-            $verb = null;
-            $action = 'Message Files';
-            $status = 'submitted';
-
-            // Try to get engagement data
-
             $engagement = $lastMessage->getEngagement();
-            if ($engagement->companyAction) {
-                $companyAction = $engagement->companyAction;
-                $verb = $companyAction->actions->slug ?? null;
-                $action = $companyAction->actions->name ?? 'Message Files';
-            }
-            if ($engagement->stage) {
-                $stages = $engagement->stage;
-                $status = $stages->slug ?? 'submitted';
-            }
-
-            // Get participant name if different from lead people
-            try {
-                if ($message->get('people_id') && $message->get('people_id') != $this->lead->people_id) {
-                    $coBuyerPeople = People::getByIdOrFail($message->get('people_id'));
-                    $notificationName = ' (' . $coBuyerPeople->name . ')';
-                }
-            } catch (Exception $e) {
-                $notificationName = null;
-            }
-
-            // Get message data
-            $messageForm = $lastMessage->message;
-            $metadata = [];
-            if (is_array($messageForm) && key_exists('data', $messageForm)) {
-                $metadata = $messageForm['data'];
-            }
-        } catch (Exception $e) {
-            $verb = 'message';
-            $action = 'Message Files';
-            $status = 'submitted';
-            $metadata = [];
+        } catch (Exception) {
+            $engagement = null;
         }
+
+        if ($engagement?->companyAction) {
+            $companyAction = $engagement->companyAction;
+            $verb = $companyAction->action->slug ?? $verb;
+            $action = $companyAction->name ?: ($companyAction->action->name ?? $action);
+        }
+
+        if ($engagement?->stage) {
+            $status = $engagement->stage->slug ?? $status;
+        }
+
+        $messageForm = $lastMessage->message;
+        if (is_array($messageForm) && key_exists('data', $messageForm)) {
+            $metadata = $messageForm['data'];
+        }
+
+        $participant = $this->resolveParticipant($engagement, $lastMessage, $message);
 
         return [
             'id' => (string) $message->getId(),
             'uuid' => $message->uuid,
-            'verb' => $verb ?? 'message',
-            'action' => $action . ($notificationName ?? ''),
+            'verb' => $verb,
+            'action' => $participant ? $action . ' (' . $participant->name . ')' : $action,
             'status' => $status,
-            'participant_name' => $notificationName ? trim($notificationName, ' ()') : null,
+            'participant_name' => $participant?->name,
             'created_at' => $message->created_at->format('Y-m-d H:i:s'),
             'last_message_at' => $lastMessage->created_at->format('Y-m-d H:i:s'),
-            'files' => $this->removeDuplicateFiles($files, $notificationName),
+            'files' => $this->removeDuplicateFiles($files),
             'metadata' => $metadata,
         ];
+    }
+
+    /**
+     * The engagement's people_id — or the message's own people_id custom field, which is what the
+     * showroom ID verification flow writes — points at the participant that submitted the action.
+     * A co-buyer's ID verification belongs to them, not to the lead's main buyer.
+     */
+    protected function resolveParticipant(?Engagement $engagement, Message $lastMessage, Message $message): ?People
+    {
+        //`?:` and not `??`: engagement.people_id is 0 on legacy rows and 0 would never fall through `??`
+        $peopleId = (int) ($engagement?->people_id ?: 0)
+            ?: (int) ($lastMessage->get('people_id') ?: 0)
+            ?: (int) ($message->get('people_id') ?: 0);
+
+        if (! $peopleId || $peopleId === (int) $this->lead->people_id) {
+            return null;
+        }
+
+        try {
+            return People::getByIdFromCompanyApp($peopleId, $this->lead->company, $this->lead->app);
+        } catch (Throwable) {
+            if ($this->lead->participants()->where('peoples_id', $peopleId)->exists()) {
+                throw new MissingParticipantPeopleIdException(
+                    'Lead ' . $this->lead->getId() . ' participant people_id ' . $peopleId . ' does not resolve'
+                );
+            }
+
+            return null;
+        }
     }
 
     protected function getLeadFileGroup(): array
@@ -173,7 +186,6 @@ class LeadChannelFilesService
         $groups = [];
 
         try {
-            // Get co-buyer participants
             $coBuyerParticipants = $this->lead->participants()
                 ->whereHas('type', function ($query) {
                     $query->where('name', 'Co-buyer');
@@ -183,7 +195,13 @@ class LeadChannelFilesService
             foreach ($coBuyerParticipants as $participant) {
                 $people = $participant->people;
 
-                // Get participant files using the standard files relationship
+                if ($people === null) {
+                    throw new MissingParticipantPeopleIdException(
+                        'Lead ' . $this->lead->getId() . ' participant ' . $participant->getId()
+                        . ' points at peoples_id ' . $participant->peoples_id . ' which does not resolve'
+                    );
+                }
+
                 $participantFiles = $people->getFiles();
 
                 if ($participantFiles->isNotEmpty()) {
@@ -201,7 +219,10 @@ class LeadChannelFilesService
                     ];
                 }
             }
-        } catch (Throwable $e) {
+        } catch (MissingParticipantPeopleIdException $e) {
+            //the generic catch below is a Throwable, so the integrity signal has to be let through first
+            throw $e;
+        } catch (Throwable) {
             // Ignore errors in participant processing
         }
 
@@ -245,7 +266,9 @@ class LeadChannelFilesService
                 'url' => $file->url,
                 'file_type' => $file->file_type ?? '',
                 'size' => $file->size ?? 0,
-                'field_name' => $file->pivot->field_name ?? '',
+                //getFiles() returns FilesystemEntities rows with the filesystem columns joined in, not
+                //a belongsToMany, so field_name is a column on the row itself and there is no pivot
+                'field_name' => $file->field_name ?? '',
                 'attributes' => $file->attributes ?? [],
             ];
         })->toArray();
@@ -253,22 +276,25 @@ class LeadChannelFilesService
 
     protected function formatFiles(array $files): array
     {
-        return array_map(function ($file) {
-            return [
-                'id' => (string) ($file['id'] ?? ''),
-                'name' => $file['name'] ?? '',
-                'url' => $file['url'] ?? '',
-                'file_type' => $file['file_type'] ?? '',
-                'size' => $file['size'] ?? 0,
-                'field_name' => $file['field_name'] ?? '',
-                'verification_status' => $file['attributes']['id_verification_status'] ?? null,
-                'verification_message' => $file['attributes']['id_verification_msg'] ?? null,
-                'attributes' => $file['attributes'] ?? [],
-            ];
-        }, $files);
+        return array_map(fn (array $file): array => $this->presentFile($file), $files);
     }
 
-    protected function removeDuplicateFiles(array $files, ?string $name = null): array
+    protected function presentFile(array $file): array
+    {
+        return [
+            'id' => (string) ($file['id'] ?? ''),
+            'name' => $file['name'] ?? '',
+            'url' => $file['url'] ?? '',
+            'file_type' => $file['file_type'] ?? '',
+            'size' => $file['size'] ?? 0,
+            'field_name' => $file['field_name'] ?? '',
+            'verification_status' => $file['attributes']['id_verification_status'] ?? null,
+            'verification_message' => $file['attributes']['id_verification_msg'] ?? null,
+            'attributes' => $file['attributes'] ?? [],
+        ];
+    }
+
+    protected function removeDuplicateFiles(array $files): array
     {
         $uniqueFiles = [];
         $hasIdVerificationMsg = false;
@@ -311,20 +337,7 @@ class LeadChannelFilesService
             }
         }
 
-        // Convert to format expected by GraphQL
-        return array_map(function ($file) {
-            return [
-                'id' => (string) ($file['id'] ?? ''),
-                'name' => $file['name'] ?? '',
-                'url' => $file['url'] ?? '',
-                'file_type' => $file['file_type'] ?? '',
-                'size' => $file['size'] ?? 0,
-                'field_name' => $file['field_name'] ?? '',
-                'verification_status' => $file['attributes']['id_verification_status'] ?? null,
-                'verification_message' => $file['attributes']['id_verification_msg'] ?? null,
-                'attributes' => $file['attributes'] ?? [],
-            ];
-        }, array_values($uniqueFiles));
+        return array_map(fn (array $file): array => $this->presentFile($file), array_values($uniqueFiles));
     }
 
     /**

--- a/tests/Guild/Integration/LeadChannelFilesTest.php
+++ b/tests/Guild/Integration/LeadChannelFilesTest.php
@@ -1,0 +1,322 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Guild\Integration;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Kanvas\ActionEngine\Actions\Models\Action;
+use Kanvas\ActionEngine\Actions\Models\CompanyAction;
+use Kanvas\ActionEngine\Engagements\Models\Engagement;
+use Kanvas\ActionEngine\Pipelines\Models\Pipeline;
+use Kanvas\ActionEngine\Pipelines\Models\PipelineStage;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\SalesAssist\Enums\ConfigurationEnum;
+use Kanvas\Filesystem\Models\Filesystem;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Leads\Exceptions\MissingParticipantPeopleIdException;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Guild\Leads\Models\LeadParticipant;
+use Kanvas\Guild\Leads\Services\LeadChannelFilesService;
+use Kanvas\Social\Channels\Actions\CreateChannelAction;
+use Kanvas\Social\Channels\DataTransferObject\Channel;
+use Kanvas\Social\Messages\Actions\CreateMessageAction;
+use Kanvas\Social\Messages\DataTransferObject\MessageInput;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Social\MessagesTypes\Models\MessageType;
+use Kanvas\SystemModules\Repositories\SystemModulesRepository;
+use Tests\TestCase;
+
+/**
+ * The showroom ID verification of a co-buyer used to come back as a generic "Message Files" group with
+ * participant_name = null: People::getByIdOrFail() does not exist, CompanyAction has no `actions`
+ * relation, and the people_id was read off the parent message instead of the engagement.
+ */
+final class LeadChannelFilesTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $connectionsToTransact = [null, 'crm', 'social', 'action_engine'];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Queue::fake();
+    }
+
+    public function testIdVerificationGroupIsAttributedToTheParticipant(): void
+    {
+        $lead = $this->makeLead();
+        $coBuyer = $this->makePeople($lead, 'Matthew Cook');
+        $message = $this->makeIdVerificationMessage($lead);
+        $this->makeEngagement($lead, $message, $coBuyer->getId());
+
+        $group = $this->groupFor($lead, $message);
+
+        $this->assertSame('id-verification', $group['verb']);
+        $this->assertSame('ID Verification (Matthew Cook)', $group['action']);
+        $this->assertSame('Matthew Cook', $group['participant_name']);
+        $this->assertSame('submitted', $group['status']);
+        $this->assertSame('id-verification', $group['files'][0]['field_name']);
+    }
+
+    public function testMainBuyerEngagementHasNoParticipantSuffix(): void
+    {
+        $lead = $this->makeLead();
+        $message = $this->makeIdVerificationMessage($lead);
+        $this->makeEngagement($lead, $message, (int) $lead->people_id);
+
+        $group = $this->groupFor($lead, $message);
+
+        $this->assertSame('id-verification', $group['verb']);
+        $this->assertSame('ID Verification', $group['action']);
+        $this->assertNull($group['participant_name']);
+    }
+
+    /**
+     * The showroom flow writes people_id on the message as well; legacy engagement rows carry
+     * people_id = 0, so the custom field has to win over that zero.
+     */
+    public function testFallsBackToTheMessagePeopleIdCustomField(): void
+    {
+        $lead = $this->makeLead();
+        $coBuyer = $this->makePeople($lead, 'Sarah Cobb');
+        $message = $this->makeIdVerificationMessage($lead);
+        $message->set('people_id', $coBuyer->getId());
+        $this->makeEngagement($lead, $message, 0);
+
+        $group = $this->groupFor($lead, $message);
+
+        $this->assertSame('ID Verification (Sarah Cobb)', $group['action']);
+        $this->assertSame('Sarah Cobb', $group['participant_name']);
+    }
+
+    public function testMessageWithoutEngagementKeepsGenericLabels(): void
+    {
+        $lead = $this->makeLead();
+        $message = $this->makeIdVerificationMessage($lead);
+
+        $group = $this->groupFor($lead, $message);
+
+        $this->assertSame('message', $group['verb']);
+        $this->assertSame('Message Files', $group['action']);
+        $this->assertNull($group['participant_name']);
+    }
+
+    public function testThrowsWhenAParticipantPeopleIdDoesNotResolve(): void
+    {
+        $lead = $this->makeLead();
+        $orphanPeopleId = 999999999;
+
+        LeadParticipant::create([
+            'leads_id' => $lead->getId(),
+            'peoples_id' => $orphanPeopleId,
+            'participants_types_id' => 0,
+        ]);
+
+        $message = $this->makeIdVerificationMessage($lead);
+        $this->makeEngagement($lead, $message, $orphanPeopleId);
+
+        $this->expectException(MissingParticipantPeopleIdException::class);
+
+        new LeadChannelFilesService($lead)->getChannelFiles();
+    }
+
+    public function testANonParticipantPeopleIdDegradesToNull(): void
+    {
+        $lead = $this->makeLead();
+        $message = $this->makeIdVerificationMessage($lead);
+        $this->makeEngagement($lead, $message, 999999998);
+
+        $group = $this->groupFor($lead, $message);
+
+        $this->assertSame('ID Verification', $group['action']);
+        $this->assertNull($group['participant_name']);
+    }
+
+    private function groupFor(Lead $lead, Message $message): array
+    {
+        $groups = new LeadChannelFilesService($lead)->getChannelFiles()['groups'];
+
+        foreach ($groups as $group) {
+            if ($group['uuid'] === $message->uuid) {
+                return $group;
+            }
+        }
+
+        $this->fail('no group came back for message ' . $message->getId());
+    }
+
+    private function makeLead(): Lead
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        $lead = Lead::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create();
+
+        //the engagement observer fans a submitted notification out to the lead stakeholders on save
+        $company->set('disable_all_notifications', true);
+
+        $pipeline = Pipeline::firstOrCreate([
+            'slug' => ConfigurationEnum::ID_VERIFICATION->value,
+            'companies_id' => $company->getId(),
+            'apps_id' => $app->getId(),
+        ], [
+            'users_id' => $user->getId(),
+            'name' => 'ID Verification',
+            'weight' => 0,
+        ]);
+
+        PipelineStage::firstOrCreate([
+            'pipelines_id' => $pipeline->getId(),
+            'slug' => 'submitted',
+        ], [
+            'name' => 'Submitted',
+            'weight' => 1,
+        ]);
+
+        $action = Action::firstOrCreate([
+            'slug' => ConfigurationEnum::ID_VERIFICATION->value,
+        ], [
+            'apps_id' => $app->getId(),
+            'companies_id' => $company->getId(),
+            'users_id' => $user->getId(),
+            'pipelines_id' => $pipeline->getId(),
+            'name' => 'ID Verification',
+        ]);
+
+        CompanyAction::firstOrCreate([
+            'actions_id' => $action->getId(),
+            'companies_id' => $company->getId(),
+            'apps_id' => $app->getId(),
+        ], [
+            'users_id' => $user->getId(),
+            'companies_branches_id' => ($company->defaultBranch ?? $company->branch()->firstOrFail())->getId(),
+            'pipelines_id' => $pipeline->getId(),
+            'name' => 'ID Verification',
+        ]);
+
+        new CreateChannelAction(new Channel(
+            apps: $app,
+            companies: $company,
+            users: $user,
+            entity_id: $lead->getId(),
+            entity_namespace: Lead::class,
+            name: (string) $lead->uuid,
+            slug: (string) $lead->uuid,
+            description: (string) $lead->uuid,
+        ))->execute();
+
+        return $lead;
+    }
+
+    private function makePeople(Lead $lead, string $name): People
+    {
+        return People::factory()
+            ->withAppId((int) $lead->apps_id)
+            ->withCompanyId((int) $lead->companies_id)
+            ->withUserId((int) $lead->users_id)
+            ->create(['name' => $name]);
+    }
+
+    /**
+     * Same shape the showroom flow builds in DriverLicenseVerificationService::createEngagement — the
+     * system module link matters because the engagement observer reads notification copy off
+     * message->entity().
+     */
+    private function makeIdVerificationMessage(Lead $lead): Message
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+
+        $messageType = MessageType::firstOrCreate([
+            'apps_id' => $app->getId(),
+            'languages_id' => 1,
+            'verb' => ConfigurationEnum::ID_VERIFICATION->value,
+        ], [
+            'name' => 'ID Verification',
+        ]);
+
+        $message = new CreateMessageAction(
+            new MessageInput(
+                app: $app,
+                company: $lead->company,
+                user: $user,
+                type: $messageType,
+                message: [
+                    'engagement_status' => 'submitted',
+                    'hashtagVisited' => ConfigurationEnum::ID_VERIFICATION->value,
+                    'text' => 'ID Verification Showroom',
+                    'source' => 'workflow',
+                    'status' => 'submitted',
+                    'verb' => ConfigurationEnum::ID_VERIFICATION->value,
+                ],
+            ),
+            SystemModulesRepository::getByModelName(Lead::class, $app),
+            $lead->getId()
+        )->execute();
+
+        $message->addFile($this->makeFilesystem($lead), 'id-verification');
+        $lead->socialChannels()->firstOrFail()->addMessage($message, $user);
+
+        return $message;
+    }
+
+    private function makeFilesystem(Lead $lead): Filesystem
+    {
+        $filesystem = new Filesystem();
+        $filesystem->apps_id = (int) $lead->apps_id;
+        $filesystem->companies_id = (int) $lead->companies_id;
+        $filesystem->users_id = (int) $lead->users_id;
+        $filesystem->name = 'id-verification-report.pdf';
+        $filesystem->path = 'files/id-verification/' . uniqid() . '.pdf';
+        $filesystem->url = 'https://cdn.salesassist.io/files/id-verification/' . uniqid() . '.pdf';
+        $filesystem->file_type = 'pdf';
+        $filesystem->size = '50433';
+        $filesystem->is_deleted = 0;
+        $filesystem->saveOrFail();
+
+        return $filesystem;
+    }
+
+    private function makeEngagement(Lead $lead, Message $message, int $peopleId): Engagement
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+
+        $pipeline = Pipeline::query()
+            ->where('slug', ConfigurationEnum::ID_VERIFICATION->value)
+            ->fromApp($app)
+            ->fromCompany($company)
+            ->firstOrFail();
+
+        $action = Action::query()->where('slug', ConfigurationEnum::ID_VERIFICATION->value)->firstOrFail();
+
+        $engagement = new Engagement();
+        $engagement->apps_id = $app->getId();
+        $engagement->companies_id = $company->getId();
+        $engagement->users_id = (int) $lead->users_id;
+        $engagement->leads_id = $lead->getId();
+        $engagement->people_id = $peopleId;
+        $engagement->companies_actions_id = CompanyAction::query()
+            ->where('actions_id', $action->getId())
+            ->fromApp($app)
+            ->fromCompany($company)
+            ->firstOrFail()
+            ->getId();
+        $engagement->message_id = $message->getId();
+        $engagement->slug = ConfigurationEnum::ID_VERIFICATION->value;
+        $engagement->entity_uuid = (string) Str::uuid();
+        $engagement->pipelines_stages_id = $pipeline->stages()->where('slug', 'submitted')->firstOrFail()->getId();
+        $engagement->saveOrFail();
+
+        return $engagement;
+    }
+}

--- a/tests/Guild/Integration/LeadChannelFilesTest.php
+++ b/tests/Guild/Integration/LeadChannelFilesTest.php
@@ -94,6 +94,27 @@ final class LeadChannelFilesTest extends TestCase
         $this->assertSame('Sarah Cobb', $group['participant_name']);
     }
 
+    /**
+     * The group is keyed on the thread parent but its files, engagement and labels come from the last
+     * submitted child, so a people_id written only on the parent still has to be picked up.
+     */
+    public function testReadsThePeopleIdOffTheThreadParentWhenTheChildCarriesTheEngagement(): void
+    {
+        $lead = $this->makeLead();
+        $coBuyer = $this->makePeople($lead, 'Dana Reyes');
+        $parent = $this->makeIdVerificationMessage($lead);
+        $parent->set('people_id', $coBuyer->getId());
+
+        $child = $this->makeIdVerificationMessage($lead, $parent);
+        $this->makeEngagement($lead, $child, 0);
+
+        $group = $this->groupFor($lead, $parent);
+
+        $this->assertSame('id-verification', $group['verb']);
+        $this->assertSame('ID Verification (Dana Reyes)', $group['action']);
+        $this->assertSame('Dana Reyes', $group['participant_name']);
+    }
+
     public function testMessageWithoutEngagementKeepsGenericLabels(): void
     {
         $lead = $this->makeLead();
@@ -231,7 +252,7 @@ final class LeadChannelFilesTest extends TestCase
      * system module link matters because the engagement observer reads notification copy off
      * message->entity().
      */
-    private function makeIdVerificationMessage(Lead $lead): Message
+    private function makeIdVerificationMessage(Lead $lead, ?Message $parent = null): Message
     {
         $app = app(Apps::class);
         $user = auth()->user();
@@ -258,6 +279,7 @@ final class LeadChannelFilesTest extends TestCase
                     'status' => 'submitted',
                     'verb' => ConfigurationEnum::ID_VERIFICATION->value,
                 ],
+                parent_id: $parent?->getId(),
             ),
             SystemModulesRepository::getByModelName(Lead::class, $app),
             $lead->getId()


### PR DESCRIPTION
## Problem

A co-buyer's ID verification came back from `lead.channel_files` as a generic group with no attribution:

```json
{ "verb": "message", "action": "Message Files", "participant_name": null, "files": [{ "field_name": "" }] }
```

Expected, and what the legacy endpoint returned:

```json
{ "verb": "id-verification", "action": "ID Verification (Matthew Cook)", "participant_name": "Matthew Cook",
  "files": [{ "field_name": "id-verification" }] }
```

Four separate failures in `LeadChannelFilesService`, all silent — nothing in logs, nothing in Sentry.

## Root causes

1. **`People::getByIdOrFail()` does not exist.** Not in Eloquent (`findOrFail` / `firstOrFail` / `valueOrFail`), not in `KanvasModelTrait` (`getById` / `getByIdFromCompany` / `getByIdFromCompanyApp`). It threw `BadMethodCallException`, which extends `Exception`, so the adjacent `catch (Exception)` swallowed it — the participant name was never resolved, for any lead, since the service landed in `a678e724e`.
2. **`CompanyAction` has no `actions` relation**, only `action` (singular). The `??` hid the null, so *every* message group reported `verb: "message"` / `action: "Message Files"` — never the real action name.
3. **`people_id` was read off the thread parent and `Engagement.people_id` was never consulted.** The Intellicheck path (`IdVerificationReportActivity` → `CreateEngagementAction`) only writes the engagement column, never the message custom field, so that flow could never resolve the participant.
4. **`field_name` was always `''`.** `getFiles()` returns `FilesystemEntities` rows with the `filesystem` columns joined in (`FilesystemEntitiesRepository::getFilesByEntity`), not a `belongsToMany`, so `$file->pivot->field_name` was null. That is the field the front end filters the ID-verification PDF by.

## What changed

- `action` comes from `CompanyAction.name` with a fallback to the catalog's `Action.name`, so a dealer-configured label wins. `verb` always from `Action.slug`.
- Participant resolution reads `Engagement.people_id` first, then the message's `people_id` custom field (what the showroom flow writes), with `?:` rather than `??` so a legacy `people_id = 0` does not short-circuit the fallback.
- Lookups go through `getByIdFromCompanyApp` — `getById` only scopes `apps_id`, so it would read a `People` from another company in the same app.
- A `peoples_id` that **is** a participant of the lead but does not resolve now throws `MissingParticipantPeopleIdException` instead of dropping the group from the payload with nothing logged. A `people_id` that is not a participant still degrades to `null`.
- Collapsed the file presenter duplicated between `formatFiles()` and `removeDuplicateFiles()` into `presentFile()`; dropped the dead second parameter of `removeDuplicateFiles()`.
- `resolveParticipant()` no longer reads the same custom field twice on childless messages (`getCustomField()` does not memoize, and the method runs per root message in the channel).

## Behaviour change to be aware of

`channel_files` is `LeadChannelFilesViewer!` (non-null), so a lead with an orphan participant now **fails the field** instead of returning an incomplete payload. That is deliberate — the alternative is a co-buyer's files silently vanishing. If we'd rather the front end not break, the one-line alternative is `report($e)` and continue.

## Known gap, left as is

`verification_status` / `verification_message` are always `null`: neither `filesystem` nor `filesystem_entities` has an `attributes` column, so the whole `id_verification_msg` propagation block in `removeDuplicateFiles()` is unreachable. The values live as **custom fields on the `Filesystem` row** (`$file->set('id_verification_status', ...)` in `VerifyPeopleIdAction`, `IdVerificationReportActivity`, `AttachDriverLicenseImagesJob`). Fixing it changes the GraphQL response and needs an eager-load strategy to avoid an N+1 per file, so it belongs in its own PR.

## Tests

New `tests/Guild/Integration/LeadChannelFilesTest.php` — 7 cases: co-buyer attribution, main-buyer with no suffix, the message-custom-field fallback, the thread-parent branch, the generic no-engagement labels, the orphan-participant throw, and a non-participant id degrading to null. **6 of them fail on the pre-fix service**; the seventh is the control.

## Verification

- 7/7 the new test file (19 assertions)
- 238/238 the `Guild` suite

Note: the `Guild` suite has a pre-existing paratest flake unrelated to this change — `app(Apps::class)->getId()` intermittently returns null in one worker's `setUp` (surfaces in `PeopleCurrentAddressTest`). Green on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)