### PR TITLE
refact: stop logic

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,6 +71,7 @@ Sub-directory `CLAUDE.md` files load additively when work touches their tree:
 - `src/Domains/Connectors/CLAUDE.md` — connector-tree-specific gotchas (Octane SDK rule, Activities/ folder, AgentRuntime caveat).
 - `graphql/schemas/CLAUDE.md` — directive conventions, FK-id-vs-relation rule, schema folder rule.
 - `src/Domains/Intelligence/FollowUp/CLAUDE.md` — generic-core vs per-entity-executor split for the agent-driven follow-up engine. Recipe for adopting follow-up on a new entity (Deal, Order, etc.).
+- `src/Domains/Guild/Customers/CLAUDE.md` — consent & do-not-contact: why a STOP on one channel silences all of them person-wide, the keyword-vs-agent split, every guard that enforces it, and why `do_not_contact` must never be renamed.
 - `src/Domains/Guild/Leads/CLAUDE.md` — receiver → lead → email flow: why the email template comes from the **rotation config** (not the job/receiver), the `user-`/`lead-` template-name prefixing, the `notification_mode`/`notification_user_mode` knobs, and how company onboarding differs from the `kanvas:sa-setup-receivers` default.
 - `src/Domains/Inventory/CLAUDE.md` — product search engine (dynamic per-tenant Algolia/Typesense/Meilisearch resolution + precedence), index naming, `shouldBeSearchable` gating, the tenant-aware reindex command, and Typesense Natural Language Search config for the recommendation agent.
 - `app/Console/Commands/Inventory/CLAUDE.md` — what each inventory command does and the order the discovery ones must run in (enrich → index → search → score).

--- a/src/Domains/Connectors/Mailgun/Actions/CreateMessageFromEmailAction.php
+++ b/src/Domains/Connectors/Mailgun/Actions/CreateMessageFromEmailAction.php
@@ -23,9 +23,14 @@ use Kanvas\Workflow\Models\ReceiverWebhookCall;
 
 class CreateMessageFromEmailAction
 {
+    /**
+     * `$suppressAgentResponse` files the mail without firing the responder workflow. Set it when the
+     * message is a stop request: the mail still belongs in the record, but nothing may answer it.
+     */
     public function __construct(
         protected ReceiverWebhookCall $webhookRequest,
         protected ?Lead $lead = null,
+        protected bool $suppressAgentResponse = false,
     ) {
     }
 
@@ -119,18 +124,20 @@ class CreateMessageFromEmailAction
                 new NotifyLeadStakeholdersService($this->lead)->onCustomerEngagement($newMessage);
             }
 
-            $channel->fireWorkflow(
-                WorkflowEnum::AFTER_ADDING_MESSAGE_TO_CHANNEL->value,
-                true,
-                [
-                       'message' => $newMessage,
-                       'user' => $newMessage->user,
-                       'app' => $newMessage->app,
-                       'company' => $newMessage->company,
-                       'communication_channel' => 'email',
-                       'text' => $text,
-                ]
-            );
+            if (! $this->suppressAgentResponse) {
+                $channel->fireWorkflow(
+                    WorkflowEnum::AFTER_ADDING_MESSAGE_TO_CHANNEL->value,
+                    true,
+                    [
+                        'message' => $newMessage,
+                        'user' => $newMessage->user,
+                        'app' => $newMessage->app,
+                        'company' => $newMessage->company,
+                        'communication_channel' => 'email',
+                        'text' => $text,
+                    ]
+                );
+            }
         }
 
         return $newMessage;

--- a/src/Domains/Connectors/Mailgun/Services/MailgunConsentService.php
+++ b/src/Domains/Connectors/Mailgun/Services/MailgunConsentService.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Connectors\Mailgun\Services;
+
+use Illuminate\Database\Eloquent\Model;
+use Kanvas\Guild\Customers\Actions\ProcessInboundConsentAction;
+use Kanvas\Guild\Customers\DataTransferObject\ConsentOutcome;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Leads\Actions\SendOptOutConfirmationAction;
+use Kanvas\Guild\Leads\Enums\LeadCommunicationChannelEnum;
+use Kanvas\Guild\Leads\Models\Lead;
+
+/**
+ * Consent detection for inbound mail, shared by both Mailgun receivers — the company lead inbox and
+ * an agent's own mailbox.
+ *
+ * Email needs a pass the other channels do not: a one-word "Unsubscribe" lands in the SUBJECT at
+ * least as often as in the body, usually with nothing under it. Everything else is the generic
+ * ProcessInboundConsentAction.
+ */
+final class MailgunConsentService
+{
+    public static function process(Model $entity, MailgunPayloadService $payload): ?ConsentOutcome
+    {
+        [$people, $lead] = self::split($entity);
+
+        if ($people === null) {
+            return null;
+        }
+
+        $outcome = self::detect($people, $lead, $payload, $payload->text());
+
+        if ($outcome->signal === null && ! $outcome->narrowedRequest) {
+            $outcome = self::detect($people, $lead, $payload, $payload->subject());
+        }
+
+        if ($outcome->applied && $outcome->isStop() && $lead !== null) {
+            new SendOptOutConfirmationAction($lead, LeadCommunicationChannelEnum::EMAIL->value)->execute();
+        }
+
+        return $outcome;
+    }
+
+    private static function detect(
+        People $people,
+        ?Lead $lead,
+        MailgunPayloadService $payload,
+        string $text,
+    ): ConsentOutcome {
+        return new ProcessInboundConsentAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::EMAIL->value,
+            body: $text,
+            lead: $lead,
+            contactValue: $payload->sender(),
+        )->execute();
+    }
+
+    /**
+     * Both receivers hand back either a Lead or the People row directly, depending on whether the
+     * sender is a prospect in a pipeline or just someone the company knows.
+     *
+     * @return array{0: People|null, 1: Lead|null}
+     */
+    private static function split(Model $entity): array
+    {
+        return match (true) {
+            $entity instanceof Lead => [$entity->people, $entity],
+            $entity instanceof People => [$entity, null],
+            default => [null, null],
+        };
+    }
+}

--- a/src/Domains/Connectors/Mailgun/Webhooks/AgentInboxWebhookJob.php
+++ b/src/Domains/Connectors/Mailgun/Webhooks/AgentInboxWebhookJob.php
@@ -13,6 +13,7 @@ use Kanvas\Connectors\Mailgun\Actions\VerifyMailgunWebhookSignatureAction;
 use Kanvas\Connectors\Mailgun\Enums\ReceiverConfigurationEnum;
 use Kanvas\Connectors\Mailgun\Services\AgentInboxSenderResolverService;
 use Kanvas\Connectors\Mailgun\Services\AgentMailboxService;
+use Kanvas\Connectors\Mailgun\Services\MailgunConsentService;
 use Kanvas\Connectors\Mailgun\Services\MailgunPayloadService;
 use Kanvas\Exceptions\ValidationException;
 use Kanvas\Guild\Customers\Models\People;
@@ -103,11 +104,24 @@ class AgentInboxWebhookJob extends ProcessWebhookJob
             return ['message' => 'Sender is not known to this company and the mailbox is restricted'];
         }
 
+        // This receiver replies inline, so consent has to be settled before the responder runs — an
+        // agent mailbox that answers "unsubscribe" with a sales pitch is the worst version of this.
+        $consentOutcome = MailgunConsentService::process($entity, $payload);
+
         $message = new CreateMessageFromAgentInboxAction(
             $this->webhookRequest,
             $agent,
             $entity
         )->execute();
+
+        if ($consentOutcome?->shouldHaltAgentTurn() === true) {
+            $message->addTag('consent-stop');
+
+            return array_merge(
+                ['message' => 'Stop request honored; no reply sent'],
+                $consentOutcome->toArray(),
+            );
+        }
 
         /** @var Channel $channel */
         $channel = $message->channels()->firstOrFail();

--- a/src/Domains/Connectors/Mailgun/Webhooks/AgentProcessEmailWebhookJob.php
+++ b/src/Domains/Connectors/Mailgun/Webhooks/AgentProcessEmailWebhookJob.php
@@ -8,6 +8,8 @@ use Illuminate\Http\Request;
 use Kanvas\Connectors\Mailgun\Actions\AttachEmailAttachmentsToLeadAction;
 use Kanvas\Connectors\Mailgun\Actions\CreateMessageFromEmailAction;
 use Kanvas\Connectors\Mailgun\Actions\VerifyMailgunWebhookSignatureAction;
+use Kanvas\Connectors\Mailgun\Services\MailgunConsentService;
+use Kanvas\Connectors\Mailgun\Services\MailgunPayloadService;
 use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
 use Kanvas\Guild\Leads\Repositories\LeadsRepository;
 use Kanvas\Workflow\Attributes\WorkflowAction;
@@ -52,8 +54,18 @@ class AgentProcessEmailWebhookJob extends ProcessWebhookJob
             }
         }
 
-        $message = new CreateMessageFromEmailAction($this->webhookRequest, $lead)
-            ->execute();
+        // Ahead of CreateMessageFromEmailAction, because that is what fires the responder workflow.
+        // Evaluating consent afterwards would let the agent read a stop request, spend a turn on it
+        // and compose a reply that the outbound guard then throws away.
+        $consentOutcome = $people === null
+            ? null
+            : MailgunConsentService::process($lead ?? $people, new MailgunPayloadService($this->webhookRequest->payload));
+
+        $message = new CreateMessageFromEmailAction(
+            $this->webhookRequest,
+            $lead,
+            suppressAgentResponse: $consentOutcome?->shouldHaltAgentTurn() ?? false,
+        )->execute();
 
         if ($lead !== null) {
             new AttachEmailAttachmentsToLeadAction($this->webhookRequest, $lead)->execute();
@@ -61,7 +73,7 @@ class AgentProcessEmailWebhookJob extends ProcessWebhookJob
 
         $this->assertAttachmentsCaptured();
 
-        return $message->toArray();
+        return array_merge($message->toArray(), $consentOutcome?->toArray() ?? []);
     }
 
     #[Override]

--- a/src/Domains/Connectors/Twilio/Enums/ConfigurationEnum.php
+++ b/src/Domains/Connectors/Twilio/Enums/ConfigurationEnum.php
@@ -25,4 +25,11 @@ enum ConfigurationEnum: string
     case TWILIO_MAX_MESSAGE_BODY_LENGTH = 'twilio_max_message_body_length';
     case TWILIO_MMS_BATCH_SIZE = 'twilio-mms-batch-size';
     case TWILIO_MMS_MAX_TOTAL_MEDIA = 'twilio-mms-max-total-media';
+
+    /**
+     * Whether Twilio answers STOP itself (default STOP filtering / Advanced Opt-Out), in which case
+     * we must NOT send our own acknowledgement. Defaults to true, because the FCC permits exactly
+     * one post-revocation message: sending none is legal, sending two is the violation.
+     */
+    case TWILIO_SENDS_OPT_OUT_REPLY = 'twilio_sends_opt_out_reply';
 }

--- a/src/Domains/Connectors/Twilio/Webhooks/ProcessTwilioWebhookJob.php
+++ b/src/Domains/Connectors/Twilio/Webhooks/ProcessTwilioWebhookJob.php
@@ -13,19 +13,24 @@ use Illuminate\Support\Facades\DB;
 use Kanvas\Connectors\Twilio\Actions\DownloadMessageFileAction;
 use Kanvas\Connectors\Twilio\Services\WebhookSignatureValidator;
 use Kanvas\Guild\Customers\Actions\CreatePeopleAction;
+use Kanvas\Guild\Customers\Actions\ProcessInboundConsentAction;
 use Kanvas\Guild\Customers\Actions\UpdatePeopleAction;
 use Kanvas\Guild\Customers\DataTransferObject\Address;
 use Kanvas\Guild\Customers\DataTransferObject\Contact;
 use Kanvas\Guild\Customers\DataTransferObject\People as PeopleDto;
+use Kanvas\Guild\Customers\Enums\ConsentSignalEnum;
 use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Customers\Models\People as PeopleModel;
 use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
+use Kanvas\Guild\Customers\Services\ConsentKeywordService;
 use Kanvas\Guild\Leads\Actions\CreateLeadAction;
 use Kanvas\Guild\Leads\Actions\CreateLeadReceiverAction;
+use Kanvas\Guild\Leads\Actions\SendOptOutConfirmationAction;
 use Kanvas\Guild\Leads\DataTransferObject\Lead as DataTransferObjectLead;
 use Kanvas\Guild\Leads\DataTransferObject\LeadReceiver;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadsEnumsConfigurationEnum;
+use Kanvas\Guild\Leads\Enums\LeadCommunicationChannelEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Models\LeadType;
 use Kanvas\Guild\Leads\Repositories\LeadsRepository;
@@ -94,6 +99,7 @@ class ProcessTwilioWebhookJob extends ProcessWebhookJob
 
         $isFromMe = $request['From'] === $request['To'];
         $consentType = $this->consentType($request);
