### PR TITLE
Fix inventory search options for non-Typesense engines

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
@@ -9,19 +9,22 @@ use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use Kanvas\Inventory\Products\Models\Products;
 use Laravel\Scout\Builder;
+use NeuronAI\Tools\HasRunKey;
 use NeuronAI\Tools\PropertyType as ToolsPropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
+use NeuronAI\Tools\TrackByInputs;
 use Override;
 use Throwable;
 
 #[AgentTool(name: 'Inventory Search', category: 'inventory')]
-class InventorySearchTool extends Tool
+class InventorySearchTool extends Tool implements HasRunKey
 {
     // Lets the voice data plane hand this tool the AGENT's tenant
     // (RunVoiceAgentToolAction::withContext), so the search binds the agent's app
     // rather than trusting whatever app(Apps::class) happens to be.
     use HasKanvasContext;
+    use TrackByInputs;
 
     public function __construct()
     {

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
@@ -128,7 +128,14 @@ class InventorySearchTool extends Tool
     {
         $query = Products::search($productName);
 
-        // `query_by` is Typesense-specific; other engines reject it as an unknown parameter.
+        // Products::search() queries `name,description`, where `name` is the
+        // translation resolved for a SINGLE locale at index time. A product
+        // whose name is only stored under `en` but indexed while another
+        // locale was active then can't be found by its English name. The
+        // `translations.name` / `translations.description` fields hold EVERY
+        // locale joined, so query those too to make the search
+        // locale-independent. Typesense-only; other engines ignore the extra
+        // fields. This overrides the query_by set inside Products::search().
         if ($query->model->isTypesense()) {
             $query->options(['query_by' => $queryBy]);
         }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
@@ -8,6 +8,7 @@ use Kanvas\Apps\Models\Apps;
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use Kanvas\Inventory\Products\Models\Products;
+use Laravel\Scout\Builder;
 use NeuronAI\Tools\PropertyType as ToolsPropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
@@ -66,13 +67,18 @@ class InventorySearchTool extends Tool
         // so fall back to the always-present base fields — search still works
         // pre-reindex and gains the locale-independent match once reindexed.
         try {
-            $products = $this->searchProducts($product_name, 'name,description,translations.name,translations.description');
+            $products = $this->searchQuery($product_name, 'name,description,translations.name,translations.description')
+                ->take(10)
+                ->get();
         } catch (Throwable $e) {
             if (! str_contains($e->getMessage(), 'Could not find a field named')) {
                 return ['message' => "Search failed: {$e->getMessage()}"];
             }
+
             try {
-                $products = $this->searchProducts($product_name, 'name,description');
+                $products = $this->searchQuery($product_name, 'name,description')
+                    ->take(10)
+                    ->get();
             } catch (Throwable $retry) {
                 return ['message' => "Search failed: {$retry->getMessage()}"];
             }
@@ -118,18 +124,15 @@ class InventorySearchTool extends Tool
         })->toArray();
     }
 
-    /**
-     * Run the Scout search with an explicit Typesense `query_by`, overriding the
-     * value Products::search() sets. Split out so __invoke can retry with a
-     * narrower field set when the collection's schema lacks the wider ones.
-     *
-     * @return \Illuminate\Support\Collection<int, Products>
-     */
-    private function searchProducts(string $query, string $queryBy): \Illuminate\Support\Collection
+    protected function searchQuery(string $productName, string $queryBy = 'name,description,translations.name,translations.description'): Builder
     {
-        return Products::search($query)
-            ->options(['query_by' => $queryBy])
-            ->take(10)
-            ->get();
+        $query = Products::search($productName);
+
+        // `query_by` is Typesense-specific; other engines reject it as an unknown parameter.
+        if ($query->model->isTypesense()) {
+            $query->options(['query_by' => $queryBy]);
+        }
+
+        return $query;
     }
 }

