### PR TITLE
hotfix: fix accounting

### DIFF
--- a/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Accounting/AccountsPayableAgent.php
@@ -9,6 +9,7 @@ use Kanvas\Intelligence\Agents\Neuron\SystemUserAgent;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\AddOrganizationApproverTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ApprovePendingItemTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\CategorizeExpenseTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ExtractExpenseReceiptTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ExtractInvoiceDataTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindBillTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\FindPurchaseOrderTool;
@@ -21,6 +22,7 @@ use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryApAgingTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryDataFreshnessTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryDueToEmployeesTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\QueryExpenseReportTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\RecordCompanyCardExpenseTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\RecordExpenseReimbursementTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\AddBillNoteTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Acumatica\ApplyApPaymentTool;
@@ -101,6 +103,9 @@ class AccountsPayableAgent extends SystemUserAgent
             new ReadEmailDetailsTool(),
             new DownloadAttachmentTool(),
             new ExtractInvoiceDataTool(),
+            // The receipt half of the same job: a card slip carries no invoice number, due date or
+            // line items, so extract_invoice_data has nothing to read off it.
+            new ExtractExpenseReceiptTool(),
             // extract_invoice_data and the inbound attachment markers both speak filesystem_id;
             // without this the agent quotes that id at a person who then has nothing to open.
             new GetFileLinkTool(),
@@ -116,9 +121,12 @@ class AccountsPayableAgent extends SystemUserAgent
         }
 
         // approve_pending_item must authorize against the real human, not actingUser() (the agent itself on @mention/channel surfaces).
+        // record_company_card_expense sits here for the same reason from the other direction: it books company
+        // money, and this agent reads inbound email, so it must never fire on a turn no person asked for.
         $requestingHuman = $this->requestingHuman();
         if ($requestingHuman !== null && $this->app !== null && $this->company !== null) {
             $tools[] = new ApprovePendingItemTool()->withContext($this->app, $this->company, $requestingHuman);
+            $tools[] = new RecordCompanyCardExpenseTool()->withContext($this->app, $this->company, $requestingHuman);
         }
 
         return $tools;
@@ -148,6 +156,16 @@ class AccountsPayableAgent extends SystemUserAgent
             . 'on DRAFT expenses only. Emailed and agent-filed receipts land on the Travel & Meals fallback '
             . 'because nothing classifies them, so a report full of "travel" usually means uncategorized, not '
             . 'a company that only travels — say so rather than reporting it at face value.',
+            '- "Book this card charge" / "expense this receipt, it went on the company Amex" → read the slip '
+            . 'with extract_expense_receipt first (extract_invoice_data is for a vendor invoice the company '
+            . 'still owes; a card receipt carries no invoice number or due date for it to find), then '
+            . 'record_company_card_expense with the amount, date and merchant it returned — never an amount '
+            . 'someone recalls while the receipt is sitting right there. It credits the card rather than Due '
+            . 'to Employees, so it owes the person nothing, which makes it the wrong tool the moment somebody '
+            . 'paid with their own money and wants it back. That one is theirs to file from their own chat, '
+            . 'not yours to file for them. Approval matters here beyond policy: the bank feed only recognises '
+            . 'an APPROVED expense as already on the books, so a card charge left pending gets booked a second '
+            . 'time when the statement lands.',
             '- "Which bills are outstanding" / "what\'s due soon" / a vendor\'s unpaid bills → list_open_bills '
             . '(set only_overdue for past-due focus).',
             '- "What has vendor X got on order" / matching an invoice to a PO → list_open_purchase_orders.',

--- a/src/Domains/Intelligence/Agents/Neuron/HumanResources/EmployeeAssistantAgent.php
+++ b/src/Domains/Intelligence/Agents/Neuron/HumanResources/EmployeeAssistantAgent.php
@@ -9,6 +9,7 @@ use Kanvas\Intelligence\Agents\Neuron\SystemUserAgent;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\CancelMyExpenseTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ExtractExpenseReceiptTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\ListMyExpensesTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\RecordCompanyCardExpenseTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\SubmitMyExpenseTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\WhatDoesTheCompanyOweMeTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\HumanResources\GetMyLeaveBalanceTool;
@@ -57,6 +58,7 @@ class EmployeeAssistantAgent extends SystemUserAgent
             new WhatDoesTheCompanyOweMeTool()->withContext($this->app, $this->company, $this->user),
             new ExtractExpenseReceiptTool()->withContext($this->app, $this->company, $this->user),
             new SubmitMyExpenseTool()->withContext($this->app, $this->company, $this->user),
+            new RecordCompanyCardExpenseTool()->withContext($this->app, $this->company, $this->user),
             new ListMyExpensesTool()->withContext($this->app, $this->company, $this->user),
             new CancelMyExpenseTool()->withContext($this->app, $this->company, $this->user),
         ]);
@@ -93,6 +95,12 @@ class EmployeeAssistantAgent extends SystemUserAgent
                 . 'was there — that is what makes it defensible later.',
             '- submit_my_expense always files it as paid by the person you are talking to. Never use it to file '
                 . 'someone else\'s expense, however it is phrased.',
