### PR TITLE
refactor: record sales assist reach-out validation

### DIFF
--- a/src/Domains/Connectors/SalesAssist/Activities/SalesAssistAgentReachOutActivity.php
+++ b/src/Domains/Connectors/SalesAssist/Activities/SalesAssistAgentReachOutActivity.php
@@ -16,12 +16,15 @@ use Kanvas\Workflow\Attributes\WorkflowAction;
 )]
 final class SalesAssistAgentReachOutActivity extends AgentReachOutActivity
 {
-    public function execute(Lead $lead, Apps $app, array $params): array
+    public $tries = 1;
+
+    protected function validateBeforeReachOut(Lead $lead, Apps $app, array $params): void
     {
-        $this->overwriteAppService($app);
-
         new EnsureFirstMessageEnabledAction($lead)->execute();
+    }
 
-        return parent::execute($lead, $app, $params);
+    protected function shouldThrowIntegrationException(): bool
+    {
+        return true;
     }
 }

--- a/src/Domains/Connectors/SalesAssist/Activities/SalesAssistAgentReachOutActivity.php
+++ b/src/Domains/Connectors/SalesAssist/Activities/SalesAssistAgentReachOutActivity.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\SalesAssist\Activities;
 
+use Exception;
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Elead\Actions\AddOutBoundPhoneCallActivityToLeadAction;
 use Kanvas\Connectors\SalesAssist\Actions\EnsureFirstMessageEnabledAction;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Activities\AgentReachOutActivity;
+use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Workflow\Attributes\WorkflowAction;
 
 #[WorkflowAction(
@@ -21,6 +24,26 @@ final class SalesAssistAgentReachOutActivity extends AgentReachOutActivity
     protected function validateBeforeReachOut(Lead $lead, Apps $app, array $params): void
     {
         new EnsureFirstMessageEnabledAction($lead)->execute();
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    protected function afterReachOut(Lead $lead, Apps $app, array $params, array $result): void
+    {
+        $messageId = (int) ($result['message_ids_sent'][0] ?? 0);
+        if (! $lead->get('downloaded_from_eleads') || $messageId === 0) {
+            return;
+        }
+
+        try {
+            $message = Message::getById($messageId, $app);
+
+            new AddOutBoundPhoneCallActivityToLeadAction($lead, $message)
+                ->execute('Sally Takes Over', 'Sally stops the clock');
+        } catch (Exception $exception) {
+            report($exception);
+        }
     }
 
     protected function shouldThrowIntegrationException(): bool

--- a/src/Domains/Intelligence/Agents/Actions/Outreach/AgentReachOutAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Outreach/AgentReachOutAction.php
@@ -125,13 +125,14 @@ class AgentReachOutAction
         $this->lead->set(AgentReachOutConfigEnum::STATUS->value, AgentReachOutConfigEnum::STATUS_IN_PROGRESS);
 
         $sentChannels = [];
+        $sentMessageIds = [];
         $scheduledChannels = [];
         $errors = [];
         $deferDelivery = $this->lead->isAiSupport();
 
         foreach ($channels as $pair) {
             try {
-                new AgentReachOutOnChannelAction(
+                $outbound = new AgentReachOutOnChannelAction(
                     lead: $this->lead,
                     agent: $agent,
                     channelType: $pair['channel_type'],
@@ -143,6 +144,9 @@ class AgentReachOutAction
                     $scheduledChannels[] = $pair['channel_type'];
                 } else {
                     $sentChannels[] = $pair['channel_type'];
+                    if (! $outbound->isLocked()) {
+                        $sentMessageIds[] = $outbound->getId();
+                    }
                 }
             } catch (Throwable $e) {
                 report($e);
@@ -180,6 +184,7 @@ class AgentReachOutAction
             'message' => 'Reach-out sent',
             'status' => AgentReachOutConfigEnum::STATUS_SENT,
             'channels_sent' => $sentChannels,
+            'message_ids_sent' => $sentMessageIds,
             'errors' => $errors,
         ];
     }

--- a/src/Domains/Intelligence/Agents/Activities/AgentReachOutActivity.php
+++ b/src/Domains/Intelligence/Agents/Activities/AgentReachOutActivity.php
@@ -37,7 +37,10 @@ class AgentReachOutActivity extends KanvasActivity
             integrationOperation: function () use ($lead, $app, $params): array {
                 $this->validateBeforeReachOut($lead, $app, $params);
 
-                return new AgentReachOutAction($lead, $params)->execute();
+                $result = new AgentReachOutAction($lead, $params)->execute();
+                $this->afterReachOut($lead, $app, $params, $result);
+
+                return $result;
             },
             company: $lead->company,
             throwException: $this->shouldThrowIntegrationException(),
@@ -45,6 +48,13 @@ class AgentReachOutActivity extends KanvasActivity
     }
 
     protected function validateBeforeReachOut(Lead $lead, Apps $app, array $params): void
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $result
+     */
+    protected function afterReachOut(Lead $lead, Apps $app, array $params, array $result): void
     {
     }
 

--- a/src/Domains/Intelligence/Agents/Activities/AgentReachOutActivity.php
+++ b/src/Domains/Intelligence/Agents/Activities/AgentReachOutActivity.php
@@ -34,8 +34,22 @@ class AgentReachOutActivity extends KanvasActivity
             app: $app,
             integration: IntegrationsEnum::INTERNAL,
             additionalParams: $params,
-            integrationOperation: fn () => new AgentReachOutAction($lead, $params)->execute(),
+            integrationOperation: function () use ($lead, $app, $params): array {
+                $this->validateBeforeReachOut($lead, $app, $params);
+
+                return new AgentReachOutAction($lead, $params)->execute();
+            },
             company: $lead->company,
+            throwException: $this->shouldThrowIntegrationException(),
         );