+        $consentOutcome = null;
         $batch = Cache::get($batchKey, [
                         'messages' => [],
                         'first_message_time' => now(),
@@ -102,14 +108,20 @@ class ProcessTwilioWebhookJob extends ProcessWebhookJob
 
         if (! $isFromMe) {
             $people = $this->processContactFromMessage($request);
-            if ($consentType === 'STOP') {
-                $people->setPhoneOptOut((string) $request['From']);
-            } elseif ($consentType === 'START') {
-                $people->setPhoneOptOut((string) $request['From'], false);
-            }
 
             $lead = $this->createLeadFromPeople($people);
             $lead->set(LeadsEnumsConfigurationEnum::IS_ENGAGEMENT->value, true);
+
+            // After the lead exists: a stop request is person-wide and every outbound guard reads
+            // the lead, so the lead has to be there for the flag to land anywhere useful.
+            $consentOutcome = new ProcessInboundConsentAction(
+                people: $people,
+                sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+                body: $request['Body'] ?? null,
+                lead: $lead,
+                contactValue: (string) $request['From'],
+                detectedSignal: $consentType,
+            )->execute();
         }
 
         $messageSlug = $this->createMessageSlug($request['SmsMessageSid'], $request['From']);
@@ -186,12 +198,22 @@ class ProcessTwilioWebhookJob extends ProcessWebhookJob
 
         $channel->addMessage($message);
 
+        // Tag on any recognised keyword, but suppress the agent only for a real stop. A bare "YES"
+        // matches Twilio's START set and used to cancel the turn for everyone — including a prospect
+        // answering "yes, book me in", who then got silence back.
         if ($consentType !== null) {
             $message->addTag('twilio-consent');
-            $message->addTag(strtolower($consentType));
+            $message->addTag($consentType->value);
+        }
+
+        if ($consentOutcome?->shouldHaltAgentTurn() === true) {
             $this->cancelPendingWorkflow($batchKey);
 
-            return [[
+            if (isset($lead) && $consentOutcome->applied) {
+                new SendOptOutConfirmationAction($lead, LeadCommunicationChannelEnum::SMS->value)->execute();
+            }
+
+            return [array_merge([
                 'message_id' => $message->getId(),
                 'uuid' => $message->uuid,
                 'channel_id' => $channel->getId(),
@@ -199,9 +221,13 @@ class ProcessTwilioWebhookJob extends ProcessWebhookJob
                 'text' => $request['Body'] ?? '',
                 'is_from_me' => false,
                 'type' => $message->messageType->name,
-                'consent_type' => $consentType,
+                // From the outcome, not $consentType: a phrase-tier stop is recognised inside
+                // ProcessInboundConsentAction and leaves the keyword matcher's result null.
+                // Uppercase is the shape this payload has always had; the enum is lowercase because
+                // it also has to match Twilio's own OptOutType casing on the way in.
+                'consent_type' => strtoupper((string) $consentOutcome->signal?->value),
                 'automated_response_suppressed' => true,
-            ]];
+            ], $consentOutcome->toArray())];
         }
 
         for ($i = 0; isset($request["MediaUrl{$i}"]); $i++) {
@@ -265,7 +291,7 @@ class ProcessTwilioWebhookJob extends ProcessWebhookJob
         })->delay(now()->addSeconds($this->batchDelaySeconds));
 
         return [
-            [
+            array_merge([
                 'message_id' => $message->getId(),
                 'uuid' => $message->uuid,
                 'channel_id' => $channel->getId(),
@@ -273,7 +299,13 @@ class ProcessTwilioWebhookJob extends ProcessWebhookJob
                 'text' => $request['Body'],
                 'is_from_me' => $request['From'] === $request['To'],
                 'type' => $messageTypeModel->name,
-            ],
+                // A recognised keyword that did not stop the conversation — START, HELP, or a "YES"
+                // from someone who was never opted out. Reported, but the agent still answers.
+                'consent_type' => $consentOutcome?->signal !== null
+                    ? strtoupper($consentOutcome->signal->value)
+                    : null,
+                'automated_response_suppressed' => false,
+            ], $consentOutcome?->toArray() ?? []),
         ];
     }
 
@@ -286,21 +318,17 @@ class ProcessTwilioWebhookJob extends ProcessWebhookJob
         Cache::put($workflowJobKey . ':cancelled', true, now()->addMinutes(15));
     }
 
-    protected function consentType(array $request): ?string
+    /**
+     * Twilio's own classification wins when present — it reflects what the carrier actually did to
+     * the number. Otherwise fall through to the shared matcher, which is the same keyword set every
+     * other inbound channel uses.
+     */
+    protected function consentType(array $request): ?ConsentSignalEnum
     {
-        $optOutType = strtoupper(trim((string) ($request['OptOutType'] ?? '')));
-        if (in_array($optOutType, ['STOP', 'START', 'HELP'], true)) {
-            return $optOutType;
-        }
+        $optOutType = strtolower(trim((string) ($request['OptOutType'] ?? '')));
+        $providerSignal = ConsentSignalEnum::tryFrom($optOutType);
 
-        $body = strtoupper(trim((string) ($request['Body'] ?? '')));
-
-        return match (true) {
-            in_array($body, ['STOP', 'STOPALL', 'UNSUBSCRIBE', 'CANCEL', 'END', 'QUIT'], true) => 'STOP',
-            in_array($body, ['START', 'YES', 'UNSTOP'], true) => 'START',
-            $body === 'HELP' => 'HELP',
-            default => null,
-        };
+        return $providerSignal ?? ConsentKeywordService::detect($request['Body'] ?? null);
     }
 
     public function createLeadFromPeople(PeopleModel $people): Lead

--- a/src/Domains/Connectors/VinSolution/Workflow/PushLeadNotesActivity.php
+++ b/src/Domains/Connectors/VinSolution/Workflow/PushLeadNotesActivity.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\VinSolution\Workflow;
 
-use Exception;
 use Kanvas\ActionEngine\Actions\Enums\ActionEnum;
 use Kanvas\ActionEngine\Enums\ActionStatusEnum;
 use Kanvas\ActionEngine\Tasks\Actions\ProcessMessageTaskUpdatesAction;
@@ -47,7 +46,9 @@ class PushLeadNotesActivity extends KanvasActivity
         $lead = $message->entity();
 
         if (! $lead) {
-            throw new Exception('Lead not found');
+            return $this->failWorkflow([
+                'error' => 'Lead not found',
+            ]);
         }
 
         return $this->executeIntegration(

--- a/src/Domains/Connectors/WaSender/Actions/CreateLeadMessageAction.php
+++ b/src/Domains/Connectors/WaSender/Actions/CreateLeadMessageAction.php
@@ -7,15 +7,19 @@ namespace Kanvas\Connectors\WaSender\Actions;
 use Kanvas\Connectors\WaSender\DataTransferObject\InboundMessage;
 use Kanvas\Connectors\WaSender\Enums\MessageTypeEnum;
 use Kanvas\Connectors\WaSender\Services\ConversationChannelService;
+use Kanvas\Guild\Customers\Actions\ProcessInboundConsentAction;
 use Kanvas\Guild\Customers\DataTransferObject\Address;
+use Kanvas\Guild\Customers\DataTransferObject\ConsentOutcome;
 use Kanvas\Guild\Customers\DataTransferObject\Contact;
 use Kanvas\Guild\Customers\DataTransferObject\People as PeopleDTO;
 use Kanvas\Guild\Customers\Models\People;
 use Kanvas\Guild\Leads\Actions\CreateLeadAction;
 use Kanvas\Guild\Leads\Actions\CreateLeadReceiverAction;
+use Kanvas\Guild\Leads\Actions\SendOptOutConfirmationAction;
 use Kanvas\Guild\Leads\DataTransferObject\Lead as DataTransferObjectLead;
 use Kanvas\Guild\Leads\DataTransferObject\LeadReceiver;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadsEnumsConfigurationEnum;
+use Kanvas\Guild\Leads\Enums\LeadCommunicationChannelEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Guild\Leads\Models\LeadReceiver as LeadReceiverModel;
 use Kanvas\Guild\Leads\Models\LeadType;
@@ -126,14 +130,30 @@ class CreateLeadMessageAction
             new NotifyLeadStakeholdersService($lead)->onCustomerEngagement($message);
         }
 
-        if ($isDocument) {
+        // The message is still filed above — a stop request is part of the record — but nothing
+        // downstream of here may run for it: no media fetch, and above all no agent turn.
+        $consentOutcome = $this->processConsent($lead, $isFromMe, $text ?? $messageBody);
+        $haltAgentTurn = $consentOutcome?->shouldHaltAgentTurn() ?? false;
+
+        if ($haltAgentTurn) {
+            $message->addTag('consent-stop');
+
+            if ($consentOutcome->applied) {
+                new SendOptOutConfirmationAction(
+                    $lead,
+                    LeadCommunicationChannelEnum::WHATSAPP->value,
+                )->execute();
+            }
+        }
+
+        if ($isDocument && ! $haltAgentTurn) {
             new DownloadMessageFileAction(
                 $channel,
                 $message,
             )->execute();
         }
 
-        if (! $isDocument) {
+        if (! $isDocument && ! $haltAgentTurn) {
             $text = $message->message['raw_data']['message']['conversation'] ?? $message->message['raw_data']['message']['extendedTextMessage']['text'] ?? null;
             [$processDocument, $lastUnprocessedImageParentMessage] = $this->resolveDocumentTrigger($channel, $text);
 
@@ -153,7 +173,7 @@ class CreateLeadMessageAction
             );
         }
 
-        return [
+        return array_merge([
             'message_id' => $message->getId(),
             'uuid' => $message->uuid,
             'channel_id' => $channel->getId(),
@@ -161,7 +181,28 @@ class CreateLeadMessageAction
             'text' => $text,
             'is_from_me' => $isFromMe,
             'type' => $messageType,
-        ];
+        ], $consentOutcome?->toArray() ?? []);
+    }
+
+    /**
+     * WhatsApp has no carrier-level opt-out to lean on the way SMS does — Meta requires the business
+     * to honor stop requests itself, including ones made on other channels.
+     */
+    private function processConsent(Lead $lead, bool $isFromMe, ?string $text): ?ConsentOutcome
+    {
+        $people = $lead->people;
+
+        if ($isFromMe || $people === null) {
+            return null;
+        }
+
+        return new ProcessInboundConsentAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::WHATSAPP->value,
+            body: $text,
+            lead: $lead,
+            contactValue: $this->inbound->conversationJid,
+        )->execute();
     }
 
     /**

--- a/src/Domains/Guild/Customers/Actions/ApplyDoNotContactAction.php
+++ b/src/Domains/Guild/Customers/Actions/ApplyDoNotContactAction.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Customers\Actions;
+
+use Baka\Support\Str;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Kanvas\Guild\Customers\DataTransferObject\ConsentOutcome;
+use Kanvas\Guild\Customers\Enums\ConsentConfigurationEnum;
+use Kanvas\Guild\Customers\Enums\ConsentMatchEnum;
+use Kanvas\Guild\Customers\Enums\ConsentSignalEnum;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Leads\Actions\RecordLeadNoteAction;
+use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Actions\HandOffAction;
+use Kanvas\Intelligence\Enums\ConfigurationEnum as IntelligenceConfigurationEnum;
+use Kanvas\Intelligence\Enums\HandOffTypeEnum;
+use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
+use Throwable;
+
+/**
+ * Person-wide do-not-contact: the single place that honors a stop request, whichever channel or
+ * caller detected it.
+ *
+ * Scope is deliberately the whole person, not the channel they used and not the lead they used.
+ * The FCC's revoke-all rule (one channel's revocation binding every channel) lands 2027-01-31, and
+ * WhatsApp's Business Policy already requires honoring requests made "on or off WhatsApp" — so a
+ * STOP over SMS silences email and WhatsApp too. `People` is apps_id + companies_id scoped, so this
+ * stays tenant-bounded by construction: opting out at one dealer does not opt out at another.
+ */
+final class ApplyDoNotContactAction
+{
+    public function __construct(
+        private readonly People $people,
+        private readonly string $sourceChannel,
+        private readonly ?Lead $lead = null,
+        private readonly ?string $reason = null,
+        private readonly ConsentMatchEnum $match = ConsentMatchEnum::EXACT,
+    ) {
+    }
+
+    public function execute(): ConsentOutcome
+    {
+        if ((bool) $this->people->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value)) {
+            return new ConsentOutcome(
+                signal: ConsentSignalEnum::STOP,
+                alreadyOptedOut: true,
+                match: $this->match,
+            );
+        }
+
+        [$contactsOptedOut, $leadsFlagged] = DB::connection('crm')->transaction(
+            fn (): array => $this->flag(),
+        );
+
+        // Notes, the compliance handoff and the ledger write all live outside the transaction and
+        // are individually best-effort: they reach other connections and other services, and none
+        // of them failing is a reason to leave the person still contactable.
+        $this->recordNotes($contactsOptedOut, $leadsFlagged);
+        $this->notifyTeam();
+        $this->emitLedgerEvent($contactsOptedOut, $leadsFlagged);
+
+        return new ConsentOutcome(
+            signal: ConsentSignalEnum::STOP,
+            applied: true,
+            contactsOptedOut: $contactsOptedOut,
+            leadsFlagged: $leadsFlagged,
+            match: $this->match,
+        );
+    }
+
+    /**
+     * @return array{0: int, 1: int} contacts opted out, leads flagged
+     */
+    private function flag(): array
+    {
+        $contactsOptedOut = $this->people->contacts()
+            ->where('is_opt_out', 0)
+            ->update(['is_opt_out' => 1]);
+
+        $this->stamp($this->people);
+
+        $leadsFlagged = 0;
+
+        // The person-level flag above is what protects leads created AFTER this point; this loop
+        // covers the ones that already exist, since every outbound guard reads the lead.
+        foreach ($this->people->leads()->fromApp($this->people->app)->get() as $lead) {
+            if ($this->flagLead($lead)) {
+                $leadsFlagged++;
+            }
+        }
+
+        return [$contactsOptedOut, $leadsFlagged];
+    }
+
+    private function flagLead(Lead $lead): bool
+    {
+        if ((bool) $lead->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value)) {
+            return false;
+        }
+
+        $this->stamp($lead);
+
+        // AI_MODE alone does not hold: resolveAiMode() lets the lead-type config outrank the stored
+        // mode unless the manual flag is set, so a muted lead would quietly start replying again.
+        $lead->set(IntelligenceConfigurationEnum::AI_MODE->value, IntelligenceModeEnum::IDLE->value);
+        $lead->set(LeadConfigurationEnum::AI_MODE_IS_MANUAL->value, true);
+
+        return true;
+    }
+
+    private function stamp(People|Lead $entity): void
+    {
+        $entity->set(ConsentConfigurationEnum::DO_NOT_CONTACT->value, 1);
+        $entity->set(ConsentConfigurationEnum::DO_NOT_CONTACT_AT->value, Carbon::now()->toIso8601String());
+        $entity->set(ConsentConfigurationEnum::DO_NOT_CONTACT_SOURCE->value, $this->sourceChannel);
+        $entity->set(ConsentConfigurationEnum::DO_NOT_CONTACT_MATCH->value, $this->match->value);
+
+        $reason = Str::trimToNull($this->reason);
+
+        if ($reason !== null) {
+            $entity->set(ConsentConfigurationEnum::DO_NOT_CONTACT_REASON->value, $reason);
+        }
+    }
+
+    private function recordNotes(int $contactsOptedOut, int $leadsFlagged): void
+    {
+        $body = $this->noteBody($contactsOptedOut, $leadsFlagged);
+
+        try {
+            new RecordPeopleNoteAction($this->people)->execute($body, 'opt-out');
+
+            if ($this->lead !== null) {
+                new RecordLeadNoteAction($this->lead)->execute($body, 'opt-out');
+            }
+        } catch (Throwable $e) {
+            report($e);
+        }
+    }
+
+    private function noteBody(int $contactsOptedOut, int $leadsFlagged): string
+    {
+        $reason = Str::trimToNull($this->reason);
+
+        return sprintf(
+            'Do-not-contact honored from %s%s. %d contact(s) opted out, %d lead(s) flagged. '
+                . 'Automated messaging is disabled across SMS, WhatsApp and email.%s',
+            $this->sourceChannel,
+            $reason !== null ? sprintf(' — "%s"', $reason) : '',
+            $contactsOptedOut,
+            $leadsFlagged,
+            // An inferred opt-out says so in the note a human reads, so a wrong call is findable and
+            // reversible rather than quietly standing forever.
+            $this->match->warrantsReview()
+                ? sprintf(' Inferred from %s rather than an explicit request — review if this looks wrong.', $this->match->value)
+                : '',
+        );
+    }
+
+    private function notifyTeam(): void
+    {
+        if ($this->lead === null) {
+            return;
+        }
+
+        try {
+            new HandOffAction(
+                lead: $this->lead,
+                app: $this->lead->app,
+                params: ['handoff_type' => HandOffTypeEnum::COMPLIANCE_INTERNAL->value],
+            )->execute();
+        } catch (Throwable $e) {
+            report($e);
+        }
+    }
+
+    private function emitLedgerEvent(int $contactsOptedOut, int $leadsFlagged): void
+    {
+        if ($this->lead === null) {
+            return;
+        }
+
+        try {
+            $this->lead->emitLedgerEvent(
+                'lead.do_not_contact',
+                payload: [
+                    'source_channel' => $this->sourceChannel,
+                    'match' => $this->match->value,
+                    'reason' => Str::trimToNull($this->reason),
+                    'people_id' => $this->people->getId(),
+                    'contacts_opted_out' => $contactsOptedOut,
+                    'leads_flagged' => $leadsFlagged,
+                ],
+            );
+        } catch (Throwable $e) {
+            report($e);
+        }
+    }
+}