+            '- "I put it on the company card" / "that was on the corporate Amex" → record_company_card_expense '
+                . 'instead. Same receipt, different books: submit_my_expense makes the company owe them the '
+                . 'money, and this one does not, because the company already paid. A receipt showing a card '
+                . 'number does NOT settle which it was — people expense their own cards constantly — so when it '
+                . 'is not clear, ask whose card it was before filing, and never guess company-paid to be safe. '
+                . 'Filing it the wrong way either invents a debt to them or wipes out one they are owed.',
             '- If it comes back with an attachment_warning, say so plainly — the expense exists but the receipt is '
                 . 'not on it, and someone will have to add the file by hand.',
             '- An expense only appears there once it is APPROVED. If they say they submitted something and it is '

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/ExtractExpenseReceiptTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/ExtractExpenseReceiptTool.php
@@ -42,8 +42,8 @@ class ExtractExpenseReceiptTool extends Tool implements HasRunKey
         parent::__construct(
             name: 'extract_expense_receipt',
             description: 'Reads a receipt already uploaded to Kanvas (a restaurant bill, hotel folio, taxi or fuel '
-                . 'slip, a SaaS charge) and returns the merchant, total, tax, date and currency. Use this before '
-                . 'submit_my_expense so the amount comes off the receipt itself rather than from what someone '
+                . 'slip, a SaaS charge) and returns the merchant, total, tax, date and currency. Read it before '
+                . 'filing the expense so the amount comes off the receipt itself rather than from what someone '
                 . 'remembers. For a vendor invoice the company still has to pay, use extract_invoice_data instead.',
         );
     }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/RecordCompanyCardExpenseTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/RecordCompanyCardExpenseTool.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
