### PR TITLE
refactor: centralize lead AI mode resolution

### DIFF
--- a/src/Domains/Guild/Leads/Models/Lead.php
+++ b/src/Domains/Guild/Leads/Models/Lead.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use InvalidArgumentException;
 use Kanvas\AdminLinks\Enums\AdminLinkSectionEnum;
 use Kanvas\AdminLinks\Traits\HasAdminLink;
 use Kanvas\Apps\Models\AppKey;
@@ -35,6 +36,7 @@ use Kanvas\Guild\Pipelines\Models\PipelineStage;
 use Kanvas\Intelligence\Enums\ConfigurationEnum as EnumsConfigurationEnum;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\FollowUp\Traits\HasFollowUpState;
+use Kanvas\Intelligence\Services\LeadConfigurationService;
 use Kanvas\Intelligence\Sessions\Models\Session;
 use Kanvas\NervousSystem\Ledger\Traits\EmitsLedgerEventsForEntity;
 use Kanvas\Social\Channels\Enums\ChannelNameEnum;
@@ -835,11 +837,34 @@ class Lead extends BaseModel implements EventResourceInterface
         $this->set(ConfigurationEnum::CONTACTED->value, $status->value);
     }
 
+    public function resolveAiMode(?bool $isWithinWorkingHours = null): ?IntelligenceModeEnum
+    {
+        $storedMode = $this->get(EnumsConfigurationEnum::AI_MODE->value);
+        if ((bool) $this->get(ConfigurationEnum::AI_MODE_IS_MANUAL->value)) {
+            return IntelligenceModeEnum::tryFrom((string) $storedMode);
+        }
+
+        if ($isWithinWorkingHours === null) {
+            try {
+                $isWithinWorkingHours = $this->company->isWithinWorkingHours(now());
+            } catch (InvalidArgumentException) {
+                $isWithinWorkingHours = true;
+            }
+        }
+
+        $configurationService = new LeadConfigurationService();
+        $defaultKey = $configurationService->getAiModeDefaultKey($this, $isWithinWorkingHours);
+        $leadTypeConfig = $this->type()->first()?->config ?? [];
+        $resolvedMode = $leadTypeConfig[$defaultKey]
+            ?? $storedMode
+            ?? $this->company->get($configurationService->getAiModeKey($this));
+
+        return IntelligenceModeEnum::tryFrom((string) $resolvedMode);
+    }
+
     public function isAiMuted(): bool
     {
-        $aiMode = $this->get(EnumsConfigurationEnum::AI_MODE->value);
-
-        $mode = IntelligenceModeEnum::tryFrom((string) $aiMode);
+        $mode = $this->resolveAiMode();
 
         return $mode?->isOff() ?? false;
     }
@@ -850,9 +875,7 @@ class Lead extends BaseModel implements EventResourceInterface
      */
     public function isAiSupport(): bool
     {
-        return IntelligenceModeEnum::tryFrom(
-            (string) $this->get(EnumsConfigurationEnum::AI_MODE->value)
-        ) === IntelligenceModeEnum::SUPPORT;
+        return $this->resolveAiMode() === IntelligenceModeEnum::SUPPORT;
     }
 
     public function canRunAiAgent(): bool

--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentChannelReplyAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentChannelReplyAction.php
@@ -74,12 +74,14 @@ class BaseAgentChannelReplyAction
             }
         }
 
