### PR TITLE
fix(voice): pass acting app to the Twilio numbers action (company->app can be null)

### DIFF
--- a/app/GraphQL/Connector/Twilio/Queries/TwilioPhoneNumbersQuery.php
+++ b/app/GraphQL/Connector/Twilio/Queries/TwilioPhoneNumbersQuery.php
@@ -37,7 +37,7 @@ class TwilioPhoneNumbersQuery
         $ctx = $this->actingContext();
 
         try {
-            $numbers = new ListCompanyPhoneNumbersAction($ctx->company)->execute();
+            $numbers = new ListCompanyPhoneNumbersAction($ctx->company, $ctx->app)->execute();
         } catch (Throwable) {
             return [];
         }

--- a/src/Domains/Connectors/Twilio/Actions/ListCompanyPhoneNumbersAction.php
+++ b/src/Domains/Connectors/Twilio/Actions/ListCompanyPhoneNumbersAction.php
@@ -4,21 +4,26 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\Twilio\Actions;
 
+use Baka\Contracts\AppInterface;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Connectors\Twilio\Client as TwilioClient;
 
 /**
  * List the phone numbers a company has purchased on its connected Twilio
- * account. Encapsulates the third-party Twilio call (creds resolved per company
- * via the connector Client) so callers never touch the SDK directly.
+ * account. Encapsulates the third-party Twilio call (company creds, falling back
+ * to the app's shared account) so callers never touch the SDK directly.
  *
- * Throws when the company has no Twilio creds (ValidationException from the
- * Client) or the Twilio API errors — the caller decides how to degrade.
+ * The app is passed in explicitly — a company can be global (apps_id 0), so its
+ * own `->app` relation may be null; the caller supplies the acting app.
+ *
+ * Throws when neither company nor app has Twilio creds (ValidationException from
+ * the Client) or the Twilio API errors — the caller decides how to degrade.
  */
 class ListCompanyPhoneNumbersAction
 {
     public function __construct(
         private readonly Companies $company,
+        private readonly AppInterface $app,
     ) {
     }
 
@@ -27,7 +32,7 @@ class ListCompanyPhoneNumbersAction
      */
     public function execute(int $limit = 200): array
     {
-        $twilio = TwilioClient::getInstanceByCompanyOrApp($this->company, $this->company->app);
+        $twilio = TwilioClient::getInstanceByCompanyOrApp($this->company, $this->app);
 
         return array_map(
             static fn ($number): array => [


### PR DESCRIPTION
## Symptom
The Twilio number **picker** stayed a text field even after inbound wiring succeeded. `ListCompanyPhoneNumbersAction` threw:

```
TypeError: getInstanceByCompanyOrApp(): Argument #2 ($app) must be of type AppInterface, null given
  … ListCompanyPhoneNumbersAction.php:30
```

## Cause
The action derived **`$this->company->app`**, but a **global company** (`apps_id` 0 — e.g. company 4055) has a **null** `app` relation. So `$app` was null → `TypeError` → the resolver's `catch (Throwable)` swallowed it → empty list → the admin picker fell back to manual entry.

Inbound webhook wiring was unaffected because `ConfigureAgentInboundWebhookAction` uses the **agent's** `->app` (always well-defined) — which is why the "Retry" flow reported ✓ wired while the picker showed nothing.

## Fix
Take the acting app **explicitly** on `ListCompanyPhoneNumbersAction`, and have the resolver pass `$ctx->app` (from `ResolvesActingContext`) instead of deriving it from the company.

This was the exact `$company->app` risk flagged (and, mea culpa, left) in the earlier backend review — confirmed real here because company 4055 is global.

## Test
`twilioAvailablePhoneNumbers` now returns the account's numbers for a global-company agent → the admin renders the dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)