### PR TITLE
feat: score ID verification on a mismatch count instead of critical-field rules

### DIFF
--- a/src/Domains/Connectors/Intellicheck/Services/IdVerificationService.php
+++ b/src/Domains/Connectors/Intellicheck/Services/IdVerificationService.php
@@ -9,6 +9,40 @@ use Throwable;
 
 class IdVerificationService
 {
+    private const int OCR_MISMATCH_FAILURE_THRESHOLD = 4;
+
+    /**
+     * Each match flag paired with the two sides it compares: [idcheck keys, OCR key].
+     * A side that arrives blank means the field was never really compared.
+     */
+    private const array OCR_FIELD_SOURCES = [
+        'isNameMatch' => [['firstName', 'lastName'], 'fullName'],
+        'isDocumentNumberMatch' => [['dLIDNumberRaw'], 'documentNumber'],
+        'isDobMatch' => [['dateOfBirth'], 'dateOfBirthFormatted'],
+        'isSexMatch' => [['gender'], 'sex'],
+        'isAddressMatch' => [['address1'], 'address'],
+        'isExpirationDateMatch' => [['expirationDate'], 'dateOfExpiryFormatted'],
+        'isIssuerNameMatch' => [['issuingJurisdictionCvt'], 'issuerName'],
+        'isIssueDateMatch' => [['issueDate'], 'dateOfIssueFormatted'],
+        'isRealIdMatch' => [['isRealID'], 'isRealID'],
+        'isHeightMatch' => [['heightCentimeters'], 'height'],
+        'isDlClassMatch' => [['driverClass'], 'dlClass'],
+    ];
+
+    /**
+     * Only these can mark the comparison incomplete. The rest are optional per issuing
+     * jurisdiction — a state that doesn't print Real ID or height omits them from the
+     * payload, and treating that as incomplete would make green unreachable there.
+     */
+    private const array OCR_REQUIRED_FIELDS = [
+        'isNameMatch',
+        'isDocumentNumberMatch',
+        'isDobMatch',
+        'isSexMatch',
+        'isAddressMatch',
+        'isExpirationDateMatch',
+    ];
+
     public static function getName(array $verificationData): string
     {
         // Try to get name from idcheck data first
@@ -91,6 +125,7 @@ class IdVerificationService
         $results = [];
         $message = '';
         $flagNotice = false;
+        $ocrNotice = false;
         $ocMatch = false;
 
         // Extract nested data safely with null coalescing
@@ -117,118 +152,48 @@ class IdVerificationService
         $results['facial_match_probability'] = $facial['matchProbability'] ?? null;
         $results['facial_liveness_probability'] = $facial['livenessProbability'] ?? null;
 
-        // OCR CHECK - ADJUSTED FOR SHOWROOM MODE
-        $hasOcrFailure = false;
-        $ocrMatchFields = [
-            'isDlClassMatch',
-            'isDobMatch',
-            'isHeightMatch',
-            'isAddressMatch',
-            'isIssueDateMatch',
-            'isDocumentNumberMatch',
-            'isIssuerNameMatch',
-            'isRealIdMatch',
-            'isSexMatch',
-            'isExpirationDateMatch',
-            'isNameMatch',
-        ];
+        $ocrMismatchedFields = [];
+        $ocrIncompleteFields = [];
+        $ocrComparedCount = 0;
 
-        // Define critical fields for showroom mode
-        $criticalFields = [
-            'isNameMatch',
-            'isDocumentNumberMatch',
-            'isDobMatch',
-            'isSexMatch',
-        ];
-
-        $ocrFailedFields = [];
-        $criticalFailedFields = [];
-        $nonCriticalFailedFields = [];
-        $allFieldsFailed = true;
-
-        foreach ($ocrMatchFields as $field) {
-            if (isset($ocrMatch[$field])) {
-                if ($ocrMatch[$field] === false) {
-                    $ocrFailedFields[] = $field;
-
-                    // Separate critical vs non-critical fields for showroom mode
-                    if ($isShowRoom && in_array($field, $criticalFields)) {
-                        $criticalFailedFields[] = $field;
-                    } else {
-                        $nonCriticalFailedFields[] = $field;
-                    }
-                } else {
-                    $allFieldsFailed = false;
+        foreach (array_keys(self::OCR_FIELD_SOURCES) as $field) {
+            if (! isset($ocrMatch[$field]) || self::hasBlankComparisonSide($field, $idCheck, $ocrData)) {
+                if (in_array($field, self::OCR_REQUIRED_FIELDS, true)) {
+                    $ocrIncompleteFields[] = $field;
                 }
-            } else {
-                $allFieldsFailed = false;
+
+                continue;
+            }
+
+            $ocrComparedCount++;
+
+            if ($ocrMatch[$field] === false) {
+                $ocrMismatchedFields[] = $field;
             }
         }
 
-        // Handle OCR failures based on mode
-        if ($isShowRoom) {
-            // In showroom mode: critical field mismatches are failures, others are flags
-            if (! empty($criticalFailedFields)) {
-                $criticalReadableFields = array_map(function ($field) {
-                    $readable = str_replace(['is', 'Match'], '', $field);
+        $ocrMismatchCount = count($ocrMismatchedFields);
+        $hasOcrFailure = $ocrMismatchCount >= self::OCR_MISMATCH_FAILURE_THRESHOLD;
 
-                    return trim(preg_replace('/(?<!^)[A-Z]/', ' $0', $readable));
-                }, $criticalFailedFields);
-
-                $failures[] = 'Critical OCR verification failed: ' . implode(', ', $criticalReadableFields);
-                $failureGroups[] = 'OCR critical mismatch';
-                $hasOcrFailure = true;
-            }
-
-            if (! empty($nonCriticalFailedFields)) {
-                $nonCriticalReadableFields = array_map(function ($field) {
-                    $readable = str_replace(['is', 'Match'], '', $field);
-
-                    return trim(preg_replace('/(?<!^)[A-Z]/', ' $0', $readable));
-                }, $nonCriticalFailedFields);
-
-                $flags[] = 'OCR verification issues: ' . implode(', ', $nonCriticalReadableFields);
-                $flagGroups[] = 'OCR non-critical mismatch';
-                $flagNotice = true;
-            }
-        } else {
-            // Original logic for non-showroom mode
-            if ($allFieldsFailed && ! empty($ocrFailedFields)) {
-                $failures[] = 'OCR verification failed: ' . implode(', ', $ocrFailedFields);
-                $failureGroups[] = 'OCR mismatch';
-            }
-
-            if (! empty($ocrFailedFields)) {
-                $readableFailedFields = array_map(function ($field) {
-                    $readable = str_replace(['is', 'Match'], '', $field);
-
-                    return trim(preg_replace('/(?<!^)[A-Z]/', ' $0', $readable));
-                }, $ocrFailedFields);
-
-                $flags[] = 'OCR verification issues: ' . implode(', ', $readableFailedFields);
-                $flagGroups[] = 'OCR mismatch';
-                $flagNotice = true;
-            }
+        if ($hasOcrFailure) {
+            $failures[] = 'Computer Vision verification failed: ' . self::readableOcrFields($ocrMismatchedFields);
+            $failureGroups[] = 'OCR mismatch';
+        } elseif ($ocrMismatchCount > 0) {
+            $flags[] = 'Computer Vision mismatches: ' . self::readableOcrFields($ocrMismatchedFields);
+            $flagGroups[] = 'OCR mismatch';
+            $flagNotice = true;
+            $ocrNotice = true;
         }
 
-        // Count total matches for reporting purposes
-        $ocrRequiredMatches = array_filter([
-            $ocrMatch['isDlClassMatch'] ?? false,
-            $ocrMatch['isDobMatch'] ?? false,
-            $ocrMatch['isHeightMatch'] ?? false,
-            $ocrMatch['isAddressMatch'] ?? false,
-            $ocrMatch['isIssueDateMatch'] ?? false,
-            $ocrMatch['isDocumentNumberMatch'] ?? false,
-            $ocrMatch['isIssuerNameMatch'] ?? false,
-            $ocrMatch['isRealIdMatch'] ?? false,
-            $ocrMatch['isSexMatch'] ?? false,
-            $ocrMatch['isExpirationDateMatch'] ?? false,
-            $ocrMatch['isNameMatch'] ?? false,
-        ]);
+        if (! empty($ocrIncompleteFields)) {
+            $flags[] = 'Computer Vision could not compare: ' . self::readableOcrFields($ocrIncompleteFields);
+            $flagGroups[] = 'OCR incomplete';
+            $flagNotice = true;
+            $ocrNotice = true;
+        }
 
-        $totalOcrMatches = count($ocrRequiredMatches);
-        $ocrMatchScore = $totalOcrMatches > 0 ? $totalOcrMatches / 11 * 100 : 0;
-        $results['ocr_required_matches'] = $ocrMatchScore;
+        $results['ocr_required_matches'] =
+            ($ocrComparedCount - $ocrMismatchCount) / count(self::OCR_FIELD_SOURCES) * 100;
         $ocMatch = ! $hasOcrFailure;
 
         // ID CHECK
@@ -404,14 +369,17 @@ class IdVerificationService
 
         if (empty($failures)) {
             // Always make sure expired IDs are flagged
-            if ($isExpired || $idCheckUnverifiable || ($flagNotice && count($flagGroupScores) >= 2)) {
+            if ($isExpired || $idCheckUnverifiable || $ocrNotice || ($flagNotice && count($flagGroupScores) >= 2)) {
                 // Create message using flag groups
                 $flagReasons = [];
                 foreach ($flaggedGroups as $group) {
                     switch ($group) {
                         case 'OCR mismatch':
-                        case 'OCR non-critical mismatch':
                             $flagReasons[] = 'document verification concerns';
+
+                            break;
+                        case 'OCR incomplete':
+                            $flagReasons[] = 'incomplete document comparison';
 
                             break;
                         case 'ID check incomplete':
@@ -458,5 +426,43 @@ class IdVerificationService
             'results' => $results,
             'ocMatch' => $ocMatch,
         ];
+    }
+
+    private static function readableOcrFields(array $fields): string
+    {
+        return implode(', ', array_map(
+            function (string $field): string {
+                $readable = str_replace(['is', 'Match'], '', $field);
+
+                return trim((string) preg_replace('/(?<!^)[A-Z]/', ' $0', $readable));
+            },
+            $fields
+        ));
+    }
+
+    private static function hasBlankComparisonSide(string $field, array $idCheck, array $ocrData): bool
+    {
+        [$idCheckKeys, $ocrKey] = self::OCR_FIELD_SOURCES[$field];
+
+        foreach ($idCheckKeys as $idCheckKey) {
+            if (self::isBlankValue($idCheck[$idCheckKey] ?? null)) {
+                return true;
+            }
+        }
+
+        return self::isBlankValue($ocrData[$ocrKey] ?? null);
+    }
+
+    /**
+     * A boolean false is a real answer, not a blank — `empty()` would wrongly
+     * discard a legitimate "Real ID: no".
+     */
+    private static function isBlankValue(mixed $value): bool
+    {
+        if ($value === null) {
+            return true;
+        }
+
+        return is_string($value) && trim($value) === '';
     }
 }

--- a/tests/Connectors/Integration/Intellicheck/IdVerificationTest.php
+++ b/tests/Connectors/Integration/Intellicheck/IdVerificationTest.php
@@ -1892,7 +1892,7 @@ final class IdVerificationTest extends TestCase
     {
         $verificationData = $this->idVerificationData();
 
-        $isShowRoom = $params['is_showroom'] ?? false;
+        $isShowRoom = ! isset($verificationData['ipqs']);
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
@@ -1917,7 +1917,7 @@ final class IdVerificationTest extends TestCase
     {
         $verificationData = $this->idVerificationFlag();
 
-        $isShowRoom = $params['is_showroom'] ?? false;
+        $isShowRoom = ! isset($verificationData['ipqs']);
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
@@ -1941,7 +1941,7 @@ final class IdVerificationTest extends TestCase
     {
         $verificationData = $this->idVerificationFlagTestA();
 
-        $isShowRoom = $params['is_showroom'] ?? false;
+        $isShowRoom = ! isset($verificationData['ipqs']);
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
@@ -1965,7 +1965,7 @@ final class IdVerificationTest extends TestCase
     {
         $verificationData = $this->idVerificationFlagTestB();
 
-        $isShowRoom = $params['is_showroom'] ?? false;
+        $isShowRoom = ! isset($verificationData['ipqs']);
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
@@ -1989,7 +1989,7 @@ final class IdVerificationTest extends TestCase
     {
         $verificationData = $this->idVerificationFlagC();
 
-        $isShowRoom = $params['is_showroom'] ?? false;
+        $isShowRoom = ! isset($verificationData['ipqs']);
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
@@ -2013,7 +2013,7 @@ final class IdVerificationTest extends TestCase
     {
         $verificationData = $this->idVerificationFlagTestD();
 
-        $isShowRoom = $params['is_showroom'] ?? false;
+        $isShowRoom = ! isset($verificationData['ipqs']);
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
@@ -2037,7 +2037,7 @@ final class IdVerificationTest extends TestCase
     {
         $verificationData = $this->idVerificationData();
 
-        $isShowRoom = $params['is_showroom'] ?? false;
+        $isShowRoom = ! isset($verificationData['ipqs']);
         $app = app(Apps::class);
         $user = auth()->user();
         $company = $user->getCurrentCompany();
@@ -2144,5 +2144,187 @@ final class IdVerificationTest extends TestCase
 
         $this->assertNotSame('green', $result['status']);
         $this->assertSame('flag', $result['status']);
+    }
+
+    /**
+     * Showroom payload (no ipqs block) where every Computer Vision field compares
+     * cleanly. Overrides let each case flip individual match flags or blank out one
+     * side of a comparison.
+     */
+    private function computerVisionPayload(array $matchOverrides = [], array $idCheckOverrides = [], array $ocrOverrides = []): array
+    {
+        return [
+            'idcheck' => [
+                'success' => true,
+                'result' => true,
+                'data' => array_merge([
+                    'processResult' => 'DocumentProcessOK',
+                    'expired' => 'no',
+                    'firstName' => 'John',
+                    'lastName' => 'Testington',
+                    'dLIDNumberRaw' => '000000000',
+                    'dateOfBirth' => '1981-11-02',
+                    'gender' => 'Male',
+                    'address1' => '1144 Belle Pond Ave',
+                    'expirationDate' => '11/11/2032',
+                    'issuingJurisdictionCvt' => 'Tennessee',
+                    'issueDate' => '11/11/2024',
+                    'isRealID' => 'Yes',
+                    'heightCentimeters' => '178',
+                    'driverClass' => 'DM',
+                ], $idCheckOverrides),
+            ],
+            'ocr_match' => [
+                'success' => true,
+                'result' => true,
+                'data' => array_merge([
+                    'isNameMatch' => true,
+                    'isDocumentNumberMatch' => true,
+                    'isDobMatch' => true,
+                    'isSexMatch' => true,
+                    'isAddressMatch' => true,
+                    'isExpirationDateMatch' => true,
+                    'isIssuerNameMatch' => true,
+                    'isIssueDateMatch' => true,
+                    'isRealIdMatch' => true,
+                    'isHeightMatch' => true,
+                    'isDlClassMatch' => true,
+                ], $matchOverrides),
+            ],
+            'OCR' => [
+                'success' => true,
+                'result' => true,
+                'data' => array_merge([
+                    'fullName' => 'John Testington',
+                    'documentNumber' => '000000000',
+                    'dateOfBirthFormatted' => '11/02/1981',
+                    'sex' => 'M',
+                    'address' => '1144 Belle Pond Ave, Knoxville, TN 37932',
+                    'dateOfExpiryFormatted' => '11/11/2032',
+                    'dateOfExpiry' => '2032-11-11',
+                    'issuerName' => 'Tennessee',
+                    'dateOfIssueFormatted' => '11/11/2024',
+                    'isRealID' => 'yes',
+                    'height' => '178 cm',
+                    'dlClass' => 'DM',
+                ], $ocrOverrides),
+            ],
+        ];
+    }
+
+    private function statusFor(array $verificationData): string
+    {
+        return IdVerificationService::processVerificationData($verificationData, 'Test User', true)['status'];
+    }
+
+    public function testEveryComputerVisionFieldMatchingPasses(): void
+    {
+        $this->assertSame('green', $this->statusFor($this->computerVisionPayload()));
+    }
+
+    public function testUpToThreeMismatchesOnlyFlag(): void
+    {
+        $this->assertSame('flag', $this->statusFor($this->computerVisionPayload(['isHeightMatch' => false])));
+
+        $this->assertSame('flag', $this->statusFor($this->computerVisionPayload([
+            'isHeightMatch' => false,
+            'isDlClassMatch' => false,
+            'isIssueDateMatch' => false,
+        ])));
+    }
+
+    public function testFourMismatchesFail(): void
+    {
+        $status = $this->statusFor($this->computerVisionPayload([
+            'isHeightMatch' => false,
+            'isDlClassMatch' => false,
+            'isIssueDateMatch' => false,
+            'isIssuerNameMatch' => false,
+        ]));
+
+        $this->assertSame('fail', $status);
+    }
+
+    /**
+     * Incomplete fields are yellow on their own and never push a mismatch count over
+     * the failure threshold — 3 mismatches stay a flag no matter how many fields
+     * could not be compared.
+     */
+    public function testIncompleteFieldsDoNotCountTowardsTheFailureThreshold(): void
+    {
+        $status = $this->statusFor($this->computerVisionPayload([
+            'isHeightMatch' => false,
+            'isDlClassMatch' => false,
+            'isIssueDateMatch' => false,
+            'isNameMatch' => null,
+            'isDobMatch' => null,
+            'isSexMatch' => null,
+            'isAddressMatch' => null,
+            'isExpirationDateMatch' => null,
+        ]));
+
+        $this->assertSame('flag', $status);
+    }
+
+    public function testBlankComparisonSideFlagsEvenWhenTheFlagSaysMatch(): void
+    {
+        $status = $this->statusFor($this->computerVisionPayload(
+            idCheckOverrides: ['dLIDNumberRaw' => '   ']
+        ));
+
+        $this->assertSame('flag', $status);
+    }
+
+    /**
+     * Real IDs, height and driver class are not printed by every jurisdiction. Their
+     * absence must stay green, or a whole state's clean scans would go yellow forever.
+     */
+    public function testMissingOptionalFieldsStayGreen(): void
+    {
+        $payload = $this->computerVisionPayload([
+            'isRealIdMatch' => null,
+            'isHeightMatch' => null,
+            'isDlClassMatch' => null,
+        ], [
+            'isRealID' => null,
+            'heightCentimeters' => null,
+            'driverClass' => null,
+        ], [
+            'isRealID' => null,
+            'height' => null,
+            'dlClass' => null,
+        ]);
+
+        $this->assertSame('green', $this->statusFor($payload));
+    }
+
+    /**
+     * The score counts fields that actually compared and matched, over all 11 — an
+     * optional field nobody could compare must not inflate it.
+     */
+    public function testMatchScoreOnlyCreditsFieldsThatActuallyCompared(): void
+    {
+        $all = IdVerificationService::processVerificationData($this->computerVisionPayload(), 'Test User', true);
+        $this->assertSame(100.0, round($all['results']['ocr_required_matches'], 2));
+
+        $payload = $this->computerVisionPayload(
+            ['isHeightMatch' => null, 'isDlClassMatch' => false],
+            ['heightCentimeters' => null],
+            ['height' => null]
+        );
+
+        $partial = IdVerificationService::processVerificationData($payload, 'Test User', true);
+
+        $this->assertSame(81.82, round($partial['results']['ocr_required_matches'], 2));
+    }
+
+    public function testBooleanFalseOnBothSidesIsAComparisonNotABlank(): void
+    {
+        $payload = $this->computerVisionPayload(
+            idCheckOverrides: ['isRealID' => false],
+            ocrOverrides: ['isRealID' => false]
+        );
+
+        $this->assertSame('green', $this->statusFor($payload));
     }
 }


### PR DESCRIPTION
## What

Computer Vision (OCR) mismatches now drive the ID verification status on one scale, identical in showroom and non-showroom:

| Condition | Status |
|---|---|
| A core field could not be compared (flag absent/`null`, or one side blank) | `flag` |
| Everything compares and matches | `green` |
| 1–3 mismatches | `flag` |
| 4 or more mismatches | `fail` |

## Why

`IdVerificationService::processVerificationData()` had two incoherent branches:

- **Showroom** failed on a *single* mismatch in 4 "critical" fields (Name, Document Number, DOB, Sex).
- **Non-showroom** only failed when all 11 fields mismatched.

Neither branch could reach yellow. The flag gate required `count($flagGroupScores) >= 2`, and `$flagGroupScores` is only filled by IPQS risk scores — which are skipped entirely in showroom. So any mismatch short of a failure resolved to **green**: four fields disagreeing between the barcode and the photo passed clean.

## Scenarios verified

Ran 22 scenarios comparing `HEAD` against the change in one process. All 6 real production fixtures are unchanged (`fail`, `green`, `flag`, `green`, `flag`, `green`), and so are the non-OCR paths — expired ID, blurry image (`idcheck.success = false`), optional fields absent.

Hardened — these used to pass green:

| Scenario | Before | After |
|---|---|---|
| 1 mismatch | `green` | `flag` |
| 2 mismatches | `green` | `flag` |
| 3 mismatches | `green` | `flag` |
| 4 mismatches | `green` | **`fail`** |
| 3 mismatches + 5 incomparable | `green` | `flag` |
| Blank side with the flag set to `true` | `green` | `flag` |

Relaxed — the requested change:

| Scenario | Before | After |
|---|---|---|
| 1 critical mismatch (Name) | `fail` | `flag` |
| 2 critical mismatches (Name + DOB) | `fail` | `flag` |

## Notes

**"Could not compare" covers only the six fields every license carries** — Name, Document Number, DOB, Sex, Address, Expiration Date. Real ID, height and driver class are optional per issuing jurisdiction; a state that does not print them omits them from the payload, and counting that as incomplete would make green unreachable there. All 6 repo fixtures are Tennessee, so the suite would not have caught it.

**No consumer branches on `'fail'`** — every caller asks `in_array($status, ['green','flag'])` for "valid ID" and `$status === 'flag'` for "expired" (`VerifyPeopleIdAction`, `IdVerificationReportActivity`, `AttachDriverLicenseImagesJob`, both SalesAssist actions). Cases that now flag instead of failing flip `intelicheck`/`scandit` from `false` to `true`, which is the intent.

**Cleanup that rode along:** the `str_replace` + `preg_replace` field-name formatter existed in 3 copies (now `readableOcrFields()`), and the 11-field list was enumerated twice (now derived from `OCR_FIELD_SOURCES`). Fixed a latent `trim(null)` deprecation in that formatter.

## Test fix

`$isShowRoom = $params['is_showroom'] ?? false` — `$params` never existed in those 7 tests, so `$isShowRoom` was always `false` and the showroom branch had never been exercised. Correcting it surfaced that the fixtures declare `is_showroom => true` while carrying an `ipqs` block, whereas production derives showroom from its absence (`IdVerificationReportActivity:47`). The tests now use that same derivation.

7 new cases on a `computerVisionPayload()` builder cover each threshold, the blank-side rule, the optional-field carve-out, and the match-score arithmetic.

## Verified

18/18 Intellicheck green (59 assertions). 48/50 SalesAssists — the 2 errors are `Missing AWS credentials` from S3 uploads, unrelated and pre-existing. `ocr_required_matches` compared against `HEAD` across all 6 fixtures: identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)