### PR TITLE
fix: attach SalesAssist reach-out messages to protocol channels

### DIFF
--- a/src/Domains/Connectors/SalesAssist/Activities/SalesAssistAgentReachOutActivity.php
+++ b/src/Domains/Connectors/SalesAssist/Activities/SalesAssistAgentReachOutActivity.php
@@ -6,10 +6,10 @@ namespace Kanvas\Connectors\SalesAssist\Activities;
 
 use Exception;
 use Kanvas\Apps\Models\Apps;
-use Kanvas\Connectors\Elead\Actions\AddOutBoundPhoneCallActivityToLeadAction;
-use Kanvas\Connectors\SalesAssist\Actions\EnsureFirstMessageEnabledAction;
-use Kanvas\Connectors\SalesAssist\Actions\CreateSocialChannelForContactAction;
 use Kanvas\Companies\Enums\ConfigurationEnum as CompanyConfigurationEnum;
+use Kanvas\Connectors\Elead\Actions\AddOutBoundPhoneCallActivityToLeadAction;
+use Kanvas\Connectors\SalesAssist\Actions\CreateSocialChannelForContactAction;
+use Kanvas\Connectors\SalesAssist\Actions\EnsureFirstMessageEnabledAction;
 use Kanvas\Guild\Customers\Models\Contact;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Activities\AgentReachOutActivity;

--- a/src/Domains/Connectors/SalesAssist/Activities/SalesAssistAgentReachOutActivity.php
+++ b/src/Domains/Connectors/SalesAssist/Activities/SalesAssistAgentReachOutActivity.php
@@ -8,8 +8,12 @@ use Exception;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Connectors\Elead\Actions\AddOutBoundPhoneCallActivityToLeadAction;
 use Kanvas\Connectors\SalesAssist\Actions\EnsureFirstMessageEnabledAction;
+use Kanvas\Connectors\SalesAssist\Actions\CreateSocialChannelForContactAction;
+use Kanvas\Companies\Enums\ConfigurationEnum as CompanyConfigurationEnum;
+use Kanvas\Guild\Customers\Models\Contact;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Activities\AgentReachOutActivity;
+use Kanvas\Social\Channels\Models\Channel;
 use Kanvas\Social\Messages\Models\Message;
 use Kanvas\Workflow\Attributes\WorkflowAction;
 
@@ -31,6 +35,8 @@ final class SalesAssistAgentReachOutActivity extends AgentReachOutActivity
      */
     protected function afterReachOut(Lead $lead, Apps $app, array $params, array $result): void
     {
+        $this->attachReachOutMessagesToProtocolChannels($lead, $app, $params, $result);
+
         $messageId = (int) ($result['message_ids_sent'][0] ?? 0);
         if (! $lead->get('downloaded_from_eleads') || $messageId === 0) {
             return;
@@ -44,6 +50,67 @@ final class SalesAssistAgentReachOutActivity extends AgentReachOutActivity
         } catch (Exception $exception) {
             report($exception);
         }
+    }
+
+    /**
+     * Agent Reach Out creates the outbound messages, while SalesAssist also
+     * exposes the legacy per-protocol channels in the lead history.
+     *
+     * @param array<string, mixed> $result
+     */
+    private function attachReachOutMessagesToProtocolChannels(
+        Lead $lead,
+        Apps $app,
+        array $params,
+        array $result
+    ): void {
+        $messageIds = array_unique(array_merge(
+            array_map('intval', $result['message_ids_sent'] ?? []),
+            array_map('intval', $result['message_ids_scheduled'] ?? []),
+        ));
+        if ($messageIds === []) {
+            return;
+        }
+
+        $agentId = (int) ($params['agent_id'] ?? $lead->company->get(
+            CompanyConfigurationEnum::AGENT_REACH_OUT_DEFAULT_AGENT_ID->value
+        ));
+        if ($agentId === 0) {
+            return;
+        }
+
+        foreach ($messageIds as $messageId) {
+            try {
+                $message = Message::getById($messageId, $app);
+                $protocol = strtolower((string) $message->get('communicationChannel'));
+                $contact = $this->contactForProtocol($lead, $protocol);
+                if (! $contact instanceof Contact) {
+                    continue;
+                }
+
+                $channelResult = new CreateSocialChannelForContactAction(
+                    $contact,
+                    $app,
+                    ['agent_id' => $agentId],
+                    $lead,
+                )->execute();
+                $channelId = (int) ($channelResult['channel_id'] ?? 0);
+                if ($channelId > 0) {
+                    Channel::getById($channelId, $app)->addMessage($message);
+                }
+            } catch (Exception $exception) {
+                report($exception);
+            }
+        }
+    }
+
+    private function contactForProtocol(Lead $lead, string $protocol): ?Contact
+    {
+        return match ($protocol) {
+            'sms' => $lead->people?->getCellPhones()->first(),
+            'email' => $lead->people?->getEmails()->first(),
+            default => null,
+        };
     }
 
     protected function shouldThrowIntegrationException(): bool

--- a/src/Domains/Intelligence/Agents/Actions/Outreach/AgentReachOutAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Outreach/AgentReachOutAction.php
@@ -121,6 +121,7 @@ class AgentReachOutAction
         $sentChannels = [];
         $sentMessageIds = [];
         $scheduledChannels = [];
+        $scheduledMessageIds = [];
         $errors = [];
         $deferDelivery = $this->lead->isAiSupport();
 
@@ -136,6 +137,7 @@ class AgentReachOutAction
                 )->execute();
                 if ($deferDelivery) {
                     $scheduledChannels[] = $pair['channel_type'];
+                    $scheduledMessageIds[] = $outbound->getId();
                 } else {
                     $sentChannels[] = $pair['channel_type'];
                     if (! $outbound->isLocked()) {
@@ -163,6 +165,8 @@ class AgentReachOutAction
                 'message' => 'Reach-out scheduled for support mode',
                 'status' => AgentReachOutConfigEnum::STATUS_SCHEDULED,
                 'channels_scheduled' => $scheduledChannels,
+                'message_ids_scheduled' => $scheduledMessageIds,
+                'message_ids_sent' => [],
                 'delay_minutes' => (int) ($this->lead->company->get(
                     CompanyConfigurationEnum::MESSAGE_MINUTES_INTERVAL->value
                 ) ?? 60),
@@ -179,6 +183,7 @@ class AgentReachOutAction
             'status' => AgentReachOutConfigEnum::STATUS_SENT,
             'channels_sent' => $sentChannels,
             'message_ids_sent' => $sentMessageIds,
+            'message_ids_scheduled' => [],
             'errors' => $errors,
         ];
     }


### PR DESCRIPTION
## Summary
- expose scheduled message IDs from Agent Reach Out
- create/reuse SalesAssist SMS and email channels
- attach sent and scheduled messages to their protocol channels

## Validation
- PHP syntax checks passed
- PHPUnit unavailable in worktree (vendor/bin/phpunit missing)