--- a/src/Domains/Guild/Customers/Actions/ProcessInboundConsentAction.php
+++ b/src/Domains/Guild/Customers/Actions/ProcessInboundConsentAction.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Customers\Actions;
+
+use Kanvas\Guild\Customers\DataTransferObject\ConsentOutcome;
+use Kanvas\Guild\Customers\Enums\ConsentConfigurationEnum;
+use Kanvas\Guild\Customers\Enums\ConsentMatchEnum;
+use Kanvas\Guild\Customers\Enums\ConsentSignalEnum;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Customers\Services\ConsentKeywordService;
+use Kanvas\Guild\Leads\Actions\RecordLeadNoteAction;
+use Kanvas\Guild\Leads\Models\Lead;
+use Throwable;
+
+/**
+ * The one call every inbound channel makes before it spends an agent turn on a message.
+ *
+ * Two deterministic tiers, in order of confidence:
+ *   1. an exact FCC keyword — unambiguous, applied on its own;
+ *   2. a do-not-contact phrase inside a sentence — applied too, unless the message narrows its own
+ *      scope ("text me instead", "don't call before 5pm"), which is a preference, not a revocation.
+ *
+ * Neither tier depends on the agent choosing to act, which is the point: a tool call is optional and
+ * a compliance control cannot be. The agent's stop_contact tool sits behind both as the net for
+ * phrasing no pattern anticipated.
+ *
+ * Callers must honor `shouldHaltAgentTurn()` on the result.
+ */
+final class ProcessInboundConsentAction
+{
+    /**
+     * `$detectedSignal` lets a provider that classifies consent for us win over body matching —
+     * Twilio's `OptOutType` is authoritative for its own numbers and can be set on a payload whose
+     * body would not match on its own.
+     */
+    public function __construct(
+        private readonly People $people,
+        private readonly string $sourceChannel,
+        private readonly ?string $body,
+        private readonly ?Lead $lead = null,
+        private readonly ?string $contactValue = null,
+        private readonly ?ConsentSignalEnum $detectedSignal = null,
+    ) {
+    }
+
+    public function execute(): ConsentOutcome
+    {
+        $signal = $this->detectedSignal ?? ConsentKeywordService::detect($this->body);
+
+        if ($signal !== null) {
+            return $this->applySignal($signal, ConsentMatchEnum::EXACT);
+        }
+
+        if (! ConsentKeywordService::matchesNoContactPhrase($this->body)) {
+            return ConsentOutcome::none();
+        }
+
+        if (ConsentKeywordService::narrowsRequestScope($this->body)) {
+            $this->flagForHuman();
+
+            return ConsentOutcome::narrowedRequest();
+        }
+
+        return $this->applySignal(ConsentSignalEnum::STOP, ConsentMatchEnum::PHRASE);
+    }
+
+    private function applySignal(ConsentSignalEnum $signal, ConsentMatchEnum $match): ConsentOutcome
+    {
+        return match ($signal) {
+            ConsentSignalEnum::STOP => new ApplyDoNotContactAction(
+                people: $this->people,
+                sourceChannel: $this->sourceChannel,
+                lead: $this->lead,
+                reason: $this->body,
+                match: $match,
+            )->execute(),
+            // "YES" is a re-subscribe keyword only for someone who is actually opted out. For everyone
+            // else it is the commonest affirmative reply there is — "yes, book me in" — and treating
+            // it as a consent event silences the agent on the most engaged message a prospect sends.
+            ConsentSignalEnum::START => $this->isOptedOut()
+                ? new RevokeDoNotContactAction(
+                    people: $this->people,
+                    sourceChannel: $this->sourceChannel,
+                    lead: $this->lead,
+                    contactValue: $this->contactValue,
+                )->execute()
+                : ConsentOutcome::none(),
+            // HELP is a carrier-level keyword the provider answers itself; nothing to apply here.
+            ConsentSignalEnum::HELP => new ConsentOutcome(signal: $signal, match: $match),
+        };
+    }
+
+    private function isOptedOut(): bool
+    {
+        return (bool) $this->people->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value);
+    }
+
+    /**
+     * A note, and deliberately nothing else.
+     *
+     * HandOffAction would be the obvious way to get a human's attention here and it is the wrong one:
+     * `COMPLIANCE_INTERNAL` opts out every phone the person has, and *any* handoff type sets
+     * `agent_hand_off`, which terminally exhausts follow-up. Both are precisely the damage this
+     * carve-out exists to prevent — the customer asked to be reached differently, not less.
+     *
+     * The inbound path already notifies stakeholders about the message itself; this note is what tells
+     * whoever reads it that the wording came close enough to an opt-out to be worth a second look.
+     */
+    private function flagForHuman(): void
+    {
+        if ($this->lead === null) {
+            return;
+        }
+
+        try {
+            new RecordLeadNoteAction($this->lead)->execute(
+                sprintf(
+                    'Customer message reads like a contact-preference change rather than an opt-out, '
+                        . 'so nothing was flagged and the agent replied normally. Their words: "%s"',
+                    trim((string) $this->body),
+                ),
+                'consent-review',
+            );
+        } catch (Throwable $e) {
+            report($e);
+        }
+    }
+}

--- a/src/Domains/Guild/Customers/Actions/RevokeDoNotContactAction.php
+++ b/src/Domains/Guild/Customers/Actions/RevokeDoNotContactAction.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Customers\Actions;
+
+use Illuminate\Support\Facades\DB;
+use Kanvas\Guild\Customers\DataTransferObject\ConsentOutcome;
+use Kanvas\Guild\Customers\Enums\ConsentConfigurationEnum;
+use Kanvas\Guild\Customers\Enums\ConsentSignalEnum;
+use Kanvas\Guild\Customers\Models\Contact;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
+use Kanvas\Guild\Leads\Models\Lead;
+
+/**
+ * START / UNSTOP — the inverse of ApplyDoNotContactAction, but deliberately not symmetric.
+ *
+ * Opting back in re-enables only the address the request came from. A blanket opt-in would also
+ * clear opt-outs this person never revoked here — a hard bounce, or a `doNotEmail` pushed in by a
+ * DMS sync — and re-open channels they never asked to re-open. Wide to silence, narrow to resume.
+ */
+final class RevokeDoNotContactAction
+{
+    public function __construct(
+        private readonly People $people,
+        private readonly string $sourceChannel,
+        private readonly ?Lead $lead = null,
+        private readonly ?string $contactValue = null,
+    ) {
+    }
+
+    public function execute(): ConsentOutcome
+    {
+        if (! (bool) $this->people->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value)) {
+            return new ConsentOutcome(signal: ConsentSignalEnum::START);
+        }
+
+        [$contactsOptedIn, $leadsCleared] = DB::connection('crm')->transaction(
+            fn (): array => $this->clear(),
+        );
+
+        return new ConsentOutcome(
+            signal: ConsentSignalEnum::START,
+            applied: true,
+            contactsOptedOut: $contactsOptedIn,
+            leadsFlagged: $leadsCleared,
+        );
+    }
+
+    /**
+     * @return array{0: int, 1: int} contacts opted back in, leads cleared
+     */
+    private function clear(): array
+    {
+        $this->people->set(ConsentConfigurationEnum::DO_NOT_CONTACT->value, 0);
+
+        $contactsOptedIn = $this->optInSourceContact();
+
+        $leadsCleared = 0;
+
+        foreach ($this->people->leads()->fromApp($this->people->app)->get() as $lead) {
+            if (! (bool) $lead->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value)) {
+                continue;
+            }
+
+            $lead->set(ConsentConfigurationEnum::DO_NOT_CONTACT->value, 0);
+
+            // Drop the manual pin rather than guessing a mode: resolveAiMode then falls back to the
+            // lead-type / company default, which is where the lead was before it was silenced.
+            $lead->set(LeadConfigurationEnum::AI_MODE_IS_MANUAL->value, false);
+
+            $leadsCleared++;
+        }
+
+        return [$contactsOptedIn, $leadsCleared];
+    }
+
+    private function optInSourceContact(): int
+    {
+        if ($this->contactValue === null) {
+            return 0;
+        }
+
+        return $this->people->contacts()
+            ->where('is_opt_out', 1)
+            ->get()
+            ->filter(fn (Contact $contact): bool => Contact::normalizeValue(
+                $contact->value,
+                (int) $contact->contacts_types_id,
+            ) === Contact::normalizeValue(
+                $this->contactValue,
+                (int) $contact->contacts_types_id,
+            ))
+            ->each(fn (Contact $contact) => $contact->optIn())
+            ->count();
+    }
+}

--- a/src/Domains/Guild/Customers/CLAUDE.md
+++ b/src/Domains/Guild/Customers/CLAUDE.md
@@ -1,0 +1,141 @@
+# Customers — Consent & Do-Not-Contact
+
+Loads when work touches `src/Domains/Guild/Customers/`. The rest of the domain (People, Contact,
+merge, duplicates) is ordinary CRUD; this file is only about the consent system, because getting it
+wrong is a regulatory problem rather than a bug.
+
+## The rule
+
+**A stop request is person-wide and channel-wide.** STOP over SMS silences WhatsApp and email too,
+across every lead that person has. There is no per-channel opt-out lane and there must not be one.
+
+Why it is not a preference:
+- FCC (47 CFR 64.1200, effective 2025-04-11) requires honoring `STOP UNSUBSCRIBE END QUIT STOPALL
+  REVOKE OPTOUT CANCEL`, and its revoke-all rule — one channel's revocation binding every channel —
+  lands 2027-01-31.
+- WhatsApp's Business Messaging Policy **already** requires honoring requests made "on or off
+  WhatsApp", so cross-channel is not optional there today.
+- The FCC also permits **exactly one** post-revocation message. Two is the violation.
+
+`People` is `apps_id` + `companies_id` scoped, so person-wide stays tenant-bounded by construction:
+opting out at one dealer does not opt out at another.
+
+## The pieces
+
+| Concern | Class |
+|---|---|
+| Is this message a consent signal? | `Services/ConsentKeywordService` |
+| Apply a stop request | `Actions/ApplyDoNotContactAction` |
+| Apply a START / re-subscribe | `Actions/RevokeDoNotContactAction` |
+| Detect + dispatch, for an inbound webhook | `Actions/ProcessInboundConsentAction` |
+| The one permitted acknowledgement | `Guild\Leads\Actions\SendOptOutConfirmationAction` |
+| Natural-language stop requests | `Intelligence\...\Tools\CRM\StopContactTool` |
+| Inbound mail (both receivers) | `Connectors\Mailgun\Services\MailgunConsentService` |
+
+State written by an opt-out, keyed by `Enums/ConsentConfigurationEnum`:
+- every `Contact` of the person → `is_opt_out = 1`
+- the `People` row → `do_not_contact` (+ reason / at / source)
+- every existing `Lead` of that person → the same, plus `ai_mode = idle` **and**
+  `lead_ai_mode_is_manual = true`
+
+**The manual pin is not optional.** `Lead::resolveAiMode()` lets the lead-type config outrank the
+stored mode unless that flag is set, so setting `ai_mode` alone leaves a silenced lead free to start
+replying again.
+
+**The people-level flag is not redundant with the lead-level one.** Flagging leads covers the ones
+that exist at the time; a connector sync can create a *new* lead for the same person afterwards, and
+it carries no flag. Every guard therefore checks both.
+
+## Where it is enforced
+
+| Guard | Covers |
+|---|---|
+| `SendMessageToLeadAction::guardDoNotContact()` | called once in `execute()`, ahead of the channel dispatch — so it covers SMS, WhatsApp, RespondIO, email and voice together |
+| `SendMessageToLeadAction::guardDestinationOptOut()` | per-address opt-outs a stop request never produced (a DMS `doNotEmail` push, a hard bounce) |
+| `LeadOutboundChannelResolver::resolve()` | follow-up returns no channels for a flagged lead |
+| `AgentReachOutAction` | cold outreach skips a flagged lead |
+| `SendEmailTool` / `SendSmsTool` | agent-initiated sends |
+
+The single `execute()`-level guard is deliberate: a per-channel `if` in each send method is how one
+channel ends up forgotten. `sendWhatsAppMessage` hands off to `sendRespondIoMessage` **before** its
+own per-address check, which is exactly that failure mode — RespondIO needs its own.
+
+## Three tiers, and only the last one is a tool
+
+Detection runs in `ProcessInboundConsentAction`, in descending order of confidence. **The first two
+are deterministic and run on message arrival, before any agent turn is dispatched** — a tool call is
+optional, and a compliance control cannot be.
+
+| Tier | What it matches | On a hit |
+|---|---|---|
+| 1. Exact keyword | the whole message is an FCC keyword | apply, `match: exact` |
+| 2. Phrase | a do-not-contact sentence inside a longer message | apply, `match: phrase` |
+| 2b. Narrowed phrase | tier 2 **plus** a scope qualifier | flag nothing, note for a human, agent still answers |
+| 3. `stop_contact` tool | anything the patterns missed | apply, `match: agent_tool` |
+
+Tier 1 matches the whole value only, so "stop by the dealership tomorrow" is not an opt-out.
+
+Tier 2 is the promoted version of what used to be `AgentReachOutAction::descriptionRequestsNoContact()`
+— a private matcher that only ever read the lead description. It now runs on inbound messages too, and
+`AgentReachOutAction` calls the shared one. Do not add a third copy.
+
+**Tier 2b is the part that is easy to get wrong.** A phrase match is an inference, and two shapes of
+message trip it while asking us to keep talking: a channel swap ("don't email me, text me instead") and
+a time window ("don't call before 5pm"). Opting either out of everything silences a live customer.
+`narrowsRequestScope()` catches both, and the result flags nothing.
+
+Tier 3 stays because the FCC requires honoring a revocation made in "any reasonable manner", and
+Twilio explicitly does **not** block non-keyword phrasing on our behalf. It is the net for phrasing no
+pattern anticipated, and for intent that only makes sense in conversation ("yeah, go ahead" answering
+"would you like me to stop?"). **Any agent that talks to prospects still needs `stop_contact` in its
+toolset and the compliance line in its instructions** — it is no longer load-bearing, but it is the
+only tier that sees the thread rather than one message.
+
+Every applied opt-out records which tier caught it in `do_not_contact_match`, so a human reviewing a
+`phrase` flag can reverse a wrong call. The lead note says so in words too.
+
+## Foot-guns
+
+**Don't rename `do_not_contact`.** Leads flagged before this system existed wrote that exact key, and
+`SendEmailTool`, `SendSmsTool`, `BatchRecipientResolverService` and `ProcessLeadCampaignJob` all read
+it. A rename silently un-flags every existing opt-out. The enum exists to stop the string drifting,
+not to change it.
+
+**Never bypass the guard except for the acknowledgement.** `allowOptOutConfirmation()` exists for
+`SendOptOutConfirmationAction` and nothing else. Anything else reaching for it is a compliance bug.
+
+**Don't send our own SMS acknowledgement when Twilio sends one.** `twilio_sends_opt_out_reply`
+defaults to **true** for that reason. Sending zero acknowledgements is legal; sending two is not.
+
+**Re-subscribe is narrow on purpose.** `RevokeDoNotContactAction` opts back in only the address the
+START came from. A blanket opt-in would clear opt-outs the person never revoked here — a hard bounce,
+a DMS-pushed `doNotEmail` — and reopen channels they never asked to reopen. Wide to silence, narrow to
+resume.
+
+**`HandOffAction` is not a neutral way to get a human's attention.** `COMPLIANCE_INTERNAL` calls
+`optOutPhoneContacts()`, and *every* handoff type sets `agent_hand_off`, which terminally exhausts
+follow-up. That is correct on a real opt-out and destructive on a narrowed request — the first version
+of tier 2b used it and silently opted out the phone of a customer who had only asked to be texted
+instead. Covered by `test_a_channel_preference_is_not_treated_as_an_opt_out`. If you want to tell a
+human something without changing state, record a note.
+
+**Email has TWO inbound receivers and both need wiring.** `AgentProcessEmailWebhookJob` is the shared
+lead inbox and `AgentInboxWebhookJob` is one agent's own address — the second replies *inline* rather
+than through a workflow rule, so it was the easier one to miss. Both go through
+`MailgunConsentService`, which adds the subject pass email needs: a one-word "Unsubscribe" lands in the
+SUBJECT at least as often as in the body, usually with nothing under it.
+
+**Order matters on the lead inbox.** `CreateMessageFromEmailAction` is what fires the responder
+workflow, so consent is evaluated *before* it and passes `suppressAgentResponse`. Evaluating it after
+let the agent read a stop request, spend a turn on it, and compose a reply the outbound guard then
+threw away.
+
+**There is no public unsubscribe endpoint, and that is deliberate.** A `List-Unsubscribe` header needs
+a URL anyone on the internet can POST to, and we are not exposing one. Email opt-out arrives the same
+way every other channel's does — through the inbound webhook, where `unsubscribe` is already a tier-1
+keyword. If deliverability ever demands the header, the `mailto:` form of `List-Unsubscribe` routes to
+the existing Mailgun inbound and needs no new surface.
+
+**The opt-out commits before the audit trail.** Notes, the compliance handoff and the ledger write all
+run outside the transaction and are individually best-effort: they reach other connections and other
+services, and none of them failing is a reason to leave the person contactable.

