### PR TITLE
feat: company and branch filters for recalculate-active-leads-count

### DIFF
--- a/app/Console/Commands/Guild/RecalculateActiveLeadsCountCommand.php
+++ b/app/Console/Commands/Guild/RecalculateActiveLeadsCountCommand.php
@@ -9,6 +9,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
+use Kanvas\Companies\Models\CompaniesBranches;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Leads\Models\Lead;
 
@@ -18,6 +19,10 @@ use Kanvas\Guild\Leads\Models\Lead;
  * for whenever a bulk write (e.g. DB::table('leads')->update(...), or
  * MergePeopleAction's raw SQL people_id rewrite) bypasses
  * LeadObserver::syncActiveLeadsCount() and leaves the counter stale.
+ *
+ * --companies_branches_id narrows who gets checked, never what gets counted —
+ * the counter is per-person across the whole company, so recounting a single
+ * branch's leads would write a number lower than the truth.
  */
 class RecalculateActiveLeadsCountCommand extends Command
 {
@@ -25,6 +30,8 @@ class RecalculateActiveLeadsCountCommand extends Command
 
     protected $signature = 'kanvas-guild:recalculate-active-leads-count
                             {--apps_id= : Limit to people belonging to this app}
+                            {--companies_id= : Limit to people belonging to this company}
+                            {--companies_branches_id= : Limit to people who have a lead in this branch (each one is still recounted across all of their open leads)}
                             {--peoples_id=* : Recalculate only these people (repeatable)}
                             {--chunk=500 : People per chunk}
                             {--dry-run : Report what would change without writing}';
@@ -42,6 +49,29 @@ class RecalculateActiveLeadsCountCommand extends Command
             $this->overwriteAppService($app);
         }
 
+        /** @var CompaniesBranches|null $branch */
+        $branch = $this->option('companies_branches_id') !== null
+            ? CompaniesBranches::getById((int) $this->option('companies_branches_id'))
+            : null;
+
+        /** @var Companies|null $company */
+        $company = $this->option('companies_id') !== null
+            ? Companies::getById((int) $this->option('companies_id'))
+            : null;
+
+        if ($branch !== null && $company !== null && (int) $branch->companies_id !== $company->getId()) {
+            $this->error(sprintf(
+                'Branch %d belongs to company %d, not %d — the run would have checked nobody and reported no drift.',
+                $branch->getId(),
+                (int) $branch->companies_id,
+                $company->getId(),
+            ));
+
+            return self::FAILURE;
+        }
+
+        $company ??= $branch?->company;
+
         $dryRun = (bool) $this->option('dry-run');
         $chunk = (int) $this->option('chunk');
         $only = array_map('intval', (array) $this->option('peoples_id'));
@@ -58,6 +88,19 @@ class RecalculateActiveLeadsCountCommand extends Command
                 ->where('id', '>', $lastId)
                 ->when($only !== [], fn ($query) => $query->whereIn('id', $only))
                 ->when($app !== null, fn ($query) => $query->fromApp($app))
+                ->when($company !== null, fn ($query) => $query->fromCompany($company))
+                // Not People::leads(), which filters is_deleted: a bulk soft-delete is
+                // the main drift source, so those people are the ones to repair.
+                ->when(
+                    $branch !== null,
+                    fn ($query) => $query->whereIn(
+                        'id',
+                        Lead::query()
+                            ->where('companies_branches_id', $branch->getId())
+                            ->where('people_id', '>', 0)
+                            ->select('people_id')
+                    )
+                )
                 ->orderBy('id')
                 ->limit($chunk)
                 ->get(['id', 'companies_id', 'active_leads_count']);

--- a/tests/Guild/RecalculateActiveLeadsCountCommandTest.php
+++ b/tests/Guild/RecalculateActiveLeadsCountCommandTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Guild;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Companies\Models\CompaniesBranches;
+use Kanvas\Guild\Customers\Factories\PeopleFactory;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Leads\Models\Lead;
+use Tests\TestCase;
+
+final class RecalculateActiveLeadsCountCommandTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $connectionsToTransact = [null, 'crm', 'ecosystem'];
+
+    private const COMMAND = 'kanvas-guild:recalculate-active-leads-count';
+
+    public function testCompanyFilterRepairsPeopleInThatCompany(): void
+    {
+        $person = $this->createPerson();
+        $this->createLead($person, leadsStatusId: 1);
+        $this->forceStaleCount($person, 99);
+
+        $this->artisan(self::COMMAND, [
+            '--companies_id' => $this->currentCompany()->getId(),
+            '--peoples_id' => [$person->getId()],
+        ])->assertExitCode(0);
+
+        $this->assertSame(1, $this->activeLeadsCount($person));
+    }
+
+    public function testCompanyFilterLeavesPeopleFromOtherCompaniesUntouched(): void
+    {
+        $person = $this->createPerson();
+        $this->createLead($person, leadsStatusId: 1);
+        $this->forceStaleCount($person, 99);
+
+        $otherCompany = Companies::factory()->create();
+
+        $this->artisan(self::COMMAND, [
+            '--companies_id' => $otherCompany->getId(),
+            '--peoples_id' => [$person->getId()],
+        ])->assertExitCode(0);
+
+        $this->assertSame(99, $this->activeLeadsCount($person));
+    }
+
+    public function testBranchFilterRepairsPeopleWithALeadInThatBranch(): void
+    {
+        $branch = $this->createBranch();
+        $person = $this->createPerson();
+        $this->createLead($person, leadsStatusId: 1, branchId: $branch->getId());
+        $this->forceStaleCount($person, 99);
+
+        $this->artisan(self::COMMAND, [
+            '--companies_branches_id' => $branch->getId(),
+            '--peoples_id' => [$person->getId()],
+        ])->assertExitCode(0);
+
+        $this->assertSame(1, $this->activeLeadsCount($person));
+    }
+
+    public function testBranchFilterLeavesPeopleWithoutALeadInThatBranchUntouched(): void
+    {
+        $branch = $this->createBranch();
+        $otherBranch = $this->createBranch();
+        $person = $this->createPerson();
+        $this->createLead($person, leadsStatusId: 1, branchId: $otherBranch->getId());
+        $this->forceStaleCount($person, 99);
+
+        $this->artisan(self::COMMAND, [
+            '--companies_branches_id' => $branch->getId(),
+            '--peoples_id' => [$person->getId()],
+        ])->assertExitCode(0);
+
+        $this->assertSame(99, $this->activeLeadsCount($person));
+    }
+
+    public function testBranchFilterStillCountsOpenLeadsFromEveryBranch(): void
+    {
+        $branch = $this->createBranch();
+        $otherBranch = $this->createBranch();
+        $person = $this->createPerson();
+        $this->createLead($person, leadsStatusId: 1, branchId: $branch->getId());
+        $this->createLead($person, leadsStatusId: 2, branchId: $otherBranch->getId());
+        $this->forceStaleCount($person, 0);
+
+        $this->artisan(self::COMMAND, [
+            '--companies_branches_id' => $branch->getId(),
+            '--peoples_id' => [$person->getId()],
+        ])->assertExitCode(0);
+
+        $this->assertSame(2, $this->activeLeadsCount($person));
+    }
+
+    public function testBranchFilterSelectsPeopleWhoseOnlyBranchLeadWasSoftDeleted(): void
+    {
+        $branch = $this->createBranch();
+        $person = $this->createPerson();
+        $lead = $this->createLead($person, leadsStatusId: 1, branchId: $branch->getId());
+
+        Lead::query()->where('id', $lead->getId())->update(['is_deleted' => 1]);
+        $this->forceStaleCount($person, 99);
+
+        $this->artisan(self::COMMAND, [
+            '--companies_branches_id' => $branch->getId(),
+            '--peoples_id' => [$person->getId()],
+        ])->assertExitCode(0);
+
+        $this->assertSame(0, $this->activeLeadsCount($person));
+    }
+
+    public function testCompanyAndBranchOfTheSameCompanyCombine(): void
+    {
+        $branch = $this->createBranch();
+        $person = $this->createPerson();
+        $this->createLead($person, leadsStatusId: 1, branchId: $branch->getId());
+        $this->forceStaleCount($person, 99);
+
+        $this->artisan(self::COMMAND, [
+            '--companies_id' => $this->currentCompany()->getId(),
+            '--companies_branches_id' => $branch->getId(),
+            '--peoples_id' => [$person->getId()],
+        ])->assertExitCode(0);
+
+        $this->assertSame(1, $this->activeLeadsCount($person));
+    }
+
+    public function testBranchFromAnotherCompanyFailsWithoutWriting(): void
+    {
+        $branch = $this->createBranch();
+        $person = $this->createPerson();
+        $this->createLead($person, leadsStatusId: 1, branchId: $branch->getId());
+        $this->forceStaleCount($person, 99);
+
+        $otherCompany = Companies::factory()->create();
+
+        $this->artisan(self::COMMAND, [
+            '--companies_id' => $otherCompany->getId(),
+            '--companies_branches_id' => $branch->getId(),
+            '--peoples_id' => [$person->getId()],
+        ])->assertExitCode(1);
+
+        $this->assertSame(99, $this->activeLeadsCount($person));
+    }
+
+    public function testDryRunReportsWithoutWriting(): void
+    {
+        $person = $this->createPerson();
+        $this->createLead($person, leadsStatusId: 1);
+        $this->forceStaleCount($person, 99);
+
+        $this->artisan(self::COMMAND, [
+            '--companies_id' => $this->currentCompany()->getId(),
+            '--peoples_id' => [$person->getId()],
+            '--dry-run' => true,
+        ])->assertExitCode(0);
+
+        $this->assertSame(99, $this->activeLeadsCount($person));
+    }
+
+    private function currentCompany(): Companies
+    {
+        return auth()->user()->getCurrentCompany();
+    }
+
+    private function createBranch(): CompaniesBranches
+    {
+        return CompaniesBranches::factory()->create([
+            'companies_id' => $this->currentCompany()->getId(),
+            'users_id' => auth()->user()->getId(),
+            'is_default' => 0,
+        ]);
+    }
+
+    private function createPerson(): People
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+
+        /** @var People $people */
+        $people = PeopleFactory::new()
+            ->withAppId($app->getId())
+            ->withCompanyId($this->currentCompany()->getId())
+            ->withUserId($user->getId())
+            ->withContacts()
+            ->create(['firstname' => 'ralc-' . uniqid('', true)]);
+
+        return $people->fresh();
+    }
+
+    private function createLead(
+        People $people,
+        int $leadsStatusId,
+        ?int $branchId = null,
+        int $ownerId = 50
+    ): Lead {
+        $app = app(Apps::class);
+        $user = auth()->user();
+
+        return Lead::factory()
+            ->withAppAndCompany($app->getId(), $this->currentCompany()->getId())
+            ->withUserId($user->getId())
+            ->withPeopleId($people->getId())
+            ->create([
+                'leads_owner_id' => $ownerId,
+                'leads_status_id' => $leadsStatusId,
+                'companies_branches_id' => $branchId ?? 0,
+            ]);
+    }
+
+    /**
+     * Query-builder update, so LeadObserver never sees it — that is the drift.
+     */
+    private function forceStaleCount(People $people, int $count): void
+    {
+        People::query()->where('id', $people->getId())->update(['active_leads_count' => $count]);
+    }
+
+    private function activeLeadsCount(People $people): int
+    {
+        return (int) People::query()->find($people->getId())->active_leads_count;
+    }
+}


