### PR TITLE
fix(salesassist): resolve the matched Reynolds lead, not the stub entity

### DIFF
--- a/src/Domains/Connectors/SalesAssist/Activities/PullLeadActivity.php
+++ b/src/Domains/Connectors/SalesAssist/Activities/PullLeadActivity.php
@@ -149,7 +149,7 @@ class PullLeadActivity extends KanvasActivity implements WorkflowActivityInterfa
         $resolvedLead = match (true) {
             $isDriveCentric => $leadModel ?? null,
             $isDealerSocket => isset($people) ? LeadsRepository::getPeopleActiveLead($people) : null,
-            $isReynolds => $entity,
+            $isReynolds => $lead ?? null,
             $isVinSolutions, $isElead => isset($pullLead[0]['id'])
                 ? Lead::getByIdFromCompanyApp((int) $pullLead[0]['id'], $company, $app)
                 : null,

--- a/tests/Connectors/Integration/SalesAssists/PullLeadActivityReynoldsResolvedLeadTest.php
+++ b/tests/Connectors/Integration/SalesAssists/PullLeadActivityReynoldsResolvedLeadTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Integration\SalesAssists;
+
+use Baka\Support\Str;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Connectors\Reynolds\Enums\ConfigurationEnum as ReynoldsConfigurationEnum;
+use Kanvas\Connectors\SalesAssist\Activities\PullLeadActivity;
+use Kanvas\Guild\Leads\Models\Lead;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Models\AgentType;
+use ReflectionClass;
+use Tests\TestCase;
+
+class PullLeadActivityReynoldsResolvedLeadTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    protected $connectionsToTransact = [null, 'crm', 'social', 'intelligence'];
+
+    /**
+     * Regression: on the Reynolds branch the activity resolved the lead as the
+     * incoming $entity instead of the lead findReynoldsLead() matched. On a sync
+     * pull $entity is a stub with id 0, so CreateSocialChannelsAfterPullAction
+     * hit its `id === 0` guard and returned early — the dealer never got the
+     * SMS/email channels.
+     */
+    public function testReynoldsPullCreatesSocialChannelsForTheMatchedLead(): void
+    {
+        $app = app(Apps::class);
+        $user = auth()->user();
+        $company = $user->getCurrentCompany();
+
+        $company->set(ReynoldsConfigurationEnum::REYNOLDS_DEALER_NUMBER->value, '12345');
+
+        $agentType = AgentType::factory()
+            ->withAppId($app->getId())
+            ->create(['name' => 'Reynolds Pull Test ' . Str::random(6)]);
+
+        Agent::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create([
+                'name' => 'Sally',
+                'agent_type_id' => $agentType->getId(),
+                'user_id' => $user->getId(),
+            ]);
+
+        $lead = Lead::factory()
+            ->withAppId($app->getId())
+            ->withCompanyId($company->getId())
+            ->create();
+
+        $phone = Str::sanitizePhoneNumber($lead->people->getCellPhones()->first()->value);
+
+        $stub = new Lead();
+        $stub->companies_id = $company->getId();
+
+        new ReflectionClass(PullLeadActivity::class)->newInstanceWithoutConstructor()
+            ->execute($stub, $app, ['phone' => $phone, 'user' => $user]);
+
+        $channelNames = $lead->socialChannels()->pluck('name')->all();
+
+        $this->assertContains(
+            'Sms ' . $lead->getId(),
+            $channelNames,
+            'Reynolds pull must open channels on the matched lead, not on the id=0 stub entity.'
+        );
+        $this->assertContains('Email ' . $lead->getId(), $channelNames);
+    }
+}


### PR DESCRIPTION
## The bug

`PullLeadActivity::execute()` builds `$resolvedLead` with a `match (true)`, and the Reynolds arm returned `$entity`:

```php
$resolvedLead = match (true) {
    $isDriveCentric  => $leadModel ?? null,
    $isDealerSocket  => isset($people) ? LeadsRepository::getPeopleActiveLead($people) : null,
    $isReynolds      => $entity,          // <-- wrong
    $isVinSolutions, $isElead => ...
};
```

The lead that was actually matched lands in the local `$lead` (from `findReynoldsLead()`). On a **sync pull**, `$entity` is a stub `Lead` with `id === 0` — that's the very first thing the activity computes (`$isSync = $entity->id === 0`).

`CreateSocialChannelsAfterPullAction::execute()` opens with:

```php
if ($this->lead->id === 0) {
    return;
}
```

So the whole post-pull block silently no-ops on ReyRey: no SMS channel, no email channel, no AI-assist channel, and `ApplyLeadClosingStatusAction` never runs. It fails quietly — the surrounding `try` only catches throws, and nothing throws.

Every other CRM arm already resolves the *pulled* model. Reynolds was the odd one out.

## The fix

```php
$isReynolds => $lead ?? null,
```

Same shape as the DriveCentric arm (`$leadModel ?? null`) — `$lead` is declared inside the `elseif ($isReynolds)` branch, so the `??` covers the case where no match was found.

## Test

`PullLeadActivityReynoldsResolvedLeadTest` — the Reynolds branch hits no external API (`findReynoldsLead()` is a DB query), so the test drives `execute()` for real and asserts the `Sms {id}` / `Email {id}` channels land on the matched lead.

- Fails on unfixed `1.x`: `Failed asserting that an array contains 'Sms 756685'`
- Passes with the fix
- Full SalesAssist slice green: `OK (54 tests, 107 assertions)`

## Scope

Cut from `1.x`, one-line production change plus the regression test. Nothing else.

Two adjacent things noticed and deliberately **left alone** for a separate PR:
- `CreateSocialChannelsAfterPullAction.php:55` uses `$params['ai_assist_agent_id']` where it means `$this->params` — undefined variable, but `??` swallows it so it always falls back to `$this->agentId`.
- `$isSync` in `PullLeadActivity::execute()` is assigned and never read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)