### PR TITLE
[1.x] fix(vinsolution): failWorkflow instead of throw when lead is missing

### DIFF
--- a/src/Domains/Connectors/VinSolution/Workflow/PushLeadNotesActivity.php
+++ b/src/Domains/Connectors/VinSolution/Workflow/PushLeadNotesActivity.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\VinSolution\Workflow;
 
-use Exception;
 use Kanvas\ActionEngine\Actions\Enums\ActionEnum;
 use Kanvas\ActionEngine\Enums\ActionStatusEnum;
 use Kanvas\ActionEngine\Tasks\Actions\ProcessMessageTaskUpdatesAction;
@@ -47,7 +46,9 @@ class PushLeadNotesActivity extends KanvasActivity
         $lead = $message->entity();
 
         if (! $lead) {
-            throw new Exception('Lead not found');
+            return $this->failWorkflow([
+                'error' => 'Lead not found',
+            ]);
         }
 
         return $this->executeIntegration(


### PR DESCRIPTION
## What

`PushLeadNotesActivity` threw `Exception('Lead not found')` when `$message->entity()` returned nothing. Now it returns `failWorkflow(['error' => 'Lead not found'])`.

## Why

A message with no resolvable lead is an expected business condition, not a system fault. `executeIntegration`'s catch calls `report($exception)`, so every occurrence flooded Sentry with non-actionable noise. `failWorkflow` still marks the activity FAILED in the integration-history UI — visible to humans and future agents — without the exception or the Sentry report.

Matches the "Workflow Activities — Don't Throw/Report Expected Skips" convention in `.claude/CLAUDE.md`.

## Scope

One file, one behavior change. The now-unused `Exception` import is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)