--- a/src/Domains/Guild/Customers/DataTransferObject/ConsentOutcome.php
+++ b/src/Domains/Guild/Customers/DataTransferObject/ConsentOutcome.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Customers\DataTransferObject;
+
+use Kanvas\Guild\Customers\Enums\ConsentMatchEnum;
+use Kanvas\Guild\Customers\Enums\ConsentSignalEnum;
+
+final readonly class ConsentOutcome
+{
+    public function __construct(
+        public ?ConsentSignalEnum $signal = null,
+        public bool $applied = false,
+        public bool $alreadyOptedOut = false,
+        public int $contactsOptedOut = 0,
+        public int $leadsFlagged = 0,
+        public ?ConsentMatchEnum $match = null,
+        public bool $narrowedRequest = false,
+    ) {
+    }
+
+    public static function none(): self
+    {
+        return new self();
+    }
+
+    /**
+     * A do-not-contact phrase that also narrowed its own scope — a channel swap or a time window.
+     * Nothing is flagged; a human is asked to look, and the agent still answers.
+     */
+    public static function narrowedRequest(): self
+    {
+        return new self(match: ConsentMatchEnum::PHRASE, narrowedRequest: true);
+    }
+
+    public function isStop(): bool
+    {
+        return $this->signal === ConsentSignalEnum::STOP;
+    }
+
+    /**
+     * A STOP ends the conversation — the caller must not spend an agent turn on it. Answering a
+     * revocation with an LLM reply risks a second post-revocation message, which is the violation
+     * the FCC's one-message allowance exists to bound.
+     */
+    public function shouldHaltAgentTurn(): bool
+    {
+        return $this->isStop();
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'consent_signal' => $this->signal?->value,
+            'consent_applied' => $this->applied,
+            'already_opted_out' => $this->alreadyOptedOut,
+            'contacts_opted_out' => $this->contactsOptedOut,
+            'leads_flagged' => $this->leadsFlagged,
+            'consent_match' => $this->match?->value,
+            'narrowed_request' => $this->narrowedRequest,
+        ];
+    }
+}

--- a/src/Domains/Guild/Customers/Enums/ConsentConfigurationEnum.php
+++ b/src/Domains/Guild/Customers/Enums/ConsentConfigurationEnum.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Customers\Enums;
+
+/**
+ * `do_not_contact` keeps its bare value: leads flagged by the agent tool before this enum existed
+ * wrote that exact key, and SendEmailTool / SendSmsTool / BatchRecipientResolverService /
+ * ProcessLeadCampaignJob all read it. Renaming it would silently un-flag every existing opt-out.
+ */
+enum ConsentConfigurationEnum: string
+{
+    case DO_NOT_CONTACT = 'do_not_contact';
+    case DO_NOT_CONTACT_REASON = 'do_not_contact_reason';
+    case DO_NOT_CONTACT_AT = 'do_not_contact_at';
+    case DO_NOT_CONTACT_SOURCE = 'do_not_contact_source';
+    case DO_NOT_CONTACT_MATCH = 'do_not_contact_match';
+    case CONFIRMATION_MESSAGE = 'opt_out_confirmation_message';
+    case CONFIRMATION_SENT_AT = 'opt_out_confirmation_sent_at';
+}

--- a/src/Domains/Guild/Customers/Enums/ConsentMatchEnum.php
+++ b/src/Domains/Guild/Customers/Enums/ConsentMatchEnum.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Customers\Enums;
+
+/**
+ * How a consent signal was recognised. Recorded on the opt-out so a human reviewing one can tell an
+ * unambiguous "STOP" from a phrase we inferred, and reverse the latter if we got it wrong.
+ */
+enum ConsentMatchEnum: string
+{
+    /** The whole message was one of the FCC keywords. No judgement involved. */
+    case EXACT = 'exact';
+
+    /** A do-not-contact phrase inside a longer sentence. Honored, but worth a human glance. */
+    case PHRASE = 'phrase';
+
+    /** The agent judged it a stop request. The loosest tier, and the one to review first. */
+    case AGENT_TOOL = 'agent_tool';
+
+    /**
+     * Whether this was inferred rather than stated. An exact keyword is an explicit act by the
+     * person and needs no second opinion; a phrase we pattern-matched and a judgement the agent made
+     * are the two a human should be able to find and reverse.
+     */
+    public function warrantsReview(): bool
+    {
+        return match ($this) {
+            self::EXACT => false,
+            self::PHRASE, self::AGENT_TOOL => true,
+        };
+    }
+}

--- a/src/Domains/Guild/Customers/Enums/ConsentSignalEnum.php
+++ b/src/Domains/Guild/Customers/Enums/ConsentSignalEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Customers\Enums;
+
+enum ConsentSignalEnum: string
+{
+    case STOP = 'stop';
+    case START = 'start';
+    case HELP = 'help';
+}

