### PR TITLE
[1.x] Dedupe People-by-email lookups onto PeoplesRepository::getByEmail

### DIFF
--- a/src/Domains/Connectors/Salesforce/Actions/PullPropertyContactAction.php
+++ b/src/Domains/Connectors/Salesforce/Actions/PullPropertyContactAction.php
@@ -9,6 +9,7 @@ use Baka\Contracts\CompanyInterface;
 use Kanvas\Connectors\Salesforce\Enums\CustomFieldEnum;
 use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
 use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
 use Kanvas\Guild\Organizations\Actions\CreateOrganizationAction;
 use Kanvas\Guild\Organizations\DataTransferObject\Organization as OrganizationData;
 use Kanvas\Inventory\Products\Models\Products;
@@ -40,7 +41,7 @@ class PullPropertyContactAction
         // one field that's actually stable across those rows, so match on it first; the per-
         // relationship id stays as a fallback for the (rare) broker with no email on file, so a
         // re-sync of that same property still finds the same People instead of duplicating again.
-        $people = $email !== '' ? $this->findByEmail($email) : null;
+        $people = $email !== '' ? PeoplesRepository::getByEmail($email, $this->company, $this->app) : null;
 
         $people ??= People::getByCustomFieldTransactionSafe(
             CustomFieldEnum::SALESFORCE_LOCATION_CONTACT_ID->value,
@@ -95,22 +96,6 @@ class PullPropertyContactAction
         $parts = explode(' ', $fullName, 2);
 
         return [$parts[0], $parts[1] ?? $parts[0]];
-    }
-
-    // People::getByEmail() exists but only scopes by apps_id — using it as-is here would risk
-    // matching a person from a different company under the same app. Every other lookup in this
-    // file (getByCustomFieldTransactionSafe) is company-scoped, so this stays consistent with that.
-    private function findByEmail(string $email): ?People
-    {
-        return People::query()
-            ->where('apps_id', $this->app->getId())
-            ->where('companies_id', $this->company->getId())
-            ->where('is_deleted', 0)
-            ->whereHas('contacts', function ($query) use ($email) {
-                $query->where('value', $email)
-                    ->where('contacts_types_id', ContactTypeEnum::EMAIL->value);
-            })
-            ->first();
     }
 
     private function syncContact(People $people, int $typeId, string $value): void

--- a/src/Domains/Connectors/Zoho/Jobs/ProcessZohoDealWebhookJob.php
+++ b/src/Domains/Connectors/Zoho/Jobs/ProcessZohoDealWebhookJob.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Kanvas\Connectors\Zoho\Jobs;
 
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\UploadedFile;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Companies\Models\Companies;
@@ -13,6 +12,7 @@ use Kanvas\Connectors\Zoho\Enums\CustomFieldEnum;
 use Kanvas\Filesystem\Actions\AttachFilesystemAction;
 use Kanvas\Filesystem\Services\FilesystemServices;
 use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Guild\Customers\Repositories\PeoplesRepository;
 use Kanvas\Guild\Deals\Actions\CreateDealAction;
 use Kanvas\Guild\Deals\Actions\UpdateDealAction;
 use Kanvas\Guild\Deals\DataTransferObject\Deal as DealData;
@@ -141,17 +141,7 @@ class ProcessZohoDealWebhookJob extends ProcessWebhookJob
             return null;
         }
 
-        /** @var People|null $people */
-        $people = People::fromApp($app)
-            ->fromCompany($company)
-            ->notDeleted()
-            ->whereHas(
-                'contacts',
-                fn (Builder $q) => $q->where('value', $email)
-            )
-            ->first();
-
-        return $people;
+        return PeoplesRepository::getByEmail($email, $company, $app);
     }
 
     protected function mapCustomFields(Deal $deal, array $zohoDealInfo, Companies $company): void

