### PR TITLE
[1.x] fix: keep existing people contacts on partial updates

### DIFF
--- a/src/Domains/Connectors/Twilio/Webhooks/ProcessTwilioWebhookJob.php
+++ b/src/Domains/Connectors/Twilio/Webhooks/ProcessTwilioWebhookJob.php
@@ -459,11 +459,13 @@ class ProcessTwilioWebhookJob extends ProcessWebhookJob
             custom_fields: [
                 'twilio_jid' => $phoneNumber,
             ],
-            tags: ['sms', 'twilio']
+            tags: ['sms', 'twilio'],
+            // We only know the number the SMS came from — anything else the person has
+            // (email, other phones) must survive the update.
+            mergeContacts: true
         );
 
         if ($existingCustomer) {
-            //$peopleDto->id = $existingCustomer->getId();
             return new UpdatePeopleAction($existingCustomer, $peopleDto)->execute();
         }
 

--- a/src/Domains/Guild/Customers/Actions/UpdatePeopleAction.php
+++ b/src/Domains/Guild/Customers/Actions/UpdatePeopleAction.php
@@ -54,7 +54,11 @@ class UpdatePeopleAction
 
         $this->people->syncTags($this->peopleData->tags);
 
-        $this->syncContactsForUpdate($this->people, $this->peopleData->contacts);
+        $this->syncContactsForUpdate(
+            $this->people,
+            $this->peopleData->contacts,
+            (bool) $this->peopleData->mergeContacts
+        );
 
         if ($this->peopleData->address->count()) {
             $this->syncAddressesForUpdate();

--- a/src/Domains/Guild/Customers/DataTransferObject/People.php
+++ b/src/Domains/Guild/Customers/DataTransferObject/People.php
@@ -47,6 +47,9 @@ class People extends Data
         public ?bool $flushPreviousAddress = false,
         public ?bool $runWorkflow = true,
         public ?bool $skipDuplicateContactCheck = false,
+        // Partial senders (a webhook that only knows the phone it came from) must set this,
+        // otherwise the update treats their one contact as the full list and deletes the rest.
+        public ?bool $mergeContacts = false,
     ) {
         $this->cleanFirstNameFromMiddleName();
     }

--- a/src/Domains/Guild/Customers/Traits/ManagesPeopleContactsTrait.php
+++ b/src/Domains/Guild/Customers/Traits/ManagesPeopleContactsTrait.php
@@ -150,7 +150,12 @@ trait ManagesPeopleContactsTrait
         return true;
     }
 
-    protected function syncContactsForUpdate(People $people, DataCollection $contacts): void
+    /**
+     * $merge = the incoming list is a partial payload (one webhook's phone, one enrichment email),
+     * so contacts it doesn't mention are left alone. Default stays authoritative: whatever is
+     * missing from the list is removed, which is what a full form/provider sync means.
+     */
+    protected function syncContactsForUpdate(People $people, DataCollection $contacts, bool $merge = false): void
     {
         if (! $contacts->count()) {
             return;
@@ -199,6 +204,10 @@ trait ManagesPeopleContactsTrait
             foreach ($savedContacts as $saved) {
                 $keepIds[] = $saved->id;
             }
+        }
+
+        if ($merge) {
+            return;
         }
 
         if (! empty($keepIds)) {

--- a/tests/Guild/Integration/PeopleContactSyncTest.php
+++ b/tests/Guild/Integration/PeopleContactSyncTest.php
@@ -111,18 +111,63 @@ final class PeopleContactSyncTest extends TestCase
         $this->assertSame(0, (int) $cells->first()->is_deleted, 'the restored row is active again');
     }
 
-    private function syncWith(People $people, array $contacts): void
+    /**
+     * A webhook only knows the number it came from. In merge mode that single contact must not
+     * read as the authoritative list — the person's email and other phones stay put.
+     */
+    public function testMergeModeKeepsContactsMissingFromThePayload(): void
+    {
+        $people = $this->createPersonWithContacts();
+        $before = $people->contacts()->orderBy('id')->pluck('id')->all();
+
+        $this->syncWith(
+            $people,
+            [new ContactData(value: '2025550122', contacts_types_id: ContactTypeEnum::CELLPHONE->value, weight: 100)],
+            merge: true
+        );
+
+        $contacts = $people->fresh()->contacts()->orderBy('id')->get();
+
+        $this->assertSame($before, $contacts->pluck('id')->all(), 'no contact may be removed in merge mode');
+        $this->assertTrue(
+            $contacts->contains('value', 'test.contact@example.com'),
+            'the email must survive a phone-only update'
+        );
+        $this->assertSame(
+            100,
+            (int) $contacts->firstWhere('contacts_types_id', ContactTypeEnum::CELLPHONE->value)->weight,
+            'the contact present in the payload is still updated'
+        );
+    }
+
+    public function testMergeModeAddsAContactTheRecordDoesNotHave(): void
+    {
+        $people = $this->createPersonWithContacts();
+
+        $this->syncWith(
+            $people,
+            [new ContactData(value: '2025550199', contacts_types_id: ContactTypeEnum::CELLPHONE->value, weight: 100)],
+            merge: true
+        );
+
+        $contacts = $people->fresh()->contacts()->get();
+
+        $this->assertCount(4, $contacts, 'the new number is appended, nothing is evicted');
+        $this->assertTrue($contacts->contains('value', '2025550199'));
+    }
+
+    private function syncWith(People $people, array $contacts, bool $merge = false): void
     {
         $runner = new class () {
             use ManagesPeopleContactsTrait;
 
-            public function run(People $people, DataCollection $contacts): void
+            public function run(People $people, DataCollection $contacts, bool $merge): void
             {
-                $this->syncContactsForUpdate($people, $contacts);
+                $this->syncContactsForUpdate($people, $contacts, $merge);
             }
         };
 
-        $runner->run($people, new DataCollection(ContactData::class, $contacts));
+        $runner->run($people, new DataCollection(ContactData::class, $contacts), $merge);
     }
 
     private function createPersonWithContacts(): People


### PR DESCRIPTION
syncContactsForUpdate treated every incoming list as authoritative, so the Twilio webhook (which only knows the sender's phone) deleted the person's email and other phones on every inbound SMS. Add a mergeContacts flag to the People DTO that skips the removal step and use it from the Twilio job.

## General Description

Please include a summary of the changes and the related issue. Highlight key points of the PR, any relevant information, and reasons for making the change.

## Related Issue

A link to the ticket or issue that this PR is related to.(if applicable)

## Checklist

A checklist of things that should be done before merging this PR. Linked to the ticket or issue that this PR is related to.(if applicable)

- [ ] I have performed a self-review of my code.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [ ] My changes generate no new warnings.
- [ ] My changes do not break any existing tests.

## Screenshots (if applicable)

Provide screenshots of impactful changes you have made so that the reviewer can quickly understand the changes.