--- a/src/Domains/Guild/Customers/Services/ConsentKeywordService.php
+++ b/src/Domains/Guild/Customers/Services/ConsentKeywordService.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Customers\Services;
+
+use Kanvas\Guild\Customers\Enums\ConsentSignalEnum;
+
+/**
+ * The one place that decides whether an inbound message is a consent signal.
+ *
+ * The keyword set is the FCC's (47 CFR 64.1200, effective 2025-04-11), which is also Twilio's
+ * default. REVOKE and OPTOUT arrived with that rule — a matcher without them is out of date.
+ *
+ * Matching is whole-value only, never substring: "stop by the dealership tomorrow" is not an
+ * opt-out, and treating it as one silences a live customer. The cost of that strictness is that
+ * "please stop texting me" does not match either — which is deliberate. The FCC requires honoring
+ * a revocation made in "any reasonable manner", and Twilio explicitly does NOT block non-keyword
+ * phrasing on our behalf, so that half of the obligation belongs to the agent's stop_contact tool.
+ * This service is the deterministic floor, not the whole of compliance.
+ */
+final class ConsentKeywordService
+{
+    private const array STOP_KEYWORDS = [
+        'STOP',
+        'STOPALL',
+        'UNSUBSCRIBE',
+        'CANCEL',
+        'END',
+        'QUIT',
+        'REVOKE',
+        'OPTOUT',
+    ];
+
+    private const array START_KEYWORDS = [
+        'START',
+        'UNSTOP',
+        'YES',
+    ];
+
+    private const array HELP_KEYWORDS = [
+        'HELP',
+        'INFO',
+    ];
+
+    /**
+     * Do-not-contact intent written as a sentence rather than a keyword. Matched inside a longer
+     * message, so this tier is fuzzier than the keyword one and callers must honor the qualifier
+     * carve-out below before acting on it.
+     */
+    private const array NO_CONTACT_PHRASES = [
+        'do not contact',
+        'dont contact',
+        'do not reach out',
+        'dont reach out',
+        'do not reachout',
+        'dont reachout',
+        'do not call',
+        'dont call',
+        'do not text',
+        'dont text',
+        'do not email',
+        'dont email',
+        'do not message',
+        'dont message',
+        'no contact',
+        'no llamar',
+        'no contactar',
+        'no me escribas',
+        'no me llamen',
+        'stop contacting',
+        'stop reaching out',
+        'stop texting',
+        'stop emailing',
+        'stop messaging',
+        'take me off',
+        'remove me',
+        'unsubscribe',
+        'dnc',
+    ];
+
+    /**
+     * A phrase hit plus one of these is a NARROWED request, not a revocation: "text me instead" is a
+     * channel preference and "don't call before 5pm" is a time window. Opting either of them out of
+     * everything silences a customer who was still talking to us.
+     */
+    private const array SCOPE_QUALIFIERS = [
+        'instead',
+        'rather than',
+        'use my',
+        'try my',
+        'en vez',
+        'mejor',
+        'before',
+        'after',
+        'until',
+        'during',
+        'between',
+        'this week',
+        'next week',
+        'tomorrow',
+        'tonight',
+        'morning',
+        'afternoon',
+        'evening',
+        'weekend',
+        'antes de',
+        'despues de',
+    ];
+
+    /**
+     * Long bodies can never match — an exact comparison against a 4-letter keyword fails the moment
+     * there is a fifth letter — so cap before doing regex work on an arbitrarily large email.
+     */
+    private const int MAX_CANDIDATE_LENGTH = 2048;
+
+    /**
+     * Phrase scanning needs a far looser cap than exact matching: a keyword comparison fails on a
+     * long body by definition, but "please remove me from your list" can sit anywhere inside one.
+     */
+    private const int MAX_PHRASE_SCAN_LENGTH = 16384;
+
+    public static function detect(?string $body): ?ConsentSignalEnum
+    {
+        foreach (self::candidates($body) as $candidate) {
+            $signal = self::match($candidate);
+
+            if ($signal !== null) {
+                return $signal;
+            }
+        }
+
+        return null;
+    }
+
+    public static function isStop(?string $body): bool
+    {
+        return self::detect($body) === ConsentSignalEnum::STOP;
+    }
+
+    /**
+     * Tier two: do-not-contact intent phrased as a sentence. Deliberately separate from detect() —
+     * a keyword match is unambiguous and can act on its own, a phrase match cannot until the caller
+     * has checked narrowsRequestScope().
+     */
+    public static function matchesNoContactPhrase(?string $text): bool
+    {
+        return self::containsAny($text, self::NO_CONTACT_PHRASES);
+    }
+
+    /**
+     * True when the message narrows what it is asking for — a different channel, or a time window.
+     * "Don't email me, text me instead" and "don't call before 5pm" both trip a no-contact phrase
+     * while asking us to keep talking, so they need a human rather than a blanket opt-out.
+     */
+    public static function narrowsRequestScope(?string $text): bool
+    {
+        return self::containsAny($text, self::SCOPE_QUALIFIERS);
+    }
+
+    private static function containsAny(?string $text, array $needles): bool
+    {
+        $normalized = self::normalizeWords($text);
+
+        if ($normalized === '') {
+            return false;
+        }
+
+        foreach ($needles as $needle) {
+            // Word boundaries so "dnc" cannot fire inside "abcdncxyz" and "no contact" cannot match
+            // part of a longer unrelated token.
+            if (preg_match('/\b' . preg_quote($needle, '/') . '\b/', $normalized) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Lowercase, drop apostrophes so "don't" reads as "dont", and collapse every other non-alphanumeric
+     * run to one space so "do-not-contact" and "do not contact" are the same string.
+     */
+    private static function normalizeWords(?string $text): string
+    {
+        $text = trim((string) $text);
+
+        if ($text === '' || mb_strlen($text) > self::MAX_PHRASE_SCAN_LENGTH) {
+            return '';
+        }
+
+        $normalized = str_replace(["'", '’', '`'], '', mb_strtolower($text));
+        $normalized = (string) preg_replace('/[^a-z0-9]+/', ' ', $normalized);
+
+        return trim((string) preg_replace('/\s+/', ' ', $normalized));
+    }
+
+    private static function match(string $candidate): ?ConsentSignalEnum
+    {
+        return match (true) {
+            in_array($candidate, self::STOP_KEYWORDS, true) => ConsentSignalEnum::STOP,
+            in_array($candidate, self::START_KEYWORDS, true) => ConsentSignalEnum::START,
+            in_array($candidate, self::HELP_KEYWORDS, true) => ConsentSignalEnum::HELP,
+            default => null,
+        };
+    }
+
+    /**
+     * Two shots at a match. The whole body covers SMS and WhatsApp, where a one-word reply IS the
+     * whole message. The first meaningful line covers email, where "Unsubscribe" arrives on line 1
+     * above a signature and a quoted thread and would never match as a whole body.
+     *
+     * @return string[]
+     */
+    private static function candidates(?string $body): array
+    {
+        $body = trim((string) $body);
+
+        if ($body === '' || mb_strlen($body) > self::MAX_CANDIDATE_LENGTH) {
+            return [];
+        }
+
+        $candidates = [self::normalize($body)];
+
+        $firstLine = self::firstMeaningfulLine($body);
+
+        if ($firstLine !== null) {
+            $candidates[] = self::normalize($firstLine);
+        }
+
+        return array_values(array_filter(array_unique($candidates)));
+    }
+
+    /**
+     * Drop quoted reply lines and stop at a signature delimiter, then take the first line with
+     * content. Without this every email opt-out is buried under "Sent from my iPhone".
+     */
+    private static function firstMeaningfulLine(string $body): ?string
+    {
+        foreach (preg_split('/\R/', $body) ?: [] as $line) {
+            $line = trim($line);
+
+            if ($line === '' || str_starts_with($line, '>')) {
+                continue;
+            }
+
+            if (preg_match('/^(--\s*$|__|sent from |on .+ wrote:)/i', $line) === 1) {
+                return null;
+            }
+
+            return $line;
+        }
+
+        return null;
+    }
+
+    /**
+     * Fold away everything that is not a letter, so "Stop.", "STOP!", "opt-out" and "Opt Out" all
+     * land on the same token. Non-letters can only ever be decoration around a keyword; none of the
+     * keywords contain one.
+     */
+    private static function normalize(string $value): string
+    {
+        return (string) preg_replace('/[^A-Z]/', '', mb_strtoupper(trim($value)));
+    }
+}

--- a/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendMessageToLeadAction.php
@@ -29,7 +29,7 @@ use Kanvas\Connectors\WaSender\Services\MessageService;
 use Kanvas\Filesystem\Actions\ProcessVideoWithGifAction;
 use Kanvas\Filesystem\Enums\MediaTypeEnum;
 use Kanvas\Filesystem\Models\Filesystem;
-use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
+use Kanvas\Guild\Customers\Enums\ConsentConfigurationEnum;
 use Kanvas\Guild\Customers\Models\Contact;
 use Kanvas\Guild\Leads\Enums\ConfigurationEnum;
 use Kanvas\Guild\Leads\Enums\LeadCommunicationChannelEnum;
@@ -75,6 +75,7 @@ class SendMessageToLeadAction
     protected ?string $attemptedTo = null;
     protected int $retryNumber = 0;
     protected ?int $parentAttemptId = null;
+    protected bool $isOptOutConfirmation = false;
 
     public function __construct(
         protected Lead $lead,
@@ -86,6 +87,18 @@ class SendMessageToLeadAction
     {
         $this->parentAttemptId = $parentAttemptId;
         $this->retryNumber = $retryNumber;
+
+        return $this;
+    }
+
+    /**
+     * Sends through the do-not-contact guard. The ONLY legitimate caller is the single
+     * post-revocation acknowledgement the FCC permits — see SendOptOutConfirmationAction.
+     * Anything else reaching for this is a compliance bug.
+     */
+    public function allowOptOutConfirmation(): self
+    {
+        $this->isOptOutConfirmation = true;
 
         return $this;
     }
@@ -102,6 +115,8 @@ class SendMessageToLeadAction
         ?Agent $fromAgent = null
     ): array {
         try {
+            $this->guardDoNotContact();
+
             if ($files !== null && $files->isNotEmpty()) {
                 $this->processedFiles = $this->prepareFiles($files);
                 $this->createVideoEngagements();
@@ -362,6 +377,9 @@ class SendMessageToLeadAction
         if ($cellphone === null || $cellphone === '') {
             throw new LeadMissingContactException('Lead does not have a cellphone number');
         }
+
+        $this->guardDestinationOptOut((string) $cellphone, LeadCommunicationChannelEnum::WHATSAPP->value);
+
         $cellphone = $this->hijackPhoneNumber((string) $cellphone, '@s.whatsapp.net');
 
         $this->sendWhatsAppMediaFiles($whatsAppMessageService, $cellphone);
@@ -426,6 +444,10 @@ class SendMessageToLeadAction
         if ($cellphone === null || $cellphone === '') {
             throw new LeadMissingContactException('Lead does not have a cellphone number');
         }
+
+        // sendWhatsAppMessage hands off to here before reaching its own guard, so RespondIO needs
+        // its own or it becomes the one WhatsApp path that ignores a per-address opt-out.
+        $this->guardDestinationOptOut((string) $cellphone, LeadCommunicationChannelEnum::WHATSAPP->value);
 
         $cellphone = $this->hijackPhoneNumber((string) $cellphone, '@s.whatsapp.net');
         $cellphone = Str::toE164($cellphone);
@@ -781,6 +803,58 @@ class SendMessageToLeadAction
         return $client->messages->create($cellphone, $payload);
     }
 
+    /**
+     * Channel-agnostic and checked once per send, ahead of the channel dispatch: a stop request is
+     * person-wide, so it has to outrank whichever channel this particular call happens to use.
+     *
+     * The people-level flag is not redundant with the lead one. ApplyDoNotContactAction flags every
+     * lead that exists at the time, but a connector sync can create a NEW lead for the same person
+     * afterwards, and that lead carries no flag of its own.
+     */
+    protected function guardDoNotContact(): void
+    {
+        if ($this->isOptOutConfirmation) {
+            return;
+        }
+
+        $isFlagged = (bool) $this->lead->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value)
+            || (bool) $this->lead->people?->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value);
+
+        if ($isFlagged) {
+            throw new LeadOptedOutException(
+                'Lead is flagged do-not-contact; no further automated messages may be sent',
+            );
+        }
+    }
+
+    /**
+     * Per-address opt-out, for the ones a stop request never produced: a DMS sync pushing
+     * `doNotEmail`, or a hard bounce. guardDoNotContact covers the person-wide case.
+     */
+    protected function guardDestinationOptOut(string $destination, string $channel): void
+    {
+        if ($this->isOptOutConfirmation) {
+            return;
+        }
+
+        $isOptedOut = $this->lead->people?->contacts()
+            ->where('is_opt_out', 1)
+            ->get()
+            ->contains(fn (Contact $contact): bool => Contact::normalizeValue(
+                (string) $contact->value,
+                (int) $contact->contacts_types_id,
+            ) === Contact::normalizeValue(
+                $destination,
+                (int) $contact->contacts_types_id,
+            )) ?? false;
+
+        if ($isOptedOut) {
+            throw new LeadOptedOutException(
+                sprintf('Destination has opted out of %s communications', $channel),
+            );
+        }
+    }
+
     protected function guardSmsDestination(string $cellphone, ?string $from): void
     {
         $normalizedFrom = $from !== null ? Str::toE164($from) : null;
@@ -788,19 +862,7 @@ class SendMessageToLeadAction
             throw new InvalidArgumentException('Twilio To and From numbers must be different');
         }
 
-        $isOptedOut = $this->lead->people?->getAllPhones()->contains(
-            fn ($contact): bool => Contact::normalizeValue(
-                (string) $contact->value,
-                (int) $contact->contacts_types_id,
-            ) === Contact::normalizeValue(
-                $cellphone,
-                ContactTypeEnum::CELLPHONE->value,
-            ) && (int) $contact->is_opt_out === 1,
-        ) ?? false;
-
-        if ($isOptedOut) {
-            throw new LeadOptedOutException('Destination phone has opted out of SMS communications');
-        }
+        $this->guardDestinationOptOut($cellphone, LeadCommunicationChannelEnum::SMS->value);
     }
 
     protected function getTwilioStatusCallbackUrl(): ?string
@@ -917,6 +979,8 @@ class SendMessageToLeadAction
         if (! $leadEmail) {
             throw new LeadMissingContactException('Lead does not have an email address');
         }
+
+        $this->guardDestinationOptOut((string) $leadEmail, LeadCommunicationChannelEnum::EMAIL->value);
 
         $mailboxAddress = $fromAgent !== null
             ? new AgentMailboxService()->addressFor($fromAgent)

--- a/src/Domains/Guild/Leads/Actions/SendOptOutConfirmationAction.php
+++ b/src/Domains/Guild/Leads/Actions/SendOptOutConfirmationAction.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Guild\Leads\Actions;
+
+use Baka\Support\Str;
+use Illuminate\Support\Carbon;
+use Kanvas\Connectors\Twilio\Enums\ConfigurationEnum as TwilioConfigurationEnum;
+use Kanvas\Guild\Customers\Enums\ConsentConfigurationEnum;
+use Kanvas\Guild\Leads\Enums\LeadCommunicationChannelEnum;
+use Kanvas\Guild\Leads\Models\Lead;
+use Throwable;
+
+/**
+ * The one acknowledgement a revoked contact is allowed to receive.
+ *
+ * The FCC permits exactly one post-revocation message, to clarify the scope of the request. That
+ * makes "send at most one" the whole job here, and it is why the text is a fixed template rather
+ * than something the agent writes: an LLM asked to say goodbye can ask a follow-up question, and a
+ * second message after a revocation is the violation.
+ */
+final class SendOptOutConfirmationAction
+{
+    private const string DEFAULT_MESSAGE = 'You have been unsubscribed and will not receive any further messages from us.';
+
+    private const array SUPPORTED_CHANNELS = [
+        LeadCommunicationChannelEnum::SMS->value,
+        LeadCommunicationChannelEnum::WHATSAPP->value,
+        LeadCommunicationChannelEnum::EMAIL->value,
+    ];
+
+    public function __construct(
+        private readonly Lead $lead,
+        private readonly string $channel,
+    ) {
+    }
+
+    public function execute(): ?array
+    {
+        if (! $this->shouldSend()) {
+            return null;
+        }
+
+        // Stamped before the send, not after: a timeout that actually delivered would otherwise
+        // leave the lead eligible for a second acknowledgement on the next inbound STOP.
+        $this->lead->set(
+            ConsentConfigurationEnum::CONFIRMATION_SENT_AT->value,
+            Carbon::now()->toIso8601String(),
+        );
+
+        try {
+            return new SendMessageToLeadAction($this->lead)
+                ->allowOptOutConfirmation()
+                ->execute(
+                    $this->channel,
+                    $this->message(),
+                    signature: false,
+                    title: 'Unsubscribed',
+                );
+        } catch (Throwable $e) {
+            report($e);
+
+            return null;
+        }
+    }
+
+    private function shouldSend(): bool
+    {
+        if (! in_array($this->channel, self::SUPPORTED_CHANNELS, true)) {
+            return false;
+        }
+
+        if ($this->lead->get(ConsentConfigurationEnum::CONFIRMATION_SENT_AT->value) !== null) {
+            return false;
+        }
+
+        // Twilio's own STOP filtering already replies on that channel; ours would be the second.
+        return ! ($this->channel === LeadCommunicationChannelEnum::SMS->value && $this->twilioRepliesItself());
+    }
+
+    private function twilioRepliesItself(): bool
+    {
+        $configured = $this->lead->company?->get(TwilioConfigurationEnum::TWILIO_SENDS_OPT_OUT_REPLY->value)
+            ?? $this->lead->app->get(TwilioConfigurationEnum::TWILIO_SENDS_OPT_OUT_REPLY->value);
+
+        return $configured === null ? true : (bool) $configured;
+    }
+
+    private function message(): string
+    {
+        $configured = Str::trimToNull(
+            (string) ($this->lead->company?->get(ConsentConfigurationEnum::CONFIRMATION_MESSAGE->value)
+                ?? $this->lead->app->get(ConsentConfigurationEnum::CONFIRMATION_MESSAGE->value)
+                ?? ''),
+        );
+
+        return $configured ?? self::DEFAULT_MESSAGE;
+    }
+}

--- a/src/Domains/Intelligence/Agents/Actions/Outreach/AgentReachOutAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Outreach/AgentReachOutAction.php
@@ -6,6 +6,8 @@ namespace Kanvas\Intelligence\Agents\Actions\Outreach;
 
 use Kanvas\Companies\Enums\ConfigurationEnum as CompanyConfigurationEnum;
 use Kanvas\Exceptions\ValidationException;
+use Kanvas\Guild\Customers\Enums\ConsentConfigurationEnum;
+use Kanvas\Guild\Customers\Services\ConsentKeywordService;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Leads\Enums\AgentReachOutConfigEnum;
@@ -81,7 +83,18 @@ class AgentReachOutAction
         }
 
         // === Do-not-contact guard ===
-        // Humans drop free-text like "do not reach out" / "no llamar" in the lead
+        // The flag first: this action names 'do_not_contact' as a skip reason but used to check only
+        // the description, so a prospect who actually asked to stop could still be cold-reached.
+        if ((bool) $this->lead->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value)
+            || (bool) $this->lead->people?->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value)
+        ) {
+            $this->lead->set(AgentReachOutConfigEnum::STATUS->value, AgentReachOutConfigEnum::STATUS_SKIPPED);
+            $this->lead->set(AgentReachOutConfigEnum::REASON->value, 'do_not_contact');
+
+            return ['message' => 'Lead is flagged do-not-contact', 'status' => 'skipped'];
+        }
+
+        // Humans also drop free-text like "do not reach out" / "no llamar" in the lead
         // description; honor it before spending an agent turn on the lead.
         if ($this->descriptionRequestsNoContact()) {
             $this->lead->set(AgentReachOutConfigEnum::STATUS->value, AgentReachOutConfigEnum::STATUS_SKIPPED);
@@ -189,58 +202,11 @@ class AgentReachOutAction
     }
 
     /**
-     * Scan the free-text lead description for human-written do-not-contact intent.
-     * Matches common English/Spanish phrasings ("do not reach out", "no contact",
-     * "don't call", "no llamar", "remove me", "dnc") regardless of spacing,
-     * apostrophe style, or punctuation.
+     * Staff type do-not-contact intent straight into the lead description ("do not reach out",
+     * "no llamar"). Same matcher the inbound channels use — see ConsentKeywordService.
      */
     private function descriptionRequestsNoContact(): bool
     {
-        $description = (string) $this->lead->description;
-        if (trim($description) === '') {
-            return false;
-        }
-
-        // Normalize: lowercase, strip apostrophes (don't → dont), collapse any
-        // non-alphanumeric run to a single space so "do-not-contact" == "do not contact".
-        $normalized = strtolower($description);
-        $normalized = str_replace(["'", '’', '`'], '', $normalized);
-        $normalized = (string) preg_replace('/[^a-z0-9]+/', ' ', $normalized);
-        $normalized = trim((string) preg_replace('/\s+/', ' ', $normalized));
-
-        $patterns = [
-            'do not contact',
-            'dont contact',
-            'do not reach out',
-            'dont reach out',
-            'do not reachout',
-            'dont reachout',
-            'do not call',
-            'dont call',
-            'do not text',
-            'dont text',
-            'do not email',
-            'dont email',
-            'do not message',
-            'dont message',
-            'no contact',
-            'no llamar',
-            'no contactar',
-            'stop contacting',
-            'stop reaching out',
-            'remove me',
-            'unsubscribe',
-            'dnc',
-        ];
-
-        foreach ($patterns as $pattern) {
-            // Word-boundary match so "dnc" doesn't fire inside "abcdncxyz" and
-            // "no contact" doesn't match a substring of a longer unrelated token.
-            if (preg_match('/\b' . preg_quote($pattern, '/') . '\b/', $normalized) === 1) {
-                return true;
-            }
-        }
-
-        return false;
+        return ConsentKeywordService::matchesNoContactPhrase((string) $this->lead->description);
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/CRM/SalesAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/CRM/SalesAgent.php
@@ -26,6 +26,7 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\LeadIntentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\LeadRefTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\RescheduleCalendarEventTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\SimilarVehiclesTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\StopContactTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\UserAvailabilityTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\VehicleInterestTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\VehicleTradeInTool;
@@ -98,6 +99,18 @@ class SalesAgent extends BaseRagAgent implements ConversesWithCustomer
                 . 'create_calendar_event, etc.) in the SAME turn. Never invent a lead_id.',
             ]);
 
