### PR TITLE
fix(voice): resolve mid-call tool by handler name, not catalog label

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/Voice/RunVoiceAgentToolAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/RunVoiceAgentToolAction.php
@@ -55,23 +55,7 @@ class RunVoiceAgentToolAction
         Bouncer::scope()->to(RolesEnums::getScope($this->agent->app));
 
         try {
-            $catalogTool = new CapabilityProvider()
-                ->getActiveTools($this->agent, CapabilityFrameworkEnum::NEURON->value)
-                ->first(fn ($tool): bool => $tool->name === $this->toolName);
-
-            if ($catalogTool === null) {
-                throw new ValidationException("Agent has no active tool named '{$this->toolName}'.");
-            }
-
-            $handlerClass = $catalogTool->handler;
-            if (empty($handlerClass) || ! class_exists($handlerClass)) {
-                throw new ValidationException("Tool '{$this->toolName}' has no runnable handler.");
-            }
-
-            $handler = app($handlerClass);
-            if (! $handler instanceof NeuronTool) {
-                throw new ValidationException("Tool '{$this->toolName}' is not executable.");
-            }
+            $handler = $this->resolveHandler();
 
             // Wire the agent's tenant context onto tools that accept it (withContext
             // from HasKanvasContext). app/company come from the agent; the acting
@@ -98,5 +82,58 @@ class RunVoiceAgentToolAction
             Bouncer::scope()->to($previousScope);
             app()->instance(Apps::class, $previousApp);
         }
+    }
+
+    /**
+     * Resolve the runnable handler for $this->toolName among the agent's active
+     * NEURON tools.
+     *
+     * The name to match is the HANDLER's own name ($handler->getName(), a valid
+     * function-call identifier like `inventory_search`) — that is what
+     * VoiceAgentSpecService advertises to the runtime and therefore what the LLM
+     * calls back with. The catalog `Tool.name` column is a human display label
+     * (e.g. `Inventory Search`) and does NOT match; keying off it made every tool
+     * whose display name differs from its handler name uncallable mid-call. The
+     * catalog name is kept only as a fallback for tools whose two names coincide.
+     */
+    private function resolveHandler(): NeuronTool
+    {
+        $tools = new CapabilityProvider()
+            ->getActiveTools($this->agent, CapabilityFrameworkEnum::NEURON->value);
+
+        $fallback = null;
+
+        foreach ($tools as $catalogTool) {
+            $handlerClass = $catalogTool->handler;
+            if (empty($handlerClass) || ! class_exists($handlerClass)) {
+                continue;
+            }
+
+            try {
+                $handler = app($handlerClass);
+            } catch (Throwable) {
+                // A handler that can't be built is skipped, not fatal — mirrors
+                // VoiceAgentSpecService, so run-time selection matches advertise-time.
+                continue;
+            }
+
+            if (! $handler instanceof NeuronTool) {
+                continue;
+            }
+
+            if ($handler->getName() === $this->toolName) {
+                return $handler;
+            }
+
+            if ($fallback === null && $catalogTool->name === $this->toolName) {
+                $fallback = $handler;
+            }
+        }
+
+        if ($fallback !== null) {
+            return $fallback;
+        }
+
+        throw new ValidationException("Agent has no active tool named '{$this->toolName}'.");
     }
 }


### PR DESCRIPTION
## Symptom

A voice agent called a tool on a live call and Kanvas threw:

```
Agent has no active tool named 'inventory_search'.
  RunVoiceAgentToolAction.php:63
```

…even though `inventory_search` **was** advertised on the spec and the LLM correctly called it. (Surfaced by the runtime's new tool-outcome logging, mctekk/kanvas-voice-agents#26.)

## Root cause

A tool carries **two different names**:

| Source | Value | Used by |
|---|---|---|
| `#[AgentTool(name: 'Inventory Search')]` → `Tool.name` column | `Inventory Search` | catalog / admin display |
| `parent::__construct(name: 'inventory_search')` → `$handler->getName()` | `inventory_search` | function-calling |

`VoiceAgentSpecService::tools()` advertises **`$handler->getName()`** — it has to, since Gemini function names can't contain spaces. So the LLM calls back with `inventory_search`. But `RunVoiceAgentToolAction` looked the tool up by **`Tool.name`** (`Inventory Search`) → no match → threw.

**Every tool whose `AgentTool` display name differs from its handler name was uncallable mid-call** (all the inventory tools, etc.).

## Fix

Resolve the handler by matching `$handler->getName()` — the exact key the spec advertised — mirroring how `VoiceAgentSpecService` derives names, so run-time selection matches advertise-time by construction. The catalog `Tool.name` is kept only as a fallback for tools whose two names happen to coincide. Handlers that can't be built are skipped (not fatal), same as the spec compiler.

## Test

`php -l` clean. Manual: a voice agent with `Inventory Search` selected can now invoke `inventory_search` on a call instead of getting "no active tool named".

🤖 Generated with [Claude Code](https://claude.com/claude-code)