### PR TITLE
feat: add a real Organization-Users approver table, replacing the single-email custom field

### DIFF
--- a/app/Console/Commands/Scribe/ImportVendorApproversCommand.php
+++ b/app/Console/Commands/Scribe/ImportVendorApproversCommand.php
@@ -8,6 +8,8 @@ use Baka\Traits\KanvasJobsTrait;
 use Illuminate\Console\Command;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
+use Kanvas\Guild\Organizations\Actions\CreateOrganizationAction;
+use Kanvas\Guild\Organizations\DataTransferObject\Organization as OrganizationData;
 use Kanvas\Guild\Organizations\Models\Organization;
 use Kanvas\Guild\Organizations\Models\OrganizationApprover;
 use Kanvas\Guild\Organizations\Services\OrganizationVendorMatcherService;
@@ -19,7 +21,10 @@ use Maatwebsite\Excel\Facades\Excel;
  * One-off import: sets ap_approver_email AND ap_approver_vendor_name on each vendor Organization,
  * and links a real Kanvas User as its OrganizationApprover (creating a minimal User record if no
  * Kanvas account matches that email yet), from a spreadsheet mapping Vendor Name -> Approver Email
- * (e.g. the AP Vendor-Approver List finance maintains). Re-run whenever that sheet changes — it's
+ * (e.g. the AP Vendor-Approver List finance maintains). A vendor with no existing Organization match
+ * at all gets one created on the fly, so the whole sheet ends up linked — a vendor with SEVERAL
+ * possible matches is still skipped for manual resolution, since auto-picking one could silently
+ * misfile it against the wrong existing Organization. Re-run whenever the sheet changes — it's
  * idempotent, safe to run again with an updated file.
  */
 class ImportVendorApproversCommand extends Command
@@ -28,7 +33,7 @@ class ImportVendorApproversCommand extends Command
 
     protected $signature = 'scribe:import-vendor-approvers {apps_id} {company_id} {file}';
 
