### PR TITLE
fix(voice): bind agent app + Bouncer scope when running a tool

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/Voice/RunVoiceAgentToolAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/RunVoiceAgentToolAction.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Actions\Voice;
 
+use Bouncer;
+use Kanvas\AccessControlList\Enums\RolesEnums;
+use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Exceptions\ValidationException;
 use Kanvas\Intelligence\Agents\Models\Agent;
@@ -41,44 +44,59 @@ class RunVoiceAgentToolAction
      */
     public function execute(): mixed
     {
-        $catalogTool = new CapabilityProvider()
-            ->getActiveTools($this->agent, CapabilityFrameworkEnum::NEURON->value)
-            ->first(fn ($tool): bool => $tool->name === $this->toolName);
-
-        if ($catalogTool === null) {
-            throw new ValidationException("Agent has no active tool named '{$this->toolName}'.");
-        }
-
-        $handlerClass = $catalogTool->handler;
-        if (empty($handlerClass) || ! class_exists($handlerClass)) {
-            throw new ValidationException("Tool '{$this->toolName}' has no runnable handler.");
-        }
-
-        $handler = app($handlerClass);
-        if (! $handler instanceof NeuronTool) {
-            throw new ValidationException("Tool '{$this->toolName}' is not executable.");
-        }
-
-        // Wire the agent's tenant context onto tools that accept it (withContext
-        // from HasKanvasContext). app/company come from the agent; the acting
-        // user is the company's dedicated AI user for this non-request path.
-        $company = $this->agent->companies_id > 0 ? Companies::find($this->agent->companies_id) : null;
-        if ($company !== null && method_exists($handler, 'withContext')) {
-            $handler->withContext($this->agent->app, $company, $company->getAiAgentUserOrFail());
-        }
+        // Cross-app: run the tool in the AGENT's app + Bouncer scope, not the
+        // runtime's app-key app. A write tool (create a lead, a channel, assign a
+        // role) resolves People/Roles under the current scope, so without this a
+        // cross-app agent hits ModelNotFoundException [People]/[Role] deep inside
+        // the tool. Same binding as CaptureVoiceCallerAction; restored in finally.
+        $previousApp = app(Apps::class);
+        app()->instance(Apps::class, $this->agent->app);
+        $previousScope = Bouncer::scope()->get();
+        Bouncer::scope()->to(RolesEnums::getScope($this->agent->app));
 
         try {
-            $handler->setInputs($this->arguments);
-            $handler->execute();
-        } catch (Throwable $e) {
-            // Never leak a stack trace to the model; hand back calm, speakable copy.
-            return ['status' => 'error', 'message' => $e->getMessage()];
+            $catalogTool = new CapabilityProvider()
+                ->getActiveTools($this->agent, CapabilityFrameworkEnum::NEURON->value)
+                ->first(fn ($tool): bool => $tool->name === $this->toolName);
+
+            if ($catalogTool === null) {
+                throw new ValidationException("Agent has no active tool named '{$this->toolName}'.");
+            }
+
+            $handlerClass = $catalogTool->handler;
+            if (empty($handlerClass) || ! class_exists($handlerClass)) {
+                throw new ValidationException("Tool '{$this->toolName}' has no runnable handler.");
+            }
+
+            $handler = app($handlerClass);
+            if (! $handler instanceof NeuronTool) {
+                throw new ValidationException("Tool '{$this->toolName}' is not executable.");
+            }
+
+            // Wire the agent's tenant context onto tools that accept it (withContext
+            // from HasKanvasContext). app/company come from the agent; the acting
+            // user is the company's dedicated AI user for this non-request path.
+            $company = $this->agent->companies_id > 0 ? Companies::find($this->agent->companies_id) : null;
+            if ($company !== null && method_exists($handler, 'withContext')) {
+                $handler->withContext($this->agent->app, $company, $company->getAiAgentUserOrFail());
+            }
+
+            try {
+                $handler->setInputs($this->arguments);
+                $handler->execute();
+            } catch (Throwable $e) {
+                // Never leak a stack trace to the model; hand back calm, speakable copy.
+                return ['status' => 'error', 'message' => $e->getMessage()];
+            }
+
+            // Tools setResult(json_encode($array)); decode so the runtime gets structure.
+            $result = $handler->getResult();
+            $decoded = json_decode($result, true);
+
+            return json_last_error() === JSON_ERROR_NONE ? $decoded : $result;
+        } finally {
+            Bouncer::scope()->to($previousScope);
+            app()->instance(Apps::class, $previousApp);
         }
-
-        // Tools setResult(json_encode($array)); decode so the runtime gets structure.
-        $result = $handler->getResult();
-        $decoded = json_decode($result, true);
-
-        return json_last_error() === JSON_ERROR_NONE ? $decoded : $result;
     }
 }


### PR DESCRIPTION
Hardens the voice **data plane** so a cross-app agent can run **write** tools without hitting the tenant-scope bug we already fixed for capture.

## Problem
`RunVoiceAgentToolAction` wired the tool's `withContext(app, company, user)` but executed under the **runtime's app-key** app + Bouncer scope. For a cross-app agent, a tool that **writes** (create a lead, a channel, assign a role) resolves People/Roles under the wrong scope and throws `ModelNotFoundException [People]`/`[Role]` deep inside the tool — the same class of bug fixed in `CaptureVoiceCallerAction` (People app-scope + the Bouncer "Admin" role lookup on channel creation).

## Fix
Bind the **agent's** app (`app()->instance(Apps::class, …)`) and **Bouncer scope** (`Bouncer::scope()->to(getScope($agentApp))`) for the duration of the tool run, restored in `finally`. Read/lookup tools were already fine; this unblocks write-heavy tools.

Prerequisite for turning on any write tool for voice (assign tools via the agent's `selectedTools`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)