--- a/src/Domains/Guild/Customers/Models/People.php
+++ b/src/Domains/Guild/Customers/Models/People.php
@@ -589,49 +589,6 @@ class People extends BaseModel
     }
 
     /**
-     * Get person by email.
-     */
-    public static function getByEmail(string $email, ?Apps $app = null): ?self
-    {
-        $app = $app ?? app(Apps::class);
-
-        return self::whereHas('contacts', function ($query) use ($email) {
-            $query->where('value', $email)
-                  ->where('contacts_types_id', ContactType::getByName(ContactTypeEnum::EMAIL->getName())->getId());
-        })->where('apps_id', $app->getId())
-          ->where('is_deleted', 0)
-          ->first();
-    }
-
-    /**
-     * Get person by phone matching (strips non-numeric characters for comparison).
-     */
-    public static function getByPhoneMatchingValue(string $phone, Companies $company, Apps $app): ?self
-    {
-        return self::whereHas('contacts', function ($query) use ($phone) {
-            $query->whereRaw("REGEXP_REPLACE(value, '[^0-9]', '') = REGEXP_REPLACE(?, '[^0-9]', '')", [$phone])
-                  ->whereIn('contacts_types_id', [
-                      ContactType::getByName(ContactTypeEnum::PHONE->getName())->getId(),
-                      ContactType::getByName(ContactTypeEnum::CELLPHONE->getName())->getId(),
-                  ]);
-        })->where('apps_id', $app->getId())
-          ->where('companies_id', $company?->getId())
-          ->where('is_deleted', 0)
-          ->first();
-    }
-
-    public static function getByMatchingValue(string $value, Companies $company, Apps $app): ?self
-    {
-        return self::whereHas('contacts', function ($query) use ($value) {
-            $query->where('value', $value);
-        })
-            ->where('companies_id', $company->getId())
-            ->where('apps_id', $app->getId())
-            ->where('is_deleted', 0)
-            ->first();
-    }
-
-    /**
      * Get all people by phone matching (strips non-numeric characters for comparison).
      */
     public static function getAllByPhoneMatchingValue(string $phone, Companies $company, Apps $app): Collection

