### PR TITLE
Fix company-scoped inventory agent searches

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Inventory/InventorySearchTool.php
@@ -33,7 +33,10 @@ class InventorySearchTool extends Tool implements HasRunKey
             description: 'Search for products in the inventory using the search engine (Typesense/Algolia) '
                 . 'over name, description and translations. Accepts free-form natural-language queries '
                 . '(e.g. "toyota azul 5 puertas"); the search engine ranks results by relevance even when '
-                . 'not all terms map to indexed fields. Returns availability and stock levels.',
+                . 'not all terms map to indexed fields. Searches only within the company bound to the agent context. '
+                . 'Returns availability and stock levels. A no_matches result means only that this search found no '
+                . 'matching indexed inventory; it does not confirm dealership unavailability. When no_matches is '
+                . 'returned, follow the RAG business rule "No Matching Inventory Results — STRICT HANDOFF RULE".',
         );
     }
 
@@ -53,15 +56,17 @@ class InventorySearchTool extends Tool implements HasRunKey
 
     public function __invoke(string $product_name): array
     {
+        if (! $this->hasTenantContext()) {
+            return $this->tenantContextMissingError('inventory search');
+        }
+
         // Bind the search to the AGENT's app. Products::search() reads the ambient
         // app(Apps::class) for both the Typesense index and the apps_id filter;
         // the voice runtime authenticates as its own app-key app, so without this
         // the tool searches the WRONG tenant's catalogue. withContext() (set by
         // RunVoiceAgentToolAction) hands us the agent's app; bind it explicitly so
         // the search can't drift to the runtime's app. Restored by the caller.
-        if ($this->hasTenantContext()) {
-            app()->instance(Apps::class, $this->app);
-        }
+        app()->instance(Apps::class, $this->app);
 
         // query_by is widened to the all-locales `translations.*` fields so a
         // product is found by its English name even when the indexed `name` was
@@ -88,7 +93,7 @@ class InventorySearchTool extends Tool implements HasRunKey
         }
 
         if ($products->isEmpty()) {
-            return ['message' => "No products found matching '{$product_name}'."];
+            return $this->noMatchesResponse($product_name);
         }
 
         $products->load('variants');
@@ -131,6 +136,13 @@ class InventorySearchTool extends Tool implements HasRunKey
     {
         $query = Products::search($productName);
 
+        if ($this->hasTenantContext()) {
+            // Scout translates this where into Algolia `filters` or Typesense `filter_by`.
+            // `companies_id` is the flat, filterable tenant field shared by Algolia and
+            // Typesense. Enforce it from the agent context instead of auth state or app flags.
+            $query->where('companies_id', $this->company->getId());
+        }
+
         // Products::search() queries `name,description`, where `name` is the
         // translation resolved for a SINGLE locale at index time. A product
         // whose name is only stored under `en` but indexed while another
@@ -144,5 +156,17 @@ class InventorySearchTool extends Tool implements HasRunKey
         }
 
         return $query;
+    }
+
+    protected function noMatchesResponse(string $productName): array
+    {
+        return [
+            'status' => 'no_matches',
+            'reason' => 'no_matching_inventory',
+            'message' => "No products found matching '{$productName}' in the scoped inventory.",
+            'inventory_availability_confirmed' => false,
+            'instruction' => 'Do not interpret this result as confirmed dealership unavailability. '
+                . 'Follow the RAG business rule "No Matching Inventory Results — STRICT HANDOFF RULE".',
+        ];
     }
 }

--- a/tests/Intelligence/Agents/NeuronInventorySearchToolTest.php
+++ b/tests/Intelligence/Agents/NeuronInventorySearchToolTest.php
@@ -41,6 +41,38 @@ final class NeuronInventorySearchToolTest extends TestCase
         $this->assertArrayNotHasKey('query_by', $query->options);
     }
 
+    public function testSearchIsExplicitlyScopedToContextCompanyForTypesense(): void
+    {
+        $this->assertSearchUsesContextCompany('typesense');
+    }
+
+    public function testSearchIsExplicitlyScopedToContextCompanyForAlgolia(): void
+    {
+        $this->assertSearchUsesContextCompany('algolia');
+    }
+
+    public function testInvokeFailsClosedWithoutTenantContext(): void
+    {
+        $result = (new InventorySearchTool())('BMW 760i');
+
+        $this->assertSame('no_tenant_context', $result['reason']);
+    }
+
+    public function testNoMatchesResponseDirectsAgentToRagBusinessRule(): void
+    {
+        $tool = $this->tool();
+        $result = $tool->exposeNoMatchesResponse('2024 Mercedes-Benz S-Class');
+
+        $this->assertStringContainsString('no_matches', $tool->getDescription());
+        $this->assertSame('no_matches', $result['status']);
+        $this->assertSame('no_matching_inventory', $result['reason']);
+        $this->assertFalse($result['inventory_availability_confirmed']);
+        $this->assertStringContainsString(
+            'No Matching Inventory Results — STRICT HANDOFF RULE',
+            $result['instruction'],
+        );
+    }
+
     public function testRunBudgetIsTrackedByInputs(): void
     {
         $tool = new InventorySearchTool();
@@ -77,6 +109,21 @@ final class NeuronInventorySearchToolTest extends TestCase
 
         app()->instance(Apps::class, $app);
     }
+
+    private function assertSearchUsesContextCompany(string $engine): void
+    {
+        $this->forceSearchEngine($engine);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+        $tool = $this->tool()->withContext(app(Apps::class), $company, $user);
+
+        $query = $tool->exposeSearchQuery('BMW 760i');
+        $companyFilters = collect($query->wheres)
+            ->where('field', 'companies_id')
+            ->where('value', $company->getId());
+
+        $this->assertNotEmpty($companyFilters);
+    }
 }
 
 final class TestableInventorySearchTool extends InventorySearchTool
@@ -84,5 +131,10 @@ final class TestableInventorySearchTool extends InventorySearchTool
     public function exposeSearchQuery(string $productName): Builder
     {
         return $this->searchQuery($productName);
+    }
+
+    public function exposeNoMatchesResponse(string $productName): array
+    {
+        return $this->noMatchesResponse($productName);
     }
 }


### PR DESCRIPTION
## Summary
- fail closed when InventorySearchTool has no tenant context
- enforce the agent company through the flat companies_id Scout filter for both Typesense and Algolia
- return a structured no_matches response that directs the agent to the RAG business rule without claiming dealership unavailability
- document the same behavior in the tool description as model-facing guidance
- add regression coverage for both search engines, missing context, and no-match guidance

## Validation
- php -l on the tool and test file
- git diff --check
- logic verified against the Products searchable document/schema and Laravel Scout's Algolia/Typesense filter compilation

Full integration tests were not run because the requested Docker environment was intentionally not started.