+        // Scoped narrowly on purpose. Obvious opt-outs are applied deterministically before this agent
+        // is ever invoked, so repeating the full list here would only invite it to re-decide cases the
+        // inbound layer already settled — including the ones it deliberately declined to flag.
+        $contextLines[] = 'COMPLIANCE: clear opt-outs ("stop", "unsubscribe", "remove me from your list") are '
+            . 'already handled before you see the message, so you will rarely need to act on one. Call '
+            . 'stop_contact ONLY when someone asks to stop hearing from us in wording those checks would miss — '
+            . 'for example agreeing to it across turns ("yes, go ahead" after you offered to stop), or an '
+            . 'unusual phrasing like "I bought elsewhere, close my file". Pass their exact words as the reason, '
+            . 'then send ONE short acknowledgement and nothing further. '
+            . 'A request to be reached DIFFERENTLY is not an opt-out: "text me instead", "email me not phone", '
+            . '"do not call before 5pm" mean keep talking on their terms — never call stop_contact for those.';
+
         return new SystemPrompt(
             background: [
                 ...$this->personaLines(),
@@ -157,6 +170,7 @@ class SalesAgent extends BaseRagAgent implements ConversesWithCustomer
             new SimilarVehiclesTool(),
             new VehicleInterestTool(),
             new VehicleTradeInTool(),
+            new StopContactTool(),
         ];
 
         if ($this->entity instanceof Message) {

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/StopContactTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/CRM/StopContactTool.php
@@ -4,38 +4,35 @@ declare(strict_types=1);
 
 namespace Kanvas\Intelligence\Agents\Neuron\Tools\CRM;
 
-use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
-use Kanvas\Guild\Leads\Actions\RecordLeadNoteAction;
-use Kanvas\Guild\Leads\Models\Lead;
-use Kanvas\Intelligence\Actions\HandOffAction;
+use Kanvas\Guild\Customers\Actions\ApplyDoNotContactAction;
+use Kanvas\Guild\Customers\Enums\ConsentMatchEnum;
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\ResolvesLeadForTool;
-use Kanvas\Intelligence\Enums\HandOffTypeEnum;
-use Kanvas\Intelligence\Enums\IntelligenceModeEnum;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
 use Override;
-use Throwable;
 
+/**
+ * The half of opt-out handling that keywords cannot cover.
+ *
+ * ConsentKeywordService catches an exact "STOP" on the way in. The FCC requires honoring a
+ * revocation made in "any reasonable manner", and Twilio explicitly does not block non-keyword
+ * phrasing on our behalf — so "please take me off your list", "no me escribas más", "I'm not
+ * interested, don't contact me again" reach the agent, and this tool is how the agent honors them.
+ */
 #[AgentTool(name: 'Stop Contact', category: 'crm')]
 class StopContactTool extends Tool
 {
     use ResolvesLeadForTool;
-
-    private const EMAIL_CONTACT_TYPES = [
-        ContactTypeEnum::EMAIL->value,
-        ContactTypeEnum::PRIMARY_EMAIL->value,
-        ContactTypeEnum::SECONDARY_EMAIL->value,
-    ];
 
     public function __construct()
     {
         parent::__construct(
             name: 'stop_contact',
             description: 'Honor a prospect who asks to stop being contacted / unsubscribe / "stop" / "remove me" / "do not contact". '
-                . 'This is a full do-not-contact: it opts their phone AND email out of future messages, turns off automated replies, '
-                . 'logs a note on the lead, and notifies a human on the team. '
+                . 'This is a full do-not-contact: it opts every phone AND email this person has out of future messages across '
+                . 'SMS, WhatsApp and email, turns off automated replies on all of their leads, logs a note, and notifies a human. '
                 . 'Call it as soon as the prospect clearly asks to stop hearing from the business. '
                 . 'You may still send ONE short acknowledgement this turn (e.g. "Done — you won\'t hear from us again."), then stop.',
         );
@@ -65,71 +62,42 @@ class StopContactTool extends Tool
         ?string $reason = null,
     ): array {
         $result = $this->resolveLeadOrError($lead_id);
+
         if (is_array($result)) {
             return $result;
         }
+
         $lead = $result;
-
-        $optedOut = [];
         $people = $lead->people;
-        if ($people !== null) {
-            if ($people->optOutPhoneContacts() > 0) {
-                $optedOut[] = 'phone';
-            }
 
-            $emailsOptedOut = $people->contacts()
-                ->whereIn('contacts_types_id', self::EMAIL_CONTACT_TYPES)
-                ->where('is_opt_out', 0)
-                ->update(['is_opt_out' => 1]);
-            if ($emailsOptedOut > 0) {
-                $optedOut[] = 'email';
-            }
+        if ($people === null) {
+            return [
+                'status' => 'error',
+                'message' => 'This lead has no person record, so there is nothing to opt out. '
+                    . 'Tell the prospect a human will follow up and hand off instead.',
+            ];
         }
 
-        $lead->set('ai_mode', IntelligenceModeEnum::IDLE->value);
-        $lead->set('do_not_contact', 1);
-        if ($reason !== null && trim($reason) !== '') {
-            $lead->set('do_not_contact_reason', trim($reason));
-        }
-
-        $noteBody = 'Prospect opted out of contact'
-            . ($reason !== null && trim($reason) !== '' ? ' — "' . trim($reason) . '"' : '')
-            . '. Automated messaging disabled across channels.';
-        $noted = new RecordLeadNoteAction($lead)->execute($noteBody, 'opt-out') !== null;
-
-        $handoffNotified = $this->notifyTeam($lead);
+        $outcome = new ApplyDoNotContactAction(
+            people: $people,
+            sourceChannel: 'agent_tool',
+            lead: $lead,
+            reason: $reason,
+            match: ConsentMatchEnum::AGENT_TOOL,
+        )->execute();
 
         return [
             'status' => 'success',
             'lead_id' => $lead_id,
-            'opted_out' => $optedOut,
+            'already_opted_out' => $outcome->alreadyOptedOut,
+            'contacts_opted_out' => $outcome->contactsOptedOut,
+            'leads_flagged' => $outcome->leadsFlagged,
             'ai_disabled' => true,
-            'note_logged' => $noted,
-            'team_notified' => $handoffNotified,
-            'note' => 'Prospect opted out: all contacts marked do-not-contact, automated messaging disabled, note logged, team notified. '
-                . 'Send ONE brief acknowledgement, then do not message this person again.',
+            'note' => $outcome->alreadyOptedOut
+                ? 'This person was already opted out. Do not message them again; do not send another acknowledgement.'
+                : 'Prospect opted out: every phone and email marked do-not-contact across all of their leads, '
+                    . 'automated messaging disabled, note logged, team notified. '
+                    . 'Send ONE brief acknowledgement, then do not message this person again.',
         ];
-    }
-
-    /**
-     * Alert a human that this lead opted out — a COMPLIANCE_INTERNAL handoff (notifies owner +
-     * the handoff role via HandOffAction). Not a "keep chatting" handoff; it is an internal
-     * compliance alert. Best-effort: never let a notification failure break the opt-out.
-     */
-    private function notifyTeam(Lead $lead): bool
-    {
-        try {
-            new HandOffAction(
-                lead: $lead,
-                app: $lead->app,
-                params: ['handoff_type' => HandOffTypeEnum::COMPLIANCE_INTERNAL->value],
-            )->execute();
-
-            return true;
-        } catch (Throwable $e) {
-            report($e);
-
-            return false;
-        }
     }
 }

--- a/src/Domains/Intelligence/FollowUp/Services/LeadOutboundChannelResolver.php
+++ b/src/Domains/Intelligence/FollowUp/Services/LeadOutboundChannelResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\FollowUp\Services;
 
 use Illuminate\Support\Collection;
+use Kanvas\Guild\Customers\Enums\ConsentConfigurationEnum;
 use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
 use Kanvas\Guild\Customers\Models\Contact;
 use Kanvas\Guild\Leads\Models\Lead;
@@ -37,6 +38,14 @@ final class LeadOutboundChannelResolver
     {
         $people = $lead->people;
         if ($people === null) {
+            return [];
+        }
+
+        // Contact-level opt-outs alone are not enough: a stop request flags the lead and the person,
+        // and a lead created after that request carries deliverable contacts it must not use.
+        if ((bool) $lead->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value)
+            || (bool) $people->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value)
+        ) {
             return [];
         }
 

--- a/tests/Connectors/Integration/Mailgun/AgentInboxWebhookJobTest.php
+++ b/tests/Connectors/Integration/Mailgun/AgentInboxWebhookJobTest.php
@@ -21,6 +21,7 @@ use Kanvas\Connectors\WordPress\Activities\PushMessageToWordPressActivity;
 use Kanvas\Connectors\WordPress\DataTransferObject\WordPressPost;
 use Kanvas\Connectors\WordPress\Enums\ConfigurationEnum as WordPressConfigurationEnum;
 use Kanvas\Filesystem\Services\FilesystemServices;
+use Kanvas\Guild\Customers\Enums\ConsentConfigurationEnum;
 use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Models\AgentType;
@@ -294,6 +295,74 @@ final class AgentInboxWebhookJobTest extends TestCase
         $people = PeoplesRepository::getByEmail($stranger, $this->company, $this->kanvasApp);
         $this->assertNotNull($people, 'An open mailbox is an inbound funnel — the sender becomes a contact.');
         $this->assertSame('Jane Prospect', $people->name);
+    }
+
+    /**
+     * This receiver replies inline, so a stop request has to be settled before the responder runs.
+     * An agent mailbox answering "unsubscribe" with a sales pitch is the worst version of this.
+     */
+    public function testAStopRequestToTheAgentMailboxIsHonoredAndNotAnswered(): void
+    {
+        $this->fakeMailgun();
+        $this->agent->set(CustomFieldEnum::MAILBOX_ACCESS->value, MailboxAccessEnum::OPEN->value);
+        $prospect = 'optout-' . Str::random(6) . '@outside.test';
+
+        $result = $this->deliver([
+            'sender' => $prospect,
+            'from' => 'Jane Prospect <' . $prospect . '>',
+            'subject' => 'Unsubscribe',
+            'stripped-text' => 'please take me off your list',
+            'Message-Id' => '<stop-' . Str::random(10) . '@outside.test>',
+        ]);
+
+        $this->assertTrue($result['consent_applied'] ?? false, 'the stop request must be applied.');
+
+        $people = PeoplesRepository::getByEmail($prospect, $this->company, $this->kanvasApp);
+        $this->assertNotNull($people);
+        $this->assertSame(1, (int) $people->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value));
+        $this->assertSame(
+            0,
+            $people->contacts()->where('is_opt_out', 0)->count(),
+            'every address of theirs is opted out, not just the one they wrote from.',
+        );
+
+        Http::assertNotSent(fn ($request): bool => str_contains($request->url(), '/messages'));
+    }
+
+    /**
+     * The subject is where a one-word unsubscribe usually lands, with nothing under it.
+     */
+    public function testAStopRequestInTheSubjectAloneIsHonored(): void
+    {
+        $this->fakeMailgun();
+        $this->agent->set(CustomFieldEnum::MAILBOX_ACCESS->value, MailboxAccessEnum::OPEN->value);
+        $prospect = 'subject-optout-' . Str::random(6) . '@outside.test';
+
+        $result = $this->deliver([
+            'sender' => $prospect,
+            'from' => 'Joe Prospect <' . $prospect . '>',
+            'subject' => 'UNSUBSCRIBE',
+            'stripped-text' => 'sent from my iPhone',
+            'Message-Id' => '<subject-stop-' . Str::random(10) . '@outside.test>',
+        ]);
+
+        $this->assertTrue($result['consent_applied'] ?? false);
+        Http::assertNotSent(fn ($request): bool => str_contains($request->url(), '/messages'));
+    }
+
+    public function testAnOrdinaryEmailToTheAgentMailboxIsStillAnswered(): void
+    {
+        $this->fakeMailgun();
+
+        $result = $this->deliver([
+            'sender' => $this->user->email,
+            'from' => 'Max <' . $this->user->email . '>',
+            'subject' => 'Quick question',
+            'stripped-text' => 'Can you stop by the Acme office tomorrow?',
+            'Message-Id' => '<ordinary-' . Str::random(10) . '@outside.test>',
+        ]);
+
+        $this->assertStringContainsString('Hola Mundo', (string) ($result['response'] ?? ''));
     }
 
     public function testTheAgentsOwnMailIsIgnored(): void

