### PR TITLE
feat(voice): release the old Twilio webhook when an agent changes its number

### DIFF
--- a/app/GraphQL/Intelligence/Mutations/AgentManagementMutation.php
+++ b/app/GraphQL/Intelligence/Mutations/AgentManagementMutation.php
@@ -12,6 +12,7 @@ use Kanvas\Intelligence\Agents\Actions\CreateAgentAction;
 use Kanvas\Intelligence\Agents\Actions\RebuildAgentToolInstructionsAction;
 use Kanvas\Intelligence\Agents\Actions\UpdateAgentAction;
 use Kanvas\Intelligence\Agents\Actions\Voice\ConfigureAgentInboundWebhookAction;
+use Kanvas\Intelligence\Agents\Actions\Voice\ReleaseInboundWebhookForNumberAction;
 use Kanvas\Intelligence\Agents\DataTransferObject\Agent as AgentDTO;
 use Kanvas\Intelligence\Agents\Models\Agent;
 use Kanvas\Intelligence\Agents\Models\AgentLlmConfig;
@@ -112,6 +113,9 @@ class AgentManagementMutation
         $app = app(Apps::class);
         $company = auth()->user()->getCurrentCompany();
         $agent = Agent::getByIdFromCompanyApp((int) $req['id'], $company, $app);
+        // Capture the agent's number BEFORE the update overwrites voice_config, so
+        // we can release the OLD number's inbound webhook if it changes below.
+        $previousNumber = trim((string) ($agent->voice_config['phone_number'] ?? ''));
         $agentType = AgentTypeModel::getById($input['agent_type_id'], app: $app);
         $agentModel = isset($input['agent_model_id']) ? AgentModel::getById($input['agent_model_id'], app: $app) : null;
         $task = isset($input['company_task_list_id']) ? TaskList::getById($input['company_task_list_id'], app: $app) : null;
@@ -165,6 +169,24 @@ class AgentManagementMutation
         // Best-effort: (re)point the agent's Twilio number at the inbound webhook
         // when its number changes. Never throws — must not block the update.
         new ConfigureAgentInboundWebhookAction($agent, $app)->execute();
+
+        // If the number actually changed (or was cleared), release the OLD number's
+        // webhook — but only when no agent anywhere still owns it (account-wide, in
+        // the action). Compare on digits so a mere format change isn't treated as a
+        // move (which would wrongly clear the number this agent still uses).
+        $newNumber = trim((string) ($agent->voice_config['phone_number'] ?? ''));
+        if (
+            $previousNumber !== ''
+            && AgentsRepository::normalizePhoneNumber($previousNumber)
+                !== AgentsRepository::normalizePhoneNumber($newNumber)
+        ) {
+            new ReleaseInboundWebhookForNumberAction(
+                $previousNumber,
+                $app,
+                $company,
+                $agent->getId(),
+            )->execute();
+        }
 
         return $agent->refresh();
     }