--- a/tests/Connectors/Integration/Zoho/ProcessZohoDealWebhookJobFindPeopleTest.php
+++ b/tests/Connectors/Integration/Zoho/ProcessZohoDealWebhookJobFindPeopleTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Integration\Zoho;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Request;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Zoho\Jobs\ProcessZohoDealWebhookJob;
+use Kanvas\Guild\Customers\Enums\ContactTypeEnum;
+use Kanvas\Guild\Customers\Models\Contact;
+use Kanvas\Guild\Customers\Models\People;
+use Kanvas\Workflow\Actions\ProcessWebhookAttemptAction;
+use Kanvas\Workflow\Models\ReceiverWebhook;
+use Kanvas\Workflow\Models\WorkflowAction;
+use ReflectionMethod;
+use Tests\TestCase;
+
+final class ProcessZohoDealWebhookJobFindPeopleTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $connectionsToTransact = [null, 'crm', 'ecosystem'];
+
+    private ReceiverWebhook $receiver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $app = app(Apps::class);
+        $user = auth()->user();
+
+        $action = WorkflowAction::firstOrCreate(
+            ['model_name' => ProcessZohoDealWebhookJob::class],
+            ['name' => 'ProcessZohoDealWebhookJob'],
+        );
+
+        $this->receiver = ReceiverWebhook::factory()
+            ->app($app->getId())
+            ->user($user->getId())
+            ->company($user->getCurrentCompany()->getId())
+            ->create([
+                'action_id' => $action->getId(),
+                'configuration' => [],
+            ]);
+    }
+
+    public function testMatchesThePersonHoldingTheEmailContact(): void
+    {
+        $email = 'zoho-deal-' . fake()->unique()->uuid . '@example.com';
+        $people = $this->makePeopleWithContact($email, ContactTypeEnum::EMAIL->value);
+
+        $this->assertSame(
+            $people->getId(),
+            $this->findPeople(['Email' => $email])?->getId(),
+        );
+    }
+
+    public function testFallsBackToPrimaryEmailKey(): void
+    {
+        $email = 'zoho-deal-' . fake()->unique()->uuid . '@example.com';
+        $people = $this->makePeopleWithContact($email, ContactTypeEnum::EMAIL->value);
+
+        $this->assertSame(
+            $people->getId(),
+            $this->findPeople(['Primary_Email' => $email])?->getId(),
+        );
+    }
+
+    /**
+     * The lookup used to query the contacts relation on `value` alone, so a person whose PHONE
+     * row happened to hold the address was returned as an email match.
+     */
+    public function testIgnoresTheAddressStoredUnderANonEmailContactType(): void
+    {
+        $email = 'zoho-deal-' . fake()->unique()->uuid . '@example.com';
+        $this->makePeopleWithContact($email, ContactTypeEnum::PHONE->value);
+
+        $this->assertNull($this->findPeople(['Email' => $email]));
+    }
+
+    /**
+     * Contacts were matched without checking `is_deleted`, so a removed address kept resolving
+     * to the person it had been detached from.
+     */
+    public function testIgnoresASoftDeletedEmailContact(): void
+    {
+        $email = 'zoho-deal-' . fake()->unique()->uuid . '@example.com';
+        $people = $this->makePeopleWithContact($email, ContactTypeEnum::EMAIL->value);
+        $people->contacts()->where('value', $email)->update(['is_deleted' => 1]);
+
+        $this->assertNull($this->findPeople(['Email' => $email]));
+    }
+
+    public function testDoesNotReachIntoAnotherCompany(): void
+    {
+        $email = 'zoho-deal-' . fake()->unique()->uuid . '@example.com';
+        $otherCompany = Companies::factory()->create(['users_id' => auth()->user()->getId()]);
+        $this->makePeopleWithContact($email, ContactTypeEnum::EMAIL->value, $otherCompany);
+
+        $this->assertNull($this->findPeople(['Email' => $email]));
+    }
+
+    public function testReturnsNullWhenTheDealCarriesNoEmail(): void
+    {
+        $this->assertNull($this->findPeople([]));
+    }
+
+    private function makePeopleWithContact(
+        string $value,
+        int $contactTypeId,
+        ?Companies $company = null
+    ): People {
+        $user = auth()->user();
+        $company ??= $user->getCurrentCompany();
+
+        $people = People::factory()
+            ->withAppId($this->receiver->app->getId())
+            ->withCompanyId($company->getId())
+            ->withUserId($user->getId())
+            ->create();
+
+        Contact::factory()->create([
+            'peoples_id' => $people->getId(),
+            'contacts_types_id' => $contactTypeId,
+            'value' => $value,
+        ]);
+
+        return $people;
+    }
+
+    private function findPeople(array $zohoDealInfo): ?People
+    {
+        $request = Request::create(
+            'https://localhost/v1/receiver/' . $this->receiver->uuid,
+            'POST',
+            [],
+        );
+
+        $job = new ProcessZohoDealWebhookJob(
+            new ProcessWebhookAttemptAction($this->receiver, $request)->execute(),
+        );
+
+        $findPeople = new ReflectionMethod($job, 'findPeople');
+        $findPeople->setAccessible(true);
+
+        return $findPeople->invoke(
+            $job,
+            $zohoDealInfo,
+            null,
+            auth()->user()->getCurrentCompany(),
+            $this->receiver->app,
+        );
+    }
+}


### PR DESCRIPTION
## General Description

Follow-up to #11220, which swapped `PullPropertyContactAction`'s private `findByEmail()` for `PeoplesRepository::getByEmail()` on `development`. Two things were left over: `1.x` never got the fix, and the now-unused private method stayed in the file on both branches.

A sweep of `1.x` for the same pattern (every `whereHas`/`whereRelation` on the `contacts` relation, every `peoples_contacts` join, every method resolving a `?People`) turned up **three** hand-rolled copies of "find a person by their email contact" living next to the repository method, each scoped differently.

