### PR TITLE
feat(voice): retry mutation for inbound-webhook wiring

### DIFF
--- a/app/GraphQL/Intelligence/Mutations/AgentManagementMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/AgentManagementMutation.php
@@ -89,6 +89,23 @@ class AgentManagementMutation
         return $agent;
     }
 
+    /**
+     * Re-run the inbound-webhook wiring for an agent's Twilio number — the admin
+     * "retry" button. Returns the ConfigureAgentInboundWebhookAction outcome
+     * ({status, message, url}); the action also persists it to
+     * voice_config.inbound_webhook so the Voice tab reflects the fresh result.
+     *
+     * @return array{status: string, message: string, url: string|null}
+     */
+    public function configureInboundWebhook(mixed $root, array $req): array
+    {
+        $app = app(Apps::class);
+        $company = auth()->user()->getCurrentCompany();
+        $agent = Agent::getByIdFromCompanyApp((int) $req['id'], $company, $app);
+
+        return new ConfigureAgentInboundWebhookAction($agent, $app)->execute();
+    }
+
     public function update(mixed $root, array $req): Agent
     {
         $input = $req['input'] ?? [];

--- a/graphql/schemas/Intelligence/voiceAgent.graphql
+++ b/graphql/schemas/Intelligence/voiceAgent.graphql
@@ -103,11 +103,22 @@ type VoiceAgentCallResult {
     tenant_id: String
 }
 
+type VoiceAgentInboundWebhookResult {
+    status: String!
+    message: String!
+    url: String
+}
+
 extend type Mutation @guard {
     "Place a one-off test call for an agent via the external voice runtime."
     sendVoiceAgentTestCall(id: ID!, to_number: String!): VoiceAgentCallResult!
         @field(
             resolver: "App\\GraphQL\\Intelligence\\Mutations\\VoiceAgentCallMutation@placeTestCall"
+        )
+    "Re-run inbound-webhook wiring for an agent's Twilio number (admin retry). Returns the resulting status."
+    configureVoiceAgentInboundWebhook(id: ID!): VoiceAgentInboundWebhookResult!
+        @field(
+            resolver: "App\\GraphQL\\Intelligence\\Mutations\\AgentManagementMutation@configureInboundWebhook"
         )
 }
 


### PR DESCRIPTION
The inbound-webhook status shown on the admin Voice tab is stored on `voice_config.inbound_webhook` and only refreshed when the agent is **saved** (create/update). So a prior failure ("Twilio credentials are not set for company …") stays stale even after the cause is fixed.

Adds `configureVoiceAgentInboundWebhook(id: ID!)` (`@guard`) → `AgentManagementMutation@configureInboundWebhook`, which re-runs `ConfigureAgentInboundWebhookAction` and returns `{status, message, url}`. The action re-persists the status, so the admin can **retry** wiring on demand (e.g. right after setting Twilio creds) without re-saving the whole agent.

Backend for the admin "Retry" button (mctekk/kanvas-core-admin-v2 follow-up). Pairs with the app-level cred fallback (#11126) so a retry succeeds off the shared app account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)