### PR TITLE
feat: let the agent resend a pending bill's invoice PDF to its approver on request

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -21,6 +21,7 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AddBillNoteTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\ApplyApPaymentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AttachBillFileTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateApBillTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\ResendBillAttachmentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\VoidApBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Approvals\CheckApprovalStatusTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Gmail\DownloadAttachmentTool;
@@ -79,6 +80,7 @@ class AccountsPayableAgent extends SystemUserAgent
             new ApplyApPaymentTool(),
             new AddBillNoteTool(),
             new AttachBillFileTool(),
+            new ResendBillAttachmentTool(),
             new ReadGoogleSheetTool(),
             new AppendGoogleSheetRowsTool(),
             new UpdateGoogleSheetCellTool(),
@@ -138,6 +140,10 @@ class AccountsPayableAgent extends SystemUserAgent
             . 'explicitly asks to record a real payment. Needs the bill_id, amount, and a payment reference.',
             '- "Add a note to bill Y" → add_bill_note; "attach this file to bill Y" → attach_bill_file. Both '
             . 'require the bill to already be pushed to Acumatica.',
+            '- "I didn\'t get the attachment" / "resend the invoice for bill Y" (an approver reporting a '
+            . 'missing PDF on a pending approval) → resend_bill_attachment with that bill_id. Works even before '
+            . 'the bill is pushed to Acumatica, unlike attach_bill_file. If it reports no_attachment_on_file, '
+            . 'say so plainly — there is genuinely nothing captured to resend, not a bug you can retry around.',
             '- "Read/check this Google Sheet" → read_google_sheet, given the URL the user shared. "Add these '
             . 'rows to the sheet" → write_google_sheet. "Mark that row as X in the sheet" → '
             . 'update_google_sheet_cell, only after confirming the exact cell with read_google_sheet first — '

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/ResendBillAttachmentTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Acumatica/ResendBillAttachmentTool.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica;
+
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Scribe\Approvals\Actions\NotifyApproverAction;
+use Kanvas\Scribe\Approvals\Actions\ResolveApproverEmailAction;
+use Kanvas\Scribe\Approvals\Enums\ApprovalCustomFieldEnum;
+use Kanvas\Scribe\Bills\Models\Bill;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use Override;
+
+/**
+ * Re-sends a pending bill's invoice PDF to its configured approver(s) on Slack — for when the
+ * original approval request went out without it. Only works when create_ap_bill actually captured
+ * a source_attachment_url at creation time; reports plainly when there is nothing on file to resend.
+ */
+#[AgentTool(name: 'Resend Bill Attachment', category: 'accounting')]
+class ResendBillAttachmentTool extends Tool
+{
+    use HasKanvasContext;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'resend_bill_attachment',
+            description: 'Re-sends a pending bill\'s invoice PDF to its configured approver(s) on Slack. Use '
+                . 'this when an approver says they did not receive the attachment with their approval request. '
+                . 'Only works if source_attachment_url was captured when the bill was created — reports plainly '
+                . 'when there is nothing on file to resend, rather than failing silently.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'bill_id',
+                type: PropertyType::INTEGER,
+                description: 'The Kanvas bill id, from create_ap_bill or the approver\'s own message. Never guess it.',
+                required: true,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(int $bill_id): array
+    {
+        $bill = Bill::query()
+            ->where('id', $bill_id)
+            ->where('apps_id', $this->app->getId())
+            ->where('companies_id', $this->company->getId())
+            ->first();
+
+        if ($bill === null) {
+            return [
+                'resent' => false,
+                'reason' => 'bill_not_found',
+                'message' => "No bill with id {$bill_id} for this app/company.",
+            ];
+        }
+
+        $attachmentUrl = trim((string) $bill->get(ApprovalCustomFieldEnum::SOURCE_ATTACHMENT_URL->value, ''));
+
+        if ($attachmentUrl === '') {
+            return [
+                'resent' => false,
+                'reason' => 'no_attachment_on_file',
+                'message' => "Bill {$bill_id} has no source_attachment_url on file — there is nothing to resend.",
+            ];
+        }
+
+        $vendor = $bill->vendor;
+        $approverEmails = $vendor !== null ? ResolveApproverEmailAction::resolveForOrganization($vendor) : [];
+
+        if ($approverEmails === []) {
+            return [
+                'resent' => false,
+                'reason' => 'no_approver_configured',
+                'message' => "No approver configured for bill {$bill_id}'s vendor — there is nobody to send it to.",
+            ];
+        }
+
+        $attachmentFilename = trim((string) $bill->get(ApprovalCustomFieldEnum::SOURCE_ATTACHMENT_FILENAME->value, '')) ?: null;
+
+        NotifyApproverAction::notifyAll(
+            approverEmails: $approverEmails,
+            app: $this->app,
+            text: "Here is the invoice for bill {$bill_id}, resent on request.",
+            attachmentUrl: $attachmentUrl,
+            attachmentFilename: $attachmentFilename,
+        );
+
+        return [
+            'resent' => true,
+            'bill_id' => $bill_id,
+            'sent_to' => $approverEmails,
+        ];
+    }
+}