--- a/tests/Intelligence/Agents/NeuronInventorySearchToolTest.php
+++ b/tests/Intelligence/Agents/NeuronInventorySearchToolTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Intelligence\Agents;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Inventory\InventorySearchTool;
+use Laravel\Scout\Builder;
+use Mockery;
+use Tests\TestCase;
+
+final class NeuronInventorySearchToolTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        app()->forgetInstance(Apps::class);
+
+        parent::tearDown();
+    }
+
+    public function testAddsQueryByOnlyForTypesense(): void
+    {
+        $this->forceSearchEngine('typesense');
+
+        $query = $this->tool()->exposeSearchQuery('BMW 760i');
+
+        $this->assertSame(
+            'name,description,translations.name,translations.description',
+            $query->options['query_by'] ?? null,
+        );
+    }
+
+    public function testDoesNotAddQueryByForOtherSearchEngines(): void
+    {
+        $this->forceSearchEngine('algolia');
+
+        $query = $this->tool()->exposeSearchQuery('BMW 760i');
+
+        $this->assertArrayNotHasKey('query_by', $query->options);
+    }
+
+    private function tool(): TestableInventorySearchTool
+    {
+        return new TestableInventorySearchTool();
+    }
+
+    private function forceSearchEngine(string $engine): void
+    {
+        $realApp = app(Apps::class);
+        $app = Mockery::mock($realApp)->makePartial();
+        $app->shouldReceive('get')->andReturnUsing(
+            fn (string $name, mixed $default = null): mixed => str_ends_with($name, 'search_engine')
+                ? $engine
+                : $realApp->get($name, $default),
+        );
+
+        app()->instance(Apps::class, $app);
+    }
+}
+
+final class TestableInventorySearchTool extends InventorySearchTool
+{
+    public function exposeSearchQuery(string $productName): Builder
+    {
+        return $this->searchQuery($productName);
+    }
+}

--- a/tests/Intelligence/Agents/NeuronInventorySearchToolTest.php
+++ b/tests/Intelligence/Agents/NeuronInventorySearchToolTest.php
@@ -8,6 +8,7 @@ use Kanvas\Apps\Models\Apps;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Inventory\InventorySearchTool;
 use Laravel\Scout\Builder;
 use Mockery;
+use NeuronAI\Tools\HasRunKey;
 use Tests\TestCase;
 
 final class NeuronInventorySearchToolTest extends TestCase
@@ -38,6 +39,25 @@ final class NeuronInventorySearchToolTest extends TestCase
         $query = $this->tool()->exposeSearchQuery('BMW 760i');
 
         $this->assertArrayNotHasKey('query_by', $query->options);
+    }
+
+    public function testRunBudgetIsTrackedByInputs(): void
+    {
+        $tool = new InventorySearchTool();
+
+        $this->assertInstanceOf(HasRunKey::class, $tool);
+
+        $tool->setInputs(['product_name' => 'BMW 760i']);
+        $firstKey = $tool->getRunKey();
+
+        $tool->setInputs(['product_name' => 'BMW X7']);
+        $secondKey = $tool->getRunKey();
+
+        $this->assertNotSame($firstKey, $secondKey);
+
+        $tool->setInputs(['product_name' => 'BMW 760i']);
+
+        $this->assertSame($firstKey, $tool->getRunKey());
     }
 
     private function tool(): TestableInventorySearchTool


### PR DESCRIPTION
## Summary

- Apply query_by only when the resolved Scout engine is Typesense.
- Preserve developments agent-tenant binding and fallback for older Typesense schemas.
- Keep Algolia and other engines free of the unsupported query_by parameter.
- Add regression coverage for Typesense and non-Typesense engines.

## Why

InventorySearchTool always sent the Typesense-specific query_by option. Engines that do not support it rejected the search with Unknown parameter: query_by. The development integration keeps its existing tenant and schema fallback behavior while gating query_by by engine.

## Verification

- PHP-CS-Fixer: clean.
- PHP syntax: clean.
- git diff --check: clean.
- Focused PHPUnit was attempted, but the shared local MySQL reached its connection limit (SQLSTATE 1040).
- PHPStan was attempted, but the local Docker process was terminated by memory pressure (exit 137).