### PR DESCRIPTION
## Why

`peoples.active_leads_count` is a counter cache maintained by `LeadObserver::syncActiveLeadsCount()`. Any bulk write that bypasses the observer (`DB::table('leads')->update(...)`, `MergePeopleAction`'s raw `people_id` rewrite) leaves it stale, and `kanvas-guild:recalculate-active-leads-count` is the repair tool.

Until now that command could only be narrowed by `--apps_id` or an explicit list of `--peoples_id`. When the drift comes from one tenant or one dealership there was no way to aim it: either pass the ids one by one, or sweep the whole app.

## What

```
--companies_id=            # filters peoples.companies_id
--companies_branches_id=   # selects people who have a lead in that branch
```

- **The branch flag narrows who gets checked, never what gets counted.** The counter is per-person across the whole company (`peoples` has no branch column — it lives on `leads`), so recounting a single branch's leads would write a number lower than the truth and corrupt the counter instead of repairing it. Each selected person is still recounted across all of their open leads. `countOpenLeadsPerPeople()` is untouched.
- A branch alone derives its company, so `--companies_branches_id` also narrows the People query by company.
- A branch belonging to a different company than `--companies_id` **fails the run** rather than checking nobody and reporting no drift.
- The branch selection subquery deliberately skips `notDeleted()`: a bulk soft-delete is the main drift source, so using `People::leads()` (which filters `is_deleted`) would exclude exactly the people that need repairing.
- `leads.companies_branches_id` is already indexed — no migration.

## Tests

First test suite for this command, 9 cases. The one that matters is `testBranchFilterStillCountsOpenLeadsFromEveryBranch`: a person with an open lead in branch A and another in branch B, counter forced to 0, run with `--companies_branches_id=A` expects **2**. If someone later "fixes" the subquery to filter the counted leads by branch too, that test fails.

Also covered: the soft-deleted-lead selection path, both flags combined, the incompatible branch/company guard, and dry-run composing with the new filters.

## Verified

- 9/9 `RecalculateActiveLeadsCountCommandTest` green
- 17/17 `LeadActiveLeadsCounterObserverTest` green (regression)
- phpstan clean on both files

## Notes for the reviewer

- `overwriteAppService` is not needed on the new path, and that was verified rather than assumed: company settings (`HashTableTrait`) are keyed by `companies_id` only with no `apps_id`, so `Lead::openLeadsStatusIds($company)` does not depend on the bound app. `Companies` has no `apps_id` column either (app membership is the `UserCompanyApps` pivot), so there is no single app to bind from a company.
- `--companies_id` alone recalculates that company's people **across every app** — `peoples` is per-app and a company can belong to several. Every count is still correct; combine with `--apps_id` to scope to one tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)