### PR TITLE
fix: log failed neuron chat turns with agent context

### DIFF
--- a/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Chat/RunNeuronChatAction.php
@@ -8,6 +8,7 @@ use Baka\Http\SafeUrlFetcher;
 use finfo;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\Log;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Guild\Customers\Services\PeopleChannelService;
 use Kanvas\Guild\Leads\Models\Lead;
@@ -113,6 +114,22 @@ class RunNeuronChatAction
             }
         } catch (Throwable $e) {
             $fallback = $this->humanizedFallback($e);
+
+            // Logged on both paths: report() only captures Issues, and a rethrown failure is reported
+            // by a caller that no longer knows which agent, session or handler it came from.
+            Log::error('Neuron chat turn failed', [
+                'agent_id' => $this->agent->getId(),
+                'apps_id' => $this->app->getId(),
+                'companies_id' => $this->agent->companies_id,
+                'users_id' => $this->user->getId(),
+                'session_id' => $sessionId,
+                'handler' => get_class($this->handler),
+                'exception' => $e::class,
+                'error' => $e->getMessage(),
+                'file' => $e->getFile() . ':' . $e->getLine(),
+                'fallback_on_failure' => $this->fallbackOnFailure,
+                'fallback' => $fallback,
+            ]);
 
             if (! $selfRecords) {
                 new KanvasConversationStore()->logTurn(

--- a/tests/Intelligence/Agents/Chat/RunNeuronChatErrorHandlingTest.php
+++ b/tests/Intelligence/Agents/Chat/RunNeuronChatErrorHandlingTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Log;
 use Kanvas\Apps\Models\Apps;
 use Kanvas\Intelligence\Agents\Actions\Chat\RunNeuronChatAction;
 use Kanvas\Intelligence\Agents\Models\Agent;
@@ -63,6 +64,40 @@ class RunNeuronChatErrorHandlingTest extends TestCase
             new RuntimeException('Gemini returned STOP with no parts'),
             fallbackOnFailure: false
         );
+    }
+
+    public function testAHumanizedFailureIsLoggedWithItsRealCause(): void
+    {
+        Log::spy();
+
+        $this->runChatWithThrowingHandler(new RuntimeException('Gemini returned STOP with no parts'));
+
+        Log::shouldHaveReceived('error')
+            ->withArgs(fn (string $message, array $context) => $message === 'Neuron chat turn failed'
+                && $context['exception'] === RuntimeException::class
+                && $context['error'] === 'Gemini returned STOP with no parts'
+                && $context['handler'] === ThrowingNeuronHandlerStub::class
+                && str_contains($context['fallback'], 'I ran into a hiccup'))
+            ->once();
+    }
+
+    public function testARethrownFailureIsStillLogged(): void
+    {
+        Log::spy();
+
+        try {
+            $this->runChatWithThrowingHandler(
+                new RuntimeException('Gemini returned STOP with no parts'),
+                fallbackOnFailure: false
+            );
+            $this->fail('Expected the failure to be rethrown.');
+        } catch (RuntimeException) {
+        }
+
+        Log::shouldHaveReceived('error')
+            ->withArgs(fn (string $message, array $context) => $message === 'Neuron chat turn failed'
+                && $context['fallback_on_failure'] === false)
+            ->once();
     }
 
     private function runChatWithThrowingHandler(Throwable $exception, bool $fallbackOnFailure = true): string


### PR DESCRIPTION
## Summary
- `RunNeuronChatAction` now writes `Log::error('Neuron chat turn failed', [...])` whenever a turn fails, before it either returns the humanized fallback ("I ran into a hiccup…") or rethrows.
- Context: `agent_id`, `apps_id`, `companies_id`, `users_id`, `session_id`, `handler`, `exception`, `error`, `file`, `fallback_on_failure`, `fallback` (which reply the user saw).
- The default `stack` channel is `single` + `sentry_logs`, so the line lands in `laravel.log` and Sentry → Logs (when `SENTRY_ENABLE_LOGS=true`).

## Why
`report($e)` only produces a Sentry issue with the bare exception, and on the rethrow path the caller that reports it no longer knows which agent/session/handler failed. This gives a searchable log line with the full turn context for every hiccup.

The raw error still never reaches the channel reply.

## Tests
- `testAHumanizedFailureIsLoggedWithItsRealCause`
- `testARethrownFailureIsStillLogged`
- `RunNeuronChatErrorHandlingTest` (9 tests) and `RunNeuronChatAttachmentTest` (2 tests) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)