--- a/tests/Connectors/Integration/Twilio/ProcessTwilioWebhookJobTest.php
+++ b/tests/Connectors/Integration/Twilio/ProcessTwilioWebhookJobTest.php
@@ -131,8 +131,12 @@ class ProcessTwilioWebhookJobTest extends TestCase
             ->firstOrFail();
 
         $this->assertSame('STOP', $stopResult[0]['consent_type']);
+        $this->assertTrue($stopResult[0]['automated_response_suppressed']);
+
+        // START is reported but must NOT suppress the reply: someone asking to hear from us again
+        // and getting silence is the opposite of honoring it.
         $this->assertSame('START', $startResult[0]['consent_type']);
-        $this->assertTrue($startResult[0]['automated_response_suppressed']);
+        $this->assertFalse($startResult[0]['automated_response_suppressed']);
         $this->assertTrue(
             $lead->people->getAllPhones()
                 ->filter(fn ($contact) => $contact->getCleanPhone() === ltrim($phone, '+'))

--- a/tests/Guild/Customers/ApplyDoNotContactActionTest.php
+++ b/tests/Guild/Customers/ApplyDoNotContactActionTest.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Guild\Customers;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Guild\Customers\Actions\ApplyDoNotContactAction;
+use Kanvas\Guild\Customers\Actions\ProcessInboundConsentAction;
+use Kanvas\Guild\Customers\Enums\ConsentConfigurationEnum;
+use Kanvas\Guild\Customers\Enums\ConsentMatchEnum;
+use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
+use Kanvas\Guild\Customers\Models\Contact;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Leads\Actions\SendMessageToLeadAction;
+use Kanvas\Guild\Leads\Enums\LeadCommunicationChannelEnum;
+use Kanvas\Guild\Leads\Factories\LeadFactory;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\FollowUp\DataTransferObject\ChannelConfig;
+use Kanvas\Intelligence\FollowUp\DataTransferObject\FollowUpConfig;
+use Kanvas\Intelligence\FollowUp\Enums\ChannelSelectionEnum;
+use Kanvas\Intelligence\FollowUp\Enums\ExhaustedActionEnum;
+use Kanvas\Intelligence\FollowUp\Enums\FollowUpModeEnum;
+use Kanvas\Intelligence\FollowUp\Services\LeadOutboundChannelResolver;
+use Tests\TestCase;
+
+final class ApplyDoNotContactActionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected array $connectionsToTransact = ['mysql', 'crm', 'ecosystem', 'intelligence'];
+
+    private Apps $kanvasApp;
+    private Companies $company;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->kanvasApp = app(Apps::class);
+        $this->company = static::$cachedUser->getCurrentCompany();
+    }
+
+    public function test_opts_out_every_contact_and_flags_every_lead_of_the_person(): void
+    {
+        $people = $this->seedPeople();
+        $this->seedContact($people, ContactTypeEnum::CELLPHONE, '+18095550111');
+        $this->seedContact($people, ContactTypeEnum::EMAIL, 'prospect@example.com');
+        $leadOne = $this->seedLead($people);
+        $leadTwo = $this->seedLead($people);
+
+        $outcome = new ApplyDoNotContactAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            lead: $leadOne,
+            reason: 'STOP',
+        )->execute();
+
+        $this->assertTrue($outcome->applied);
+        $this->assertTrue($outcome->isStop());
+        $this->assertSame(2, $outcome->contactsOptedOut);
+        $this->assertSame(2, $outcome->leadsFlagged);
+
+        $this->assertSame(
+            0,
+            $people->contacts()->where('is_opt_out', 0)->count(),
+            'a stop request is person-wide: no contact of any type may remain deliverable.',
+        );
+
+        $this->assertTrue((bool) $people->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value));
+        $this->assertTrue((bool) $leadOne->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value));
+        $this->assertTrue(
+            (bool) $leadTwo->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value),
+            'the lead they were NOT talking on must be flagged too.',
+        );
+    }
+
+    public function test_is_idempotent(): void
+    {
+        $people = $this->seedPeople();
+        $this->seedContact($people, ContactTypeEnum::CELLPHONE, '+18095550112');
+        $lead = $this->seedLead($people);
+
+        new ApplyDoNotContactAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            lead: $lead,
+        )->execute();
+
+        $second = new ApplyDoNotContactAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            lead: $lead,
+        )->execute();
+
+        $this->assertTrue($second->alreadyOptedOut);
+        $this->assertFalse($second->applied);
+        $this->assertSame(0, $second->contactsOptedOut);
+    }
+
+    /**
+     * The point of the whole feature: STOP arrives on one channel and every other channel goes quiet.
+     */
+    public function test_stop_on_sms_blocks_whatsapp_and_email_sends(): void
+    {
+        $people = $this->seedPeople();
+        $this->seedContact($people, ContactTypeEnum::CELLPHONE, '+18095550113');
+        $this->seedContact($people, ContactTypeEnum::EMAIL, 'blocked@example.com');
+        $lead = $this->seedLead($people);
+
+        new ProcessInboundConsentAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            body: 'STOP',
+            lead: $lead,
+        )->execute();
+
+        foreach ([
+            LeadCommunicationChannelEnum::SMS->value,
+            LeadCommunicationChannelEnum::WHATSAPP->value,
+            LeadCommunicationChannelEnum::EMAIL->value,
+        ] as $channel) {
+            $result = new SendMessageToLeadAction($lead->refresh())->execute($channel, 'Still there?');
+
+            $this->assertFalse($result['success'], $channel . ' send should not succeed after a stop request.');
+            $this->assertSame('opted_out', $result['classification'], $channel . ' should classify as opted_out.');
+        }
+    }
+
+    /**
+     * The person-level flag exists for exactly this: a connector sync creating a fresh lead after the
+     * opt-out would otherwise hand the guards a lead with no flag on it.
+     */
+    public function test_a_lead_created_after_the_opt_out_is_still_blocked(): void
+    {
+        $people = $this->seedPeople();
+        $this->seedContact($people, ContactTypeEnum::CELLPHONE, '+18095550114');
+        $originalLead = $this->seedLead($people);
+
+        new ApplyDoNotContactAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            lead: $originalLead,
+        )->execute();
+
+        $newLead = $this->seedLead($people);
+
+        $result = new SendMessageToLeadAction($newLead)->execute(
+            LeadCommunicationChannelEnum::SMS->value,
+            'Fresh lead, same human',
+        );
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('opted_out', $result['classification']);
+    }
+
+    /**
+     * Tier two. No exact keyword anywhere in this message, and no agent involved — the deterministic
+     * phrase pass is what has to catch it.
+     */
+    public function test_a_phrased_stop_request_is_applied_without_the_agent(): void
+    {
+        $people = $this->seedPeople();
+        $this->seedContact($people, ContactTypeEnum::CELLPHONE, '+18095550116');
+        $lead = $this->seedLead($people);
+
+        $outcome = new ProcessInboundConsentAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            body: 'please take me off your list, I am not interested',
+            lead: $lead,
+        )->execute();
+
+        $this->assertTrue($outcome->applied);
+        $this->assertTrue($outcome->shouldHaltAgentTurn());
+        $this->assertSame(ConsentMatchEnum::PHRASE, $outcome->match);
+        $this->assertTrue((bool) $people->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value));
+        $this->assertSame(
+            ConsentMatchEnum::PHRASE->value,
+            $people->get(ConsentConfigurationEnum::DO_NOT_CONTACT_MATCH->value),
+            'the flag records that this was inferred, so a human can reverse a wrong call.',
+        );
+    }
+
+    /**
+     * The expensive false positive: a channel preference must not silence a customer who is still
+     * talking to us. Nothing is flagged, and the agent is still allowed to answer.
+     */
+    public function test_a_channel_preference_is_not_treated_as_an_opt_out(): void
+    {
+        $people = $this->seedPeople();
+        $this->seedContact($people, ContactTypeEnum::CELLPHONE, '+18095550117');
+        $this->seedContact($people, ContactTypeEnum::EMAIL, 'prefers-sms@example.com');
+        $lead = $this->seedLead($people);
+
+        $outcome = new ProcessInboundConsentAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::EMAIL->value,
+            body: "don't email me, text me instead",
+            lead: $lead,
+        )->execute();
+
+        $this->assertFalse($outcome->applied);
+        $this->assertTrue($outcome->narrowedRequest);
+        $this->assertFalse($outcome->shouldHaltAgentTurn(), 'the agent must still answer them.');
+
+        $this->assertFalse((bool) $people->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value));
+        $this->assertSame(
+            2,
+            $people->contacts()->where('is_opt_out', 0)->count(),
+            'no contact may be opted out by a preference change.',
+        );
+
+        $result = new SendMessageToLeadAction($lead->refresh())->execute(
+            LeadCommunicationChannelEnum::SMS->value,
+            'Sure — texting you from now on.',
+        );
+        $this->assertNotSame('opted_out', $result['classification'] ?? null);
+    }
+
+    public function test_a_time_window_is_not_treated_as_an_opt_out(): void
+    {
+        $people = $this->seedPeople();
+        $this->seedContact($people, ContactTypeEnum::CELLPHONE, '+18095550118');
+        $lead = $this->seedLead($people);
+
+        $outcome = new ProcessInboundConsentAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            body: "don't call me before 5pm",
+            lead: $lead,
+        )->execute();
+
+        $this->assertFalse($outcome->applied);
+        $this->assertTrue($outcome->narrowedRequest);
+        $this->assertFalse((bool) $people->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value));
+    }
+
+    /**
+     * "YES" is in Twilio's START set, so it used to register as a consent event for everyone and
+     * suppress the agent turn — on the single most engaged reply a prospect can send.
+     */
+    public function test_yes_from_someone_who_never_opted_out_is_not_a_consent_event(): void
+    {
+        $people = $this->seedPeople();
+        $this->seedContact($people, ContactTypeEnum::CELLPHONE, '+18095550120');
+        $lead = $this->seedLead($people);
+
+        $outcome = new ProcessInboundConsentAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            body: 'YES',
+            lead: $lead,
+        )->execute();
+
+        $this->assertNull($outcome->signal, 'a bare yes from an engaged prospect is just a reply.');
+        $this->assertFalse($outcome->shouldHaltAgentTurn(), 'the agent must be allowed to answer it.');
+    }
+
+    public function test_yes_from_someone_opted_out_still_re_subscribes_them(): void
+    {
+        $people = $this->seedPeople();
+        $this->seedContact($people, ContactTypeEnum::CELLPHONE, '+18095550121');
+        $lead = $this->seedLead($people);
+
+        new ApplyDoNotContactAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            lead: $lead,
+        )->execute();
+
+        $outcome = new ProcessInboundConsentAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            body: 'YES',
+            lead: $lead,
+            contactValue: '+18095550121',
+        )->execute();
+
+        $this->assertTrue($outcome->applied);
+        $this->assertFalse((bool) $people->refresh()->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value));
+    }
+
+    public function test_an_ordinary_message_touches_nothing(): void
+    {
+        $people = $this->seedPeople();
+        $this->seedContact($people, ContactTypeEnum::CELLPHONE, '+18095550119');
+        $lead = $this->seedLead($people);
+
+        $outcome = new ProcessInboundConsentAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            body: 'Can I stop by the dealership tomorrow to see the Civic?',
+            lead: $lead,
+        )->execute();
+
+        $this->assertNull($outcome->signal);
+        $this->assertFalse($outcome->applied);
+        $this->assertFalse($outcome->narrowedRequest);
+        $this->assertFalse($outcome->shouldHaltAgentTurn());
+        $this->assertFalse((bool) $people->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value));
+    }
+
+    public function test_follow_up_resolver_offers_no_channels_for_a_flagged_lead(): void
+    {
+        $people = $this->seedPeople();
+        $this->seedContact($people, ContactTypeEnum::CELLPHONE, '+18095550115');
+        $this->seedContact($people, ContactTypeEnum::EMAIL, 'followup@example.com');
+        $lead = $this->seedLead($people);
+
+        $config = $this->followUpConfig();
+
+        $this->assertNotEmpty(
+            new LeadOutboundChannelResolver()->resolve($lead, $config),
+            'sanity: the lead is reachable before the opt-out.',
+        );
+
+        new ApplyDoNotContactAction(
+            people: $people,
+            sourceChannel: LeadCommunicationChannelEnum::SMS->value,
+            lead: $lead,
+        )->execute();
+
+        $this->assertSame(
+            [],
+            new LeadOutboundChannelResolver()->resolve($lead->refresh(), $config),
+            'follow-up must not schedule a nudge on a do-not-contact lead.',
+        );
+    }
+
+    private function followUpConfig(): FollowUpConfig
+    {
+        return new FollowUpConfig(
+            enabled: true,
+            mode: FollowUpModeEnum::TIME_BASED,
+            timeBased: null,
+            goalBased: null,
+            maxRetries: 3,
+            exhaustedAction: ExhaustedActionEnum::STOP,
+            agentName: null,
+            promptTemplate: null,
+            channels: [
+                new ChannelConfig(type: LeadCommunicationChannelEnum::SMS->value, enabled: true),
+                new ChannelConfig(type: LeadCommunicationChannelEnum::EMAIL->value, enabled: true),
+            ],
+            channelSelection: ChannelSelectionEnum::PRIORITY_ONLY,
+            respectWorkHours: false,
+            respectLeadOptOuts: true,
+            writeSystemMessageOnStageChange: false,
+        );
+    }
+
+    private function seedPeople(): People
+    {
+        return People::create([
+            'apps_id' => $this->kanvasApp->getId(),
+            'companies_id' => $this->company->getId(),
+            'users_id' => static::$cachedUser->getId(),
+            'firstname' => 'Consent',
+            'lastname' => 'Tester',
+            'name' => 'Consent Tester',
+        ]);
+    }
+
+    private function seedContact(People $people, ContactTypeEnum $type, string $value): Contact
+    {
+        return Contact::create([
+            'peoples_id' => $people->getId(),
+            'contacts_types_id' => $type->value,
+            'value' => $value,
+            'is_opt_out' => 0,
+            'weight' => 0,
+        ]);
+    }
+
+    private function seedLead(People $people): Lead
+    {
+        return new LeadFactory()
+            ->withAppId($this->kanvasApp->getId())
+            ->withCompanyId($this->company->getId())
+            ->withUserId(static::$cachedUser->getId())
+            ->withPeopleId($people->getId())
+            ->create();
+    }
+}