--- a/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
+++ b/tests/Scribe/Intelligence/AccountsPayableAgentToolsTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Scribe\Intelligence;
 
+use Illuminate\Http\Client\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Http;
 use Kanvas\Connectors\Acumatica\Enums\CustomFieldEnum;
 use Kanvas\Guild\Organizations\Actions\AddApproverToOrganizationAction;
 use Kanvas\Guild\Organizations\Models\Organization;
+use Kanvas\Intelligence\AgentRuntime\Enums\AgentChannelTokenEnum;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Models\AgentType;
 use Kanvas\Intelligence\Agents\Neuron\Accounting\AccountsPayableAgent;
@@ -23,6 +26,8 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryApAgingTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AddBillNoteTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AttachBillFileTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\CreateApBillTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\ResendBillAttachmentTool;
+use Kanvas\Scribe\Approvals\Enums\ApprovalConfigurationEnum;
 use Kanvas\Scribe\Approvals\Enums\OrganizationApproverCustomFieldEnum;
 use Kanvas\Scribe\Bills\Actions\CreateBillAction;
 use Kanvas\Scribe\Bills\Actions\ReceiveBillAction;
@@ -533,6 +538,99 @@ class AccountsPayableAgentToolsTest extends ScribeTestCase
 
         $this->assertTrue($result['created']);
         $this->assertArrayNotHasKey('attachment_warning', $result);
