### PR TITLE
fix(credit700): wait 20s for the engagement row before submitting the credit application

### DIFF
--- a/src/Domains/Connectors/Credit700/Workflow/SubmitCreditApplicationActivity.php
+++ b/src/Domains/Connectors/Credit700/Workflow/SubmitCreditApplicationActivity.php
@@ -15,8 +15,6 @@ use Kanvas\Workflow\KanvasActivity;
 #[WorkflowAction]
 class SubmitCreditApplicationActivity extends KanvasActivity
 {
-    private const ENGAGEMENT_WAIT_SECONDS = 20;
-
     public $tries = 3;
 
     /**
@@ -34,7 +32,7 @@ class SubmitCreditApplicationActivity extends KanvasActivity
             integrationOperation: function ($message, $app, $integrationCompany, $additionalParams): array {
                 // The engagement row is written by a separate flow that can still be in-flight when
                 // this activity picks up the message, so getEngagement() throws ModelNotFoundException.
-                sleep(self::ENGAGEMENT_WAIT_SECONDS);
+                sleep(20);
 
                 $result = new SubmitCreditApplicationAction($message)->execute();
 

--- a/src/Domains/Connectors/Credit700/Workflow/SubmitCreditApplicationActivity.php
+++ b/src/Domains/Connectors/Credit700/Workflow/SubmitCreditApplicationActivity.php
@@ -15,6 +15,8 @@ use Kanvas\Workflow\KanvasActivity;
 #[WorkflowAction]
 class SubmitCreditApplicationActivity extends KanvasActivity
 {
+    private const ENGAGEMENT_WAIT_SECONDS = 20;
+
     public $tries = 3;
 
     /**
@@ -30,6 +32,10 @@ class SubmitCreditApplicationActivity extends KanvasActivity
             integration: IntegrationsEnum::CREDIT700,
             additionalParams: $params,
             integrationOperation: function ($message, $app, $integrationCompany, $additionalParams): array {
+                // The engagement row is written by a separate flow that can still be in-flight when
+                // this activity picks up the message, so getEngagement() throws ModelNotFoundException.
+                sleep(self::ENGAGEMENT_WAIT_SECONDS);
+
                 $result = new SubmitCreditApplicationAction($message)->execute();
 
                 return [


### PR DESCRIPTION
## Problem

`SubmitCreditApplicationActivity` fails in the `workflow` queue with:

```
Illuminate\Database\Eloquent\ModelNotFoundException: No query results for model [Kanvas\ActionEngine\Engagements\Models\Engagement].
#3 src/Domains/Social/Messages/Models/Message.php(341): Relation->__call('firstOrFail')
#4 src/Domains/Connectors/Credit700/Actions/SubmitCreditApplicationAction.php(30): Message->getEngagement()
#5 src/Domains/Connectors/Credit700/Workflow/SubmitCreditApplicationActivity.php(33)
```

The activity is dispatched off the message, but the `engagements` row that points back at that message is written by a separate flow that can still be in-flight when the worker picks the job up. `Message::getEngagement()` uses `firstOrFail()`, so the activity blows up instead of finding the engagement a moment later.

## Change

Sleep 20s at the top of the integration operation, before `SubmitCreditApplicationAction` runs, so the engagement write has landed by the time `getEngagement()` is called.

- `src/Domains/Connectors/Credit700/Workflow/SubmitCreditApplicationActivity.php` — `ENGAGEMENT_WAIT_SECONDS = 20` const + `sleep()` inside the `integrationOperation` closure (so we only pay the delay when the Credit700 integration is actually enabled for the company).

## Notes

This is the mitigation asked for, not a structural fix — it trades a blocked worker slot for 20s per submission against the race. The real fix is either dispatching the activity only after the engagement is committed, or polling/retrying the lookup instead of a fixed wait. Volume on this activity is low so the blocked slot is acceptable for now; the existing `$tries = 3` still covers the case where 20s isn't enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)