+
+use Baka\Support\Str;
+use Illuminate\Support\Carbon;
+use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\FilesExpenseForTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\RequiresHumanCaller;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\ResolvesFilesystemForTool;
+use Kanvas\Intelligence\Tools\Traits\ReportsToolOutcome;
+use Kanvas\Scribe\Expenses\Actions\CreateExpenseAction;
+use Kanvas\Scribe\Expenses\Actions\SubmitExpenseForApprovalAction;
+use Kanvas\Scribe\Expenses\DataTransferObject\Expense as ExpenseData;
+use Kanvas\Scribe\Expenses\Enums\ExpensePaidByEnum;
+use NeuronAI\Tools\HasRunKey;
+use NeuronAI\Tools\PropertyType;
+use NeuronAI\Tools\Tool;
+use NeuronAI\Tools\ToolProperty;
+use NeuronAI\Tools\TrackByInputs;
+use Override;
+use Throwable;
+
+/**
+ * Files a charge the COMPANY already paid on its own card, and submits it for approval.
+ *
+ * The counterpart to submit_my_expense, and the reason both exist rather than one tool with a
+ * paid_by argument: the two book opposite things. A personal outlay credits Due to Employees and
+ * leaves the company owing the employee; a card swipe credits Credit Card Liability and owes nobody
+ * anything. Handing that choice to a model as a parameter means one bad guess quietly invents — or
+ * quietly erases — a debt to a person. Fixing paid_by per tool makes the choice the caller's, made
+ * in words, before the tool is picked.
+ *
+ * `paid_by_users_id` stays null, matching what PDF ingest writes for a card receipt. The column is
+ * what the Due-to-Employees report pays out against, so a name in it on a company-paid row is a
+ * claim waiting to be honoured twice. Who filed this is already on `users_id`, which is the question
+ * anyone actually asks of a card charge.
+ *
+ * Approval is not ceremony here: the bank-feed reconciler only counts APPROVED expenses when it
+ * looks for a charge the books already hold (BankTransactionMatchService::findBookedExpense), so a
+ * card expense that never gets approved is one the Mercury feed will happily book a second time.
+ */
+#[AgentTool(name: 'Record Company Card Expense', category: 'accounting')]
+class RecordCompanyCardExpenseTool extends Tool implements HasRunKey
+{
+    use FilesExpenseForTool;
+    use HasKanvasContext;
+    use ReportsToolOutcome;
+    use RequiresHumanCaller;
+    use ResolvesFilesystemForTool;
+    use TrackByInputs;
+
+    public function __construct()
+    {
+        parent::__construct(
+            name: 'record_company_card_expense',
+            description: 'Files a purchase paid on a COMPANY card — a card the business issued, where the money '
+                . 'has already left the company and nobody is owed anything back. Not for money somebody paid '
+                . 'out of their own pocket and wants back — that is a reimbursement claim, a different entry on '
+                . 'the books — so ask whose card it was when the receipt does not say. Read the receipt with '
+                . 'extract_expense_receipt first when there is one.',
+        );
+    }
+
+    /**
+     * @return array<int, ToolProperty>
+     */
+    #[Override]
+    protected function properties(): array
+    {
+        return [
+            new ToolProperty(
+                name: 'amount',
+                type: PropertyType::NUMBER,
+                description: 'Total charged to the card, in `currency`, including tax. Must be greater than zero.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'description',
+                type: PropertyType::STRING,
+                description: 'What the company bought and what for — e.g. "Figma seats for the design team". '
+                    . 'Include who it was for on a client expense.',
+                required: true,
+            ),
+            new ToolProperty(
+                name: 'expense_date',
+                type: PropertyType::STRING,
+                description: 'ISO date (YYYY-MM-DD) of the charge. Defaults to today when genuinely unknown — '
+                    . 'prefer the date on the receipt, since that is what the card statement will show.',
+                required: false,
+            ),
+            new ToolProperty(
+                name: 'merchant',
+                type: PropertyType::STRING,
+                description: 'Where it was spent (the store, airline, software vendor).',
+                required: false,
+            ),
+            new ToolProperty(
+                name: 'tax_amount',
+                type: PropertyType::NUMBER,
+                description: 'Tax included in `amount`, when the receipt breaks it out. Defaults to 0.',
+                required: false,
+            ),
+            new ToolProperty(
+                name: 'currency',
+                type: PropertyType::STRING,
+                description: 'ISO currency of `amount`. Defaults to USD.',
+                required: false,
+            ),
+            new ToolProperty(
+                name: 'card_last4',
+                type: PropertyType::STRING,
+                description: 'The last 4 digits of the card, when the receipt or the person gives them. Worth '
+                    . 'passing whenever you have it — it is what tells Finance which card on the statement this '
+                    . 'belongs to when several are in use.',
+                required: false,
+            ),
+            new ToolProperty(
+                name: 'filesystem_id',
+                type: PropertyType::INTEGER,
+                description: 'The uploaded receipt, when there is one — it gets attached to the expense.',
+                required: false,
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function __invoke(
+        float $amount,
+        string $description,
+        ?string $expense_date = null,
+        ?string $merchant = null,
+        ?float $tax_amount = null,
+        ?string $currency = null,
+        ?string $card_last4 = null,
+        ?int $filesystem_id = null,
+    ): array {
+        if (! $this->hasTenantContext()) {
+            return $this->tenantContextMissingError('expense');
+        }
+
+        // Not the Due-to-Employees argument that guards submit_my_expense — nothing is owed here.
+        // This one posts a real credit against the company's card on approval, and an agent turn is
+        // steered by whatever it last read: an inbound invoice email, a scraped page. The person in
+        // the conversation is the assertion that the charge is real, and lands on `users_id` as the
+        // only audit trail the row will ever have.
+        $user = $this->humanCallerOrDenial('record a company-card expense', 'Say plainly that NOTHING was filed.');
+
+        if (is_array($user)) {
+            return $user;
+        }
+
+        $refusal = $this->nonPositiveAmountRefusal($amount);
+
+        if ($refusal !== null) {
+            return $refusal;
+        }
+
+        $expenseAccountId = $this->expenseAccountOrDenial();
+
+        if (is_array($expenseAccountId)) {
+            return $expenseAccountId;
+        }
+
+        $tax = $tax_amount ?? 0.0;
+        $last4 = $this->normalizeCardLast4($card_last4);
+
+        try {
+            $expense = new CreateExpenseAction(
+                data: new ExpenseData(
+                    app: $this->app,
+                    company: $this->company,
+                    lines: $this->singleExpenseLine(
+                        $description,
+                        $amount,
+                        $tax,
+                        $expenseAccountId,
+                    ),
+                    expense_date: $expense_date !== null ? Carbon::parse($expense_date) : Carbon::today(),
+                    currency: $currency ?? 'USD',
+                    fx_rate_to_base: 1.0,
+                    paid_by: ExpensePaidByEnum::COMPANY_CARD,
+                    vendor_display_name: Str::trimToNull($merchant),
+                    notes: $description,
+                    metadata: array_filter([
+                        'submitted_via' => 'agent',
+                        'card_last4' => $last4,
+                    ], fn (mixed $value): bool => $value !== null),
+                ),
+                user: $user,
+            )->execute();
+        } catch (Throwable $e) {
+            report($e);
+
+            return $this->failed(
+                'I could not file that expense: ' . $e->getMessage(),
+                ['status' => 'not_created'],
+                guidance: 'Say plainly that the expense was NOT filed.',
+            );
+        }
+
+        $attachmentWarning = $this->attachExpenseReceipt($expense, $filesystem_id, $user);
+
+        $submitted = new SubmitExpenseForApprovalAction(
+            expense: $expense,
+            user: $user,
+        )->execute();
+
+        return $this->ok(
+            array_filter([
+                'status' => 'submitted',
+                'expense_id' => $submitted->getId(),
+                'expense_number' => $submitted->expense_number,
+                'total' => (float) $submitted->total_native,
+                'currency' => $submitted->currency,
+                'expense_status' => $submitted->status->value,
+                'paid_by' => $submitted->paid_by->value,
+                'card_last4' => $last4,
+                'attachment_warning' => $attachmentWarning,
+                'message' => 'Filed as paid on the company card and sent for approval. Nobody is owed anything '
+                    . 'for it — the company has already paid.',
+            ], fn (mixed $value): bool => $value !== null),
+        );
+    }
+
+    /**
+     * Models hand this over however the receipt printed it — "****0768", "xxxx-0768", "Visa 0768".
+     * Keeping the digits is the whole value of the field, and a mangled one silently fails to line up
+     * against the statement later.
+     */
+    private function normalizeCardLast4(?string $cardLast4): ?string
+    {
+        $digits = (string) preg_replace('/\D/', '', (string) $cardLast4);
+
+        return strlen($digits) < 4 ? null : substr($digits, -4);
+    }
+}

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/SubmitMyExpenseTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Accounting/SubmitMyExpenseTool.php
@@ -5,28 +5,23 @@ declare(strict_types=1);
 namespace Kanvas\Intelligence\Agents\Neuron\Tools\Accounting;
 
 use Baka\Support\Str;
-use Baka\Users\Contracts\UserInterface;
 use Illuminate\Support\Carbon;
 use Kanvas\Intelligence\Agents\Attributes\AgentTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\FilesExpenseForTool;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\HasKanvasContext;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\RequiresHumanCaller;
 use Kanvas\Intelligence\Agents\Neuron\Tools\Traits\ResolvesFilesystemForTool;
 use Kanvas\Intelligence\Tools\Traits\ReportsToolOutcome;
-use Kanvas\Scribe\Expenses\Actions\AttachExpenseReceiptAction;
 use Kanvas\Scribe\Expenses\Actions\CreateExpenseAction;
 use Kanvas\Scribe\Expenses\Actions\SubmitExpenseForApprovalAction;
 use Kanvas\Scribe\Expenses\DataTransferObject\Expense as ExpenseData;
-use Kanvas\Scribe\Expenses\DataTransferObject\ExpenseLine as ExpenseLineData;
 use Kanvas\Scribe\Expenses\Enums\ExpensePaidByEnum;
-use Kanvas\Scribe\Expenses\Models\Expense;
-use Kanvas\Scribe\PdfIngest\Traits\ExtractsPdfPayloadValuesTrait;
 use NeuronAI\Tools\HasRunKey;
 use NeuronAI\Tools\PropertyType;
 use NeuronAI\Tools\Tool;
 use NeuronAI\Tools\ToolProperty;
 use NeuronAI\Tools\TrackByInputs;
 use Override;
-use Spatie\LaravelData\DataCollection;
 use Throwable;
 
 /**
@@ -36,12 +31,13 @@ use Throwable;
  * is a parameter. That is the point of the tool rather than a convenience: it is what creates the
  * Due to Employees liability, and it is what stops a model from filing someone else's expense or
  * quietly booking a personal outlay as company-paid (which would leave the employee owed money with
- * nothing on the books saying so).
+ * nothing on the books saying so). A charge the company itself paid is the sibling tool,
+ * record_company_card_expense — a different credit, so a different tool rather than an argument.
  */
 #[AgentTool(name: 'Submit My Expense', category: 'accounting')]
 class SubmitMyExpenseTool extends Tool implements HasRunKey
 {
-    use ExtractsPdfPayloadValuesTrait;
+    use FilesExpenseForTool;
     use HasKanvasContext;
     use ReportsToolOutcome;
     use RequiresHumanCaller;
@@ -54,9 +50,10 @@ class SubmitMyExpenseTool extends Tool implements HasRunKey
             name: 'submit_my_expense',
             description: 'Files an expense YOU paid out of pocket and submits it for approval — a client dinner, a '
                 . 'taxi, a hotel, anything you covered personally and want reimbursed. Always files it as paid by '
-                . 'the person you are talking to, so never call it on behalf of someone else. Read the receipt with '
-                . 'extract_expense_receipt first when there is one, and confirm the amount with the person before '
-                . 'filing.',
+                . 'the person you are talking to, so never call it on behalf of someone else, and not for a '
+                . 'charge the company already paid on its own card — that is record_company_card_expense. Read '
+                . 'the receipt with extract_expense_receipt first when there is one, and confirm the amount with '
+                . 'the person before filing.',
         );
     }
 
@@ -136,22 +133,16 @@ class SubmitMyExpenseTool extends Tool implements HasRunKey
             return $user;
         }
 
-        if ($amount <= 0) {
-            return $this->invalidArgs(
-                'An expense needs an amount greater than zero.',
-                ['status' => 'invalid_amount'],
-                guidance: 'Ask the person for the amount before calling again.',
-            );
+        $refusal = $this->nonPositiveAmountRefusal($amount);
+
+        if ($refusal !== null) {
+            return $refusal;
         }
 
-        $expenseAccountId = $this->resolveDefaultExpenseAccountId();
+        $expenseAccountId = $this->expenseAccountOrDenial();
 
-        if ($expenseAccountId === null) {
-            return $this->denied(
-                'This company\'s chart of accounts has no expense account to book this against.',
-                ['status' => 'no_expense_account'],
-                guidance: 'Say the expense was NOT filed and that Finance needs to set up an expense account.',
-            );
+        if (is_array($expenseAccountId)) {
+            return $expenseAccountId;
         }
 
         $tax = $tax_amount ?? 0.0;
@@ -161,14 +152,12 @@ class SubmitMyExpenseTool extends Tool implements HasRunKey
                 data: new ExpenseData(
                     app: $this->app,
                     company: $this->company,
-                    lines: new DataCollection(ExpenseLineData::class, [
-                        new ExpenseLineData(
-                            description: $description,
-                            amount_native: $amount - $tax,
-                            expense_account_id: $expenseAccountId,
-                            tax_amount_native: $tax,
-                        ),
-                    ]),
+                    lines: $this->singleExpenseLine(
+                        $description,
+                        $amount,
+                        $tax,
+                        $expenseAccountId,
+                    ),
                     expense_date: $expense_date !== null ? Carbon::parse($expense_date) : Carbon::today(),
                     currency: $currency ?? 'USD',
                     fx_rate_to_base: 1.0,
@@ -192,7 +181,7 @@ class SubmitMyExpenseTool extends Tool implements HasRunKey
             );
         }
 
-        $attachmentWarning = $this->attachReceipt($expense, $filesystem_id, $user);
+        $attachmentWarning = $this->attachExpenseReceipt($expense, $filesystem_id, $user);
 
         $submitted = new SubmitExpenseForApprovalAction(
             expense: $expense,
@@ -213,35 +202,5 @@ class SubmitMyExpenseTool extends Tool implements HasRunKey
                     . 'you once a manager approves it.',
             ], fn (mixed $value): bool => $value !== null),
         );
