### PR TITLE
hotfix: fail the workflow instead of throwing when a Reynolds note message has no lead

### DIFF
--- a/src/Domains/Connectors/Reynolds/Activities/PushLeadNotesActivity.php
+++ b/src/Domains/Connectors/Reynolds/Activities/PushLeadNotesActivity.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Kanvas\Connectors\Reynolds\Activities;
 
 use Baka\Support\Url;
-use Exception;
 use Kanvas\ActionEngine\Actions\Enums\ActionEnum;
 use Kanvas\ActionEngine\Engagements\Repositories\EngagementRepository;
 use Kanvas\ActionEngine\Enums\ActionStatusEnum;
@@ -72,7 +71,10 @@ class PushLeadNotesActivity extends KanvasActivity
 
         $lead = $message->entity();
         if (! $lead instanceof Lead) {
-            throw new Exception('Lead not found');
+            return $this->failWorkflow([
+                'message_id' => $message->getId(),
+                'error' => 'Lead not found',
+            ]);
         }
 
         return $this->executeIntegration(

--- a/tests/Connectors/Integration/Reynolds/PushLeadNotesActivityTest.php
+++ b/tests/Connectors/Integration/Reynolds/PushLeadNotesActivityTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Connectors\Integration\Reynolds;
+
+use Kanvas\Apps\Models\Apps;
+use Kanvas\Companies\Models\Companies;
+use Kanvas\Connectors\Reynolds\Activities\PushLeadNotesActivity;
+use Kanvas\Connectors\Reynolds\Enums\ConfigurationEnum;
+use Kanvas\Social\Messages\Models\Message;
+use Kanvas\Workflow\Models\StoredWorkflow;
+use Tests\TestCase;
+
+final class PushLeadNotesActivityTest extends TestCase
+{
+    /**
+     * A Reynolds rule fires on every message of its type, including ones that were never linked to
+     * a Lead — so a missing entity is a routine skip, not a fault. It used to throw and reached
+     * Sentry 13k times in two weeks (KANVAS-ECOSYSTEM-69R).
+     */
+    public function testFailsTheWorkflowWhenTheMessageHasNoLeadInsteadOfThrowing(): void
+    {
+        $this->configureReynolds();
+
+        $result = $this->activity()->execute(
+            $this->makeMessageWithoutEntity(),
+            app(Apps::class),
+            []
+        );
+
+        $this->assertSame('Lead not found', $result['error']);
+    }
+
+    private function activity(): PushLeadNotesActivity
+    {
+        return new PushLeadNotesActivity(
+            0,
+            now()->toDateTimeString(),
+            StoredWorkflow::make(),
+            []
+        );
+    }
+
+    private function configureReynolds(): void
+    {
+        $company = $this->company();
+
+        $company->set(ConfigurationEnum::REYNOLDS_ENDPOINT->value, 'https://example.com/salesassist');
+        $company->set(ConfigurationEnum::REYNOLDS_USERNAME->value, 'user');
+        $company->set(ConfigurationEnum::REYNOLDS_PASSWORD->value, 'secret');
+        $company->set(ConfigurationEnum::REYNOLDS_DEALER_NUMBER->value, '1');
+        $company->set(ConfigurationEnum::REYNOLDS_STORE_NUMBER->value, '2');
+        $company->set(ConfigurationEnum::REYNOLDS_AREA_NUMBER->value, '3');
+    }
+
+    private function makeMessageWithoutEntity(): Message
+    {
+        return Message::factory()
+            ->withAppId(app(Apps::class)->getId())
+            ->withCompanyId($this->company()->getId())
+            ->create(['message' => ['content' => 'Plain note, never linked to a lead']]);
+    }
+
+    private function company(): Companies
+    {
+        return auth()->user()->getCurrentCompany();
+    }
+}


### PR DESCRIPTION
Fixes the Sentry flood in [KANVAS-ECOSYSTEM-69R](https://sentry.io/issues/?query=KANVAS-ECOSYSTEM-69R) — **13K events in 15 days**, unhandled, regressed.

## What was wrong

`PushLeadNotesActivity::execute()` threw `Exception('Lead not found')` when `$message->entity()` did not return a `Lead`:

```php
$lead = $message->entity();
if (! $lead instanceof Lead) {
    throw new Exception('Lead not found');
}
```

`Message::entity()` returns `null` whenever the message has no `appModuleMessage` row — routine for any message the Reynolds rule fires on that was never linked to a lead (plain agent notes, unwired verbs). That is an expected business skip, not a fault.

Worse, the throw sits **before** `executeIntegration`, so its `catch`/`report()` never sees it. The exception bubbled straight out of the queue worker into Sentry, and `$tries = 3` multiplied every occurrence.

VinSolution's equivalent activity (`src/Domains/Connectors/VinSolution/Workflow/PushLeadNotesActivity.php:47`) already handles this correctly — the Reynolds copy was written with a throw instead.

## The fix

Return `failWorkflow` instead, per the "Workflow Activities — Don't Throw/Report Expected Skips" convention in `CLAUDE.md`. The step is still flagged `FAILED` in the integration-history UI for humans and future agents, without an exception or a Sentry report:

```php
$lead = $message->entity();
if (! $lead instanceof Lead) {
    return $this->failWorkflow([
        'message_id' => $message->getId(),
        'error' => 'Lead not found',
    ]);
}
```

`use Exception;` dropped — no longer referenced in the file.

## Test plan

New regression test `tests/Connectors/Integration/Reynolds/PushLeadNotesActivityTest.php` builds a message with no linked entity and asserts the returned `error`. Verified both directions in the container:

| | result |
|---|---|
| without the fix | `E` — `Exception: Lead not found` at `PushLeadNotesActivity.php:75` |
| with the fix | `OK (1 test, 1 assertion)` |
| whole `tests/Connectors/Integration/Reynolds/` | `17 tests, 47 assertions, 6 skipped` — green |

The 6 skips are the pre-existing `markTestSkipped` spec-limitation tests in `PushVoiToExistingLeadTest`.

## Not in scope

`DealerSocketLeadService.php:123` still throws `Exception('Lead not found in DealerSocket with Customer ID: ...')`. It is a service rather than an activity and does not appear in this Sentry issue, so it was left alone — easy to sweep in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)