### PR TITLE
fix(credit700): mark RouteOne rejections FAILED and report the gateway error

### DIFF
--- a/src/Domains/Connectors/Credit700/Workflow/SubmitCreditApplicationActivity.php
+++ b/src/Domains/Connectors/Credit700/Workflow/SubmitCreditApplicationActivity.php
@@ -51,14 +51,27 @@ class SubmitCreditApplicationActivity extends KanvasActivity
                 }
 
                 if (! $result['success']) {
-                    report(new Exception('RouteOne rejected the credit application for message ' . $message->getId()));
+                    $error = $result['response']['Creditsystem_Error']['@attributes'] ?? [];
+
+                    report(new Exception(sprintf(
+                        'RouteOne rejected the credit application for message %s: [%s] %s',
+                        $message->getId(),
+                        $error['id'] ?? 'no id',
+                        $error['message'] ?? 'no transaction id returned'
+                    )));
+
+                    return $this->failWorkflow([
+                        'message' => 'RouteOne rejected the credit application',
+                        'success' => false,
+                        'transaction_id' => $result['transaction_id'],
+                        'token' => $result['token'],
+                        'entity' => $result['response'],
+                    ]);
                 }
 
                 return [
-                    'message' => $result['success']
-                        ? 'Credit application submitted to RouteOne successfully'
-                        : 'RouteOne rejected the credit application',
-                    'success' => $result['success'],
+                    'message' => 'Credit application submitted to RouteOne successfully',
+                    'success' => true,
                     'transaction_id' => $result['transaction_id'],
                     'token' => $result['token'],
                     'entity' => $result['response'],


### PR DESCRIPTION
Follow-up to #11225.

## Problem

When RouteOne rejects a submission it answers with a `Creditsystem_Error` and no transaction id:

```json
"entity": {
  "Creditsystem_Error": { "@attributes": { "id": "1008", "message": "Invalid City" } },
  "custom_report": []
}
```

`submitToRouteOne()` turns that into `success: false`, and #11225 reported it to Sentry — but the activity still returned normally, so the integration history showed the run as **CONNECTED**, and the Sentry message didn't say *why* it was rejected.

## Change

`SubmitCreditApplicationActivity`, rejection path only:

- `return $this->failWorkflow([...])` so the run is flagged **FAILED** in the integration history (same payload as before, `entity` still carries the RouteOne response).
- The Sentry report now includes the gateway error id and message pulled from `Creditsystem_Error.@attributes`:
  `RouteOne rejected the credit application for message 123: [1008] Invalid City`
  Falls back to `[no id] no transaction id returned` when RouteOne sends no error block. No applicant data goes into the message.

The success return is unchanged apart from dropping the now-dead ternaries (`success` is always `true` at that point).

## Tests

```
tests/Connectors/Integration/Credit700/  →  OK (10 tests, 65 assertions)
```

No new test: driving `execute()` needs an integration-company + engagement + lead fixture and eats the 20s `sleep()` from #11223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)