-    }
-
-    /**
-     * A receipt that fails to attach must not sink an otherwise valid expense — the amount is already
-     * on the books and the file can be added later, so this reports rather than throws.
-     */
-    private function attachReceipt(Expense $expense, ?int $filesystemId, UserInterface $user): ?string
-    {
-        if ($filesystemId === null) {
-            return null;
-        }
-
-        $receipt = $this->findTenantFile($filesystemId);
-
-        if ($receipt === null) {
-            return "No file with filesystem_id {$filesystemId} for this app — the expense was filed without it.";
-        }
-
-        try {
-            new AttachExpenseReceiptAction(
-                expense: $expense,
-                filesystem: $receipt,
-                user: $user,
-                metadata: ['attached_via' => 'agent'],
-            )->execute();
-        } catch (Throwable $e) {
-            return 'The expense was filed but the receipt could not be attached: ' . $e->getMessage();
-        }
-
-        return null;
     }
 }

--- a/src/Domains/Intelligence/Agents/Neuron/Tools/Traits/FilesExpenseForTool.php
+++ b/src/Domains/Intelligence/Agents/Neuron/Tools/Traits/FilesExpenseForTool.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Neuron\Tools\Traits;
+
+use Baka\Users\Contracts\UserInterface;
+use Kanvas\Scribe\Expenses\Actions\AttachExpenseReceiptAction;
+use Kanvas\Scribe\Expenses\DataTransferObject\ExpenseLine as ExpenseLineData;
+use Kanvas\Scribe\Expenses\Models\Expense;
+use Kanvas\Scribe\PdfIngest\Traits\ExtractsPdfPayloadValuesTrait;
+use Spatie\LaravelData\DataCollection;
+use Throwable;
+
+/**
+ * Everything a "file an expense from what someone said in chat" tool needs EXCEPT the paid_by
+ * decision, so that decision stays the only thing separating one such tool from the next. Splitting
+ * these out is what keeps a second paid_by lane from arriving as a second copy of the first, which
+ * is how the refusal texts and the tax-split drift apart.
+ *
+ * Requires HasKanvasContext (`$this->app` / `$this->company`), ReportsToolOutcome and
+ * ResolvesFilesystemForTool on the host.
+ */
+trait FilesExpenseForTool
+{
+    use ExtractsPdfPayloadValuesTrait;
+
+    /**
+     * The finished refusal to return verbatim, or null when the amount is usable.
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function nonPositiveAmountRefusal(float $amount): ?array
+    {
+        if ($amount > 0) {
+            return null;
+        }
+
+        return $this->invalidArgs(
+            'An expense needs an amount greater than zero.',
+            ['status' => 'invalid_amount'],
+            guidance: 'Ask the person for the amount before calling again.',
+        );
+    }
+
+    /**
+     * The account the line lands on, or the finished refusal when the tenant's chart of accounts has
+     * nothing to book against.
+     *
+     * @return int|array<string, mixed>
+     */
+    protected function expenseAccountOrDenial(): int|array
+    {
+        return $this->resolveDefaultExpenseAccountId() ?? $this->denied(
+            'This company\'s chart of accounts has no expense account to book this against.',
+            ['status' => 'no_expense_account'],
+            guidance: 'Say the expense was NOT filed and that Finance needs to set up an expense account.',
+        );
+    }
+
+    /**
+     * A receipt is one number, and that number is what the person paid — tax included. So the tax
+     * comes back OUT of the total rather than being added on top of it, or the expense books high by
+     * the tax on every single call.
+     *
+     * @return DataCollection<ExpenseLineData>
+     */
+    protected function singleExpenseLine(
+        string $description,
+        float $amount,
+        float $tax,
+        int $expenseAccountId,
+    ): DataCollection {
+        return new DataCollection(ExpenseLineData::class, [
+            new ExpenseLineData(
+                description: $description,
+                amount_native: $amount - $tax,
+                expense_account_id: $expenseAccountId,
+                tax_amount_native: $tax,
+            ),
+        ]);
+    }
+
+    /**
+     * A receipt that fails to attach must not sink an otherwise valid expense — the amount is already
+     * on the books and the file can be added later, so this reports rather than throws.
+     */
+    protected function attachExpenseReceipt(Expense $expense, ?int $filesystemId, UserInterface $user): ?string
+    {
+        if ($filesystemId === null) {
+            return null;
+        }
+
+        $receipt = $this->findTenantFile($filesystemId);
+
+        if ($receipt === null) {
+            return "No file with filesystem_id {$filesystemId} for this company — the expense was filed without it.";
+        }
+
+        try {
+            new AttachExpenseReceiptAction(
+                expense: $expense,
+                filesystem: $receipt,
+                user: $user,
+                metadata: ['attached_via' => 'agent'],
+            )->execute();
+        } catch (Throwable $e) {
+            return 'The expense was filed but the receipt could not be attached: ' . $e->getMessage();
+        }
+
+        return null;
+    }
+}

