### PR TITLE
fix(voice): inventory_search matches + returns the English product name

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
@@ -43,7 +43,20 @@ class InventorySearchTool extends Tool
     public function __invoke(string $product_name): array
     {
         try {
-            $products = Products::search($product_name)->take(10)->get();
+            // Products::search() queries `name,description`, where `name` is the
+            // translation resolved for a SINGLE locale at index time. A product
+            // whose name is only stored under `en` but indexed while another
+            // locale was active then can't be found by its English name. The
+            // `translations.name` / `translations.description` fields hold EVERY
+            // locale joined, so query those too to make the search
+            // locale-independent. Typesense-only; other engines ignore the extra
+            // fields. This overrides the query_by set inside Products::search().
+            $products = Products::search($product_name)
+                ->options([
+                    'query_by' => 'name,description,translations.name,translations.description',
+                ])
+                ->take(10)
+                ->get();
         } catch (Throwable $e) {
             return ['message' => "Search failed: {$e->getMessage()}"];
         }
@@ -61,7 +74,10 @@ class InventorySearchTool extends Tool
 
             return [
                 'id' => $product->getId(),
-                'name' => $product->name,
+                // Prefer the English name so the agent speaks a stable, readable
+                // label regardless of the call's locale; fall back to the resolved
+                // accessor when no `en` translation exists.
+                'name' => $product->getTranslation('name', 'en') ?: $product->name,
                 'slug' => $product->slug,
                 'is_published' => (bool) $product->is_published,
                 'is_available' => $isAvailable,


### PR DESCRIPTION
## Symptom

A voice agent searched **"Mitsubishi Outlander"** via `inventory_search` and got `No products found`, though the DB has many. Product `name` is stored as translatable JSON, e.g. `{"en":"2021 Mazda CX-5"}`.

## Cause

The Typesense index has two relevant fields:
- `name` — `toSearchableArray()` sets `'name' => $this->name`, the translation resolved for **one** locale at index time.
- `translations.name` — `getAllTranslationsAsString('name')`, **all** locales joined.

`Products::search()` does `query_by => 'name,description'` — it never queries `translations.name`. So a product whose name is only under `en` but was indexed while another locale (e.g. `es`) was active has an empty/mismatched `name` field and is **unfindable by its English name**, even though `translations.name` holds it.

## Fix (scoped to the voice tool)

`InventorySearchTool` only:
1. `query_by` now includes `translations.name,translations.description` — overriding the value `Products::search()` sets, via the same `->options([...])` pattern used across the models. Typesense-only; other engines ignore the extra fields. Makes the search locale-independent.
2. Returns the **English** name (`getTranslation('name','en')`, fallback to the resolved accessor) so the agent speaks a stable label regardless of the call's locale.

Platform-wide `Products::search()` is **unchanged** — this touches only the agent tool.

## Caveats
- Products indexed **before** `translations.*` existed in the index need a `scout:import` (scoped to the app) to carry those fields.
- This does **not** address an `apps_id`-scope mismatch (voice agent in a different app than the inventory) — `Products::search()` filters `where('apps_id', $app->getId())`. If results are still empty after this + a reindex, that's the remaining cause.

## Test

`php -l` clean. Manual: an agent whose app owns the inventory can now find a car by its English name and receives the English label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)