--- a/tests/Guild/Customers/ConsentKeywordServiceTest.php
+++ b/tests/Guild/Customers/ConsentKeywordServiceTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Guild\Customers;
+
+use Kanvas\Guild\Customers\Enums\ConsentSignalEnum;
+use Kanvas\Guild\Customers\Services\ConsentKeywordService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCaseUnit;
+
+final class ConsentKeywordServiceTest extends TestCaseUnit
+{
+    public static function stopKeywordProvider(): array
+    {
+        return [
+            'stop' => ['STOP'],
+            'lowercase' => ['stop'],
+            'mixed case' => ['Stop'],
+            'trailing period' => ['STOP.'],
+            'exclamation' => ['stop!'],
+            'surrounding whitespace' => ["  stop \n"],
+            'stopall' => ['STOPALL'],
+            'stop all spaced' => ['STOP ALL'],
+            'unsubscribe' => ['unsubscribe'],
+            'cancel' => ['CANCEL'],
+            'end' => ['end'],
+            'quit' => ['QUIT'],
+            'revoke' => ['revoke'],
+            'optout' => ['OPTOUT'],
+            'opt-out hyphenated' => ['opt-out'],
+            'opt out spaced' => ['Opt Out'],
+        ];
+    }
+
+    #[DataProvider('stopKeywordProvider')]
+    public function testDetectsStopKeywords(string $body): void
+    {
+        $this->assertSame(ConsentSignalEnum::STOP, ConsentKeywordService::detect($body));
+        $this->assertTrue(ConsentKeywordService::isStop($body));
+    }
+
+    public static function notAStopProvider(): array
+    {
+        return [
+            'stop inside a sentence' => ['stop by the dealership tomorrow'],
+            'stop as a request' => ['please stop texting me'],
+            'cancel an appointment' => ['I need to cancel my appointment on friday'],
+            'end of lease' => ['when does my lease end'],
+            'quit in context' => ['I quit my job so I need a cheaper payment'],
+            'empty' => [''],
+            'whitespace only' => ["   \n  "],
+            'null' => [null],
+            'digits only' => ['12345'],
+        ];
+    }
+
+    #[DataProvider('notAStopProvider')]
+    public function testDoesNotDetectStopInProse(?string $body): void
+    {
+        $this->assertNotSame(ConsentSignalEnum::STOP, ConsentKeywordService::detect($body));
+        $this->assertFalse(ConsentKeywordService::isStop($body));
+    }
+
+    public function testDetectsStartAndHelp(): void
+    {
+        $this->assertSame(ConsentSignalEnum::START, ConsentKeywordService::detect('START'));
+        $this->assertSame(ConsentSignalEnum::START, ConsentKeywordService::detect('unstop'));
+        $this->assertSame(ConsentSignalEnum::START, ConsentKeywordService::detect('Yes'));
+        $this->assertSame(ConsentSignalEnum::HELP, ConsentKeywordService::detect('help'));
+    }
+
+    /**
+     * Email is the reason first-line matching exists: a one-word reply always arrives wrapped in a
+     * signature and a quoted thread, and would never match as a whole body.
+     */
+    public function testDetectsStopOnFirstLineOfAnEmailReply(): void
+    {
+        $body = "Unsubscribe\n\n--\nSent from my iPhone\n\n> On Tue, someone wrote:\n> Hi, checking in about the Civic";
+
+        $this->assertSame(ConsentSignalEnum::STOP, ConsentKeywordService::detect($body));
+    }
+
+    public function testIgnoresKeywordBuriedInQuotedThread(): void
+    {
+        $body = "Thanks for the update, sounds good\n\n> Reply STOP to opt out";
+
+        $this->assertNull(ConsentKeywordService::detect($body));
+    }
+
+    /**
+     * The first-line pass bails on the signature delimiter, but the whole-body pass still matches:
+     * everything in this message is either decoration or the keyword. Honoring it is the safe
+     * direction — the whole-body pass can only ever fire when there is nothing else being said.
+     */
+    public function testKeywordUnderASignatureDelimiterStillMatchesAsAWholeBody(): void
+    {
+        $this->assertSame(ConsentSignalEnum::STOP, ConsentKeywordService::detect("--\nSTOP"));
+    }
+
+    public function testOversizedBodyIsNotScanned(): void
+    {
+        $this->assertNull(ConsentKeywordService::detect(str_repeat('a', 4096)));
+    }
+
+    public static function noContactPhraseProvider(): array
+    {
+        return [
+            'plain' => ['please stop texting me'],
+            'apostrophe' => ["don't contact me again"],
+            'curly apostrophe' => ['don’t contact me again'],
+            'hyphenated' => ['this is a do-not-contact request'],
+            'take me off' => ['take me off your list please'],
+            'remove me' => ['remove me from your mailing list'],
+            'spanish no llamar' => ['por favor no llamar mas'],
+            'spanish no me escribas' => ['no me escribas mas por favor'],
+            'dnc shorthand' => ['customer says DNC'],
+            'stop reaching out' => ['I would like you to stop reaching out'],
+        ];
+    }
+
+    #[DataProvider('noContactPhraseProvider')]
+    public function testMatchesNoContactPhrase(string $text): void
+    {
+        $this->assertTrue(ConsentKeywordService::matchesNoContactPhrase($text));
+        $this->assertNull(
+            ConsentKeywordService::detect($text),
+            'phrases must NOT come back as exact keyword matches.',
+        );
+    }
+
+    public static function innocentTextProvider(): array
+    {
+        return [
+            'buying signal' => ['I am interested, what is the price on the Civic?'],
+            'dnc inside a word' => ['my account number is abcdncxyz'],
+            'contact as a noun' => ['who is my main contact there?'],
+            'calling about' => ['I am calling about the trade in value'],
+            'empty' => [''],
+            'null' => [null],
+        ];
+    }
+
+    #[DataProvider('innocentTextProvider')]
+    public function testDoesNotMatchInnocentText(?string $text): void
+    {
+        $this->assertFalse(ConsentKeywordService::matchesNoContactPhrase($text));
+    }
+
+    /**
+     * The false positives that cost a live customer: both trip a no-contact phrase while asking us to
+     * keep talking, so the caller must treat them as a preference, not a revocation.
+     */
+    public static function narrowedRequestProvider(): array
+    {
+        return [
+            'channel swap' => ["don't email me, text me instead"],
+            'use my other number' => ['do not call this line, use my cell'],
+            'time window' => ["don't call me before 5pm"],
+            'time window after' => ['do not text after 9pm please'],
+            'weekend' => ['do not contact me on the weekend'],
+            'spanish channel swap' => ['no llamar, mejor escribeme'],
+        ];
+    }
+
+    #[DataProvider('narrowedRequestProvider')]
+    public function testNarrowedRequestsAreRecognised(string $text): void
+    {
+        $this->assertTrue(
+            ConsentKeywordService::matchesNoContactPhrase($text),
+            'sanity: these do trip the phrase matcher.',
+        );
+        $this->assertTrue(
+            ConsentKeywordService::narrowsRequestScope($text),
+            'and must be recognised as narrowed, so they are never auto-applied.',
+        );
+    }
+
+    public static function unqualifiedRequestProvider(): array
+    {
+        return [
+            'flat' => ['please stop contacting me'],
+            'again is emphasis not a qualifier' => ["don't contact me again"],
+            'remove' => ['take me off your list'],
+        ];
+    }
+
+    #[DataProvider('unqualifiedRequestProvider')]
+    public function testRealOptOutsAreNotTreatedAsNarrowed(string $text): void
+    {
+        $this->assertTrue(ConsentKeywordService::matchesNoContactPhrase($text));
+        $this->assertFalse(ConsentKeywordService::narrowsRequestScope($text));
+    }
+
+    /**
+     * Unlike exact matching, a phrase can sit anywhere inside a long email, so the length cap has to
+     * be far looser than the keyword one.
+     */
+    public function testPhraseIsFoundInsideALongBody(): void
+    {
+        $body = str_repeat('Thanks for the detailed quote breakdown. ', 60)
+            . 'Anyway please take me off your list.';
+
+        $this->assertTrue(ConsentKeywordService::matchesNoContactPhrase($body));
+    }
+}

--- a/tests/Guild/Unit/SendMessageToLeadActionTest.php
+++ b/tests/Guild/Unit/SendMessageToLeadActionTest.php
@@ -96,7 +96,9 @@ final class SendMessageToLeadActionTest extends TestCaseUnit
             ->andReturn('+12722917870');
 
         $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('get')->andReturn(null)->byDefault();
         $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
+        $lead->shouldReceive('getAttribute')->with('people')->andReturn(null);
 
         $action = new class ($lead) extends SendMessageToLeadAction {
             public string $capturedFrom = '';
@@ -127,6 +129,7 @@ final class SendMessageToLeadActionTest extends TestCaseUnit
             ->andReturnUsing(static fn (string $key) => $configuration[$key] ?? null);
 
         $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('get')->andReturn(null)->byDefault();
         $lead->shouldReceive('getAttribute')->with('people')->andReturn(null);
         $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
 
@@ -156,6 +159,7 @@ final class SendMessageToLeadActionTest extends TestCaseUnit
             ->andReturn(null);
 
         $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('get')->andReturn(null)->byDefault();
         $lead->shouldReceive('getAttribute')->with('people')->andReturn(null);
         $lead->shouldReceive('getAttribute')->with('app')->andReturn($app);
 
@@ -211,6 +215,7 @@ final class SendMessageToLeadActionTest extends TestCaseUnit
             ->andReturn(null);
 
         $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('get')->andReturn(null)->byDefault();
         $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
 
         $action = $this->makeAction($lead);
@@ -226,6 +231,7 @@ final class SendMessageToLeadActionTest extends TestCaseUnit
             ->andReturn(true);
 
         $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('get')->andReturn(null)->byDefault();
         $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
 
         $action = $this->makeAction($lead);
@@ -248,6 +254,7 @@ final class SendMessageToLeadActionTest extends TestCaseUnit
             ->andReturn(null);
 
         $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('get')->andReturn(null)->byDefault();
         $lead->shouldReceive('getAttribute')->with('people')->andReturn($people);
         $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
 
@@ -634,6 +641,7 @@ final class SendMessageToLeadActionTest extends TestCaseUnit
             ->andReturn(1);
 
         $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('get')->andReturn(null)->byDefault();
         $lead->shouldReceive('getAttribute')->with('people')->andReturn($people);
         $lead->shouldReceive('getAttribute')->with('company')->andReturn(null);
         $lead->shouldReceive('getAttribute')->with('uuid')->andReturn('lead-uuid');
@@ -706,6 +714,7 @@ final class SendMessageToLeadActionTest extends TestCaseUnit
             ->andReturn(null);
 
         $lead = Mockery::mock(Lead::class);
+        $lead->shouldReceive('get')->andReturn(null)->byDefault();
         $lead->shouldReceive('getAttribute')->with('people')->andReturn(null);
         $lead->shouldReceive('getAttribute')->with('company')->andReturn($company);
         $lead->shouldReceive('getAttribute')->with('uuid')->andReturn('lead-uuid');

--- a/tests/Intelligence/Agents/Tools/ReceptionistToolsTest.php
+++ b/tests/Intelligence/Agents/Tools/ReceptionistToolsTest.php
@@ -9,6 +9,8 @@ use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
 use Kanvas\Event\Events\Models\EventType;
 use Kanvas\Event\Support\Setup;
+use Kanvas\Guild\Customers\Enums\ConsentConfigurationEnum;
+use Kanvas\Guild\Leads\Enums\ConfigurationEnum as LeadConfigurationEnum;
 use Kanvas\Guild\Leads\Models\Lead;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\BookingOptionsTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\CRM\EventConfigurationTool;
@@ -268,13 +270,17 @@ class ReceptionistToolsTest extends TestCase
 
         $this->assertSame('success', $result['status']);
         $this->assertTrue($result['ai_disabled']);
-        $this->assertTrue($result['note_logged']);
-        $this->assertContains('phone', $result['opted_out']);
-        $this->assertContains('email', $result['opted_out']);
+        $this->assertFalse($result['already_opted_out']);
+        $this->assertGreaterThanOrEqual(2, $result['contacts_opted_out'], 'phone and email both opt out.');
+        $this->assertGreaterThanOrEqual(1, $result['leads_flagged']);
 
         $fresh = Lead::getById($lead->getId());
         $this->assertSame(IntelligenceModeEnum::IDLE->value, $fresh->get('ai_mode'));
         $this->assertSame(1, (int) $fresh->get('do_not_contact'));
+
+        // Without the manual pin the lead-type config can outrank the stored mode and the lead
+        // quietly starts replying again.
+        $this->assertTrue((bool) $fresh->get(LeadConfigurationEnum::AI_MODE_IS_MANUAL->value));
 
         $this->assertTrue(
             $lead->people->contacts()->where('value', 'optout@example.com')->where('is_opt_out', 1)->exists()
@@ -283,9 +289,24 @@ class ReceptionistToolsTest extends TestCase
             $lead->people->contacts()->where('value', '18095559999')->where('is_opt_out', 1)->exists()
         );
 
-        // Team is alerted via a best-effort compliance handoff (deep notification delivery is
-        // HandOffAction's concern; the tool just reports whether it ran).
-        $this->assertIsBool($result['team_notified']);
+        // Person-wide, not lead-wide: this is what silences SMS, WhatsApp and email together, and
+        // what blocks a lead created for this person after the opt-out.
+        $this->assertSame(1, (int) $lead->people->get(ConsentConfigurationEnum::DO_NOT_CONTACT->value));
+    }
+
+    public function testStopContactIsIdempotent(): void
+    {
+        Notification::fake();
+        $lead = $this->makeLead();
+        $lead->people->addCellPhone('+18095559998');
+
+        $this->withTenant(new StopContactTool())->__invoke(lead_id: $lead->getId());
+        $second = $this->withTenant(new StopContactTool())->__invoke(lead_id: $lead->getId());
+
+        $this->assertSame('success', $second['status']);
+        $this->assertTrue($second['already_opted_out']);
+        $this->assertSame(0, $second['contacts_opted_out']);
+        $this->assertStringContainsString('already opted out', $second['note']);
     }
 
     public function testFaqLookupReturnsCompanyFaqsAndIsTenantScoped(): void


### PR DESCRIPTION
… name

OrganizationVendorMatcherService's plain Jaccard score penalizes a short
vendor name by however many extra qualifier words a longer legal name
carries, so a genuine match (e.g. "Foo" vs "Foo (Client Trust + Foo,
Inc.)") can fall under the candidate floor and be reported as no match at
all instead of linking to the obvious vendor.

Now, full token containment counts as a confident match only when the
longer name repeats the short name's token verbatim — that repetition is
the real signal, not containment by itself, so a coincidental shared
prefix with an unrelated company still falls back to plain Jaccard.## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