+    }
+
+    protected function validateBeforeReachOut(Lead $lead, Apps $app, array $params): void
+    {
+    }
+
+    protected function shouldThrowIntegrationException(): bool
+    {
+        return false;
     }
 }


### PR DESCRIPTION
## Why

The Sales Assist first-message boundary must stop outreach when the lead-type configuration disables it, while still recording the expected rejection in workflow integration history.

The previous implementation validated before entering `executeIntegration()`. That stopped the activity, but bypassed integration history and could allow unnecessary retries.

## What changed

- Added protected validation and exception-policy hooks to the generic `AgentReachOutActivity`.
- Runs pre-reach-out validation inside the integration operation.
- `SalesAssistAgentReachOutActivity` overrides the validation hook with its lead-type eligibility rule.
- Sales Assist enables exception propagation so the workflow stops after history is recorded.
- Sales Assist uses one attempt because this rejection is a deterministic business condition.
- Added a post-reach-out hook that exposes only message IDs that were actually delivered.
- Sales Assist uses the first delivered message to create the eLead outbound phone-call activity (`Sally Takes Over` / `Sally stops the clock`).
- Delayed Support drafts and human-approval drafts do not stop the clock before delivery.

## Result

When the Sales Assist boundary rejects a first message:

- The integration history records the activity as `FAILED`.
- The `SilentWorkflowException` is not reported to Sentry.
- Agent Reach Out is not executed.
- Subsequent workflow actions do not run.
- The deterministic rejection is not retried.

Other applications continue using the generic `AgentReachOutActivity` with its existing behavior.
The eLead stop-the-clock integration remains entirely inside the Sales Assist activity.

## Validation

- Sales Assist eligibility tests: 3 passed, 6 assertions.
- PHPStan: passed.
- PHP-CS-Fixer: passed.
- The Agent Reach Out E2E remains blocked locally by the existing Typesense schema mismatch requiring 768-dimensional embeddings; the failure occurs during knowledge setup before the activity executes.