--- a/src/Domains/Intelligence/Agents/Actions/Voice/ReleaseInboundWebhookForNumberAction.php
+++ b/src/Domains/Intelligence/Agents/Actions/Voice/ReleaseInboundWebhookForNumberAction.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kanvas\Intelligence\Agents\Actions\Voice;
+
+use Baka\Contracts\AppInterface;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Twilio\Client as TwilioClient;
+use Kanvas\Exceptions\ValidationException;
+use Kanvas\Intelligence\Agents\Models\Agent;
+use Kanvas\Intelligence\Agents\Repositories\AgentsRepository;
+use Throwable;
+
+use function Sentry\captureException;
+
+/**
+ * Release a Twilio number's inbound webhook when an agent stops using it.
+ *
+ * The counterpart to ConfigureAgentInboundWebhookAction: when an agent changes
+ * (or clears) its phone number, that action wires the NEW number but nothing
+ * clears the OLD one, leaving a stale `voiceUrl` pointing at the runtime. This
+ * clears it — but ONLY when no voice agent anywhere still owns the number.
+ *
+ * The ownership check is ACCOUNT-WIDE on purpose: voice agents share one Twilio
+ * account, and a phone-number string belongs to exactly one account, so any
+ * agent in ANY app still carrying that number means the webhook is in use and
+ * must be left in place (clearing it would kill that agent's inbound). Scanning
+ * all voice-configured agents is cheap — the set is small.
+ *
+ * NON-BLOCKING and NEVER throws: it runs on agent save and must not break it.
+ * Returns a structured outcome the caller can log.
+ */
+class ReleaseInboundWebhookForNumberAction
+{
+    public function __construct(
+        private readonly string $number,
+        private readonly AppInterface $app,
+        private readonly ?Companies $company = null,
+        // The agent that just moved off the number. It no longer carries it (the
+        // update already applied), so this is belt-and-suspenders against a race
+        // where the caller passes an agent still holding the old value.
+        private readonly ?int $exceptAgentId = null,
+    ) {
+    }
+
+    /**
+     * @return array{status: string, message: string}
+     *   status: released | kept | idle | error
+     */
+    public function execute(): array
+    {
+        $number = trim($this->number);
+        if ($number === '') {
+            return $this->result('idle', 'No previous number to release.');
+        }
+
+        if ($this->stillOwned($number)) {
+            return $this->result('kept', "{$number} is still assigned to another agent; webhook left in place.");
+        }
+
+        try {
+            // Company creds if the company has its own; else the app-level creds
+            // (the shared account the number lives on). Throws when neither is set.
+            $twilio = $this->company !== null
+                ? TwilioClient::getInstanceByAppOrCompany($this->app, $this->company)
+                : TwilioClient::getInstance($this->app);
+
+            $numbers = $twilio->incomingPhoneNumbers->read(['phoneNumber' => $number], 1);
+            if ($numbers === []) {
+                // Not on this account (maybe never wired, or a different account) —
+                // nothing to clear.
+                return $this->result('idle', "{$number} is not a number in the connected Twilio account.");
+            }
+
+            // Blank the voiceUrl so calls to this released number no longer reach
+            // the runtime. Re-wired automatically if any agent claims it again.
+            $twilio->incomingPhoneNumbers($numbers[0]->sid)->update([
+                'voiceUrl' => '',
+                'voiceMethod' => 'POST',
+            ]);
+
+            return $this->result('released', "Cleared the inbound webhook on {$number}.");
+        } catch (ValidationException $e) {
+            // Expected, actionable misconfiguration — no need to page Sentry.
+            return $this->result('error', $e->getMessage());
+        } catch (Throwable $e) {
+            captureException($e);
+
+            return $this->result('error', 'Could not reach Twilio to clear the inbound webhook.');
+        }
+    }
+
+    /**
+     * Whether ANY other voice agent (any app) still carries this number. A Twilio
+     * number string is unique to one account, so a match anywhere means it's live.
+     */
+    private function stillOwned(string $number): bool
+    {
+        $normalized = AgentsRepository::normalizePhoneNumber($number);
+        if ($normalized === '') {
+            // Un-normalizable input — never risk clearing a webhook on a guess.
+            return true;
+        }
+
+        $agents = Agent::query()
+            ->notDeleted()
+            ->whereNotNull('voice_config')
+            ->get();
+
+        foreach ($agents as $agent) {
+            if ($this->exceptAgentId !== null && $agent->getId() === $this->exceptAgentId) {
+                continue;
+            }
+
+            $stored = $agent->voice_config['phone_number'] ?? null;
+            if (! empty($stored) && AgentsRepository::normalizePhoneNumber((string) $stored) === $normalized) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array{status: string, message: string}
+     */
+    private function result(string $status, string $message): array
+    {
+        return ['status' => $status, 'message' => $message];
+    }
+}


### PR DESCRIPTION
## Why

`ConfigureAgentInboundWebhookAction` only ever **sets** a number's `voiceUrl` (wires it to the runtime); nothing ever clears it. So changing an agent's phone number wires the **new** number but leaves the **old** number's webhook pointing at the runtime forever — a stale inbound route.

## What

Add `ReleaseInboundWebhookForNumberAction`, wired into `AgentManagementMutation::update`:
- Capture the agent's number **before** the update overwrites `voice_config`.
- After re-wiring the new number, if the number actually **changed or was cleared** (compared on digits, so a format-only change isn't treated as a move), clear the **old** number's `voiceUrl`.
- **Only** clear it when **no voice agent anywhere still owns it.**

### Ownership check is account-wide on purpose
Voice agents share one Twilio account, and a phone-number string belongs to exactly one account — so if any agent in **any app** still carries that number, the webhook is in use and must be left in place. Clearing it otherwise would kill that agent's inbound. This is exactly the duplicate-number situation we just hit: two agents on the same number, one moved off — the number's webhook must survive because the other agent still uses it. The action scans all `notDeleted` voice-configured agents (small set) and refuses to clear if any (other than the one being edited) matches.

## Scope / non-goals
- Best-effort, never throws (same contract as the wiring action) — must not block agent save.
- Only the `update` path (create has no old number; the retry mutation doesn't change the number).
- **Does not** change which agent answers a *still-assigned* number — that's `voiceAgentByNumber` (the number→agent map), not the webhook. This is hygiene for **released** numbers.

## Test
`php -l` clean on both files. Manual (needs Twilio + a real number):
1. Assign number A to an agent (webhook wired on A). Change it to B → B wired, and A's `voiceUrl` cleared (A now owned by nobody).
2. Two agents on the same number A; move one to B → A's webhook is **kept** (the other agent still owns A), B wired.
3. Format-only edit (e.g. `+1 219…` → `+1219…`) → no release fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)