+    }
+
+    public function test_resend_bill_attachment_resends_the_stored_pdf(): void
+    {
+        $vendor = $this->seedTestOrganization('Windwalk Games Corp');
+        new AddApproverToOrganizationAction($vendor, static::$cachedUser)->execute();
+        $accountCode = (string) Account::query()
+            ->where('id', $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS))
+            ->value('account_number');
+
+        $agent = Agent::factory()
+            ->withAppId($this->kanvasApp->getId())
+            ->withCompanyId($this->company->getId())
+            ->create(['name' => 'Apex', 'user_id' => static::$cachedUser->getId()]);
+        $agent->set(AgentChannelTokenEnum::SLACK_BOT_TOKEN->value, 'xoxb-test-token');
+        $originalNotifierAgentId = $this->kanvasApp->get(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value);
+        $this->kanvasApp->set(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value, (string) $agent->getId());
+
+        try {
+            Http::fake([
+                'slack.com/api/users.lookupByEmail' => Http::response(['ok' => true, 'user' => ['id' => 'U123']]),
+                'slack.com/api/conversations.open' => Http::response(['ok' => true, 'channel' => ['id' => 'D123']]),
+                'cdn.example.test/*' => Http::response('%PDF-1.4 fake bytes', 200),
+                'slack.com/api/files.getUploadURLExternal' => Http::response([
+                    'ok' => true,
+                    'upload_url' => 'https://files.slack.com/upload/v1/abc123',
+                    'file_id' => 'F123',
+                ]),
+                'files.slack.com/upload/v1/abc123' => Http::response('', 200),
+                'slack.com/api/files.completeUploadExternal' => Http::response(['ok' => true]),
+                'slack.com/api/chat.postMessage' => Http::response(['ok' => true, 'ts' => '1700000000.000100']),
+            ]);
+
+            $created = new CreateApBillTool()
+                ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+                ->__invoke(
+                    vendor_name: 'Windwalk Games Corp',
+                    amount: 500.0,
+                    gl_account_number: $accountCode,
+                    memo: 'Resend test',
+                    invoice_number: 'RESEND-1',
+                    push_to_acumatica: false,
+                    source_email_message_id: 'MSG_RESEND_1',
+                    source_attachment_url: 'https://cdn.example.test/invoice-resend.pdf',
+                    source_attachment_filename: 'invoice-resend.pdf',
+                );
+
+            $result = new ResendBillAttachmentTool()
+                ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+                ->__invoke(bill_id: (int) $created['bill_id']);
+
+            $this->assertTrue($result['resent']);
+            Http::assertSent(fn (Request $request): bool => str_contains($request->url(), 'files.getUploadURLExternal'));
+        } finally {
+            $this->kanvasApp->set(ApprovalConfigurationEnum::SLACK_NOTIFIER_AGENT_ID->value, $originalNotifierAgentId);
+        }
+    }
+
+    public function test_resend_bill_attachment_reports_no_attachment_on_file(): void
+    {
+        $vendor = $this->seedTestOrganization('Windwalk Games Corp');
+        new AddApproverToOrganizationAction($vendor, static::$cachedUser)->execute();
+        $accountCode = (string) Account::query()
+            ->where('id', $this->accountIdBySubType(AccountSubTypeEnum::TRAVEL_AND_MEALS))
+            ->value('account_number');
+
+        $created = new CreateApBillTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(
+                vendor_name: 'Windwalk Games Corp',
+                amount: 500.0,
+                gl_account_number: $accountCode,
+                memo: 'No attachment on file',
+                invoice_number: 'RESEND-2',
+                push_to_acumatica: false,
+            );
+
+        $result = new ResendBillAttachmentTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(bill_id: (int) $created['bill_id']);
+
+        $this->assertFalse($result['resent']);
+        $this->assertSame('no_attachment_on_file', $result['reason']);
+    }
+
+    public function test_resend_bill_attachment_reports_bill_not_found(): void
+    {
+        $result = new ResendBillAttachmentTool()
+            ->withContext($this->kanvasApp, $this->company, static::$cachedUser)
+            ->__invoke(bill_id: 999999999);
+
+        $this->assertFalse($result['resent']);
+        $this->assertSame('bill_not_found', $result['reason']);
     }
 
     public function test_approve_pending_item_requires_the_configured_approver(): void


### PR DESCRIPTION
## Summary
Follow-up to the attachment_warning fix (#11123) — flagging that the attachment is missing is only half the fix. If a source_attachment_url genuinely exists (was captured at creation but the initial Slack upload failed, or the approver just wants it resent), there was no clean way to get it to them short of the agent improvising something ad hoc.

`resend_bill_attachment(bill_id)`:
- Looks up the bill's stored `source_attachment_url`/`source_attachment_filename` custom fields.
- Resolves the vendor's configured approver(s) and re-sends the PDF via the same `NotifyApproverAction` used everywhere else.
- Reports `no_attachment_on_file` plainly when there's genuinely nothing captured — not a bug to retry around.

Wired into `AccountsPayableAgent`'s guidance: "I didn't get the attachment" / "resend the invoice for bill Y" → this tool.

## Test plan
- [x] Resends the stored PDF (asserts the real Slack upload sequence fires)
- [x] Reports `no_attachment_on_file` when nothing was captured
- [x] Reports `bill_not_found` for an unknown id
- [x] Full suite: 37/37 passing