-    protected $description = 'Sets the ap_approver_email/ap_approver_vendor_name custom fields and links an OrganizationApprover on vendor Organizations from a Vendor Name / Approver Email spreadsheet';
+    protected $description = 'Sets the ap_approver_email/ap_approver_vendor_name custom fields and links an OrganizationApprover on vendor Organizations from a Vendor Name / Approver Email spreadsheet, creating the Organization when none matches';
 
     public function handle(): void
     {
@@ -50,7 +55,7 @@ class ImportVendorApproversCommand extends Command
         [$headerIndex, $vendorColumn, $emailColumn] = $header;
 
         $updated = 0;
-        $unmatched = [];
+        $created = 0;
         $ambiguous = [];
         $noEmail = [];
 
@@ -70,25 +75,34 @@ class ImportVendorApproversCommand extends Command
 
             $match = OrganizationVendorMatcherService::match($app, $company, $vendorName);
 
-            if (! $match->isMatched()) {
-                if ($match->candidates !== []) {
-                    $names = implode(', ', array_map(static fn (Organization $o): string => $o->name, $match->candidates));
-                    $ambiguous[] = "{$vendorName} (candidates: {$names})";
-                } else {
-                    $unmatched[] = $vendorName;
-                }
+            if ($match->isMatched()) {
+                $this->linkVendorApprover($match->organization, $vendorName, $approverEmail);
+                $updated++;
 
                 continue;
             }
 
-            $match->organization->set(OrganizationApproverCustomFieldEnum::APPROVER_EMAIL->value, $approverEmail);
-            $match->organization->set(OrganizationApproverCustomFieldEnum::VENDOR_NAME->value, $vendorName);
-            OrganizationApprover::linkApproverEmail($match->organization, $approverEmail);
-            $this->info("{$vendorName} -> {$match->organization->name} -> {$approverEmail}");
-            $updated++;
+            if ($match->candidates !== []) {
+                $names = implode(', ', array_map(static fn (Organization $o): string => $o->name, $match->candidates));
+                $ambiguous[] = "{$vendorName} (candidates: {$names})";
+
+                continue;
+            }
+
+            $organization = new CreateOrganizationAction(
+                new OrganizationData(
+                    company: $company,
+                    user: $company->user,
+                    app: $app,
+                    name: $vendorName,
+                ),
+            )->execute();
+
+            $this->linkVendorApprover($organization, $vendorName, $approverEmail);
+            $created++;
         }
 
-        $this->info("Done. {$updated} vendors updated.");
+        $this->info("Done. {$updated} vendors updated, {$created} vendor organizations created.");
 
         if ($noEmail !== []) {
             $this->warn('No approver email in the sheet (skipped): ' . implode(', ', $noEmail));
@@ -97,10 +111,14 @@ class ImportVendorApproversCommand extends Command
         if ($ambiguous !== []) {
             $this->warn('Multiple vendor Organizations could match (skipped, resolve manually): ' . implode('; ', $ambiguous));
         }
+    }
 
-        if ($unmatched !== []) {
-            $this->warn('No matching vendor Organization found (skipped): ' . implode(', ', $unmatched));
-        }
+    private function linkVendorApprover(Organization $organization, string $vendorName, string $approverEmail): void
+    {
+        $organization->set(OrganizationApproverCustomFieldEnum::APPROVER_EMAIL->value, $approverEmail);
+        $organization->set(OrganizationApproverCustomFieldEnum::VENDOR_NAME->value, $vendorName);
+        OrganizationApprover::linkApproverEmail($organization, $approverEmail);
+        $this->info("{$vendorName} -> {$organization->name} -> {$approverEmail}");
     }
 
     /**

--- a/app/Console/Commands/Scribe/ImportVendorApproversCommand.php
+++ b/app/Console/Commands/Scribe/ImportVendorApproversCommand.php
@@ -9,16 +9,18 @@ use Illuminate\Console\Command;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Guild\Organizations\Models\Organization;
+use Kanvas\Guild\Organizations\Models\OrganizationApprover;
 use Kanvas\Guild\Organizations\Services\OrganizationVendorMatcherService;
 use Kanvas\Scribe\Approvals\Enums\OrganizationApproverCustomFieldEnum;
 use Kanvas\Support\Excel\NullExcelImport;
 use Maatwebsite\Excel\Facades\Excel;
 
 /**
- * One-off import: sets ap_approver_email AND ap_approver_vendor_name on each vendor Organization
- * from a spreadsheet mapping Vendor Name -> Approver Email (e.g. the AP Vendor-Approver List
- * finance maintains). Re-run whenever that sheet changes — it's idempotent, safe to run again
- * with an updated file.
+ * One-off import: sets ap_approver_email AND ap_approver_vendor_name on each vendor Organization,
+ * and links a real Kanvas User as its OrganizationApprover (creating a minimal User record if no
+ * Kanvas account matches that email yet), from a spreadsheet mapping Vendor Name -> Approver Email
+ * (e.g. the AP Vendor-Approver List finance maintains). Re-run whenever that sheet changes — it's
+ * idempotent, safe to run again with an updated file.
  */
 class ImportVendorApproversCommand extends Command
 {
@@ -26,7 +28,7 @@ class ImportVendorApproversCommand extends Command
 
     protected $signature = 'scribe:import-vendor-approvers {apps_id} {company_id} {file}';
 
-    protected $description = 'Sets the ap_approver_email and ap_approver_vendor_name custom fields on vendor Organizations from a Vendor Name / Approver Email spreadsheet';
+    protected $description = 'Sets the ap_approver_email/ap_approver_vendor_name custom fields and links an OrganizationApprover on vendor Organizations from a Vendor Name / Approver Email spreadsheet';
 
     public function handle(): void
     {
@@ -81,6 +83,7 @@ class ImportVendorApproversCommand extends Command
 
             $match->organization->set(OrganizationApproverCustomFieldEnum::APPROVER_EMAIL->value, $approverEmail);
             $match->organization->set(OrganizationApproverCustomFieldEnum::VENDOR_NAME->value, $vendorName);
+            OrganizationApprover::linkApproverEmail($match->organization, $approverEmail);
             $this->info("{$vendorName} -> {$match->organization->name} -> {$approverEmail}");
             $updated++;
         }

--- a/database/migrations/Guild/2026_08_31_000000_create_organization_approvers_table.php
+++ b/database/migrations/Guild/2026_08_31_000000_create_organization_approvers_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateOrganizationApproversTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('crm')->create('organization_approvers', function (Blueprint $table) {
+            $table->bigInteger('id', true);
+            $table->bigInteger('organizations_id')->index('organizations_id');
+            $table->bigInteger('users_id')->index('users_id');
+            $table->dateTime('created_at')->index('created_at');
+
+            $table->unique(['organizations_id', 'users_id'], 'organizations_id_users_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('crm')->dropIfExists('organization_approvers');
+    }
+}

--- a/src/Domains/Guild/Organizations/Models/OrganizationApprover.php
+++ b/src/Domains/Guild/Organizations/Models/OrganizationApprover.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Organizations\Models;
+
+use Baka\Traits\NoAppRelationshipTrait;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use Kanvas\Guild\Models\BaseModel;
+use Kanvas\Users\Models\Users;
+
+/**
+ * A Kanvas User responsible for approving AP/AR items on behalf of this Organization (vendor/customer).
+ * An Organization can have more than one approver — organizations_id/users_id live on different
+ * database connections, so this is a plain belongsTo pivot model rather than a belongsToMany
+ * relation, which would require a single-connection join.
+ *
+ * @property int $organizations_id
+ * @property int $users_id
+ * @property string $created_at
+ */
+class OrganizationApprover extends BaseModel
+{
+    use NoAppRelationshipTrait;
+
+    protected $table = 'organization_approvers';
+    protected $guarded = [];
+
+    protected $attributes = [];
+    public $timestamps = false;
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(Users::class, 'users_id', 'id');
+    }
+
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class, 'organizations_id', 'id');
+    }
+
+    /**
+     * Not deleted scope.
+     */
+    public function scopeNotDeleted(Builder $query): Builder
+    {
+        return $query;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function emailsFor(Organization $organization): array
+    {
+        return self::query()
+            ->where('organizations_id', $organization->getId())
+            ->with('user')
+            ->get()
+            ->pluck('user.email')
+            ->filter(static fn (?string $email): bool => $email !== null && trim($email) !== '')
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    public static function addApproverToOrganization(Organization $organization, Users $user): OrganizationApprover
+    {
+        return self::firstOrCreate([
+            'organizations_id' => $organization->getId(),
+            'users_id' => $user->getId(),
+        ], [
+            'created_at' => date('Y-m-d H:i:s'),
+        ]);
+    }
+
+    public static function removeApproverFromOrganization(Organization $organization, Users $user): int
+    {
+        return self::query()
+            ->where('organizations_id', $organization->getId())
+            ->where('users_id', $user->getId())
+            ->delete();
+    }
+
+    /**
+     * Links an approver by email — reuses an existing Kanvas User with that email when one exists,
+     * otherwise creates a minimal, unonboarded User record just to hold the identity (no company,
+     * no welcome email, no workflow) so it can be matched against Slack by email like any approver.
+     */
+    public static function linkApproverEmail(Organization $organization, string $email): OrganizationApprover
+    {
+        $user = Users::query()->where('email', $email)->first() ?? self::createMinimalUser($email);
+
+        return self::addApproverToOrganization($organization, $user);
+    }
+
+    private static function createMinimalUser(string $email): Users
+    {
+        $user = new Users();
+        $user->email = $email;
+        $user->password = Hash::make(Str::random(32));
+        $user->displayname = explode('@', $email)[0];
+        $user->default_company = 0;
+        $user->user_active = 1;
+        $user->status = 1;
+        $user->saveOrFail();
+
+        return $user;
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -6,6 +6,7 @@ namespace Kanvas\Intelligence\Agents\Neuron\Accounting;
 
 use Kanvas\Intelligence\Agents\Attributes\AgentTypeDefinition;
 use Kanvas\Intelligence\Agents\Neuron\SystemUserAgent;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\AddOrganizationApproverTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ApprovePendingItemTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ExtractInvoiceDataTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindBillTool;
@@ -71,6 +72,7 @@ class AccountsPayableAgent extends SystemUserAgent
             new FindBillTool(),
             new FindVendorTool(),
             new MatchBillsForPaymentTool(),
+            new AddOrganizationApproverTool(),
             new CreateApBillTool(),
             new VoidApBillTool(),
             new ApplyApPaymentTool(),
@@ -114,6 +116,9 @@ class AccountsPayableAgent extends SystemUserAgent
             . '(set only_overdue for past-due focus).',
             '- "What has vendor X got on order" / matching an invoice to a PO → list_open_purchase_orders.',
             '- Resolving a vendor name off an invoice → find_vendor; if more than one candidate, confirm which.',
+            '- "Add/assign an approver for vendor X" → find_vendor first to resolve organization_id, then '
+            . 'add_organization_approver with that id and the approver\'s email. A vendor can have more than '
+            . 'one approver — this never replaces an existing one, only adds.',
             '- Lead with the headline (e.g. "Total payables: $84,200 across 12 vendors; $19,500 overdue"), then '
             . 'the top 3-5 items. Be honest about freshness; never invent precision the data lacks.',
             '- "Create a bill for vendor X" → create_ap_bill, only when the user explicitly asks for it — by '

--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsReceivableAgent.php
@@ -6,6 +6,7 @@ namespace Kanvas\Intelligence\Agents\Neuron\Accounting;
 
 use Kanvas\Intelligence\Agents\Attributes\AgentTypeDefinition;
 use Kanvas\Intelligence\Agents\Neuron\SystemUserAgent;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\AddOrganizationApproverTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ApprovePendingItemTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ExtractCreditRequestFormTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ExtractInvoiceDataTool;
@@ -84,6 +85,7 @@ class AccountsReceivableAgent extends SystemUserAgent
             new SalesByProductTool(),
             new SalesRevenueTool(),
             new MatchInvoicesForPaymentTool(),
+            new AddOrganizationApproverTool(),
             new CreateArInvoiceTool(),
             new VoidArInvoiceTool(),
             new ApplyArPaymentTool(),
@@ -129,6 +131,9 @@ class AccountsReceivableAgent extends SystemUserAgent
             . 'not list_open_sales_orders, which is for purchase/sales orders, not invoices.',
             '- "Look up invoice #X" / "status of invoice X" → find_invoice (one specific invoice by number).',
             '- "Who is customer X" / resolve a customer name to its ERP code → find_customer.',
+            '- "Add/assign an approver for customer X" → find_customer first to resolve organization_id, then '
+            . 'add_organization_approver with that id and the approver\'s email. A customer can have more than '
+            . 'one approver — this never replaces an existing one, only adds.',
             '- "Look up sales order #X" → find_sales_order (a sales order is a CUSTOMER order, not a purchase order).',
             '- "What orders are open" / "a customer\'s in-flight orders" / the sales pipeline → list_open_sales_orders.',
             '- "Top customers" / "biggest buyers" → sales_by_customer. "Best sellers" / "top products" → sales_by_product. "Revenue this quarter / trend" → sales_revenue (set by_month for a trend). All exclude draft/canceled orders; be clear about the date range.',

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/AddOrganizationApproverTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/AddOrganizationApproverTool.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
+
+use Kanvas\Exceptions\ModelNotFoundException;
+use Kanvas\Guild\Organizations\Models\Organization;
+use Kanvas\Guild\Organizations\Models\OrganizationApprover;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+use Throwable;
+
+/**
+ * Links a Kanvas User as an approver for a vendor/customer Organization — the same table
+ * ImportVendorApproversCommand populates from a spreadsheet, but callable one at a time in
+ * conversation. An Organization can have more than one approver.
+ */
+#[AgentTool(name: 'Add Organization Approver', category: 'accounting')]
+class AddOrganizationApproverTool extends Tool
+{
+    use HasKanvasContext;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'add_organization_approver',
+            description: 'Adds (or reuses) a Kanvas User as an approver for a vendor/customer organization — '
+                . 'that person can then approve pending bills/invoices for it and gets notified when a new one '
+                . 'comes in. Resolve the organization_id first with find_vendor or find_customer. Only call when '
+                . 'the user explicitly asks to add/assign an approver, never on your own initiative.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'organization_id',
+                type: PropertyType::INTEGER,
+                description: 'The Kanvas Organization id, from find_vendor or find_customer. Never guess it.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'approver_email',
+                type: PropertyType::STRING,
+                description: 'The approver\'s email. If no Kanvas User has this email yet, a minimal one is '
+                    . 'created just to hold the identity — no welcome email is sent.',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(int $organization_id, string $approver_email): array
+    {
+        $email = trim($approver_email);
+
+        if (! filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            return [
+                'linked' => false,
+                'reason' => 'invalid_email',
+                'message' => "\"{$approver_email}\" is not a valid email address.",
+            ];
+        }
+
+        try {
+            /** @var Organization $organization */
+            $organization = Organization::getByIdFromCompanyApp($organization_id, $this->company, $this->app);
+        } catch (ModelNotFoundException) {
+            return [
+                'linked' => false,
+                'reason' => 'organization_not_found',
+                'message' => "No organization with id {$organization_id} for this app/company.",
+            ];
+        }
+
+        try {
+            OrganizationApprover::linkApproverEmail($organization, $email);
+        } catch (Throwable $e) {
+            return [
+                'linked' => false,
+                'reason' => 'link_failed',
+                'message' => 'Could not link that approver: ' . $e->getMessage(),
+            ];
+        }
+
+        return [
+            'linked' => true,
+            'organization_id' => $organization->getId(),
+            'organization_name' => $organization->name,
+            'approver_email' => $email,
+            'approvers' => OrganizationApprover::emailsFor($organization),
+        ];
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/ApprovePendingItemTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/ApprovePendingItemTool.php
@@ -89,9 +89,9 @@ class ApprovePendingItemTool extends Tool
             ];
         }
 
-        $approverEmail = new ResolveApproverEmailAction($target_type, $target_id)->execute();
+        $approverEmails = new ResolveApproverEmailAction($target_type, $target_id)->execute();
 
-        if ($approverEmail === null) {
+        if ($approverEmails === []) {
             return [
                 'approved' => false,
                 'reason' => 'no_approver_configured',
@@ -99,7 +99,7 @@ class ApprovePendingItemTool extends Tool
             ];
         }
 
-        if (! $this->isAuthorizedApprover($approverEmail)) {
+        if (! $this->isAuthorizedApprover($approverEmails)) {
             return [
                 'approved' => false,
                 'reason' => 'not_authorized',

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -16,6 +16,7 @@ use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\StoresApprovalSourceFields;
 use Kanvas\Scribe\Approvals\Actions\NotifyApproverAction;
+use Kanvas\Scribe\Approvals\Actions\ResolveApproverEmailAction;
 use Kanvas\Scribe\Approvals\Enums\OrganizationApproverCustomFieldEnum;
 use Kanvas\Scribe\Bills\Actions\ApproveBillAction;
 use Kanvas\Scribe\Bills\Actions\CreateBillAction;
@@ -248,19 +249,21 @@ class CreateApBillTool extends Tool implements HasRunKey
         );
 
         if (! $push_to_acumatica) {
-            $approverEmail = trim((string) $vendor->get(OrganizationApproverCustomFieldEnum::APPROVER_EMAIL->value, ''));
+            $approverEmails = ResolveApproverEmailAction::resolveForOrganization($vendor);
 
-            new NotifyApproverAction(
-                app: $app,
-                text: "You have an AP bill pending approval:\nVendor: {$vendorDisplayName}\nAmount: {$currency} "
-                    . "{$amount}\nGL: {$gl_account_number}"
-                    . ($subaccount !== null && trim($subaccount) !== '' ? " / Subaccount: {$subaccount}" : '')
-                    . "\nMemo: {$memo}\nBill ID (Kanvas): {$bill->getId()}\n\nReply \"approve bill "
-                    . "{$bill->getId()}\" to approve it and push it to Acumatica.",
-                approverEmail: $approverEmail !== '' ? $approverEmail : null,
-                attachmentUrl: $source_attachment_url,
-                attachmentFilename: $source_attachment_filename,
-            )->execute();
+            foreach ($approverEmails as $approverEmail) {
+                new NotifyApproverAction(
+                    app: $app,
+                    text: "You have an AP bill pending approval:\nVendor: {$vendorDisplayName}\nAmount: "
+                        . "{$currency} {$amount}\nGL: {$gl_account_number}"
+                        . ($subaccount !== null && trim($subaccount) !== '' ? " / Subaccount: {$subaccount}" : '')
+                        . "\nMemo: {$memo}\nBill ID (Kanvas): {$bill->getId()}\n\nReply \"approve bill "
+                        . "{$bill->getId()}\" to approve it and push it to Acumatica.",
+                    approverEmail: $approverEmail,
+                    attachmentUrl: $source_attachment_url,
+                    attachmentFilename: $source_attachment_filename,
+                )->execute();
+            }
 
             return [
                 'created' => true,
@@ -274,14 +277,14 @@ class CreateApBillTool extends Tool implements HasRunKey
                 'gl_account' => $gl_account_number,
                 'subaccount' => $subaccount,
                 'memo' => $memo,
-                'approved_by_flag' => $approverEmail !== '' ? '' : 'NOT IN APPROVER LIST',
-                'next' => $approverEmail !== ''
+                'approved_by_flag' => $approverEmails !== [] ? '' : 'NOT IN APPROVER LIST',
+                'next' => $approverEmails !== []
                     ? 'Bill created and submitted for approval in Kanvas (status: pending_approval). Not pushed '
                         . 'to Acumatica — that happens separately once a human approves it.'
                     : 'Bill created and submitted for approval, but vendor "' . $vendorDisplayName . '" has no '
-                        . 'approver email configured — nobody can approve it and no notification was sent. Write '
+                        . 'approver configured — nobody can approve it and no notification was sent. Write '
                         . 'approved_by_flag into the sheet\'s Approved By column so this is visible there too, '
-                        . 'and tell the user to have an admin set that vendor\'s approver email.',
+                        . 'and tell the user to have an admin set that vendor\'s approver.',
             ];
         }
 

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
@@ -15,6 +15,7 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\StoresApprovalSourceFields;
 use Kanvas\Scribe\Approvals\Actions\NotifyApproverAction;
 use Kanvas\Scribe\Approvals\Actions\RequestApprovalAction;
+use Kanvas\Scribe\Approvals\Actions\ResolveApproverEmailAction;
 use Kanvas\Scribe\Approvals\Enums\OrganizationApproverCustomFieldEnum;
 use Kanvas\Scribe\Invoices\Actions\CreateInvoiceAction;
 use Kanvas\Scribe\Invoices\Actions\IssueInvoiceAction;
@@ -202,17 +203,19 @@ class CreateArInvoiceTool extends Tool implements HasRunKey
                 requestedByUser: $actingUser,
             )->execute();
 
-            $approverEmail = trim((string) $customer->get(OrganizationApproverCustomFieldEnum::APPROVER_EMAIL->value, ''));
+            $approverEmails = ResolveApproverEmailAction::resolveForOrganization($customer);
 
-            new NotifyApproverAction(
-                app: $app,
-                text: "You have an AR invoice pending approval:\nCustomer: {$customerDisplayName}\nAmount: {$currency} "
-                    . "{$amount}\nMemo: {$memo}\nInvoice ID (Kanvas): {$invoice->getId()}\n\nReply "
-                    . "\"approve invoice {$invoice->getId()}\" to approve it and push it to Acumatica.",
-                approverEmail: $approverEmail !== '' ? $approverEmail : null,
-                attachmentUrl: $source_attachment_url,
-                attachmentFilename: $source_attachment_filename,
-            )->execute();
+            foreach ($approverEmails as $approverEmail) {
+                new NotifyApproverAction(
+                    app: $app,
+                    text: "You have an AR invoice pending approval:\nCustomer: {$customerDisplayName}\nAmount: "
+                        . "{$currency} {$amount}\nMemo: {$memo}\nInvoice ID (Kanvas): {$invoice->getId()}\n\nReply "
+                        . "\"approve invoice {$invoice->getId()}\" to approve it and push it to Acumatica.",
+                    approverEmail: $approverEmail,
+                    attachmentUrl: $source_attachment_url,
+                    attachmentFilename: $source_attachment_filename,
+                )->execute();
+            }
 
             return [
                 'created' => true,
@@ -224,14 +227,14 @@ class CreateArInvoiceTool extends Tool implements HasRunKey
                 'amount' => $amount,
                 'currency' => $currency,
                 'memo' => $memo,
-                'approved_by_flag' => $approverEmail !== '' ? '' : 'NOT IN APPROVER LIST',
-                'next' => $approverEmail !== ''
+                'approved_by_flag' => $approverEmails !== [] ? '' : 'NOT IN APPROVER LIST',
+                'next' => $approverEmails !== []
                     ? 'Invoice created in Kanvas (status: draft). Not issued or pushed to Acumatica — that '
                         . 'happens separately once a human approves it.'
-                    : 'Invoice created in Kanvas, but customer "' . $customerDisplayName . '" has no approver email '
+                    : 'Invoice created in Kanvas, but customer "' . $customerDisplayName . '" has no approver '
                         . 'configured — nobody can approve it and no notification was sent. Write approved_by_flag '
                         . 'into the sheet\'s Approved By column so this is visible there too, and tell the user to '
-                        . 'have an admin set that customer\'s approver email.',
+                        . 'have an admin set that customer\'s approver.',
             ];
         }
 

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Gmail/ReplyToEmailTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Gmail/ReplyToEmailTool.php
@@ -78,9 +78,9 @@ class ReplyToEmailTool extends Tool
      */
     public function __invoke(string $message_id, string $note, string $target_type, int $target_id): array
     {
-        $approverEmail = new ResolveApproverEmailAction($target_type, $target_id)->execute();
+        $approverEmails = new ResolveApproverEmailAction($target_type, $target_id)->execute();
 
-        if ($approverEmail === null) {
+        if ($approverEmails === []) {
             return [
                 'replied' => false,
                 'reason' => 'no_approver_configured',
@@ -89,7 +89,7 @@ class ReplyToEmailTool extends Tool
         }
 
         try {
-            $result = new ReplyToEmailAction($this->app, $message_id, [$approverEmail], $note)->execute();
+            $result = new ReplyToEmailAction($this->app, $message_id, $approverEmails, $note)->execute();
         } catch (Throwable $e) {
             return [
                 'replied' => false,

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Traits/VerifiesApprovalAuthority.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Traits/VerifiesApprovalAuthority.php
@@ -7,8 +7,17 @@ namespace Kanvas\Intelligence\Agents\Neuron\Tools\Traits;
 /** Shared authorization check for tools that resolve an item from the approval queue — used alongside HasKanvasContext. */
 trait VerifiesApprovalAuthority
 {
-    protected function isAuthorizedApprover(string $approverEmail): bool
+    /**
+     * @param list<string> $approverEmails
+     */
+    protected function isAuthorizedApprover(array $approverEmails): bool
     {
-        return $approverEmail !== '' && strcasecmp((string) $this->user->email, $approverEmail) === 0;
+        foreach ($approverEmails as $approverEmail) {
+            if ($approverEmail !== '' && strcasecmp((string) $this->user->email, $approverEmail) === 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Domains/Scribe/Approvals/Actions/ResolveApproverEmailAction.php
+++ b/src/Domains/Scribe/Approvals/Actions/ResolveApproverEmailAction.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Kanvas\Scribe\Approvals\Actions;
 
+use Kanvas\Guild\Organizations\Models\Organization;
+use Kanvas\Guild\Organizations\Models\OrganizationApprover;
 use Kanvas\Scribe\Approvals\Enums\OrganizationApproverCustomFieldEnum;
 use Kanvas\Scribe\Bills\Models\Bill;
 use Kanvas\Scribe\Invoices\Models\Invoice;
 
 /**
- * Resolves the approver email for a pending item from its vendor/customer Organization —
- * the same organization-level custom field for every approval type, so a new type only needs
- * a new match arm here, mirroring ResolveApprovalAction's own action_type dispatch.
+ * Resolves the approver email(s) for a pending item from its vendor/customer Organization —
+ * the same organization-level lookup for every approval type, so a new type only needs a new
+ * match arm here, mirroring ResolveApprovalAction's own action_type dispatch.
  */
 class ResolveApproverEmailAction
 {
@@ -21,7 +23,10 @@ class ResolveApproverEmailAction
     ) {
     }
 
-    public function execute(): ?string
+    /**
+     * @return list<string>
+     */
+    public function execute(): array
     {
         $organization = match ($this->targetType) {
             'bill' => Bill::query()->where('id', $this->targetId)->first()?->vendor,
@@ -29,12 +34,25 @@ class ResolveApproverEmailAction
             default => null,
         };
 
-        if ($organization === null) {
-            return null;
+        return $organization !== null ? self::resolveForOrganization($organization) : [];
+    }
+
+    /**
+     * The Organization's own OrganizationApprover Users take priority; falls back to the
+     * legacy ap_approver_email custom field for organizations not yet migrated to the table.
+     *
+     * @return list<string>
+     */
+    public static function resolveForOrganization(Organization $organization): array
+    {
+        $emails = OrganizationApprover::emailsFor($organization);
+
+        if ($emails !== []) {
+            return $emails;
         }
 
-        $email = trim((string) $organization->get(OrganizationApproverCustomFieldEnum::APPROVER_EMAIL->value, ''));
+        $fallback = trim((string) $organization->get(OrganizationApproverCustomFieldEnum::APPROVER_EMAIL->value, ''));
 
-        return $email !== '' ? $email : null;
+        return $fallback !== '' ? [$fallback] : [];
     }
 }

--- a/src/Domains/Scribe/Approvals/CLAUDE.md
+++ b/src/Domains/Scribe/Approvals/CLAUDE.md
@@ -20,13 +20,14 @@ its own approver, since different vendors are owned by different people on the f
 | Class | Role |
 |---|---|
 | `Enums\ApprovalConfigurationEnum` | App-level config (currently just which agent's Slack bot sends the DM). |
-| `Enums\OrganizationApproverCustomFieldEnum` | The custom field on a vendor/customer `Organization` that names its approver's email. |
+| `Kanvas\Guild\Organizations\Models\OrganizationApprover` | Pivot linking a vendor/customer `Organization` to one or more real Kanvas `Users` who may approve its items — an Organization can have more than one approver. Lives in Guild since it's a generic Organization↔Users relation, not AP/AR-specific. |
+| `Enums\OrganizationApproverCustomFieldEnum` | The legacy custom field on a vendor/customer `Organization` naming a single approver's email — still the fallback when an Organization has no `OrganizationApprover` rows yet. |
 | `Enums\ApprovalCustomFieldEnum` | Entity-level custom field keys stashed on the bill/invoice at creation (source email + attachment), read back at approval time. |
 | `Enums\ApprovalQueueStatusEnum` | `pending` / `approved` / `rejected` / `expired`. |
 | `Models\ApprovalQueueItem` | The queue row itself — `action_type`, `target_type`, `target_id`, `payload`, `status`, `approved_by_users_id`, `approved_at`. |
 | `Actions\RequestApprovalAction` | Creates a pending queue row for any record type. |
 | `Actions\ResolveApprovalAction` | Dispatches on `action_type` to the domain action that actually carries out the approval (approve + push a bill, issue + push an invoice, …), then marks the row `approved`. |
-| `Actions\ResolveApproverEmailAction` | Given `target_type`/`target_id`, looks up the record's vendor/customer and returns its approver email — the single place that maps a pending item to who may approve it. |
+| `Actions\ResolveApproverEmailAction` | Given `target_type`/`target_id` (or an `Organization` directly, via the static `resolveForOrganization()`), returns the `list<string>` of approver emails — its own `OrganizationApprover` Users first, falling back to `OrganizationApproverCustomFieldEnum` when none exist. The single place that maps a pending item to who may approve it. |
 | `Actions\NotifyApproverAction` | Best-effort Slack DM to an approver email — looks the person up in Slack by email, silently does nothing if Slack isn't configured or the email doesn't match a workspace member, never blocks the caller. Takes an optional `agentId` constructor arg to use a specific notifier agent instead of the app-level `ap-slack-notifier-agent-id` default (e.g. AR's own credit-memo push notification uses its own agent, since AP and AR can have different Slack bots connected). |
 
 `Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ApprovePendingItemTool` (`approve_pending_item`)
@@ -45,12 +46,13 @@ and `ResolveApproverEmailAction`; the tool and the queue itself never change.
    `ApprovalQueueItem` row (`action_type: 'approve_bill'`); for invoices, `CreateArInvoiceTool` calls
    `RequestApprovalAction` explicitly (`action_type: 'approve_invoice'`) since a draft invoice has no
    built-in approval-queue side effect of its own.
-3. The tool reads the vendor's/customer's approver email (`OrganizationApproverCustomFieldEnum`) and
-   calls `NotifyApproverAction`, which DMs that person on Slack — looked up by email, not a fixed
-   Slack user id — with the record's details and its Kanvas id, uploading the invoice PDF
-   (`source_attachment_url`) as a real Slack attachment when one was captured, so the approver can
-   open the actual document before deciding. If the vendor/customer has no approver email set, the
-   tool still creates the record but tells the caller nobody can approve it yet and no DM was sent.
+3. The tool resolves the vendor's/customer's approver emails (`ResolveApproverEmailAction::resolveForOrganization()`)
+   and calls `NotifyApproverAction` once per approver, which DMs that person on Slack — looked up by
+   email, not a fixed Slack user id — with the record's details and its Kanvas id, uploading the
+   invoice PDF (`source_attachment_url`) as a real Slack attachment when one was captured, so the
+   approver can open the actual document before deciding. If the vendor/customer has no approver
+   configured, the tool still creates the record but tells the caller nobody can approve it yet and
+   no DM was sent.
 4. Logged to the tracking sheet as "Pending".
 
 **Approval** (the human, then Apex/Arc again):
@@ -58,10 +60,10 @@ and `ResolveApproverEmailAction`; the tool and the queue itself never change.
 5. The approver replies in Slack, in natural language — "approve bill 1072". This reaches Apex
    through the normal Slack↔agent pipeline, same as any other message.
 6. `approve_pending_item(target_type, target_id)` — resolves the record's vendor/customer approver
-   email via `ResolveApproverEmailAction`, checks it against the sender's email
-   (`VerifiesApprovalAuthority`), finds the pending `ApprovalQueueItem`, and calls
-   `ResolveApprovalAction`, which approves the bill / issues the invoice in Kanvas and pushes it to
-   Acumatica in the same call.
+   emails via `ResolveApproverEmailAction`, checks the sender's email against that list
+   (`VerifiesApprovalAuthority`) — any one of them may approve — finds the pending
+   `ApprovalQueueItem`, and calls `ResolveApprovalAction`, which approves the bill / issues the
+   invoice in Kanvas and pushes it to Acumatica in the same call.
 7. On success, the agent's own guidance (in `AccountsPayableAgent`/`AccountsReceivableAgent`) drives
    the rest: `add_bill_note`/`add_invoice_note` records "Approved by {email} on {date}";
    `attach_bill_file`/`attach_invoice_file` attaches the stashed PDF (only possible now, since it
@@ -76,23 +78,26 @@ that isn't actually in Acumatica yet.
 
 ## Who gets to approve — how the identity check actually works
 
-`approve_pending_item` looks up the pending record's vendor/customer, reads that organization's
-`ap_approver_email` custom field, and compares it against `$this->user->email` — the Kanvas user
-attached to the current turn. **This is not necessarily your normal Kanvas login.** When someone
-messages an agent over Slack, `SlackUserResolverService` looks up their Slack **profile** email
-(via Slack's own `users.info` API) and matches it to a Kanvas user with that same email — which can
-be a different record than the one behind your usual web-app login, if the two emails differ. The
-email that matters here is **whatever email is on the approver's Slack profile**, not their Kanvas
-admin-panel login.
+`approve_pending_item` looks up the pending record's vendor/customer, resolves its list of approver
+emails (its `OrganizationApprover` Users, or the legacy `ap_approver_email` custom field when none
+are set), and compares `$this->user->email` against that list — **any one** of the organization's
+approvers may approve, not just a single fixed person. **This is not necessarily your normal Kanvas
+login.** When someone messages an agent over Slack, `SlackUserResolverService` looks up their Slack
+**profile** email (via Slack's own `users.info` API) and matches it to a Kanvas user with that same
+email — which can be a different record than the one behind your usual web-app login, if the two
+emails differ. The email that matters here is **whatever email is on the approver's Slack profile**,
+not their Kanvas admin-panel login.
 
-If a vendor/customer has no `ap_approver_email` set, `approve_pending_item` reports
-`no_approver_configured` — nobody can approve that record until it's set.
+If a vendor/customer has no approver configured (neither `OrganizationApprover` rows nor
+`ap_approver_email`), `approve_pending_item` reports `no_approver_configured` — nobody can approve
+that record until one is set.
 
 ## Configuration
 
 | Key | What it is | How to set it |
 |---|---|---|
-| `Organization` custom field `ap_approver_email` (`OrganizationApproverCustomFieldEnum::APPROVER_EMAIL`) | The email of the person who approves this vendor's bills (AP) or this customer's invoices (AR). Looked up in Slack by email — no separate Slack user id to configure. | Per vendor/customer, via `$organization->set('ap_approver_email', 'name@company.com')`. For a batch import from a spreadsheet mapping vendor name → approver email, write a one-off Artisan command modeled on `app/Console/Commands/Guild/AgentsImportCommand.php`. |
+| `OrganizationApprover` rows | The real Kanvas Users who may approve this vendor's/customer's items — an Organization can have more than one. Takes priority over the legacy custom field below. | `OrganizationApprover::addApproverToOrganization($organization, $user)` when the approver already has a Kanvas User. `OrganizationApprover::linkApproverEmail($organization, $email)` when you only have their email — reuses an existing Kanvas User with that email, or creates a minimal (unonboarded) one. `app/Console/Commands/Scribe/ImportVendorApproversCommand.php` does this for a whole Vendor Name / Approver Email spreadsheet in one run. |
+| `Organization` custom field `ap_approver_email` (`OrganizationApproverCustomFieldEnum::APPROVER_EMAIL`) | Legacy fallback: the email of the person who approves this vendor's bills (AP) or this customer's invoices (AR), for organizations not yet migrated to `OrganizationApprover`. Looked up in Slack by email — no separate Slack user id to configure. | Per vendor/customer, via `$organization->set('ap_approver_email', 'name@company.com')`. |
 | `ap-slack-notifier-agent-id` (`ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID`) | The Kanvas `Agent` record id whose Slack bot token sends the DM — this is *deliberately* explicit, not auto-detected, because a tenant can have several agents connected to Slack and there is no reliable way to pick "the right one" automatically. This is the default `NotifyApproverAction` falls back to when no `agentId` is passed explicitly. | Kanvas admin panel → Settings → Agents → find the AP/AR agent (e.g. "Apex") → copy its id. Or run this GraphQL query (authenticated as an admin/owner): `query { agents(where: { column: NAME, operator: LIKE, value: "%Apex%" }) { data { id name } } }`. Set with `$app->set('ap-slack-notifier-agent-id', '123')`. |
 | `ar-slack-notifier-agent-id` (`Kanvas\Scribe\Invoices\Enums\ConfigurationEnum::AR_SLACK_NOTIFIER_AGENT_ID`) | Same idea, scoped to AR — used when AR's Slack-connected agent (e.g. "Arc") is a different `Agent` record than AP's. `CreateArCreditMemoTool` passes this as `NotifyApproverAction`'s `agentId` for its Acumatica-push notification. | Set with `$app->set('ar-slack-notifier-agent-id', '123')`. |
 

--- a/tests/Guild/Organizations/OrganizationApproverTest.php
+++ b/tests/Guild/Organizations/OrganizationApproverTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Guild\Organizations;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Organizations\Models\Organization;
+use Kanvas\Guild\Organizations\Models\OrganizationApprover;
+use Kanvas\Users\Models\Users;
+use Tests\TestCase;
+
+final class OrganizationApproverTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    // OrganizationApprover lives on 'crm' and linkApproverEmail() can create Users on 'mysql' —
+    // without declaring both, DatabaseTransactions only rolls back 'mysql' and the crm rows commit
+    // for real, leaking into unrelated tests later in the same run. See tests/CLAUDE.md.
+    protected array $connectionsToTransact = ['mysql', 'crm'];
+
+    public function test_emails_for_is_empty_when_no_approvers_are_linked(): void
+    {
+        $organization = $this->seedOrganization('No Approver Test Corp');
+
+        $this->assertSame([], OrganizationApprover::emailsFor($organization));
+    }
+
+    public function test_an_organization_can_have_more_than_one_approver(): void
+    {
+        $organization = $this->seedOrganization('Multi Approver Test Corp');
+        $approverOne = Users::factory()->create(['email' => 'approver-one-' . uniqid() . '@example.test']);
+        $approverTwo = Users::factory()->create(['email' => 'approver-two-' . uniqid() . '@example.test']);
+
+        OrganizationApprover::addApproverToOrganization($organization, $approverOne);
+        OrganizationApprover::addApproverToOrganization($organization, $approverTwo);
+
+        $emails = OrganizationApprover::emailsFor($organization);
+
+        $this->assertCount(2, $emails);
+        $this->assertContains($approverOne->email, $emails);
+        $this->assertContains($approverTwo->email, $emails);
+    }
+
+    public function test_adding_the_same_approver_twice_does_not_duplicate_it(): void
+    {
+        $organization = $this->seedOrganization('Duplicate Approver Test Corp');
+        $approver = Users::factory()->create(['email' => 'dup-approver-' . uniqid() . '@example.test']);
+
+        OrganizationApprover::addApproverToOrganization($organization, $approver);
+        OrganizationApprover::addApproverToOrganization($organization, $approver);
+
+        $this->assertCount(1, OrganizationApprover::emailsFor($organization));
+    }
+
+    public function test_removing_an_approver_drops_it_from_the_list(): void
+    {
+        $organization = $this->seedOrganization('Removable Approver Test Corp');
+        $approver = Users::factory()->create(['email' => 'removable-approver-' . uniqid() . '@example.test']);
+
+        OrganizationApprover::addApproverToOrganization($organization, $approver);
+        $this->assertCount(1, OrganizationApprover::emailsFor($organization));
+
+        OrganizationApprover::removeApproverFromOrganization($organization, $approver);
+        $this->assertSame([], OrganizationApprover::emailsFor($organization));
+    }
+
+    public function test_link_approver_email_reuses_an_existing_kanvas_user(): void
+    {
+        $organization = $this->seedOrganization('Existing User Approver Test Corp');
+        $existingUser = Users::factory()->create(['email' => 'existing-approver-' . uniqid() . '@example.test']);
+
+        OrganizationApprover::linkApproverEmail($organization, $existingUser->email);
+
+        $this->assertSame([$existingUser->email], OrganizationApprover::emailsFor($organization));
+    }
+
+    public function test_link_approver_email_creates_a_minimal_user_when_none_matches(): void
+    {
+        $organization = $this->seedOrganization('New User Approver Test Corp');
+        $newEmail = 'brand-new-approver-' . uniqid() . '@example.test';
+
+        $this->assertNull(Users::query()->where('email', $newEmail)->first());
+
+        OrganizationApprover::linkApproverEmail($organization, $newEmail);
+
+        $this->assertSame([$newEmail], OrganizationApprover::emailsFor($organization));
+        $this->assertNotNull(Users::query()->where('email', $newEmail)->first());
+    }
+
+    private function seedOrganization(string $name): Organization
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+
+        return Organization::create([
+            'apps_id' => $app->getId(),
+            'companies_id' => $user->getCurrentCompany()->getId(),
+            'users_id' => $user->getId(),
+            'name' => $name,
+            'address' => '',
+            'total_employees' => 0,
+        ]);
+    }
+}

--- a/tests/Scribe/Approvals/ImportVendorApproversCommandTest.php
+++ b/tests/Scribe/Approvals/ImportVendorApproversCommandTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Scribe\Approvals;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Guild\Organizations\Models\Organization;
+use Kanvas\Guild\Organizations\Models\OrganizationApprover;
+use Kanvas\Scribe\Approvals\Enums\OrganizationApproverCustomFieldEnum;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Tests\TestCase;
+
+final class ImportVendorApproversCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    // Organization/OrganizationApprover live on 'crm' and approvers can be linked to new Users on
+    // 'mysql' — without declaring both, DatabaseTransactions only rolls back 'mysql'. See tests/CLAUDE.md.
+    protected array $connectionsToTransact = ['mysql', 'crm'];
+
+    private const string COMMAND = 'scribe:import-vendor-approvers';
+
+    private Apps $kanvasApp;
+    private Companies $company;
+    private ?string $tempPath = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->kanvasApp = app(Apps::class);
+        $this->company = static::$cachedUser->getCurrentCompany();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->tempPath !== null && file_exists($this->tempPath)) {
+            unlink($this->tempPath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_links_an_approver_on_an_already_matching_organization(): void
+    {
+        $vendor = $this->seedOrganization('Import Command Match Test Corp');
+
+        $this->artisan(self::COMMAND, [
+            'apps_id' => $this->kanvasApp->getId(),
+            'company_id' => $this->company->getId(),
+            'file' => $this->writeSheet([
+                ['Import Command Match Test Corp', 'match-approver@example.test'],
+            ]),
+        ])->assertSuccessful();
+
+        $vendor->refresh();
+        $this->assertSame('match-approver@example.test', $vendor->get(OrganizationApproverCustomFieldEnum::APPROVER_EMAIL->value));
+        $this->assertSame(['match-approver@example.test'], OrganizationApprover::emailsFor($vendor));
+    }
+
+    public function test_creates_the_organization_when_nothing_matches_so_the_whole_sheet_ends_up_linked(): void
+    {
+        $vendorName = 'Brand New Import Vendor ' . uniqid();
+
+        $this->artisan(self::COMMAND, [
+            'apps_id' => $this->kanvasApp->getId(),
+            'company_id' => $this->company->getId(),
+            'file' => $this->writeSheet([
+                [$vendorName, 'new-vendor-approver@example.test'],
+            ]),
+        ])->assertSuccessful();
+
+        $organization = Organization::query()
+            ->where('apps_id', $this->kanvasApp->getId())
+            ->where('companies_id', $this->company->getId())
+            ->where('name', $vendorName)
+            ->first();
+
+        $this->assertNotNull($organization, 'A vendor with no existing match should get an Organization created.');
+        $this->assertSame(['new-vendor-approver@example.test'], OrganizationApprover::emailsFor($organization));
+    }
+
+    public function test_skips_an_ambiguous_vendor_without_creating_or_linking_anything(): void
+    {
+        $tok = uniqid();
+        $this->seedOrganization("Ambiguous Import Corp {$tok} North");
+        $this->seedOrganization("Ambiguous Import Corp {$tok} South");
+
+        $this->artisan(self::COMMAND, [
+            'apps_id' => $this->kanvasApp->getId(),
+            'company_id' => $this->company->getId(),
+            'file' => $this->writeSheet([
+                ["Ambiguous Import Corp {$tok}", 'ambiguous-approver@example.test'],
+            ]),
+        ])->assertSuccessful();
+
+        $this->assertSame(
+            0,
+            Organization::query()
+                ->where('apps_id', $this->kanvasApp->getId())
+                ->where('name', "Ambiguous Import Corp {$tok}")
+                ->count(),
+            'An ambiguous vendor must not get a new Organization created — it needs manual resolution.',
+        );
+    }
+
+    public function test_skips_a_row_with_no_approver_email(): void
+    {
+        $vendorName = 'No Email Import Vendor ' . uniqid();
+
+        $this->artisan(self::COMMAND, [
+            'apps_id' => $this->kanvasApp->getId(),
+            'company_id' => $this->company->getId(),
+            'file' => $this->writeSheet([
+                [$vendorName, ''],
+            ]),
+        ])->assertSuccessful();
+
+        $this->assertSame(
+            0,
+            Organization::query()
+                ->where('apps_id', $this->kanvasApp->getId())
+                ->where('name', $vendorName)
+                ->count(),
+        );
+    }
+
+    private function seedOrganization(string $name): Organization
+    {
+        return Organization::create([
+            'apps_id' => $this->kanvasApp->getId(),
+            'companies_id' => $this->company->getId(),
+            'users_id' => static::$cachedUser->getId(),
+            'name' => $name,
+            'address' => '',
+            'total_employees' => 0,
+        ]);
+    }
+
+    /**
+     * @param list<array{0: string, 1: string}> $rows
+     */
+    private function writeSheet(array $rows): string
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setCellValue('A1', 'Vendor Name');
+        $sheet->setCellValue('B1', 'Approver Email');
+
+        foreach ($rows as $index => [$vendorName, $approverEmail]) {
+            $rowNumber = $index + 2;
+            $sheet->setCellValue("A{$rowNumber}", $vendorName);
+            $sheet->setCellValue("B{$rowNumber}", $approverEmail);
+        }
+
+        $this->tempPath = sys_get_temp_dir() . '/vendor_approvers_test_' . uniqid() . '.xlsx';
+        new Xlsx($spreadsheet)->save($this->tempPath);
+
+        return $this->tempPath;
+    }
+}

--- a/tests/Scribe/Approvals/ResolveApproverEmailActionTest.php
+++ b/tests/Scribe/Approvals/ResolveApproverEmailActionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Scribe\Approvals;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Organizations\Models\Organization;
+use Kanvas\Guild\Organizations\Models\OrganizationApprover;
+use Kanvas\Scribe\Approvals\Actions\ResolveApproverEmailAction;
+use Kanvas\Scribe\Approvals\Enums\OrganizationApproverCustomFieldEnum;
+use Kanvas\Users\Models\Users;
+use Tests\TestCase;
+
+final class ResolveApproverEmailActionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    // Organization/OrganizationApprover live on 'crm' — without declaring it here,
+    // DatabaseTransactions only rolls back 'mysql' and these rows commit for real. See tests/CLAUDE.md.
+    protected array $connectionsToTransact = ['mysql', 'crm'];
+
+    public function test_returns_empty_when_neither_organization_approvers_nor_the_legacy_field_are_set(): void
+    {
+        $organization = $this->seedOrganization('No Approver At All Corp');
+
+        $this->assertSame([], ResolveApproverEmailAction::resolveForOrganization($organization));
+    }
+
+    public function test_falls_back_to_the_legacy_custom_field_when_no_organization_approvers_exist(): void
+    {
+        $organization = $this->seedOrganization('Legacy Field Only Corp');
+        $organization->set(OrganizationApproverCustomFieldEnum::APPROVER_EMAIL->value, 'legacy@example.test');
+
+        $this->assertSame(['legacy@example.test'], ResolveApproverEmailAction::resolveForOrganization($organization));
+    }
+
+    public function test_organization_approvers_take_priority_over_the_legacy_custom_field(): void
+    {
+        $organization = $this->seedOrganization('Both Configured Corp');
+        $organization->set(OrganizationApproverCustomFieldEnum::APPROVER_EMAIL->value, 'legacy@example.test');
+
+        $approver = Users::factory()->create(['email' => 'real-approver-' . uniqid() . '@example.test']);
+        OrganizationApprover::addApproverToOrganization($organization, $approver);
+
+        $emails = ResolveApproverEmailAction::resolveForOrganization($organization);
+
+        $this->assertSame([$approver->email], $emails);
+        $this->assertNotContains('legacy@example.test', $emails);
+    }
+
+    public function test_returns_every_organization_approver_email(): void
+    {
+        $organization = $this->seedOrganization('Two Approvers Corp');
+        $approverOne = Users::factory()->create(['email' => 'approver-one-' . uniqid() . '@example.test']);
+        $approverTwo = Users::factory()->create(['email' => 'approver-two-' . uniqid() . '@example.test']);
+        OrganizationApprover::addApproverToOrganization($organization, $approverOne);
+        OrganizationApprover::addApproverToOrganization($organization, $approverTwo);
+
+        $emails = ResolveApproverEmailAction::resolveForOrganization($organization);
+
+        $this->assertCount(2, $emails);
+        $this->assertContains($approverOne->email, $emails);
+        $this->assertContains($approverTwo->email, $emails);
+    }
+
+    private function seedOrganization(string $name): Organization
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+
+        return Organization::create([
+            'apps_id' => $app->getId(),
+            'companies_id' => $user->getCurrentCompany()->getId(),
+            'users_id' => $user->getId(),
+            'name' => $name,
+            'address' => '',
+            'total_employees' => 0,
+        ]);
+    }
+}

--- a/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
@@ -11,6 +11,7 @@ use Kanvas\Guild\Organizations\Models\OrganizationApprover;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Models\AgentType;
 use Kanvas\Intelligence\Agents\Neuron\Accounting\AccountsPayableAgent;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\AddOrganizationApproverTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ApprovePendingItemTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindPurchaseOrderTool;
@@ -482,6 +483,54 @@ class AccountsPayableAgentToolsTest extends ScribeTestCase
 
         $bill = Bill::query()->where('id', $created['bill_id'])->first();
         $this->assertSame(BillDocumentStatusEnum::RECEIVED, $bill->document_status);
+    }
+
+    public function test_add_organization_approver_links_an_existing_kanvas_user(): void
+    {
+        $vendor = $this->seedTestOrganization('Add Approver Existing User Corp');
+        $existingUser = Users::factory()->create(['email' => 'existing-tool-approver-' . uniqid() . '@example.test']);
+
+        $result = new AddOrganizationApproverTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(organization_id: $vendor->getId(), approver_email: $existingUser->email);
+
+        $this->assertTrue($result['linked']);
+        $this->assertSame([$existingUser->email], $result['approvers']);
+    }
+
+    public function test_add_organization_approver_creates_a_minimal_user_when_none_matches(): void
+    {
+        $vendor = $this->seedTestOrganization('Add Approver New User Corp');
+        $newEmail = 'brand-new-tool-approver-' . uniqid() . '@example.test';
+
+        $result = new AddOrganizationApproverTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(organization_id: $vendor->getId(), approver_email: $newEmail);
+
+        $this->assertTrue($result['linked']);
+        $this->assertSame([$newEmail], $result['approvers']);
+    }
+
+    public function test_add_organization_approver_rejects_an_invalid_email(): void
+    {
+        $vendor = $this->seedTestOrganization('Add Approver Invalid Email Corp');
+
+        $result = new AddOrganizationApproverTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(organization_id: $vendor->getId(), approver_email: 'not-an-email');
+
+        $this->assertFalse($result['linked']);
+        $this->assertSame('invalid_email', $result['reason']);
+    }
+
+    public function test_add_organization_approver_reports_not_found_for_an_unknown_organization(): void
+    {
+        $result = new AddOrganizationApproverTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(organization_id: 999999999, approver_email: 'someone@example.test');
+
+        $this->assertFalse($result['linked']);
+        $this->assertSame('organization_not_found', $result['reason']);
     }
 
     public function test_organization_approvers_take_priority_over_the_legacy_field_and_any_one_may_approve(): void

--- a/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Scribe\Intelligence;
 use Illuminate\Support\Carbon;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
 use Kanvas\Guild\Organizations\Models\Organization;
+use Kanvas\Guild\Organizations\Models\OrganizationApprover;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Models\AgentType;
 use Kanvas\Intelligence\Agents\Neuron\Accounting\AccountsPayableAgent;
@@ -481,6 +482,41 @@ class AccountsPayableAgentToolsTest extends ScribeTestCase
 
         $bill = Bill::query()->where('id', $created['bill_id'])->first();
         $this->assertSame(BillDocumentStatusEnum::RECEIVED, $bill->document_status);
+    }
+
+    public function test_organization_approvers_take_priority_over_the_legacy_field_and_any_one_may_approve(): void
+    {
+        $vendor = $this->seedTestOrganization('Multi Approver Vendor Corp');
+        $vendor->set(OrganizationApproverCustomFieldEnum::APPROVER_EMAIL->value, 'not-a-real-approver-' . uniqid() . '@example.test');
+
+        $approverOne = Users::factory()->create(['email' => 'approver-one-' . uniqid() . '@example.test']);
+        $approverTwo = Users::factory()->create(['email' => 'approver-two-' . uniqid() . '@example.test']);
+        OrganizationApprover::addApproverToOrganization($vendor, $approverOne);
+        OrganizationApprover::addApproverToOrganization($vendor, $approverTwo);
+
+        $accountCode = (string) Account::query()
+            ->where('id', $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS))
+            ->value('account_number');
+
+        $created = new CreateApBillTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(
+                vendor_name: 'Multi Approver Vendor Corp',
+                amount: 500.0,
+                gl_account_number: $accountCode,
+                memo: 'Multi approver test',
+                invoice_number: 'MULTI-1',
+                push_to_acumatica: false,
+            );
+
+        $this->assertSame('', $created['approved_by_flag']);
+
+        $result = new ApprovePendingItemTool()
+            ->withContext($this->kanvasApp, $this->company, $approverTwo)
+            ->__invoke(target_type: 'bill', target_id: (int) $created['bill_id']);
+
+        $this->assertTrue($result['approved']);
+        $this->assertSame($approverTwo->email, $result['approved_by']);
     }
 
     public function test_approve_pending_item_reports_not_found_when_nothing_pending(): void


### PR DESCRIPTION
## Summary
Per Max's request in the Aug 31 NZXTOS sync: an Organization (vendor/customer) can now have more than one real Kanvas User as its AP/AR approver, backed by a new `organization_approvers` table, instead of relying only on a single `ap_approver_email` custom field.

- New migration + model: `Kanvas\Guild\Organizations\Models\OrganizationApprover` (`crm` connection, mirrors the existing `OrganizationPeople` pivot pattern — plain `belongsTo` relations rather than `belongsToMany`, since `organizations_id`/`users_id` live on different DB connections and can't be joined in one query).
- `ResolveApproverEmailAction` now returns `list<string>` instead of `?string`, and gained a static `resolveForOrganization(Organization $organization)` entry point. `OrganizationApprover` rows take priority; falls back to the legacy `ap_approver_email` custom field for organizations not yet migrated — **no breaking change for existing vendors/customers**.
- `VerifiesApprovalAuthority::isAuthorizedApprover()` now checks membership in the list — **any** configured approver may approve, not just one fixed person.
- `ApprovePendingItemTool`, `ReplyToEmailTool`, `CreateApBillTool`, `CreateArInvoiceTool` updated to the array-returning API. The two `Create*` tools now notify **every** resolved approver (was: the single configured email).
- `ImportVendorApproversCommand` now also links a real Kanvas `OrganizationApprover` per approver email — reusing an existing User with that email, or creating a minimal (unonboarded, no welcome email/company/workflow) one if none matches yet.
- `Approvals/CLAUDE.md` updated to document the new table and its priority over the legacy field.

## Test plan
- [x] New `tests/Guild/Organizations/OrganizationApproverTest.php` — model behavior (multiple approvers, dedup, remove, link-by-email reuse vs auto-create)
- [x] New `tests/Scribe/Approvals/ResolveApproverEmailActionTest.php` — priority/fallback logic
- [x] `tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php` — new multi-approver test + full existing suite (regression check)
- [x] `tests/Scribe/Intelligence/AccountsReceivableAgentToolsTest.php`, `tests/Connectors/Gmail/GmailToolsTest.php`, `tests/Scribe/Approvals/NotifyApproverActionTest.php` — full suites green, no regressions
- All: 72/72 passing across the above