### PR TITLE
refactor: centralize the per-approver Slack notify loop into NotifyApproverAction::notifyAll

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateApBillTool.php
@@ -251,19 +251,17 @@ class CreateApBillTool extends Tool implements HasRunKey
         if (! $push_to_acumatica) {
             $approverEmails = ResolveApproverEmailAction::resolveForOrganization($vendor);
 
-            foreach ($approverEmails as $approverEmail) {
-                new NotifyApproverAction(
-                    app: $app,
-                    text: "You have an AP bill pending approval:\nVendor: {$vendorDisplayName}\nAmount: "
-                        . "{$currency} {$amount}\nGL: {$gl_account_number}"
-                        . ($subaccount !== null && trim($subaccount) !== '' ? " / Subaccount: {$subaccount}" : '')
-                        . "\nMemo: {$memo}\nBill ID (Kanvas): {$bill->getId()}\n\nReply \"approve bill "
-                        . "{$bill->getId()}\" to approve it and push it to Acumatica.",
-                    approverEmail: $approverEmail,
-                    attachmentUrl: $source_attachment_url,
-                    attachmentFilename: $source_attachment_filename,
-                )->execute();
-            }
+            NotifyApproverAction::notifyAll(
+                approverEmails: $approverEmails,
+                app: $app,
+                text: "You have an AP bill pending approval:\nVendor: {$vendorDisplayName}\nAmount: {$currency} "
+                    . "{$amount}\nGL: {$gl_account_number}"
+                    . ($subaccount !== null && trim($subaccount) !== '' ? " / Subaccount: {$subaccount}" : '')
+                    . "\nMemo: {$memo}\nBill ID (Kanvas): {$bill->getId()}\n\nReply \"approve bill "
+                    . "{$bill->getId()}\" to approve it and push it to Acumatica.",
+                attachmentUrl: $source_attachment_url,
+                attachmentFilename: $source_attachment_filename,
+            );
 
             return [
                 'created' => true,

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/CreateArInvoiceTool.php
@@ -205,17 +205,15 @@ class CreateArInvoiceTool extends Tool implements HasRunKey
 
             $approverEmails = ResolveApproverEmailAction::resolveForOrganization($customer);
 
-            foreach ($approverEmails as $approverEmail) {
-                new NotifyApproverAction(
-                    app: $app,
-                    text: "You have an AR invoice pending approval:\nCustomer: {$customerDisplayName}\nAmount: "
-                        . "{$currency} {$amount}\nMemo: {$memo}\nInvoice ID (Kanvas): {$invoice->getId()}\n\nReply "
-                        . "\"approve invoice {$invoice->getId()}\" to approve it and push it to Acumatica.",
-                    approverEmail: $approverEmail,
-                    attachmentUrl: $source_attachment_url,
-                    attachmentFilename: $source_attachment_filename,
-                )->execute();
-            }
+            NotifyApproverAction::notifyAll(
+                approverEmails: $approverEmails,
+                app: $app,
+                text: "You have an AR invoice pending approval:\nCustomer: {$customerDisplayName}\nAmount: "
+                    . "{$currency} {$amount}\nMemo: {$memo}\nInvoice ID (Kanvas): {$invoice->getId()}\n\nReply "
+                    . "\"approve invoice {$invoice->getId()}\" to approve it and push it to Acumatica.",
+                attachmentUrl: $source_attachment_url,
+                attachmentFilename: $source_attachment_filename,
+            );
 
             return [
                 'created' => true,

--- a/src/Domains/Scribe/Approvals/Actions/NotifyApproverAction.php
+++ b/src/Domains/Scribe/Approvals/Actions/NotifyApproverAction.php
@@ -30,6 +30,32 @@ class NotifyApproverAction
     ) {
     }
 
+    /**
+     * Notifies every email in the list — e.g. all of an Organization's resolved approvers, where a
+     * single fixed recipient isn't enough. Each is still independently best-effort.
+     *
+     * @param list<string> $approverEmails
+     */
+    public static function notifyAll(
+        array $approverEmails,
+        Apps $app,
+        string $text,
+        ?string $attachmentUrl = null,
+        ?string $attachmentFilename = null,
+        ?string $agentId = null,
+    ): void {
+        foreach ($approverEmails as $approverEmail) {
+            new self(
+                app: $app,
+                text: $text,
+                approverEmail: $approverEmail,
+                attachmentUrl: $attachmentUrl,
+                attachmentFilename: $attachmentFilename,
+                agentId: $agentId,
+            )->execute();
+        }
+    }
+
     public function execute(): void
     {
         $agentId = $this->agentId ?? (string) ($this->app->get(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value) ?? '');

--- a/tests/Scribe/Approvals/NotifyApproverActionTest.php
+++ b/tests/Scribe/Approvals/NotifyApproverActionTest.php
@@ -122,6 +122,34 @@ class NotifyApproverActionTest extends TestCase
         Http::assertNothingSent();
     }
 
+    public function test_notify_all_sends_one_message_per_email(): void
+    {
+        $this->configureNotifierAgent();
+        Http::fake([
+            'slack.com/api/users.lookupByEmail' => Http::response(['ok' => true, 'user' => ['id' => 'U123']]),
+            'slack.com/api/conversations.open' => Http::response(['ok' => true, 'channel' => ['id' => 'D123']]),
+            'slack.com/api/chat.postMessage' => Http::response(['ok' => true, 'ts' => '1700000000.000100']),
+        ]);
+
+        NotifyApproverAction::notifyAll(
+            approverEmails: ['first@example.test', 'second@example.test'],
+            app: $this->kanvasApp,
+            text: 'You have an AP bill pending approval',
+        );
+
+        Http::assertSentCount(6);
+    }
+
+    public function test_notify_all_does_nothing_for_an_empty_list(): void
+    {
+        $this->configureNotifierAgent();
+        Http::fake();
+
+        NotifyApproverAction::notifyAll(approverEmails: [], app: $this->kanvasApp, text: 'Nothing to send');
+
+        Http::assertNothingSent();
+    }
+
     public function test_it_does_nothing_when_the_email_does_not_match_a_slack_workspace_member(): void
     {
         $this->configureNotifierAgent();


### PR DESCRIPTION
## Summary
Follow-up cleanup on top of #11091 (already merged) — `CreateApBillTool` and `CreateArInvoiceTool` each had their own identical `foreach ($approverEmails as $approverEmail) { new NotifyApproverAction(...)->execute(); }` loop. Collapsed into one static `NotifyApproverAction::notifyAll()` helper; both tools now call it directly.

## Test plan
- [x] New `NotifyApproverActionTest` cases for `notifyAll()` (multiple emails, empty list)
- [x] Full `AccountsPayableAgentToolsTest` / `AccountsReceivableAgentToolsTest` — no regressions