### PR TITLE
fix(voice): resolve Twilio creds app-first for number picker + inbound webhook

### DIFF
--- a/src/Domains/Connectors/Twilio/Actions/ListCompanyPhoneNumbersAction.php
+++ b/src/Domains/Connectors/Twilio/Actions/ListCompanyPhoneNumbersAction.php
@@ -10,11 +10,15 @@ use Kanvas\Connectors\Twilio\Client as TwilioClient;
 
 /**
  * List the phone numbers a company has purchased on its connected Twilio
- * account. Encapsulates the third-party Twilio call (company creds, falling back
- * to the app's shared account) so callers never touch the SDK directly.
+ * account. Encapsulates the third-party Twilio call (the app's shared account
+ * first, falling back to the company's own creds) so callers never touch the SDK
+ * directly.
  *
- * The app is passed in explicitly — a company can be global (apps_id 0), so its
- * own `->app` relation may be null; the caller supplies the acting app.
+ * App-first on purpose: the voice number picker runs on one shared app account,
+ * and a stray per-company BYOK cred pointing at a different account must not
+ * shadow it (it was listing the wrong numbers). The app is passed in explicitly
+ * — a company can be global (apps_id 0), so its own `->app` relation may be null;
+ * the caller supplies the acting app.
  *
  * Throws when neither company nor app has Twilio creds (ValidationException from
  * the Client) or the Twilio API errors — the caller decides how to degrade.
@@ -32,7 +36,7 @@ class ListCompanyPhoneNumbersAction
      */
     public function execute(int $limit = 200): array
     {
-        $twilio = TwilioClient::getInstanceByCompanyOrApp($this->company, $this->app);
+        $twilio = TwilioClient::getInstanceByAppOrCompany($this->app, $this->company);
 
         return array_map(
             static fn ($number): array => [

--- a/src/Domains/Connectors/Twilio/Client.php
+++ b/src/Domains/Connectors/Twilio/Client.php
@@ -47,6 +47,24 @@ final class Client
     }
 
     /**
+     * App-level creds first (a single shared Twilio account), falling back to the
+     * company's own only if the app has none. The inverse of
+     * getInstanceByCompanyOrApp: use this where the app account is authoritative
+     * and stray per-company creds must NOT shadow it — the voice-agent number
+     * picker and inbound-webhook wiring run on one shared account, so a leftover
+     * company BYOK cred silently pointing at a different account was listing the
+     * wrong numbers. Trades away per-company BYOK for those paths on purpose.
+     */
+    public static function getInstanceByAppOrCompany(AppInterface $app, Companies $company): TwilioClient
+    {
+        try {
+            return self::getInstance($app);
+        } catch (ValidationException) {
+            return self::getInstanceByCompany($company);
+        }
+    }
+
+    /**
      * Validate Twilio credentials.
      */
     public static function validateCredentials(string $sid, string $token): bool

--- a/src/Domains/Intelligence/Agents/Actions/Voice/ConfigureAgentInboundWebhookAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/ConfigureAgentInboundWebhookAction.php
@@ -74,9 +74,11 @@ class ConfigureAgentInboundWebhookAction
         }
 
         try {
-            // Company creds if the company has its own; else the app-level creds
-            // (shared account). Throws ValidationException when neither is set.
-            $twilio = TwilioClient::getInstanceByCompanyOrApp($company, $this->agent->app);
+            // App-level creds first (the shared account the number lives on),
+            // falling back to the company's own only if the app has none — so a
+            // stray company BYOK cred can't wire the webhook onto the wrong
+            // account. Throws ValidationException when neither is set.
+            $twilio = TwilioClient::getInstanceByAppOrCompany($this->agent->app, $company);
 
             // Twilio updates a number by SID, so resolve it first.
             $numbers = $twilio->incomingPhoneNumbers->read(['phoneNumber' => $number], 1);


### PR DESCRIPTION
## Why

Setting Twilio keys on the **app** integration panel wasn't connecting the voice-agent number picker to that account — the dropdown came back empty/wrong.

Root cause: both voice Twilio paths resolved creds **company-first** (`getInstanceByCompanyOrApp`). The voice setup uses a single **shared app-level** Twilio account, but if the acting company had any leftover/stale BYOK Twilio cred, `getInstanceByCompany` succeeded and we talked to the *wrong* account — the app keys were never read. The number-picker resolver swallows failures (`catch (Throwable) { return []; }`), so this looked identical to "no numbers."

## What

- Add `Client::getInstanceByAppOrCompany($app, $company)` — app creds first, company fallback (the inverse of the existing `getInstanceByCompanyOrApp`, which stays for BYOK-first callers).
- Point both voice paths at it:
  - `ListCompanyPhoneNumbersAction` (the `twilioAvailablePhoneNumbers` number picker)
  - `ConfigureAgentInboundWebhookAction` (inbound webhook wiring on agent save)

Trades away per-company BYOK **for these two voice paths only** — on purpose. The shared app account is authoritative for voice; no other callers of the old method exist.

## Test

`php -l` clean on all three files. Verify: with app-level Twilio creds set and a company that has stale/other creds, the picker now lists the **app** account's numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)