-        $isAiMuted = $lead instanceof Lead
-            ? $lead->isAiMuted()
-            : IntelligenceModeEnum::tryFrom((string) $lead->get('ai_mode'))?->isOff() ?? false;
+        if ($this->respectsLeadAiMode) {
+            $isAiMuted = $lead instanceof Lead
+                ? $lead->isAiMuted()
+                : IntelligenceModeEnum::tryFrom((string) $lead->get('ai_mode'))?->isOff() ?? false;
 
-        if ($this->respectsLeadAiMode && $isAiMuted) {
-            throw new AgentReplySkippedException('Ai Agent Off for this lead');
+            if ($isAiMuted) {
+                throw new AgentReplySkippedException('Ai Agent Off for this lead');
+            }
         }
 
         if ($message->is_un_response) {

--- a/src/Domains/Intelligence/Agents/Actions/BaseAgentChannelReplyAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/BaseAgentChannelReplyAction.php
@@ -17,7 +17,6 @@ use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Traits\DispatchesAttachmentDescriptionTrait;
 use Kanvas\Intelligence\Agents\Types\ADKAgent;
 use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
-use Kanvas\Intelligence\Services\LeadConfigurationService;
 use Kanvas\Intelligence\Sessions\Models\Session;
 use Kanvas\Social\Channels\Models\Channel;
 use Kanvas\Social\Messages\Actions\CreateMessageAction;
@@ -75,13 +74,11 @@ class BaseAgentChannelReplyAction
             }
         }
 
-        $configService = new LeadConfigurationService();
-        $aiModeKey = $lead instanceof Lead
-            ? $configService->getAiModeKey($lead)
-            : 'ai_mode';
+        $isAiMuted = $lead instanceof Lead
+            ? $lead->isAiMuted()
+            : IntelligenceModeEnum::tryFrom((string) $lead->get('ai_mode'))?->isOff() ?? false;
 
