### PR TITLE
fix(voice): bind inventory_search to the agent's app; restore schema fallback

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Neuron\Tools\Inventory;
 
+use Kanvas\Apps\Models\Apps;
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use Kanvas\Inventory\Products\Models\Products;
 use NeuronAI\Tools\PropertyType as ToolsPropertyType;
 use NeuronAI\Tools\Tool;
@@ -15,6 +17,11 @@ use Throwable;
 #[AgentTool(name: 'Inventory Search', category: 'inventory')]
 class InventorySearchTool extends Tool
 {
+    // Lets the voice data plane hand this tool the AGENT's tenant
+    // (RunVoiceAgentToolAction::withContext), so the search binds the agent's app
+    // rather than trusting whatever app(Apps::class) happens to be.
+    use HasKanvasContext;
+
     public function __construct()
     {
         parent::__construct(
@@ -42,23 +49,33 @@ class InventorySearchTool extends Tool
 
     public function __invoke(string $product_name): array
     {
+        // Bind the search to the AGENT's app. Products::search() reads the ambient
+        // app(Apps::class) for both the Typesense index and the apps_id filter;
+        // the voice runtime authenticates as its own app-key app, so without this
+        // the tool searches the WRONG tenant's catalogue. withContext() (set by
+        // RunVoiceAgentToolAction) hands us the agent's app; bind it explicitly so
+        // the search can't drift to the runtime's app. Restored by the caller.
+        if ($this->hasTenantContext()) {
+            app()->instance(Apps::class, $this->app);
+        }
+
+        // query_by is widened to the all-locales `translations.*` fields so a
+        // product is found by its English name even when the indexed `name` was
+        // resolved under another locale. A collection created before those fields
+        // existed rejects them ("Could not find a field named `translations.name`"),
+        // so fall back to the always-present base fields — search still works
+        // pre-reindex and gains the locale-independent match once reindexed.
         try {
-            // Products::search() queries `name,description`, where `name` is the
-            // translation resolved for a SINGLE locale at index time. A product
-            // whose name is only stored under `en` but indexed while another
-            // locale was active then can't be found by its English name. The
-            // `translations.name` / `translations.description` fields hold EVERY
-            // locale joined, so query those too to make the search
-            // locale-independent. Typesense-only; other engines ignore the extra
-            // fields. This overrides the query_by set inside Products::search().
-            $products = Products::search($product_name)
-                ->options([
-                    'query_by' => 'name,description,translations.name,translations.description',
-                ])
-                ->take(10)
-                ->get();
+            $products = $this->searchProducts($product_name, 'name,description,translations.name,translations.description');
         } catch (Throwable $e) {
-            return ['message' => "Search failed: {$e->getMessage()}"];
+            if (! str_contains($e->getMessage(), 'Could not find a field named')) {
+                return ['message' => "Search failed: {$e->getMessage()}"];
+            }
+            try {
+                $products = $this->searchProducts($product_name, 'name,description');
+            } catch (Throwable $retry) {
+                return ['message' => "Search failed: {$retry->getMessage()}"];
+            }
         }
 
         if ($products->isEmpty()) {
@@ -99,5 +116,20 @@ class InventorySearchTool extends Tool
                 })->toArray(),
             ];
         })->toArray();
+    }
+
+    /**
+     * Run the Scout search with an explicit Typesense `query_by`, overriding the
+     * value Products::search() sets. Split out so __invoke can retry with a
+     * narrower field set when the collection's schema lacks the wider ones.
+     *
+     * @return \Illuminate\Support\Collection<int, Products>
+     */
+    private function searchProducts(string $query, string $queryBy): \Illuminate\Support\Collection
+    {
+        return Products::search($query)
+            ->options(['query_by' => $queryBy])
+            ->take(10)
+            ->get();
     }
 }


### PR DESCRIPTION
## Two fixes in the voice `inventory_search` tool

### 1. Bind the search to the AGENT's app (the "pass the app to the tool" ask)
`Products::search()` reads the ambient `app(Apps::class)` for **both** the Typesense index and the `apps_id` filter. The voice runtime authenticates as its own app-key app, so the tool could search the **wrong tenant's** catalogue (reported: agent on app 2, search hitting app 1).

The tool now uses `HasKanvasContext`. `RunVoiceAgentToolAction` already calls `withContext($agent->app, $company, $user)` on any tool that has the method, so the tool receives the **agent's** app and binds it right before the search — it can no longer drift to the runtime's app. The caller's `finally` restores the previous app.

> Note: this makes the tool deterministically search **the resolved agent's** app. If the runtime resolves an agent that itself lives in app 1, the search will still (correctly) be app 1 — that case is a wiring issue (which agent the dialed number/`agent_id` points at), not something the tool can override.

### 2. Restore the query_by schema fallback (regression fix)
The `translations.name`/`translations.description` fields were added to `query_by` for locale-independent English-name matching, but a Typesense collection created **before** those fields existed rejects them — `Could not find a field named `translations.name`` — which broke the whole search. Now it retries with the base `name,description` on that specific error, so search works pre-reindex and gains the wider match once the collection is reindexed.

**This fallback was stranded** off the earlier PR (#11170) and never reached `development` — only the first commit merged, so the schema error is currently live. This PR brings it in.

## Scope
Only `InventorySearchTool` (Neuron). Used by voice agents and `SalesAgent`. `Products::search()` and all other search paths are unchanged.

## Test
`php -l` clean. Manual: a voice agent whose company is set now searches its own app's inventory and finds a car by English name (post-reindex), with no schema error pre-reindex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)