### 1. `Salesforce/Actions/PullPropertyContactAction::findByEmail`

The #11220 case, unfixed on `1.x`. Same query as the repository **minus the contact-row `is_deleted` filter** — a detached address still matched, merging a broker onto a stale contact. Call repointed and the dead private method removed.

### 2. `Zoho/Jobs/ProcessZohoDealWebhookJob::findPeople`

```php
->whereHas('contacts', fn (Builder $q) => $q->where('value', $email))
```

Tenant scoping was fine, but it matched on `value` alone:
- **no `contacts_types_id` filter** — an address stored in a phone or "other" contact row counted as an email match
- **no contact `is_deleted` filter** — same stale-address problem as above

### 3. Three dead lookups on the `People` model

| Method | Why it goes |
|---|---|
| `People::getByEmail` | zero callers; `apps_id`-scoped only (no `companies_id`) — which is exactly why the Salesforce author wrote a private copy instead of reusing it |
| `People::getByPhoneMatchingValue` | zero callers |
| `People::getByMatchingValue` | zero callers; duplicates `PeoplesRepository::getByValue` |

Verified against the whole tree (`src`, `app`, `tests`, `graphql`, config) — the only reference to any of them was the explanatory comment in the Salesforce action, which goes with it.

## Checked and deliberately left alone

- **Phone lookups are already centralized** on `PeoplesRepository::getByPhoneNumber` (10 call sites — WaSender, RespondIO, ElevenLabs, Twilio, Voice). No hand-rolled copies.
- `SalesAssist/PullLeadActivity` returns a **Lead** via a ranked join across email/phone/client-id. Different query, not a duplicate.
- `Elead/PullLeadAction` uses `getAllBy*MatchingValue` for a deliberate multi-match + name-ranking fallback.
- `Mercury/PullMercuryCustomersAction::findByEmail` is an **Organization** lookup on a direct `email` column; no `OrganizationsRepository` exists at all. Single copy, correctly scoped.
- Apollo feeds/reports and the CRM search tools (`FindPersonTool`, `SearchLeadsTool`, `SearchDealsTool`) are filters and LIKE searches, not identity resolution.

## Not in this PR

`People::findByEmailOrCreate` / `findByPhoneOrCreate` are the same app-only scoping but **have live callers** (`VinSolution/PushCoBuyerAction`, `SalesAssist/PushLeadNotesActivity`), so they can match a person from another company under the same app and then write to them. Fixing that changes matching behaviour for two connectors and needs its own tests — separate PR.

Also worth its own pass: ~13 sites doing `Users::where('email', $x)->first()` instead of `UsersRepository::getByEmail()`. Not a drop-in (the repository throws where `->first()` returns null).

## Tests

Added `tests/Connectors/Integration/Zoho/ProcessZohoDealWebhookJobFindPeopleTest.php` — locks the two behaviour fixes (wrong contact type, soft-deleted contact) plus the cross-company case and the happy path.

`PullPropertyContactActionTest` already covers the Salesforce action, including `testDoesNotMergeIntoAnUnrelatedBrokerInADifferentCompany`, so the swap there is guarded.

⚠️ **The suite was not run locally** — the test container mounts the `development` checkout and its DB is migrated for that branch, so running `1.x` tests would have meant switching that checkout out from under uncommitted work. `php -l` and php-cs-fixer are clean; leaving the actual run to CI. To run locally:

```bash
docker exec -it phpkanvas-ecosystem bash -c "cd /var/www/html && php vendor/bin/phpunit tests/Connectors/Integration/Zoho/ProcessZohoDealWebhookJobFindPeopleTest.php tests/Connectors/Integration/Salesforce/PullPropertyContactActionTest.php"
```

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation (if needed).
- [x] My changes generate no new warnings.
- [ ] My changes do not break any existing tests. — *not verified locally, see above*

🤖 Generated with [Claude Code](https://claude.com/claude-code)