-        $mode = IntelligenceModeEnum::tryFrom((string) $lead->get($aiModeKey));
-        if ($this->respectsLeadAiMode && $mode?->isOff()) {
+        if ($this->respectsLeadAiMode && $isAiMuted) {
             throw new AgentReplySkippedException('Ai Agent Off for this lead');
         }
 

--- a/src/Domains/Intelligence/Agents/Actions/Outreach/AgentReachOutAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Outreach/AgentReachOutAction.php
@@ -8,9 +8,7 @@ use Kanvas\Companies\Enums\ConfigurationEnum as CompanyConfigurationEnum;
 use Kanvas\Exceptions\ValidationException;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Models\Agent;
-use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\Leads\Enums\AgentReachOutConfigEnum;
-use Kanvas\Intelligence\Services\LeadConfigurationService;
 use Throwable;
 
 /**
@@ -76,11 +74,7 @@ class AgentReachOutAction
         }
 
         // === AI-mode mute check ===
-        $leadAiMode = IntelligenceModeEnum::tryFrom(
-            (string) $this->lead->get(new LeadConfigurationService()->getAiModeKey($this->lead))
-        );
-
-        if ($leadAiMode?->isOff()) {
+        if ($this->lead->isAiMuted()) {
             $this->lead->set(AgentReachOutConfigEnum::STATUS->value, AgentReachOutConfigEnum::STATUS_MUTED);
 
             return ['message' => 'Lead AI mode is off', 'status' => 'muted'];

--- a/src/Domains/Intelligence/Agents/Traits/HandlesSupportModeDelayedResponseTrait.php
+++ b/src/Domains/Intelligence/Agents/Traits/HandlesSupportModeDelayedResponseTrait.php
@@ -9,9 +9,7 @@ use Kanvas\Companies\Enums\ConfigurationEnum as CompanyConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Enums\ConfigurationEnum;
-use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\Jobs\SendUnrespondedAgentMessageJob;
-use Kanvas\Intelligence\Services\LeadConfigurationService;
 use Kanvas\Intelligence\Sessions\Models\Session;
 use Kanvas\Social\Channels\Models\Channel;
 use Kanvas\Social\Messages\Models\Message;
@@ -43,10 +41,7 @@ trait HandlesSupportModeDelayedResponseTrait
             return null;
         }
 
-        $configService = new LeadConfigurationService();
-        $supportMode = $lead->get($configService->getAiModeKey($lead)) == IntelligenceModeEnum::SUPPORT->value;
-
-        if (! $supportMode) {
+        if (! $lead->isAiSupport()) {
             return null;
         }
 

--- a/src/Domains/Intelligence/Jobs/SendUnrespondedAgentMessageJob.php
+++ b/src/Domains/Intelligence/Jobs/SendUnrespondedAgentMessageJob.php
@@ -20,8 +20,6 @@ use Kanvas\Connectors\VinSolution\Actions\PushNoteToLeadAction;
 use Kanvas\Connectors\VinSolution\Enums\CustomFieldEnum as EnumsCustomFieldEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Models\Agent;
-use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
-use Kanvas\Intelligence\Services\LeadConfigurationService;
 use Kanvas\Intelligence\Sessions\Models\Session;
 use Kanvas\Intelligence\Triggers\Enums\TriggersEnum;
 use Kanvas\Services\DailyReportService;
@@ -61,9 +59,7 @@ class SendUnrespondedAgentMessageJob implements ShouldQueue
 
         $lead = $this->message->entity();
 
-        $aiModeKey = $lead instanceof Lead ? new LeadConfigurationService()->getAiModeKey($lead) : 'ai_mode';
-        $aiMode = $lead->get($aiModeKey);
-        if ($aiMode !== IntelligenceModeEnum::SUPPORT->value) {
+        if (! $lead instanceof Lead || ! $lead->isAiSupport()) {
             return;
         }
 

--- a/src/Domains/Intelligence/Workflows/LeadAgentFirstMessageOutreachActivity.php
+++ b/src/Domains/Intelligence/Workflows/LeadAgentFirstMessageOutreachActivity.php
@@ -24,7 +24,6 @@ use Kanvas\Guild\Leads\Exceptions\LeadMissingContactException;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Enums\ConfigurationEnum as EnumsConfigurationEnum;
-use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\Leads\Actions\CreateLeadContextInfoAction;
 use Kanvas\Intelligence\Leads\Actions\CreateLeadFirstEngagementMessageAction;
 use Kanvas\Intelligence\Services\LeadConfigurationService;
@@ -77,8 +76,7 @@ class LeadAgentFirstMessageOutreachActivity extends KanvasActivity
             integration: IntegrationsEnum::INTERNAL,
             additionalParams: $params,
             integrationOperation: function ($lead, $app, $integrationCompany, $additionalParams) use ($params) {
-                $leadAiMode = IntelligenceModeEnum::tryFrom((string) $lead->get(new LeadConfigurationService()->getAiModeKey($lead)));
-                if ($leadAiMode?->isOff()) {
+                if ($lead->isAiMuted()) {
                     return [
                         'ai_mode is OFF',
                     ];
@@ -142,7 +140,7 @@ class LeadAgentFirstMessageOutreachActivity extends KanvasActivity
                     }
                 }
 
-                $currentAiMode = IntelligenceModeEnum::tryFrom((string) $lead->get(new LeadConfigurationService()->getAiModeKey($lead)));
+                $currentAiMode = $lead->resolveAiMode();
                 $disableSending = $currentAiMode?->isOff() ?? false;
 
                 $leadType = $lead->type()->first();
@@ -376,7 +374,7 @@ class LeadAgentFirstMessageOutreachActivity extends KanvasActivity
 
     private function shouldSendFirstMessageNow(Lead $lead): bool
     {
-        $aiMode = IntelligenceModeEnum::tryFrom((string) $lead->get(new LeadConfigurationService()->getAiModeKey($lead)));
+        $aiMode = $lead->resolveAiMode();
         if ($aiMode?->isOff()) {
             return false;
         }
@@ -389,7 +387,7 @@ class LeadAgentFirstMessageOutreachActivity extends KanvasActivity
 
         if (! $isWithinWorkingHours) {
             return true;
-        } elseif ($lead->get(new LeadConfigurationService()->getAiModeKey($lead)) === IntelligenceModeEnum::SUPPORT->value) {
+        } elseif ($lead->isAiSupport()) {
             return false;
         } else {
             return true;

--- a/tests/Intelligence/Services/LeadConfigurationServiceV2Test.php
+++ b/tests/Intelligence/Services/LeadConfigurationServiceV2Test.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\Intelligence\Services;
 
 use Kanvas\Apps\Models\Apps;
+use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Models\LeadType;
+use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use Kanvas\Intelligence\Services\LeadConfigurationService;
 use Tests\TestCase;
 
@@ -127,6 +129,42 @@ class LeadConfigurationServiceV2Test extends TestCase
             'ai_mode_open_default',
             new LeadConfigurationService()->getAiModeDefaultKey($lead, true)
         );
+    }
+
+    public function testLeadResolvesAutomaticAiModeFromWorkingHoursDefault(): void
+    {
+        $lead = $this->createLead('Internet', [
+            'internet_ai_mode_open_default' => IntelligenceModeEnum::FULL_ON->value,
+            'internet_ai_mode_closed_default' => IntelligenceModeEnum::SUPPORT->value,
+        ]);
+        $lead->set('ai_mode', IntelligenceModeEnum::IDLE->value);
+
+        $this->assertSame(IntelligenceModeEnum::FULL_ON, $lead->resolveAiMode(true));
+        $this->assertSame(IntelligenceModeEnum::SUPPORT, $lead->resolveAiMode(false));
+    }
+
+    public function testLeadManualAiModeOverridesWorkingHoursDefaults(): void
+    {
+        $lead = $this->createLead('Internet', [
+            'internet_ai_mode_open_default' => IntelligenceModeEnum::FULL_ON->value,
+            'internet_ai_mode_closed_default' => IntelligenceModeEnum::SUPPORT->value,
+        ]);
+        $lead->set('ai_mode', IntelligenceModeEnum::IDLE->value);
+        $lead->set(LeadConfigurationEnum::AI_MODE_IS_MANUAL->value, true);
+
+        $this->assertSame(IntelligenceModeEnum::IDLE, $lead->resolveAiMode(true));
+        $this->assertSame(IntelligenceModeEnum::IDLE, $lead->resolveAiMode(false));
+        $this->assertTrue($lead->isAiMuted());
+        $this->assertFalse($lead->isAiSupport());
+    }
+
+    public function testLeadAiModeFallsBackToStoredModeWhenDefaultIsMissing(): void
+    {
+        $lead = $this->createLead('NoDefaults');
+        $lead->set('ai_mode', IntelligenceModeEnum::SUPPORT->value);
+
+        $this->assertSame(IntelligenceModeEnum::SUPPORT, $lead->resolveAiMode(true));
+        $this->assertTrue($lead->isAiSupport());
     }
 
     public function testGetFollowUpDefaultKeyReturnsActiveKeyForActiveStatus(): void


### PR DESCRIPTION
## Why

Lead AI-mode checks were reading the persisted `ai_mode` directly. That value can become stale when dealership working hours change, and it bypasses the lead-type `_ai_mode_open_default` / `_ai_mode_closed_default` rules unless Trigger Intelligence has just run.

AI-mode resolution must also preserve an explicit manual override.

## What changed

- Added `Lead::resolveAiMode()` as the single source for effective lead AI mode.
- When `lead_ai_mode_is_manual` is true, the persisted `ai_mode` wins.
- Otherwise, the resolver checks current dealership hours and selects the Lead Type's matching open/closed default.
- If the Lead Type has no matching default, it falls back to the persisted/company AI mode for backward compatibility.
- Updated `isAiMuted()` and `isAiSupport()` to use the resolver.
- Replaced direct lead AI-mode validation in:
  - Agent channel responders
  - Agent Reach Out
  - Support-mode delayed-response dispatch and execution
  - Legacy First Message outreach
  - Delayed first-message command indirectly through the Lead helpers

Administrative commands and Trigger Intelligence continue writing the persisted mode; they are mutations, not runtime validations.

## Effective precedence

1. Manual persisted mode, when `lead_ai_mode_is_manual = true`.
2. Lead Type `_ai_mode_open_default` during working hours.
3. Lead Type `_ai_mode_closed_default` outside working hours.
4. Persisted/company mode as compatibility fallback.

## Validation

- Lead configuration/resolution: 18 tests passed, 45 assertions.
- Agent Reach Out: 20 tests passed, 53 assertions.
- PHPStan: passed for all changed production files.
- PHP-CS-Fixer: passed.
- `git diff --check`: passed.