--- a/src/Domains/Scribe/Expenses/Actions/AttachExpenseReceiptAction.php
+++ b/src/Domains/Scribe/Expenses/Actions/AttachExpenseReceiptAction.php
@@ -47,6 +47,8 @@ class AttachExpenseReceiptAction
             $receipt->metadata = $this->metadata;
             $receipt->save();
 
+            $this->expense->addFile($this->filesystem, 'receipt_' . $receipt->getKey());
+
             return $receipt->refresh();
         });
     }

--- a/tests/Scribe/Expenses/ExpenseLifecycleTest.php
+++ b/tests/Scribe/Expenses/ExpenseLifecycleTest.php
@@ -491,6 +491,56 @@ class ExpenseLifecycleTest extends TestCase
         $this->assertSame(0.92, $receipt->metadata['ocr_confidence']);
     }
 
+    /**
+     * `ScribeExpense` exposes both `receipts` and the platform-standard `files`. A client reading
+     * `files` — the field every other Kanvas entity carries — must not find an expense empty while
+     * its receipt sits under a field only Scribe knows about.
+     */
+    public function test_attach_receipt_also_exposes_the_file_under_files(): void
+    {
+        $draft = $this->createDraftExpense(amount: 75.0);
+        $filesystem = $this->createFilesystemRow();
+
+        new AttachExpenseReceiptAction(
+            expense: $draft,
+            filesystem: $filesystem,
+            user: static::$cachedUser,
+        )->execute();
+
+        $files = $draft->filesForGraphType()->get();
+
+        $this->assertCount(1, $files);
+        $this->assertSame($filesystem->name, $files->first()->name);
+    }
+
+    /**
+     * The reason the field_name is keyed per receipt. With filesystem_allow_duplicate_files_by_name off
+     * — the default — AttachFilesystemAction rebinds the row already holding that field_name rather than
+     * adding one, so a constant 'receipt' would drop the first file the moment a second was attached,
+     * while `receipts` kept showing both.
+     */
+    public function test_a_second_receipt_does_not_displace_the_first_under_files(): void
+    {
+        $draft = $this->createDraftExpense(amount: 75.0);
+        $first = $this->createFilesystemRow();
+        $second = $this->createFilesystemRow();
+
+        foreach ([$first, $second] as $filesystem) {
+            new AttachExpenseReceiptAction(
+                expense: $draft,
+                filesystem: $filesystem,
+                user: static::$cachedUser,
+            )->execute();
+        }
+
+        $names = $draft->filesForGraphType()->get()->pluck('name')->all();
+
+        $this->assertCount(2, $names);
+        $this->assertContains($first->name, $names);
+        $this->assertContains($second->name, $names);
+        $this->assertSame(2, $draft->receipts()->count());
+    }
+
     public function test_attach_receipt_rejected_on_voided_expense(): void
     {
         $draft = $this->createDraftExpense(amount: 75.0);

--- a/tests/Scribe/Intelligence/RecordCompanyCardExpenseToolTest.php
+++ b/tests/Scribe/Intelligence/RecordCompanyCardExpenseToolTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Scribe\Intelligence;
+
+use Kanvas\Intelligence\Agents\Enums\ToolOutcomeEnum;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\RecordCompanyCardExpenseTool;
+use Kanvas\Intelligence\Agents\Neuron\Tools\Accounting\WhatDoesTheCompanyOweMeTool;
+use Kanvas\Scribe\Expenses\Actions\ApproveExpenseAction;
+use Kanvas\Scribe\Expenses\Enums\ExpensePaidByEnum;
+use Kanvas\Scribe\Expenses\Enums\ExpenseReimbursementStatusEnum;
+use Kanvas\Scribe\Expenses\Enums\ExpenseStatusEnum;
+use Kanvas\Scribe\Expenses\Models\Expense;
+use Kanvas\Scribe\Ledger\Enums\AccountSubTypeEnum;
+use Kanvas\Scribe\Ledger\Models\JournalEntry;
+use Kanvas\Scribe\Ledger\Models\JournalEntryLine;
+use Kanvas\Users\Models\Users;
+use Tests\Scribe\ScribeTestCase;
+
+final class RecordCompanyCardExpenseToolTest extends ScribeTestCase
+{
+    public function test_files_the_charge_against_the_company_card_and_submits_it(): void
+    {
+        $employee = $this->seedTestEmployee('card-expense');
+
+        $result = $this->record($employee, 3.79, 'Mouthwash for the office first-aid kit');
+
+        $this->assertSame('submitted', $result['status'], (string) ($result['message'] ?? ''));
+        $this->assertSame('company_card', $result['paid_by']);
+        $this->assertEqualsWithDelta(3.79, $result['total'], 0.005);
+
+        $expense = Expense::getById($result['expense_id']);
+        $this->assertSame(ExpensePaidByEnum::COMPANY_CARD, $expense->paid_by);
+        $this->assertSame(ExpenseStatusEnum::PENDING_APPROVAL, $expense->status);
+        $this->assertSame(ExpenseReimbursementStatusEnum::NOT_APPLICABLE, $expense->reimbursement_status);
+        $this->assertSame('CVS Pharmacy', $expense->vendor_display_name);
+    }
+
+    /**
+     * `paid_by_users_id` is what the Due-to-Employees report pays out against, so a name in it on a
+     * company-paid row is a claim waiting to be honoured. The filer belongs on `users_id`, which is
+     * the question anyone actually asks of a card charge, and that one is still answered.
+     */
+    public function test_names_the_filer_without_making_them_a_creditor(): void
+    {
+        $employee = $this->seedTestEmployee('card-expense');
+
+        $expense = Expense::getById($this->record($employee, 3.79, 'Office supplies')['expense_id']);
+
+        $this->assertNull($expense->paid_by_users_id);
+        $this->assertSame($employee->getId(), (int) $expense->users_id);
+    }
+
+    /**
+     * The whole reason this is a separate tool from submit_my_expense. Filed through that one, the
+     * same receipt leaves the company owing the employee; through this one it must never do so — not
+     * before approval, and not after, which is where a wrong paid_by would finally surface as money.
+     */
+    public function test_the_company_never_ends_up_owing_the_person_who_filed_it(): void
+    {
+        $employee = $this->seedTestEmployee('card-expense');
+
+        $expense = Expense::getById($this->record($employee, 145.50, 'Team lunch on the company card')['expense_id']);
+
+        new ApproveExpenseAction(expense: $expense, approver: static::$cachedUser)->execute();
+
+        $owed = new WhatDoesTheCompanyOweMeTool()
+            ->withContext($this->kanvasApp, $this->company, $employee)
+            ->__invoke();
+
+        $this->assertSame('nothing_owed', $owed['status']);
+    }
+
+    /**
+     * The ledger-level version of the same claim, and the one the bank feed reads: approval has to
+     * credit Credit Card Liability, because that is the account the card's own statement rows land
+     * against. Credit the wrong one and BankTransactionMatchService::findBookedExpense stops
+     * recognising this charge as already booked, and the Mercury feed posts it a second time.
+     */
+    public function test_approval_credits_the_card_and_not_due_to_employees(): void
+    {
+        $employee = $this->seedTestEmployee('card-expense');
+
+        $expense = Expense::getById($this->record($employee, 150.00, 'Annual SaaS renewal')['expense_id']);
+        new ApproveExpenseAction(expense: $expense, approver: static::$cachedUser)->execute();
+
+        $credits = JournalEntryLine::query()
+            ->whereIn(
+                'journal_entry_id',
+                JournalEntry::query()
+                    ->where('apps_id', $this->kanvasApp->getId())
+                    ->where('source_type', 'expense')
+                    ->where('source_id', $expense->getId())
+                    ->select('id')
+            )
+            ->where('credit_base', '>', 0)
+            ->pluck('credit_base', 'account_id');
+
+        $cardAccount = $this->accountIdBySubType(AccountSubTypeEnum::CREDIT_CARD_LIABILITY);
+        $employeeAccount = $this->accountIdBySubType(AccountSubTypeEnum::DUE_TO_EMPLOYEES);
+
+        $this->assertEqualsWithDelta(150.00, (float) $credits[$cardAccount], 0.005);
+        $this->assertArrayNotHasKey($employeeAccount, $credits);
+    }
+
+    public function test_splits_tax_out_of_the_total_rather_than_adding_to_it(): void
+    {
+        $employee = $this->seedTestEmployee('card-expense');
+
+        $expense = Expense::getById($this->record($employee, 4.19, 'Mouthwash', taxAmount: 0.40)['expense_id']);
+
+        $this->assertEqualsWithDelta(4.19, (float) $expense->total_native, 0.005);
+        $this->assertEqualsWithDelta(3.79, (float) $expense->subtotal_native, 0.005);
+        $this->assertEqualsWithDelta(0.40, (float) $expense->tax_native, 0.005);
+    }
+
+    /**
+     * Receipts print the card every which way, and the digits are the entire value of the field —
+     * they are what ties this row to one card on a statement carrying several.
+     */
+    public function test_keeps_the_card_digits_however_the_receipt_printed_them(): void
+    {
+        $employee = $this->seedTestEmployee('card-expense');
+
+        $result = $this->record($employee, 4.19, 'Mouthwash', cardLast4: 'VISA ****0768');
+
+        $this->assertSame('0768', $result['card_last4']);
+        $this->assertSame('0768', Expense::getById($result['expense_id'])->metadata['card_last4']);
+    }
+
+    public function test_drops_a_card_reference_it_cannot_read(): void
+    {
+        $employee = $this->seedTestEmployee('card-expense');
+
+        $result = $this->record($employee, 4.19, 'Mouthwash', cardLast4: 'the blue one');
+
+        $this->assertArrayNotHasKey('card_last4', $result);
+        $this->assertArrayNotHasKey('card_last4', Expense::getById($result['expense_id'])->metadata ?? []);
+    }
+
+    public function test_attaches_the_receipt_when_one_is_given(): void
+    {
+        $employee = $this->seedTestEmployee('card-expense');
+        $receipt = $this->createFilesystemRow();
+
+        $result = $this->record($employee, 4.19, 'Mouthwash', filesystemId: (int) $receipt->getKey());
+
+        $this->assertArrayNotHasKey('attachment_warning', $result);
+        $this->assertSame(1, Expense::getById($result['expense_id'])->receipts()->count());
+    }
+
+    public function test_reports_a_missing_receipt_without_losing_the_expense(): void
+    {
+        $employee = $this->seedTestEmployee('card-expense');
+
+        $result = $this->record($employee, 4.19, 'Mouthwash', filesystemId: 99999999);
+
+        $this->assertSame('submitted', $result['status']);
+        $this->assertStringContainsString('99999999', $result['attachment_warning']);
+    }
+
+    /**
+     * This one books company money rather than a debt to a person, so the Due-to-Employees argument
+     * that guards submit_my_expense does not apply. The guard still has to hold, for the other
+     * reason: an agent turn is steered by whatever it last read, and this agent reads inbound email.
+     */
+    public function test_refuses_to_book_company_money_on_an_agents_own_turn(): void
+    {
+        $agentUser = $this->seedTestEmployee('agent-identity');
+        $agent = Agent::factory()
+            ->withAppId($this->kanvasApp->getId())
+            ->withCompanyId($this->company->getId())
+            ->create(['name' => 'Polly', 'user_id' => $agentUser->getId()]);
+
+        $result = new RecordCompanyCardExpenseTool()
+            ->withContext(
+                $this->kanvasApp,
+                $this->company,
+                $agentUser,
+                $agent,
+            )
+            ->__invoke(amount: 4.19, description: 'A charge nobody asked for');
+
+        $this->assertFalse($result['success']);
+        $this->assertSame('agent_caller', $result['status']);
+        $this->assertSame(ToolOutcomeEnum::DENIED->value, $result['outcome']);
+        $this->assertSame(
+            0,
+            Expense::query()
+                ->where('apps_id', $this->kanvasApp->getId())
+                ->where('users_id', $agentUser->getId())
+                ->count(),
+        );
+    }
+
+    public function test_refuses_an_amount_that_is_not_a_charge(): void
+    {
+        $result = $this->record($this->seedTestEmployee('card-expense'), 0.0, 'Nothing');
+
+        $this->assertSame('invalid_amount', $result['status']);
+        $this->assertFalse($result['success']);
+        $this->assertSame(ToolOutcomeEnum::INVALID_ARGS->value, $result['outcome']);
+    }
+
+    public function test_fails_closed_without_a_tenant(): void
+    {
+        $result = new RecordCompanyCardExpenseTool()->__invoke(amount: 4.19, description: 'x');
+
+        $this->assertSame('no_tenant_context', $result['reason']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function record(
+        Users $employee,
+        float $amount,
+        string $description,
+        ?float $taxAmount = null,
+        ?string $cardLast4 = null,
+        ?int $filesystemId = null,
+    ): array {
+        return new RecordCompanyCardExpenseTool()
+            ->withContext($this->kanvasApp, $this->company, $employee)
+            ->__invoke(
+                amount: $amount,
+                description: $description,
+                expense_date: '2026-06-15',
+                merchant: 'CVS Pharmacy',
+                tax_amount: $taxAmount,
+                card_last4: $cardLast4,
+                filesystem_id: $filesystemId,
+            );
+    }
+}


### PR DESCRIPTION
People own a notes channel of their own now, so a note posted on a person
reaches this activity with Message::entity() resolving to People. The guard
only checked for null, so a People fell through to the Lead-only
setContactStatus() and fataled the queue worker (KANVAS-ECOSYSTEM-6CE).
