### PR TITLE
feat(voice): fall back to app-level Twilio creds when company has none

### DIFF
--- a/src/Domains/Connectors/Twilio/Actions/ListCompanyPhoneNumbersAction.php
+++ b/src/Domains/Connectors/Twilio/Actions/ListCompanyPhoneNumbersAction.php
@@ -27,7 +27,7 @@ class ListCompanyPhoneNumbersAction
      */
     public function execute(int $limit = 200): array
     {
-        $twilio = TwilioClient::getInstanceByCompany($this->company);
+        $twilio = TwilioClient::getInstanceByCompanyOrApp($this->company, $this->company->app);
 
         return array_map(
             static fn ($number): array => [

--- a/src/Domains/Connectors/Twilio/Client.php
+++ b/src/Domains/Connectors/Twilio/Client.php
@@ -32,6 +32,21 @@ final class Client
     }
 
     /**
+     * Company creds if the company has its own (per-dealer BYOK), otherwise the
+     * app-level creds (a shared Twilio account). Lets a company without its own
+     * Twilio still use the app's — e.g. voice-agent number listing / inbound
+     * webhook wiring on a single shared account.
+     */
+    public static function getInstanceByCompanyOrApp(Companies $company, AppInterface $app): TwilioClient
+    {
+        try {
+            return self::getInstanceByCompany($company);
+        } catch (ValidationException) {
+            return self::getInstance($app);
+        }
+    }
+
+    /**
      * Validate Twilio credentials.
      */
     public static function validateCredentials(string $sid, string $token): bool

--- a/src/Domains/Intelligence/Agents/Actions/Voice/ConfigureAgentInboundWebhookAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/ConfigureAgentInboundWebhookAction.php
@@ -74,8 +74,9 @@ class ConfigureAgentInboundWebhookAction
         }
 
         try {
-            // Throws ValidationException when the company has no Twilio creds.
-            $twilio = TwilioClient::getInstanceByCompany($company);
+            // Company creds if the company has its own; else the app-level creds
+            // (shared account). Throws ValidationException when neither is set.
+            $twilio = TwilioClient::getInstanceByCompanyOrApp($company, $this->agent->app);
 
             // Twilio updates a number by SID, so resolve it first.
             $numbers = $twilio->incomingPhoneNumbers->read(['phoneNumber' => $number], 1);


### PR DESCRIPTION
The voice **number picker** (and the inbound-webhook wiring) read Twilio creds strictly from the agent's **company** (`getInstanceByCompany`). When creds are set at the **app level** (the config-panel keys) but not on the company, the picker showed *"Twilio credentials are not set for company … (ID: 4055)"* and fell back to manual entry — even though the app had valid creds.

## Fix
Add `TwilioClient::getInstanceByCompanyOrApp($company, $app)` — company BYOK if the company has its own creds, otherwise the shared **app-level** account — and use it in:
- `ListCompanyPhoneNumbersAction` (the `twilioAvailablePhoneNumbers` picker)
- `ConfigureAgentInboundWebhookAction` (inbound webhook wiring)

Per-dealer company creds still take precedence. New method is additive; existing callers unchanged. The messaging `AgentChannelResponderAction` is intentionally left company-only (out of scope).

## Result
With app-level Twilio creds set, `twilioAvailablePhoneNumbers` now returns the account's numbers → the admin renders the **dropdown** instead of the manual-entry fallback, and inbound-webhook wiring works off the shared account.

Pairs with the admin picker (mctekk/kanvas-core-admin-v2#1000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)