### PR TITLE
fix: recognize a trade name repeated inside a longer qualified vendor name

### DIFF
--- a/src/Domains/Guild/Organizations/Services/OrganizationVendorMatcherService.php
+++ b/src/Domains/Guild/Organizations/Services/OrganizationVendorMatcherService.php
@@ -105,8 +105,39 @@ final class OrganizationVendorMatcherService
 
         $needleSet = array_unique($needleTokens);
         $candidateSet = array_unique($candidateTokens);
-        $union = array_unique(array_merge($needleSet, $candidateSet));
+        $intersection = count(array_intersect($needleSet, $candidateSet));
 
-        return count(array_intersect($needleSet, $candidateSet)) / count($union);
+        if ($intersection === 0) {
+            return 0.0;
+        }
+
+        $union = count(array_unique(array_merge($needleSet, $candidateSet)));
+        $isFullContainment = $intersection === min(count($needleSet), count($candidateSet));
+
+        // A short needle fully contained in a longer name is only trustworthy when the longer name
+        // repeats that token verbatim (a trade name spelled out again in its own legal form) — plain
+        // containment alone can be a coincidental prefix shared with an unrelated company.
+        if ($isFullContainment && self::needleRepeatsInCandidate($needleSet, $candidateTokens)) {
+            return 1.0;
+        }
+
+        return $intersection / $union;
+    }
+
+    /**
+     * @param list<string> $needleSet
+     * @param list<string> $candidateTokensRaw
+     */
+    private static function needleRepeatsInCandidate(array $needleSet, array $candidateTokensRaw): bool
+    {
+        $counts = array_count_values($candidateTokensRaw);
+
+        foreach ($needleSet as $token) {
+            if (($counts[$token] ?? 0) >= 2) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Guild/Organizations/OrganizationVendorMatcherServiceTest.php
+++ b/tests/Guild/Organizations/OrganizationVendorMatcherServiceTest.php
@@ -35,6 +35,21 @@ final class OrganizationVendorMatcherServiceTest extends TestCase
         $this->assertSame('GmbH-PENNER + PARTNER GBR', $result->organization->name);
     }
 
+    public function test_matches_a_short_trade_name_fully_contained_in_a_longer_qualified_name(): void
+    {
+        // The trade name repeated verbatim inside a fuller, parenthetically-qualified legal name.
+        $this->seedOrganization('Acme Tax (Client Trust + Acme Tax, Inc.)');
+
+        $result = OrganizationVendorMatcherService::match(
+            app(Apps::class),
+            $this->currentCompany(),
+            'Acme Tax',
+        );
+
+        $this->assertTrue($result->isMatched());
+        $this->assertSame('Acme Tax (Client Trust + Acme Tax, Inc.)', $result->organization->name);
+    }
+
     public function test_matches_an_exact_name_with_full_confidence(): void
     {
         $this->seedOrganization('Vendor Matcher Test Corp');


### PR DESCRIPTION
## General Description

`OrganizationVendorMatcherService`'s score was plain Jaccard, which penalizes a short vendor name by however many extra qualifier words a longer legal name carries. A real match like `Foo` vs `Foo (Client Trust + Foo, Inc.)` could score just under the candidate floor and get reported as no match at all, instead of linking to the obvious vendor — found while reviewing a real `import_vendor_approvers` run where a legitimate vendor kept showing as unmatched.

Full token containment now counts as a confident match only when the longer name repeats the short name's token verbatim (the "TradeName (... + TradeName, Inc.)" pattern) — that repetition is the actual signal, not containment alone, so a short name that's merely a coincidental prefix of an unrelated company's longer name still falls back to plain Jaccard and stays in the low-confidence/ambiguous path as before.

## Test plan

- [x] New test: a short trade name fully repeated inside a longer, qualifier-heavy name now matches confidently
- [x] Existing matcher tests unaffected (exact match, unrelated name, ambiguous tie, legal-suffix variant)
- [x] Full suite re-run: `OrganizationVendorMatcherServiceTest`, `ImportVendorApproversCommandTest`, `AccountsPayableAgentToolsTest` — 62/62 passing